### PR TITLE
Fix leak due to missing free after a host function call.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,9 @@ let package = Package(
                 "-Xlinker",
                 "--export=swjs_call_host_function",
                 "-Xlinker",
-                "--export=swjs_prepare_host_function_call"
+                "--export=swjs_prepare_host_function_call",
+                "-Xlinker",
+                "--export=swjs_cleanup_host_function_call"
               ])
             ]),
         .target(

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -11,6 +11,7 @@ declare const global: GlobalVariable;
 
 interface SwiftRuntimeExportedFunctions {
     swjs_prepare_host_function_call(size: number): pointer;
+    swjs_cleanup_host_function_call(argv: pointer): void;
     swjs_call_host_function(
         host_func_id: number,
         argv: pointer, argc: number,
@@ -112,6 +113,7 @@ export class SwiftRuntime {
                 output = result
             })
             exports.swjs_call_host_function(host_func_id, argv, argc, callback_func_ref)
+            exports.swjs_cleanup_host_function_call(argv)
             return output
         }
 

--- a/Sources/JavaScriptKit/JSFunction.swift
+++ b/Sources/JavaScriptKit/JSFunction.swift
@@ -76,6 +76,11 @@ public func _prepare_host_function_call(_ argc: Int32) -> UnsafeMutableRawPointe
     return malloc(Int(argumentSize))!
 }
 
+@_cdecl("swjs_cleanup_host_function_call")
+public func _cleanup_host_function_call(_ pointer: UnsafeMutableRawPointer) {
+    free(pointer)
+}
+
 @_cdecl("swjs_call_host_function")
 public func _call_host_function(
     _ hostFuncRef: JavaScriptHostFuncRef,


### PR DESCRIPTION
`_prepare_host_function_call` calls malloc and returns a pointer which is not freed after the host function call is completed. 