### PR TITLE
Add Package@swift-5.2.swift to support the older version

### DIFF
--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -1,0 +1,40 @@
+// swift-tools-version:5.2
+
+import PackageDescription
+
+let package = Package(
+    name: "JavaScriptKit",
+    products: [
+        .library(name: "JavaScriptKit", targets: ["JavaScriptKit"])
+    ],
+    targets: [
+        .target(
+            name: "JavaScriptKit",
+            dependencies: ["_CJavaScriptKit"],
+            linkerSettings: [
+                .unsafeFlags(
+                    [
+                        "-Xlinker",
+                        "--export=swjs_call_host_function",
+                        "-Xlinker",
+                        "--export=swjs_prepare_host_function_call",
+                        "-Xlinker",
+                        "--export=swjs_cleanup_host_function_call"
+                    ]
+                )
+            ]),
+        .target(
+            name: "_CJavaScriptKit",
+            linkerSettings: [
+                .unsafeFlags(
+                    [
+                        "-Xlinker",
+                        "--allow-undefined",
+                    ]
+                )
+            ]),
+        .testTarget(
+            name: "JavaScriptKitTests",
+            dependencies: ["JavaScriptKit"]),
+    ]
+)


### PR DESCRIPTION
This allows using the upstream toolchain for things like `swift test --generate-linuxmain`, which can be useful for packages that depend on `JavaScriptKit`. This is purely additive and `Package.swift` with 5.3 manifest is left untouched.