### PR TITLE
Prevent early deallocation of object references

### DIFF
--- a/IntegrationTests/JavaScriptKitExec/Sources/JavaScriptKitExec/main.swift
+++ b/IntegrationTests/JavaScriptKitExec/Sources/JavaScriptKitExec/main.swift
@@ -299,3 +299,27 @@ Object_Conversion: do {
 } catch {
     print(error)
 }
+
+ObjectRef_Lifetime: do {
+    // ```js
+    // global.globalObject1 = {
+    //   "prop_1": {
+    //     "nested_prop": 1,
+    //   },
+    //   "prop_2": 2,
+    //   "prop_3": true,
+    //   "prop_4": [
+    //     3, 4, "str_elm_1", 5,
+    //   ],
+    //   ...
+    // }
+    // ```
+
+    let identity = JSClosure { $0[0] }
+    let ref1 = getJSValue(this: .global, name: "globalObject1").object!
+    let ref2 = identity(ref1).object!
+    try expectEqual(ref1.prop_2, .number(2))
+    try expectEqual(ref2.prop_2, .number(2))
+} catch {
+    print(error)
+}

--- a/Sources/JavaScriptKit/JSObject.swift
+++ b/Sources/JavaScriptKit/JSObject.swift
@@ -1,10 +1,26 @@
 import _CJavaScriptKit
 
+private struct Weak<T: AnyObject> {
+  weak var ref: T?
+}
+
+private var cache = [UInt32: Weak<JSObjectRef>]()
+
 @dynamicMemberLookup
 public class JSObjectRef: Equatable {
     internal var id: UInt32
     init(id: UInt32) {
         self.id = id
+    }
+
+    static func retrieve(id: UInt32) -> JSObjectRef {
+        if id != 0, let ref = cache[id]?.ref {
+            return ref
+        } else {
+            let ref = JSObjectRef(id: id)
+            cache[id] = Weak(ref: ref)
+            return ref
+        }
     }
 
     @_disfavoredOverload
@@ -46,7 +62,9 @@ public class JSObjectRef: Equatable {
     static let _JS_Predef_Value_Global: UInt32 = 0
     public static let global = JSObjectRef(id: _JS_Predef_Value_Global)
 
-    deinit { _destroy_ref(id) }
+    deinit {
+      _destroy_ref(id)
+    }
 
     public static func == (lhs: JSObjectRef, rhs: JSObjectRef) -> Bool {
         return lhs.id == rhs.id

--- a/Sources/JavaScriptKit/JSObject.swift
+++ b/Sources/JavaScriptKit/JSObject.swift
@@ -63,7 +63,8 @@ public class JSObjectRef: Equatable {
     public static let global = JSObjectRef(id: _JS_Predef_Value_Global)
 
     deinit {
-      _destroy_ref(id)
+        cache[id] = nil
+        _destroy_ref(id)
     }
 
     public static func == (lhs: JSObjectRef, rhs: JSObjectRef) -> Bool {

--- a/Sources/JavaScriptKit/JSValueConvertible.swift
+++ b/Sources/JavaScriptKit/JSValueConvertible.swift
@@ -111,7 +111,7 @@ extension RawJSValue: JSValueConvertible {
             let string = String(decodingCString: UnsafePointer(buffer), as: UTF8.self)
             return .string(string)
         case JavaScriptValueKind_Object:
-            return .object(JSObjectRef(id: UInt32(payload1)))
+            return .object(JSObjectRef.retrieve(id: UInt32(payload1)))
         case JavaScriptValueKind_Null:
             return .null
         case JavaScriptValueKind_Undefined:


### PR DESCRIPTION
Currently, when two references are created for the same object (i.e. with the same `id`), deallocating the first references invalidates the second. This is can cause crashes, which is reproduced in the newly added test. To avoid this issue, a new private `cache` of weak references is created, which can retrieve the same `JSObjectRef` instance for the same id, when called from `RawJSValue.jsValue()`.

Obviously, this adds some overhead on object retrieval when the Swift <-> JS bridge is crossed, but I think invalid references are a much more serious problem than this overhead. I don't know yet what implementation could be more efficient, if that's possible at all.