### PR TITLE
Reapply "Fix `JSClosure` leak (#240)"

### DIFF
--- a/IntegrationTests/TestSuites/Sources/ConcurrencyTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/ConcurrencyTests/main.swift
@@ -123,12 +123,16 @@ func entrypoint() async throws {
             try expectEqual(result, .number(3))
         }
         try expectGTE(diff, 200)
+#if JAVASCRIPTKIT_WITHOUT_WEAKREFS
+        delayObject.closure = nil
+        delayClosure.release()
+#endif
     }
 
     try await asyncTest("Async JSPromise: then") {
         let promise = JSPromise { resolve in
             _ = JSObject.global.setTimeout!(
-                JSClosure { _  in
+                JSOneshotClosure { _  in
                     resolve(.success(JSValue.number(3)))
                     return .undefined
                 }.jsValue,
@@ -149,7 +153,7 @@ func entrypoint() async throws {
     try await asyncTest("Async JSPromise: then(success:failure:)") {
         let promise = JSPromise { resolve in
             _ = JSObject.global.setTimeout!(
-                JSClosure { _ in
+                JSOneshotClosure { _ in
                     resolve(.failure(JSError(message: "test").jsValue))
                     return .undefined
                 }.jsValue,
@@ -168,7 +172,7 @@ func entrypoint() async throws {
     try await asyncTest("Async JSPromise: catch") {
         let promise = JSPromise { resolve in
             _ = JSObject.global.setTimeout!(
-                JSClosure { _ in
+                JSOneshotClosure { _ in
                     resolve(.failure(JSError(message: "test").jsValue))
                     return .undefined
                 }.jsValue,

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/UnitTestUtils.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/UnitTestUtils.swift
@@ -111,7 +111,7 @@ func expectThrow<T>(_ body: @autoclosure () throws -> T, file: StaticString = #f
 }
 
 func wrapUnsafeThrowableFunction(_ body: @escaping () -> Void, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> Error {
-    JSObject.global.callThrowingClosure.function!(JSClosure { _ in 
+    JSObject.global.callThrowingClosure.function!(JSOneshotClosure { _ in
             body() 
             return .undefined
     })

--- a/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
+++ b/IntegrationTests/TestSuites/Sources/PrimaryTests/main.swift
@@ -254,12 +254,18 @@ try test("Closure Lifetime") {
     do {
         let c1 = JSClosure { _ in .number(4) }
         try expectEqual(c1(), .number(4))
+#if JAVASCRIPTKIT_WITHOUT_WEAKREFS
+        c1.release()
+#endif
     }
 
     do {
         let c1 = JSClosure { _ in fatalError("Crash while closure evaluation") }
         let error = try expectThrow(try evalClosure.throws(c1)) as! JSValue
         try expectEqual(error.description, "RuntimeError: unreachable")
+#if JAVASCRIPTKIT_WITHOUT_WEAKREFS
+        c1.release()
+#endif
     }
 }
 
@@ -866,16 +872,24 @@ try test("Symbols") {
     // }.prop
     // Object.defineProperty(hasInstanceClass, Symbol.hasInstance, { value: () => true })
     let hasInstanceObject = JSObject.global.Object.function!.new()
-    hasInstanceObject.prop = JSClosure { _ in .undefined }.jsValue
+    let hasInstanceObjectClosure = JSClosure { _ in .undefined }
+    hasInstanceObject.prop = hasInstanceObjectClosure.jsValue
     let hasInstanceClass = hasInstanceObject.prop.function!
     let propertyDescriptor = JSObject.global.Object.function!.new()
-    propertyDescriptor.value = JSClosure { _ in .boolean(true) }.jsValue
+    let propertyDescriptorClosure = JSClosure { _ in .boolean(true) }
+    propertyDescriptor.value = propertyDescriptorClosure.jsValue
     _ = JSObject.global.Object.function!.defineProperty!(
         hasInstanceClass, JSSymbol.hasInstance,
         propertyDescriptor
     )
     try expectEqual(hasInstanceClass[JSSymbol.hasInstance].function!().boolean, true)
     try expectEqual(JSObject.global.Object.isInstanceOf(hasInstanceClass), true)
+#if JAVASCRIPTKIT_WITHOUT_WEAKREFS
+    hasInstanceObject.prop = .undefined
+    propertyDescriptor.value = .undefined
+    hasInstanceObjectClosure.release()
+    propertyDescriptorClosure.release()
+#endif
 }
 
 struct AnimalStruct: Decodable {


### PR DESCRIPTION
Seems like something wrong is happening in https://github.com/swiftwasm/JavaScriptKit/actions/runs/8659623850. I need stress test this before re-landing this.

This reverts commit 8780e5f005933c1d83d74942a14f78c1fc03e499.