### PR TITLE
Added discardableresult 

### DIFF
--- a/Sources/JavaScriptKit/JSValue.swift
+++ b/Sources/JavaScriptKit/JSValue.swift
@@ -104,7 +104,8 @@ public extension JSValue {
 #if !hasFeature(Embedded)
     /// An unsafe convenience method of `JSObject.subscript(_ name: String) -> ((ConvertibleToJSValue...) -> JSValue)?`
     /// - Precondition: `self` must be a JavaScript Object and specified member should be a callable object.
-    subscript(dynamicMember name: String) -> ((ConvertibleToJSValue...) -> JSValue) {
+    @_disfavoredOverload
+    subscript(dynamicMember name: String) -> DiscardableResultClosure {
         object![dynamicMember: name]!
     }
 #endif


### PR DESCRIPTION
This prevents the warnings for unused results through `@discardableResult` which means you no longer need `_ =` everywhere.

TODO: Update comments and readme