### PR TITLE
Add `stackSize` parameter to `WebWorkerTaskExecutor` and `WebWorkerDedicatedExecutor`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SWIFT_SDK_ID ?= wasm32-unknown-wasi
 .PHONY: bootstrap
 bootstrap:
 	npm ci
-	npx playwright install
+	npx playwright install chromium-headless-shell
 
 .PHONY: unittest
 unittest:

--- a/Sources/JavaScriptEventLoop/WebWorkerDedicatedExecutor.swift
+++ b/Sources/JavaScriptEventLoop/WebWorkerDedicatedExecutor.swift
@@ -39,12 +39,19 @@ public final class WebWorkerDedicatedExecutor: SerialExecutor {
     private let underlying: WebWorkerTaskExecutor
 
     /// - Parameters:
+    ///   - stackSize: The stack size for each worker thread. Default is `nil` (use the platform default stack size).
     ///   - timeout: The maximum time to wait for all worker threads to be started. Default is 3 seconds.
     ///   - checkInterval: The interval to check if all worker threads are started. Default is 5 microseconds.
     /// - Throws: An error if any worker thread fails to initialize within the timeout period.
-    public init(timeout: Duration = .seconds(3), checkInterval: Duration = .microseconds(5)) async throws {
+    /// - Note: The default stack size of wasi-libc is typically 128KB.
+    public init(
+        stackSize: Int? = nil,
+        timeout: Duration = .seconds(3),
+        checkInterval: Duration = .microseconds(5)
+    ) async throws {
         let underlying = try await WebWorkerTaskExecutor(
             numberOfThreads: 1,
+            stackSize: stackSize,
             timeout: timeout,
             checkInterval: checkInterval
         )

--- a/Tests/JavaScriptEventLoopTests/WebWorkerTaskExecutorTests.swift
+++ b/Tests/JavaScriptEventLoopTests/WebWorkerTaskExecutorTests.swift
@@ -122,6 +122,12 @@ final class WebWorkerTaskExecutorTests: XCTestCase {
         executor.terminate()
     }
 
+    func testThreadStackSize() async throws {
+        // Sanity check for stackSize parameter
+        let executor = try await WebWorkerTaskExecutor(numberOfThreads: 3, stackSize: 512 * 1024)
+        executor.terminate()
+    }
+
     func testTaskGroupRunOnDifferentThreads() async throws {
         let executor = try await WebWorkerTaskExecutor(numberOfThreads: 2)
 


### PR DESCRIPTION
This is useful for extending the stack size of the worker threads as wasi-libc's default stack size is typically 128KB, which may not be sufficient for some workloads.