### PR TITLE
BridgeJS: Fix TypeScript constructor signature generation

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -599,7 +599,7 @@ struct BridgeJSLink {
             jsLines.append(contentsOf: funcLines.map { $0.indent(count: 4) })
 
             dtsExportEntryLines.append(
-                "constructor\(renderTSSignature(parameters: constructor.parameters, returnType: .swiftHeapObject(klass.name), effects: constructor.effects));"
+                "new\(renderTSSignature(parameters: constructor.parameters, returnType: .swiftHeapObject(klass.name), effects: constructor.effects));"
                     .indent(count: 4)
             )
         }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.d.ts
@@ -51,10 +51,10 @@ export interface UUID extends SwiftHeapObject {
 }
 export type Exports = {
     Greeter: {
-        constructor(name: string): Greeter;
+        new(name: string): Greeter;
     }
     Converter: {
-        constructor(): Converter;
+        new(): Converter;
     }
     UUID: {
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.Export.d.ts
@@ -17,7 +17,7 @@ export interface Greeter extends SwiftHeapObject {
 }
 export type Exports = {
     Greeter: {
-        constructor(name: string): Greeter;
+        new(name: string): Greeter;
     }
     takeGreeter(greeter: Greeter): void;
 }


### PR DESCRIPTION
Change constructor signature from 'constructor(...)' to 'new(...)' in generated TypeScript declaration files, which is the correct syntax for constructor call signatures in TypeScript.