### PR TITLE
BridgeJS: fix: switch to direct TypeSyntax initialiser

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -759,7 +759,7 @@ public class ExportSwift {
             identifierType.name.text == "Optional",
             let genericArgs = identifierType.genericArgumentClause?.arguments,
             genericArgs.count == 1,
-            let argType = genericArgs.first?.argument
+            let argType = TypeSyntax(genericArgs.first?.argument)
         {
             if let baseType = lookupType(for: argType) {
                 return .optional(baseType)
@@ -772,7 +772,7 @@ public class ExportSwift {
             memberType.name.text == "Optional",
             let genericArgs = memberType.genericArgumentClause?.arguments,
             genericArgs.count == 1,
-            let argType = genericArgs.first?.argument
+            let argType = TypeSyntax(genericArgs.first?.argument)
         {
             if let wrappedType = lookupType(for: argType) {
                 return .optional(wrappedType)


### PR DESCRIPTION
This PR updates `ExportSwift.lookupType` to handle changes introduced in newer SwiftSyntax, that would result in failed compilation with errors like:

```
cannot convert value of type 'GenericArgumentSyntax.Argument' to expected argument type 'TypeSyntax'
```

This happened because in newer SwiftSyntax the `.argument` property of GenericArgumentSyntax no longer returns a TypeSyntax directly, but a new wrapper type (GenericArgumentSyntax.Argument). 
I've just noticed this while working with other wasm32 Swift SDK with threads support, update approach should work properly for all sdk versions.
