### PR TITLE
PackageToJS: Remove "playwright" dependency declaration from generated package.json

### DIFF
--- a/Plugins/PackageToJS/Templates/package.json
+++ b/Plugins/PackageToJS/Templates/package.json
@@ -9,13 +9,5 @@
     },
     "dependencies": {
         "@bjorn3/browser_wasi_shim": "0.3.0"
-    },
-    "peerDependencies": {
-        "playwright": "^1.51.0"
-    },
-    "peerDependenciesMeta": {
-        "playwright": {
-            "optional": true
-        }
     }
 }


### PR DESCRIPTION
We alreawdy recommend users to declare playwright dep in their own package.json, so it doesn't make sense to have it declared here as well.

```
Playwright is not available in the current environment.
Please run the following command to install it:

$ npm install playwright && npx playwright install chromium
```

Actually, the declaration also makes things more complicated when users already have playwright dependency declared with a different version. Given that users unlikely commit the generated package.json into their repositories, it can't be a part of "workspace" either, so there is no benefit to have it here.