### PR TITLE
BridgeJS: @JS Protocol with methods support

### DIFF
--- a/Benchmarks/Sources/Generated/JavaScript/BridgeJS.ExportSwift.json
+++ b/Benchmarks/Sources/Generated/JavaScript/BridgeJS.ExportSwift.json
@@ -720,5 +720,8 @@
       }
     }
   ],
-  "moduleName" : "Benchmarks"
+  "moduleName" : "Benchmarks",
+  "protocols" : [
+
+  ]
 }

--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/JavaScript/BridgeJS.ExportSwift.json
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/JavaScript/BridgeJS.ExportSwift.json
@@ -138,5 +138,8 @@
   "functions" : [
 
   ],
-  "moduleName" : "PlayBridgeJS"
+  "moduleName" : "PlayBridgeJS",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -435,6 +435,8 @@ extension BridgeType {
         case .void: return .void
         case .swiftHeapObject:
             throw BridgeJSCoreError("swiftHeapObject is not supported in imported signatures")
+        case .swiftProtocol:
+            throw BridgeJSCoreError("swiftProtocol is not supported in imported signatures")
         case .caseEnum, .rawValueEnum, .associatedValueEnum, .namespaceEnum:
             throw BridgeJSCoreError("Enum types are not yet supported in TypeScript imports")
         case .optional:
@@ -465,6 +467,8 @@ extension BridgeType {
         case .void: return .void
         case .swiftHeapObject:
             throw BridgeJSCoreError("swiftHeapObject is not supported in imported signatures")
+        case .swiftProtocol:
+            throw BridgeJSCoreError("swiftProtocol is not supported in imported signatures")
         case .caseEnum, .rawValueEnum, .associatedValueEnum, .namespaceEnum:
             throw BridgeJSCoreError("Enum types are not yet supported in TypeScript imports")
         case .optional:

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -74,6 +74,7 @@ public enum BridgeType: Codable, Equatable, Sendable {
     case rawValueEnum(String, SwiftEnumRawType)
     case associatedValueEnum(String)
     case namespaceEnum(String)
+    case swiftProtocol(String)
 }
 
 public enum WasmCoreType: String, Codable, Sendable {
@@ -269,6 +270,18 @@ public enum EnumType: String, Codable, Sendable {
 
 // MARK: - Exported Skeleton
 
+public struct ExportedProtocol: Codable, Equatable {
+    public let name: String
+    public let methods: [ExportedFunction]
+    public let namespace: [String]?
+
+    public init(name: String, methods: [ExportedFunction], namespace: [String]? = nil) {
+        self.name = name
+        self.methods = methods
+        self.namespace = namespace
+    }
+}
+
 public struct ExportedFunction: Codable, Equatable, Sendable {
     public var name: String
     public var abiName: String
@@ -407,12 +420,20 @@ public struct ExportedSkeleton: Codable {
     public let functions: [ExportedFunction]
     public let classes: [ExportedClass]
     public let enums: [ExportedEnum]
+    public let protocols: [ExportedProtocol]
 
-    public init(moduleName: String, functions: [ExportedFunction], classes: [ExportedClass], enums: [ExportedEnum]) {
+    public init(
+        moduleName: String,
+        functions: [ExportedFunction],
+        classes: [ExportedClass],
+        enums: [ExportedEnum],
+        protocols: [ExportedProtocol] = []
+    ) {
         self.moduleName = moduleName
         self.functions = functions
         self.classes = classes
         self.enums = enums
+        self.protocols = protocols
     }
 }
 
@@ -514,6 +535,9 @@ extension BridgeType {
             return nil
         case .namespaceEnum:
             return nil
+        case .swiftProtocol:
+            // Protocols pass JSObject IDs as Int32
+            return .i32
         }
     }
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/Protocol.swift
@@ -1,0 +1,41 @@
+import JavaScriptKit
+
+@JS protocol MyViewControllerDelegate {
+    func onSomethingHappened()
+    func onValueChanged(_ value: String)
+    func onCountUpdated(count: Int) -> Bool
+    func onLabelUpdated(_ prefix: String, _ suffix: String)
+    func isCountEven() -> Bool
+}
+
+@JS class MyViewController {
+    @JS
+    var delegate: MyViewControllerDelegate
+
+    @JS
+    var secondDelegate: MyViewControllerDelegate?
+
+    @JS init(delegate: MyViewControllerDelegate) {
+        self.delegate = delegate
+    }
+
+    @JS func triggerEvent() {
+        delegate.onSomethingHappened()
+    }
+
+    @JS func updateValue(_ value: String) {
+        delegate.onValueChanged(value)
+    }
+
+    @JS func updateCount(_ count: Int) -> Bool {
+        return delegate.onCountUpdated(count: count)
+    }
+
+    @JS func updateLabel(_ prefix: String, _ suffix: String) {
+        delegate.onLabelUpdated(prefix, suffix)
+    }
+
+    @JS func checkEvenCount() -> Bool {
+        return delegate.isCountEven()
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.Export.d.ts
@@ -1,0 +1,44 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export interface MyViewControllerDelegate {
+    onSomethingHappened(): void;
+    onValueChanged(value: string): void;
+    onCountUpdated(count: number): boolean;
+    onLabelUpdated(prefix: string, suffix: string): void;
+    isCountEven(): boolean;
+}
+
+/// Represents a Swift heap object like a class instance or an actor instance.
+export interface SwiftHeapObject {
+    /// Release the heap object.
+    ///
+    /// Note: Calling this method will release the heap object and it will no longer be accessible.
+    release(): void;
+}
+export interface MyViewController extends SwiftHeapObject {
+    triggerEvent(): void;
+    updateValue(value: string): void;
+    updateCount(count: number): boolean;
+    updateLabel(prefix: string, suffix: string): void;
+    checkEvenCount(): boolean;
+    delegate: MyViewControllerDelegate;
+    secondDelegate: MyViewControllerDelegate | null;
+}
+export type Exports = {
+    MyViewController: {
+        new(delegate: MyViewControllerDelegate): MyViewController;
+    }
+}
+export type Imports = {
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.Export.js
@@ -1,0 +1,286 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let tmpRetTag;
+    let tmpRetStrings = [];
+    let tmpRetInts = [];
+    let tmpRetF32s = [];
+    let tmpRetF64s = [];
+    let tmpParamInts = [];
+    let tmpParamF32s = [];
+    let tmpParamF64s = [];
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            const bjs = {};
+            importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                tmpRetString = textDecoder.decode(bytes);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                return swift.memory.retain(textDecoder.decode(bytes));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr, len);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_tag"] = function(tag) {
+                tmpRetTag = tag;
+            }
+            bjs["swift_js_push_int"] = function(v) {
+                tmpRetInts.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                tmpRetF32s.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                tmpRetF64s.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                const value = textDecoder.decode(bytes);
+                tmpRetStrings.push(value);
+            }
+            bjs["swift_js_pop_param_int32"] = function() {
+                return tmpParamInts.pop();
+            }
+            bjs["swift_js_pop_param_f32"] = function() {
+                return tmpParamF32s.pop();
+            }
+            bjs["swift_js_pop_param_f64"] = function() {
+                return tmpParamF64s.pop();
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    const bytes = new Uint8Array(memory.buffer, ptr, len);
+                    tmpRetString = textDecoder.decode(bytes);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            // Wrapper functions for module: TestModule
+            if (!importObject["TestModule"]) {
+                importObject["TestModule"] = {};
+            }
+            importObject["TestModule"]["bjs_MyViewController_wrap"] = function(pointer) {
+                const obj = MyViewController.__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
+            TestModule["bjs_MyViewControllerDelegate_onSomethingHappened"] = function bjs_MyViewControllerDelegate_onSomethingHappened(self) {
+                try {
+                    swift.memory.getObject(self).onSomethingHappened();
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_onValueChanged"] = function bjs_MyViewControllerDelegate_onValueChanged(self, value) {
+                try {
+                    const valueObject = swift.memory.getObject(value);
+                    swift.memory.release(value);
+                    swift.memory.getObject(self).onValueChanged(valueObject);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_onCountUpdated"] = function bjs_MyViewControllerDelegate_onCountUpdated(self, count) {
+                try {
+                    let ret = swift.memory.getObject(self).onCountUpdated(count);
+                    return ret ? 1 : 0;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_onLabelUpdated"] = function bjs_MyViewControllerDelegate_onLabelUpdated(self, prefix, suffix) {
+                try {
+                    const prefixObject = swift.memory.getObject(prefix);
+                    swift.memory.release(prefix);
+                    const suffixObject = swift.memory.getObject(suffix);
+                    swift.memory.release(suffix);
+                    swift.memory.getObject(self).onLabelUpdated(prefixObject, suffixObject);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_isCountEven"] = function bjs_MyViewControllerDelegate_isCountEven(self) {
+                try {
+                    let ret = swift.memory.getObject(self).isCountEven();
+                    return ret ? 1 : 0;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            /// Represents a Swift heap object like a class instance or an actor instance.
+            class SwiftHeapObject {
+                static __wrap(pointer, deinit, prototype) {
+                    const obj = Object.create(prototype);
+                    obj.pointer = pointer;
+                    obj.hasReleased = false;
+                    obj.deinit = deinit;
+                    obj.registry = new FinalizationRegistry((pointer) => {
+                        deinit(pointer);
+                    });
+                    obj.registry.register(this, obj.pointer);
+                    return obj;
+                }
+            
+                release() {
+                    this.registry.unregister(this);
+                    this.deinit(this.pointer);
+                }
+            }
+            class MyViewController extends SwiftHeapObject {
+                static __construct(ptr) {
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_MyViewController_deinit, MyViewController.prototype);
+                }
+            
+                constructor(delegate) {
+                    const ret = instance.exports.bjs_MyViewController_init(swift.memory.retain(delegate));
+                    return MyViewController.__construct(ret);
+                }
+                triggerEvent() {
+                    instance.exports.bjs_MyViewController_triggerEvent(this.pointer);
+                }
+                updateValue(value) {
+                    const valueBytes = textEncoder.encode(value);
+                    const valueId = swift.memory.retain(valueBytes);
+                    instance.exports.bjs_MyViewController_updateValue(this.pointer, valueId, valueBytes.length);
+                    swift.memory.release(valueId);
+                }
+                updateCount(count) {
+                    const ret = instance.exports.bjs_MyViewController_updateCount(this.pointer, count);
+                    return ret !== 0;
+                }
+                updateLabel(prefix, suffix) {
+                    const prefixBytes = textEncoder.encode(prefix);
+                    const prefixId = swift.memory.retain(prefixBytes);
+                    const suffixBytes = textEncoder.encode(suffix);
+                    const suffixId = swift.memory.retain(suffixBytes);
+                    instance.exports.bjs_MyViewController_updateLabel(this.pointer, prefixId, prefixBytes.length, suffixId, suffixBytes.length);
+                    swift.memory.release(prefixId);
+                    swift.memory.release(suffixId);
+                }
+                checkEvenCount() {
+                    const ret = instance.exports.bjs_MyViewController_checkEvenCount(this.pointer);
+                    return ret !== 0;
+                }
+                get delegate() {
+                    const ret = instance.exports.bjs_MyViewController_delegate_get(this.pointer);
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                }
+                set delegate(value) {
+                    instance.exports.bjs_MyViewController_delegate_set(this.pointer, swift.memory.retain(value));
+                }
+                get secondDelegate() {
+                    instance.exports.bjs_MyViewController_secondDelegate_get(this.pointer);
+                    const optResult = tmpRetString;
+                    tmpRetString = undefined;
+                    return optResult;
+                }
+                set secondDelegate(value) {
+                    const isSome = value != null;
+                    instance.exports.bjs_MyViewController_secondDelegate_set(this.pointer, +isSome, isSome ? swift.memory.retain(value) : 0);
+                }
+            }
+            return {
+                MyViewController,
+            };
+        },
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Async.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Async.json
@@ -174,5 +174,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.json
@@ -642,5 +642,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumAssociatedValue.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumAssociatedValue.json
@@ -782,5 +782,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumCase.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumCase.json
@@ -306,5 +306,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.json
@@ -396,5 +396,8 @@
   "functions" : [
 
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumRawType.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumRawType.json
@@ -1476,5 +1476,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Namespaces.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Namespaces.json
@@ -172,5 +172,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Optionals.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Optionals.json
@@ -689,5 +689,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveParameters.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveParameters.json
@@ -59,5 +59,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveReturn.json
@@ -75,5 +75,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PropertyTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PropertyTypes.json
@@ -350,5 +350,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Protocol.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Protocol.json
@@ -1,0 +1,305 @@
+{
+  "classes" : [
+    {
+      "constructor" : {
+        "abiName" : "bjs_MyViewController_init",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "parameters" : [
+          {
+            "label" : "delegate",
+            "name" : "delegate",
+            "type" : {
+              "swiftProtocol" : {
+                "_0" : "MyViewControllerDelegate"
+              }
+            }
+          }
+        ]
+      },
+      "methods" : [
+        {
+          "abiName" : "bjs_MyViewController_triggerEvent",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "triggerEvent",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_MyViewController_updateValue",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "updateValue",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_MyViewController_updateCount",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "updateCount",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "count",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "bool" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_MyViewController_updateLabel",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "updateLabel",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "prefix",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            },
+            {
+              "label" : "_",
+              "name" : "suffix",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_MyViewController_checkEvenCount",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "checkEvenCount",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "bool" : {
+
+            }
+          }
+        }
+      ],
+      "name" : "MyViewController",
+      "properties" : [
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "delegate",
+          "type" : {
+            "swiftProtocol" : {
+              "_0" : "MyViewControllerDelegate"
+            }
+          }
+        },
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "secondDelegate",
+          "type" : {
+            "optional" : {
+              "_0" : {
+                "swiftProtocol" : {
+                  "_0" : "MyViewControllerDelegate"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "swiftCallName" : "MyViewController"
+    }
+  ],
+  "enums" : [
+
+  ],
+  "functions" : [
+
+  ],
+  "moduleName" : "TestModule",
+  "protocols" : [
+    {
+      "methods" : [
+        {
+          "abiName" : "bjs_MyViewControllerDelegate_onSomethingHappened",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "onSomethingHappened",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_MyViewControllerDelegate_onValueChanged",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "onValueChanged",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_MyViewControllerDelegate_onCountUpdated",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "onCountUpdated",
+          "parameters" : [
+            {
+              "label" : "count",
+              "name" : "count",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "bool" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_MyViewControllerDelegate_onLabelUpdated",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "onLabelUpdated",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "prefix",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            },
+            {
+              "label" : "_",
+              "name" : "suffix",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_MyViewControllerDelegate_isCountEven",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "isCountEven",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "bool" : {
+
+            }
+          }
+        }
+      ],
+      "name" : "MyViewControllerDelegate"
+    }
+  ]
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Protocol.swift
@@ -1,0 +1,174 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+@_spi(BridgeJS) import JavaScriptKit
+
+struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProtocolWrapper {
+    let jsObject: JSObject
+
+    func onSomethingHappened() {
+    @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_onSomethingHappened")
+    func _extern_onSomethingHappened(this: Int32)
+    _extern_onSomethingHappened(this: Int32(bitPattern: jsObject.id))
+    }
+
+    func onValueChanged(_ value: String) {
+        @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_onValueChanged")
+        func _extern_onValueChanged(this: Int32, value: Int32)
+        _extern_onValueChanged(this: Int32(bitPattern: jsObject.id), value: value.bridgeJSLowerParameter())
+    }
+
+    func onCountUpdated(count: Int) -> Bool {
+        @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_onCountUpdated")
+        func _extern_onCountUpdated(this: Int32, count: Int32) -> Int32
+        let ret = _extern_onCountUpdated(this: Int32(bitPattern: jsObject.id), count: count.bridgeJSLowerParameter())
+        return Bool.bridgeJSLiftReturn(ret)
+    }
+
+    func onLabelUpdated(_ prefix: String, _ suffix: String) {
+        @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_onLabelUpdated")
+        func _extern_onLabelUpdated(this: Int32, prefix: Int32, suffix: Int32)
+        _extern_onLabelUpdated(this: Int32(bitPattern: jsObject.id), prefix: prefix.bridgeJSLowerParameter(), suffix: suffix.bridgeJSLowerParameter())
+    }
+
+    func isCountEven() -> Bool {
+        @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_isCountEven")
+        func _extern_isCountEven(this: Int32) -> Int32
+        let ret = _extern_isCountEven(this: Int32(bitPattern: jsObject.id))
+        return Bool.bridgeJSLiftReturn(ret)
+    }
+
+    static func bridgeJSLiftParameter(_ value: Int32) -> Self {
+        return AnyMyViewControllerDelegate(jsObject: JSObject(id: UInt32(bitPattern: value)))
+    }
+}
+
+@_expose(wasm, "bjs_MyViewController_init")
+@_cdecl("bjs_MyViewController_init")
+public func _bjs_MyViewController_init(delegate: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = MyViewController(delegate: AnyMyViewControllerDelegate.bridgeJSLiftParameter(delegate))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_MyViewController_triggerEvent")
+@_cdecl("bjs_MyViewController_triggerEvent")
+public func _bjs_MyViewController_triggerEvent(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    MyViewController.bridgeJSLiftParameter(_self).triggerEvent()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_MyViewController_updateValue")
+@_cdecl("bjs_MyViewController_updateValue")
+public func _bjs_MyViewController_updateValue(_self: UnsafeMutableRawPointer, valueBytes: Int32, valueLength: Int32) -> Void {
+    #if arch(wasm32)
+    MyViewController.bridgeJSLiftParameter(_self).updateValue(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_MyViewController_updateCount")
+@_cdecl("bjs_MyViewController_updateCount")
+public func _bjs_MyViewController_updateCount(_self: UnsafeMutableRawPointer, count: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = MyViewController.bridgeJSLiftParameter(_self).updateCount(_: Int.bridgeJSLiftParameter(count))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_MyViewController_updateLabel")
+@_cdecl("bjs_MyViewController_updateLabel")
+public func _bjs_MyViewController_updateLabel(_self: UnsafeMutableRawPointer, prefixBytes: Int32, prefixLength: Int32, suffixBytes: Int32, suffixLength: Int32) -> Void {
+    #if arch(wasm32)
+    MyViewController.bridgeJSLiftParameter(_self).updateLabel(_: String.bridgeJSLiftParameter(prefixBytes, prefixLength), _: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_MyViewController_checkEvenCount")
+@_cdecl("bjs_MyViewController_checkEvenCount")
+public func _bjs_MyViewController_checkEvenCount(_self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = MyViewController.bridgeJSLiftParameter(_self).checkEvenCount()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_MyViewController_delegate_get")
+@_cdecl("bjs_MyViewController_delegate_get")
+public func _bjs_MyViewController_delegate_get(_self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = MyViewController.bridgeJSLiftParameter(_self).delegate as! AnyMyViewControllerDelegate
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_MyViewController_delegate_set")
+@_cdecl("bjs_MyViewController_delegate_set")
+public func _bjs_MyViewController_delegate_set(_self: UnsafeMutableRawPointer, value: Int32) -> Void {
+    #if arch(wasm32)
+    MyViewController.bridgeJSLiftParameter(_self).delegate = AnyMyViewControllerDelegate.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_MyViewController_secondDelegate_get")
+@_cdecl("bjs_MyViewController_secondDelegate_get")
+public func _bjs_MyViewController_secondDelegate_get(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = MyViewController.bridgeJSLiftParameter(_self).secondDelegate.flatMap {
+        $0 as? AnyMyViewControllerDelegate
+    }
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_MyViewController_secondDelegate_set")
+@_cdecl("bjs_MyViewController_secondDelegate_set")
+public func _bjs_MyViewController_secondDelegate_set(_self: UnsafeMutableRawPointer, valueIsSome: Int32, valueValue: Int32) -> Void {
+    #if arch(wasm32)
+    MyViewController.bridgeJSLiftParameter(_self).secondDelegate = Optional<AnyMyViewControllerDelegate>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_MyViewController_deinit")
+@_cdecl("bjs_MyViewController_deinit")
+public func _bjs_MyViewController_deinit(pointer: UnsafeMutableRawPointer) {
+    Unmanaged<MyViewController>.fromOpaque(pointer).release()
+}
+
+extension MyViewController: ConvertibleToJSValue, _BridgedSwiftHeapObject {
+    var jsValue: JSValue {
+        #if arch(wasm32)
+        @_extern(wasm, module: "TestModule", name: "bjs_MyViewController_wrap")
+        func _bjs_MyViewController_wrap(_: UnsafeMutableRawPointer) -> Int32
+        #else
+        func _bjs_MyViewController_wrap(_: UnsafeMutableRawPointer) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_MyViewController_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticFunctions.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticFunctions.json
@@ -322,5 +322,8 @@
   "functions" : [
 
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticProperties.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticProperties.json
@@ -326,5 +326,8 @@
   "functions" : [
 
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StringParameter.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StringParameter.json
@@ -57,5 +57,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StringReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StringReturn.json
@@ -24,5 +24,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftClass.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftClass.json
@@ -132,5 +132,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Throws.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Throws.json
@@ -24,5 +24,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/VoidParameterVoidReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/VoidParameterVoidReturn.json
@@ -24,5 +24,8 @@
       }
     }
   ],
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "protocols" : [
+
+  ]
 }

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift-to-JavaScript.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift-to-JavaScript.md
@@ -66,6 +66,7 @@ This command will:
 - <doc:Exporting-Swift-Function>
 - <doc:Exporting-Swift-Class>
 - <doc:Exporting-Swift-Enum>
+- <doc:Exporting-Swift-Protocols>
 - <doc:Exporting-Swift-Optional>
 - <doc:Exporting-Swift-Default-Parameters>
 - <doc:Exporting-Swift-Static-Functions>

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Protocols.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Protocols.md
@@ -1,0 +1,209 @@
+# Exporting Swift Protocols
+
+Learn how to expose Swift protocols to JavaScript as TypeScript interfaces.
+
+## Overview
+
+> Tip: You can quickly preview what interfaces will be exposed on the Swift/TypeScript sides using the [BridgeJS Playground](https://swiftwasm.org/JavaScriptKit/PlayBridgeJS/).
+
+BridgeJS allows you to export Swift protocols as TypeScript interfaces. JavaScript objects implementing these interfaces can be passed to Swift code, enabling protocol-oriented design across the Swift-JavaScript boundary.
+
+When you mark a protocol with `@JS`, BridgeJS generates:
+
+- A TypeScript interface with the protocol's method signatures
+- A Swift wrapper struct (`Any{ProtocolName}`) that conforms to the protocol and bridges calls to JavaScript objects
+
+## Example: Counter Protocol
+
+Mark a Swift protocol with `@JS` to expose it:
+
+```swift
+import JavaScriptKit
+
+@JS protocol Counter {
+    func increment(by amount: Int)
+    func reset()
+    func getValue() -> Int
+}
+
+@JS class CounterManager {
+    var delegate: Counter
+    
+    @JS init(delegate: Counter) {
+        self.delegate = delegate
+    }
+    
+    @JS func incrementTwice() {
+        delegate.increment(by: 1)
+        delegate.increment(by: 1)
+    }
+    
+    @JS func getCurrentValue() -> Int {
+        return delegate.getValue()
+    }
+}
+```
+
+In JavaScript:
+
+```javascript
+import { init } from "./.build/plugins/PackageToJS/outputs/Package/index.js";
+const { exports } = await init({});
+
+// Implement the Counter protocol
+const counterImpl = {
+    count: 0,
+    increment(amount) {
+        this.count += amount;
+    },
+    reset() {
+        this.count = 0;
+    },
+    getValue() {
+        return this.count;
+    }
+};
+
+// Pass the implementation to Swift
+const manager = new exports.CounterManager(counterImpl);
+manager.incrementTwice();
+console.log(manager.getCurrentValue()); // 2
+```
+
+The generated TypeScript interface:
+
+```typescript
+export interface Counter {
+    increment(amount: number): void;
+    reset(): void;
+    getValue(): number;
+}
+
+export type Exports = {
+    CounterManager: {
+        new(delegate: Counter): CounterManager;
+    }
+}
+```
+
+## Generated Wrapper
+
+BridgeJS generates a Swift wrapper struct for each `@JS` protocol. This wrapper holds a `JSObject` reference and forwards protocol method calls to the JavaScript implementation:
+
+```swift
+struct AnyCounter: Counter, _BridgedSwiftProtocolWrapper {
+    let jsObject: JSObject
+
+    func increment(by amount: Int) {
+        @_extern(wasm, module: "TestModule", name: "bjs_Counter_increment")
+        func _extern_increment(this: Int32, amount: Int32)
+        _extern_increment(
+            this: Int32(bitPattern: jsObject.id), 
+            amount: amount.bridgeJSLowerParameter()
+        )
+    }
+
+    func reset() {
+        @_extern(wasm, module: "TestModule", name: "bjs_Counter_reset")
+        func _extern_reset(this: Int32)
+        _extern_reset(this: Int32(bitPattern: jsObject.id))
+    }
+
+    func getValue() -> Int {
+        @_extern(wasm, module: "TestModule", name: "bjs_Counter_getValue")
+        func _extern_getValue(this: Int32) -> Int32
+        let ret = _extern_getValue(this: Int32(bitPattern: jsObject.id))
+        return Int.bridgeJSLiftReturn(ret)
+    }
+
+    static func bridgeJSLiftParameter(_ value: Int32) -> Self {
+        return AnyCounter(jsObject: JSObject(id: UInt32(bitPattern: value)))
+    }
+}
+```
+
+## Swift Implementation
+
+You can also implement protocols in Swift and use them from JavaScript:
+
+```swift
+@JS protocol Counter {
+    func increment(by amount: Int)
+    func reset()
+    func getValue() -> Int
+}
+
+final class SwiftCounter: Counter {
+    private var count = 0
+    
+    func increment(by amount: Int) {
+        count += amount
+    }
+    
+    func reset() {
+        count = 0
+    }
+    
+    func getValue() -> Int {
+        return count
+    }
+}
+
+@JS func createCounter() -> Counter {
+    return SwiftCounter()
+}
+```
+
+From JavaScript:
+
+```javascript
+const counter = exports.createCounter();
+counter.increment(5);
+counter.increment(3);
+console.log(counter.getValue()); // 8
+counter.reset();
+console.log(counter.getValue()); // 0
+```
+
+## How It Works
+
+When you pass a JavaScript object implementing a protocol to Swift:
+
+1. **JavaScript Side**: The object is stored in JavaScriptKit's memory heap and its ID is passed as an `Int32` to Swift
+2. **Swift Side**: BridgeJS creates an `Any{ProtocolName}` wrapper that holds a `JSObject` reference
+3. **Method Calls**: Protocol method calls are forwarded through WASM to the JavaScript implementation
+4. **Memory Management**: The `JSObject` reference keeps the JavaScript object alive using JavaScriptKit's retain/release system. When the Swift wrapper is deallocated, the JavaScript object is automatically released.
+
+## Supported Features
+
+| Swift Feature | Status |
+|:--------------|:-------|
+| Method requirements: `func method()` | ✅ |
+| Method requirements with parameters | ✅ |
+| Method requirements with return values | ✅ |
+| Throwing method requirements: `func method() throws(JSException)` | ✅ |
+| Async method requirements: `func method() async` | ✅ |
+| Optional protocol methods | ❌ |
+| Property requirements: `var property: Type { get }` | ❌ |
+| Property requirements: `var property: Type { get set }` | ❌ |
+| Associated types | ❌ |
+| Protocol inheritance | ❌ |
+| Protocol composition: `Protocol1 & Protocol2` | ❌ |
+| Generics | ❌ |
+
+### Type Support for Protocol Method Parameters and Return Types
+
+Protocol method parameters and return values have more limited type support compared to regular exported Swift functions and classes.
+
+**Supported Types:**
+- Primitives: `Bool`, `Int`, `Float`, `Double`
+- `String`
+- `JSObject`
+
+**Not Supported:**
+- `@JS class` types
+- `@JS enum` types (case, raw value, or associated value)
+- `@JS protocol` types
+- Optional types: `Int?`, `String?`, etc.
+
+> Note: For regular `@JS func` and `@JS class` exports (not within protocols), all these types including optionals, enums, and classes are fully supported. See <doc:Exporting-Swift-Function> and <doc:Exporting-Swift-Optional> for more information.

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -857,6 +857,87 @@ enum APIOptionalResult {
         "const:\(StaticPropertyHolder.staticConstant),var:\(StaticPropertyHolder.staticVariable),computed:\(StaticPropertyHolder.computedProperty),readonly:\(StaticPropertyHolder.readOnlyComputed)"
 }
 
+// MARK: - Protocol Tests
+
+@JS protocol Counter {
+    func increment(by amount: Int)
+    func getValue() -> Int
+    func setLabelElements(_ labelPrefix: String, _ labelSuffix: String)
+    func getLabel() -> String
+    func isEven() -> Bool
+}
+
+@JS class CounterManager {
+
+    @JS var counter: Counter
+    @JS var backupCounter: Counter?
+
+    @JS init(counter: Counter) {
+        self.counter = counter
+        self.backupCounter = nil
+    }
+
+    @JS func incrementByAmount(_ amount: Int) {
+        counter.increment(by: amount)
+    }
+
+    @JS func setCounterLabel(_ prefix: String, _ suffix: String) {
+        counter.setLabelElements(prefix, suffix)
+    }
+
+    @JS func isCounterEven() -> Bool {
+        return counter.isEven()
+    }
+
+    @JS func getCounterLabel() -> String {
+        return counter.getLabel()
+    }
+
+    @JS func getCurrentValue() -> Int {
+        return counter.getValue()
+    }
+
+    @JS func incrementBoth() {
+        counter.increment(by: 1)
+        backupCounter?.increment(by: 1)
+    }
+
+    @JS func getBackupValue() -> Int? {
+        return backupCounter?.getValue()
+    }
+
+    @JS func hasBackup() -> Bool {
+        return backupCounter != nil
+    }
+}
+
+@JS class SwiftCounter: Counter {
+    private var value: Int = 0
+    private var label: String = ""
+
+    @JS init() {}
+
+    @JS func increment(by amount: Int) {
+        value += amount
+    }
+
+    @JS func getValue() -> Int {
+        return value
+    }
+
+    @JS func setLabelElements(_ labelPrefix: String, _ labelSuffix: String) {
+        self.label = labelPrefix + labelSuffix
+    }
+
+    @JS func getLabel() -> String {
+        return label
+    }
+
+    @JS func isEven() -> Bool {
+        return value % 2 == 0
+    }
+}
+
 class ExportAPITests: XCTestCase {
     func testAll() {
         var hasDeinitGreeter = false

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.ExportSwift.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.ExportSwift.swift
@@ -6,6 +6,47 @@
 
 @_spi(BridgeJS) import JavaScriptKit
 
+struct AnyCounter: Counter, _BridgedSwiftProtocolWrapper {
+    let jsObject: JSObject
+
+    func increment(by amount: Int) {
+    @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Counter_increment")
+    func _extern_increment(this: Int32, amount: Int32)
+    _extern_increment(this: Int32(bitPattern: jsObject.id), amount: amount.bridgeJSLowerParameter())
+    }
+
+    func getValue() -> Int {
+        @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Counter_getValue")
+        func _extern_getValue(this: Int32) -> Int32
+        let ret = _extern_getValue(this: Int32(bitPattern: jsObject.id))
+        return Int.bridgeJSLiftReturn(ret)
+    }
+
+    func setLabelElements(_ labelPrefix: String, _ labelSuffix: String) {
+        @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Counter_setLabelElements")
+        func _extern_setLabelElements(this: Int32, labelPrefix: Int32, labelSuffix: Int32)
+        _extern_setLabelElements(this: Int32(bitPattern: jsObject.id), labelPrefix: labelPrefix.bridgeJSLowerParameter(), labelSuffix: labelSuffix.bridgeJSLowerParameter())
+    }
+
+    func getLabel() -> String {
+        @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Counter_getLabel")
+        func _extern_getLabel(this: Int32) -> Int32
+        let ret = _extern_getLabel(this: Int32(bitPattern: jsObject.id))
+        return String.bridgeJSLiftReturn(ret)
+    }
+
+    func isEven() -> Bool {
+        @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Counter_isEven")
+        func _extern_isEven(this: Int32) -> Int32
+        let ret = _extern_isEven(this: Int32(bitPattern: jsObject.id))
+        return Bool.bridgeJSLiftReturn(ret)
+    }
+
+    static func bridgeJSLiftParameter(_ value: Int32) -> Self {
+        return AnyCounter(jsObject: JSObject(id: UInt32(bitPattern: value)))
+    }
+}
+
 extension Direction: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
@@ -3241,5 +3282,249 @@ extension StaticPropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject {
         }
         #endif
         return .object(JSObject(id: UInt32(bitPattern: _bjs_StaticPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}
+
+@_expose(wasm, "bjs_CounterManager_init")
+@_cdecl("bjs_CounterManager_init")
+public func _bjs_CounterManager_init(counter: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = CounterManager(counter: AnyCounter.bridgeJSLiftParameter(counter))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_incrementByAmount")
+@_cdecl("bjs_CounterManager_incrementByAmount")
+public func _bjs_CounterManager_incrementByAmount(_self: UnsafeMutableRawPointer, amount: Int32) -> Void {
+    #if arch(wasm32)
+    CounterManager.bridgeJSLiftParameter(_self).incrementByAmount(_: Int.bridgeJSLiftParameter(amount))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_setCounterLabel")
+@_cdecl("bjs_CounterManager_setCounterLabel")
+public func _bjs_CounterManager_setCounterLabel(_self: UnsafeMutableRawPointer, prefixBytes: Int32, prefixLength: Int32, suffixBytes: Int32, suffixLength: Int32) -> Void {
+    #if arch(wasm32)
+    CounterManager.bridgeJSLiftParameter(_self).setCounterLabel(_: String.bridgeJSLiftParameter(prefixBytes, prefixLength), _: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_isCounterEven")
+@_cdecl("bjs_CounterManager_isCounterEven")
+public func _bjs_CounterManager_isCounterEven(_self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = CounterManager.bridgeJSLiftParameter(_self).isCounterEven()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_getCounterLabel")
+@_cdecl("bjs_CounterManager_getCounterLabel")
+public func _bjs_CounterManager_getCounterLabel(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = CounterManager.bridgeJSLiftParameter(_self).getCounterLabel()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_getCurrentValue")
+@_cdecl("bjs_CounterManager_getCurrentValue")
+public func _bjs_CounterManager_getCurrentValue(_self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = CounterManager.bridgeJSLiftParameter(_self).getCurrentValue()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_incrementBoth")
+@_cdecl("bjs_CounterManager_incrementBoth")
+public func _bjs_CounterManager_incrementBoth(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    CounterManager.bridgeJSLiftParameter(_self).incrementBoth()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_getBackupValue")
+@_cdecl("bjs_CounterManager_getBackupValue")
+public func _bjs_CounterManager_getBackupValue(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = CounterManager.bridgeJSLiftParameter(_self).getBackupValue()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_hasBackup")
+@_cdecl("bjs_CounterManager_hasBackup")
+public func _bjs_CounterManager_hasBackup(_self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = CounterManager.bridgeJSLiftParameter(_self).hasBackup()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_counter_get")
+@_cdecl("bjs_CounterManager_counter_get")
+public func _bjs_CounterManager_counter_get(_self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = CounterManager.bridgeJSLiftParameter(_self).counter as! AnyCounter
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_counter_set")
+@_cdecl("bjs_CounterManager_counter_set")
+public func _bjs_CounterManager_counter_set(_self: UnsafeMutableRawPointer, value: Int32) -> Void {
+    #if arch(wasm32)
+    CounterManager.bridgeJSLiftParameter(_self).counter = AnyCounter.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_backupCounter_get")
+@_cdecl("bjs_CounterManager_backupCounter_get")
+public func _bjs_CounterManager_backupCounter_get(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = CounterManager.bridgeJSLiftParameter(_self).backupCounter.flatMap {
+        $0 as? AnyCounter
+    }
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_backupCounter_set")
+@_cdecl("bjs_CounterManager_backupCounter_set")
+public func _bjs_CounterManager_backupCounter_set(_self: UnsafeMutableRawPointer, valueIsSome: Int32, valueValue: Int32) -> Void {
+    #if arch(wasm32)
+    CounterManager.bridgeJSLiftParameter(_self).backupCounter = Optional<AnyCounter>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_CounterManager_deinit")
+@_cdecl("bjs_CounterManager_deinit")
+public func _bjs_CounterManager_deinit(pointer: UnsafeMutableRawPointer) {
+    Unmanaged<CounterManager>.fromOpaque(pointer).release()
+}
+
+extension CounterManager: ConvertibleToJSValue, _BridgedSwiftHeapObject {
+    var jsValue: JSValue {
+        #if arch(wasm32)
+        @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_CounterManager_wrap")
+        func _bjs_CounterManager_wrap(_: UnsafeMutableRawPointer) -> Int32
+        #else
+        func _bjs_CounterManager_wrap(_: UnsafeMutableRawPointer) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_CounterManager_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}
+
+@_expose(wasm, "bjs_SwiftCounter_init")
+@_cdecl("bjs_SwiftCounter_init")
+public func _bjs_SwiftCounter_init() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = SwiftCounter()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftCounter_increment")
+@_cdecl("bjs_SwiftCounter_increment")
+public func _bjs_SwiftCounter_increment(_self: UnsafeMutableRawPointer, amount: Int32) -> Void {
+    #if arch(wasm32)
+    SwiftCounter.bridgeJSLiftParameter(_self).increment(by: Int.bridgeJSLiftParameter(amount))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftCounter_getValue")
+@_cdecl("bjs_SwiftCounter_getValue")
+public func _bjs_SwiftCounter_getValue(_self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = SwiftCounter.bridgeJSLiftParameter(_self).getValue()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftCounter_setLabelElements")
+@_cdecl("bjs_SwiftCounter_setLabelElements")
+public func _bjs_SwiftCounter_setLabelElements(_self: UnsafeMutableRawPointer, labelPrefixBytes: Int32, labelPrefixLength: Int32, labelSuffixBytes: Int32, labelSuffixLength: Int32) -> Void {
+    #if arch(wasm32)
+    SwiftCounter.bridgeJSLiftParameter(_self).setLabelElements(_: String.bridgeJSLiftParameter(labelPrefixBytes, labelPrefixLength), _: String.bridgeJSLiftParameter(labelSuffixBytes, labelSuffixLength))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftCounter_getLabel")
+@_cdecl("bjs_SwiftCounter_getLabel")
+public func _bjs_SwiftCounter_getLabel(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = SwiftCounter.bridgeJSLiftParameter(_self).getLabel()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftCounter_isEven")
+@_cdecl("bjs_SwiftCounter_isEven")
+public func _bjs_SwiftCounter_isEven(_self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = SwiftCounter.bridgeJSLiftParameter(_self).isEven()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftCounter_deinit")
+@_cdecl("bjs_SwiftCounter_deinit")
+public func _bjs_SwiftCounter_deinit(pointer: UnsafeMutableRawPointer) {
+    Unmanaged<SwiftCounter>.fromOpaque(pointer).release()
+}
+
+extension SwiftCounter: ConvertibleToJSValue, _BridgedSwiftHeapObject {
+    var jsValue: JSValue {
+        #if arch(wasm32)
+        @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_SwiftCounter_wrap")
+        func _bjs_SwiftCounter_wrap(_: UnsafeMutableRawPointer) -> Int32
+        #else
+        func _bjs_SwiftCounter_wrap(_: UnsafeMutableRawPointer) -> Int32 {
+            fatalError("Only available on WebAssembly")
+        }
+        #endif
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_SwiftCounter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
 }

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.ExportSwift.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.ExportSwift.json
@@ -1162,6 +1162,352 @@
         }
       ],
       "swiftCallName" : "StaticPropertyHolder"
+    },
+    {
+      "constructor" : {
+        "abiName" : "bjs_CounterManager_init",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "parameters" : [
+          {
+            "label" : "counter",
+            "name" : "counter",
+            "type" : {
+              "swiftProtocol" : {
+                "_0" : "Counter"
+              }
+            }
+          }
+        ]
+      },
+      "methods" : [
+        {
+          "abiName" : "bjs_CounterManager_incrementByAmount",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "incrementByAmount",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "amount",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_CounterManager_setCounterLabel",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "setCounterLabel",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "prefix",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            },
+            {
+              "label" : "_",
+              "name" : "suffix",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_CounterManager_isCounterEven",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "isCounterEven",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "bool" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_CounterManager_getCounterLabel",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "getCounterLabel",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_CounterManager_getCurrentValue",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "getCurrentValue",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "int" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_CounterManager_incrementBoth",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "incrementBoth",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_CounterManager_getBackupValue",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "getBackupValue",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "optional" : {
+              "_0" : {
+                "int" : {
+
+                }
+              }
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_CounterManager_hasBackup",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "hasBackup",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "bool" : {
+
+            }
+          }
+        }
+      ],
+      "name" : "CounterManager",
+      "properties" : [
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "counter",
+          "type" : {
+            "swiftProtocol" : {
+              "_0" : "Counter"
+            }
+          }
+        },
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "backupCounter",
+          "type" : {
+            "optional" : {
+              "_0" : {
+                "swiftProtocol" : {
+                  "_0" : "Counter"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "swiftCallName" : "CounterManager"
+    },
+    {
+      "constructor" : {
+        "abiName" : "bjs_SwiftCounter_init",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "parameters" : [
+
+        ]
+      },
+      "methods" : [
+        {
+          "abiName" : "bjs_SwiftCounter_increment",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "increment",
+          "parameters" : [
+            {
+              "label" : "by",
+              "name" : "amount",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_SwiftCounter_getValue",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "getValue",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "int" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_SwiftCounter_setLabelElements",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "setLabelElements",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "labelPrefix",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            },
+            {
+              "label" : "_",
+              "name" : "labelSuffix",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_SwiftCounter_getLabel",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "getLabel",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_SwiftCounter_isEven",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "isEven",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "bool" : {
+
+            }
+          }
+        }
+      ],
+      "name" : "SwiftCounter",
+      "properties" : [
+
+      ],
+      "swiftCallName" : "SwiftCounter"
     }
   ],
   "enums" : [
@@ -5435,5 +5781,122 @@
       }
     }
   ],
-  "moduleName" : "BridgeJSRuntimeTests"
+  "moduleName" : "BridgeJSRuntimeTests",
+  "protocols" : [
+    {
+      "methods" : [
+        {
+          "abiName" : "bjs_Counter_increment",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "increment",
+          "parameters" : [
+            {
+              "label" : "by",
+              "name" : "amount",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_Counter_getValue",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "getValue",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "int" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_Counter_setLabelElements",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "setLabelElements",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "labelPrefix",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            },
+            {
+              "label" : "_",
+              "name" : "labelSuffix",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_Counter_getLabel",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "getLabel",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_Counter_isEven",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "isEven",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "bool" : {
+
+            }
+          }
+        }
+      ],
+      "name" : "Counter"
+    }
+  ]
 }


### PR DESCRIPTION
##  Introduction

This PR adds basic support for exporting Swift protocols to JS / TS using BridgeJS plugin.

## Overview

BridgeJS now supports exporting Swift protocols as TypeScript interfaces. JavaScript objects implementing these interfaces can be passed to Swift code, where they are automatically wrapped in generated Swift struct that forward method calls and property accesses to the JavaScript implementation.

When you mark a protocol with `@JS`, BridgeJS generates:
- A TypeScript interface with the protocol's method signatures and properties
- A Swift wrapper struct (`Any{ProtocolName}`) that conforms to the protocol
- JavaScript bridge code that forwards calls between Swift and JavaScript

## Current Limitations

This PR covers support for methods and basic types in parameters and return types, as these types are supported in both Export / Import directions.
Support for properties, `Optional` and others will be posted in separate PR as changeset is quite large.
 
## Testing

Basic tests with protocol implementation on JS and Swift side used as delegate property of protocol type are added.

## Documentation

Added to `Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Protocols.md`
