### PR TITLE
Tests: Reduce usage of Xlinker flags in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,6 @@ unittest:
 	@echo Running unit tests
 	env JAVASCRIPTKIT_EXPERIMENTAL_BRIDGEJS=1 swift package --swift-sdk "$(SWIFT_SDK_ID)" \
 	    --disable-sandbox \
-	    -Xlinker --stack-first \
-	    -Xlinker --global-base=524288 \
-	    -Xlinker -z \
-	    -Xlinker stack-size=524288 \
 	    js test --prelude ./Tests/prelude.mjs -Xnode --expose-gc
 
 .PHONY: regenerate_swiftpm_resources

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,15 @@ let shouldBuildForEmbedded = Context.environment["JAVASCRIPTKIT_EXPERIMENTAL_EMB
 let useLegacyResourceBundling =
     Context.environment["JAVASCRIPTKIT_USE_LEGACY_RESOURCE_BUNDLING"].flatMap(Bool.init) ?? false
 
+let testingLinkerFlags: [LinkerSetting] = [
+    .unsafeFlags([
+        "-Xlinker", "--stack-first",
+        "-Xlinker", "--global-base=524288",
+        "-Xlinker", "-z",
+        "-Xlinker", "stack-size=524288",
+    ])
+]
+
 let package = Package(
     name: "JavaScriptKit",
     platforms: [
@@ -55,7 +64,8 @@ let package = Package(
             dependencies: ["JavaScriptKit"],
             swiftSettings: [
                 .enableExperimentalFeature("Extern")
-            ]
+            ],
+            linkerSettings: testingLinkerFlags
         ),
 
         .target(
@@ -70,7 +80,8 @@ let package = Package(
         .target(name: "_CJavaScriptBigIntSupport", dependencies: ["_CJavaScriptKit"]),
         .testTarget(
             name: "JavaScriptBigIntSupportTests",
-            dependencies: ["JavaScriptBigIntSupport", "JavaScriptKit"]
+            dependencies: ["JavaScriptBigIntSupport", "JavaScriptKit"],
+            linkerSettings: testingLinkerFlags
         ),
 
         .target(
@@ -92,7 +103,8 @@ let package = Package(
             ],
             swiftSettings: [
                 .enableExperimentalFeature("Extern")
-            ]
+            ],
+            linkerSettings: testingLinkerFlags
         ),
         .target(
             name: "JavaScriptEventLoopTestSupport",
@@ -107,7 +119,8 @@ let package = Package(
             dependencies: [
                 "JavaScriptKit",
                 "JavaScriptEventLoopTestSupport",
-            ]
+            ],
+            linkerSettings: testingLinkerFlags
         ),
         .target(
             name: "JavaScriptFoundationCompat",
@@ -119,7 +132,8 @@ let package = Package(
             name: "JavaScriptFoundationCompatTests",
             dependencies: [
                 "JavaScriptFoundationCompat"
-            ]
+            ],
+            linkerSettings: testingLinkerFlags
         ),
         .plugin(
             name: "PackageToJS",
@@ -163,7 +177,8 @@ let package = Package(
             ],
             swiftSettings: [
                 .enableExperimentalFeature("Extern")
-            ]
+            ],
+            linkerSettings: testingLinkerFlags
         ),
     ]
 )


### PR DESCRIPTION
I'd like to make the development setup to be more conventional so that new contributors can get started easier.