### PR TITLE
BridgeJS: Namespaced elements in Exports

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -260,6 +260,9 @@ public enum EnumEmitStyle: String, Codable, Sendable {
 }
 
 public struct ExportedEnum: Codable, Equatable, Sendable {
+    public static let valuesSuffix = "Values"
+    public static let objectSuffix = "Object"
+
     public let name: String
     public let swiftCallName: String
     public let explicitAccessControl: String?
@@ -277,6 +280,14 @@ public struct ExportedEnum: Codable, Equatable, Sendable {
         } else {
             return .associatedValue
         }
+    }
+
+    public var valuesName: String {
+        emitStyle == .tsEnum ? name : "\(name)\(Self.valuesSuffix)"
+    }
+
+    public var objectTypeName: String {
+        "\(name)\(Self.objectSuffix)"
     }
 
     public init(

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.Export.d.ts
@@ -93,9 +93,13 @@ export type Exports = {
     roundTripOptionalAPIOptionalResult(result: APIOptionalResultTag | null): APIOptionalResultTag | null;
     APIResult: APIResultObject
     ComplexResult: ComplexResultObject
-    Result: ResultObject
-    NetworkingResult: NetworkingResultObject
     APIOptionalResult: APIOptionalResultObject
+    API: {
+        NetworkingResult: NetworkingResultObject
+    },
+    Utilities: {
+        Result: ResultObject
+    },
 }
 export type Imports = {
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.Export.js
@@ -830,9 +830,13 @@ export async function createInstantiator(options, swift) {
                 },
                 APIResult: APIResultValues,
                 ComplexResult: ComplexResultValues,
-                Result: ResultValues,
-                NetworkingResult: NetworkingResultValues,
                 APIOptionalResult: APIOptionalResultValues,
+                API: {
+                    NetworkingResult: NetworkingResultValues,
+                },
+                Utilities: {
+                    Result: ResultValues,
+                },
             };
             _exports = exports;
             return exports;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.d.ts
@@ -83,19 +83,31 @@ export interface TestServer extends SwiftHeapObject {
     call(method: Internal.SupportedMethodTag): void;
 }
 export type Exports = {
-    Converter: {
-        new(): Converter;
-    }
-    HTTPServer: {
-        new(): HTTPServer;
-    }
-    TestServer: {
-        new(): TestServer;
-    }
-    Method: MethodObject
-    LogLevel: LogLevelObject
-    Port: PortObject
-    SupportedMethod: SupportedMethodObject
+    Configuration: {
+        LogLevel: LogLevelObject
+        Port: PortObject
+    },
+    Networking: {
+        API: {
+            HTTPServer: {
+                new(): HTTPServer;
+            }
+            Method: MethodObject
+        },
+        APIV2: {
+            Internal: {
+                TestServer: {
+                    new(): TestServer;
+                }
+                SupportedMethod: SupportedMethodObject
+            },
+        },
+    },
+    Utils: {
+        Converter: {
+            new(): Converter;
+        }
+    },
 }
 export type Imports = {
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.js
@@ -333,18 +333,30 @@ export async function createInstantiator(options, swift) {
                 globalThis.Utils = {};
             }
             const exports = {
-                Converter,
-                HTTPServer,
-                TestServer,
-                Method: MethodValues,
-                LogLevel: LogLevelValues,
-                Port: PortValues,
-                SupportedMethod: SupportedMethodValues,
+                Configuration: {
+                    LogLevel: LogLevelValues,
+                    Port: PortValues,
+                },
+                Networking: {
+                    API: {
+                        HTTPServer,
+                        Method: MethodValues,
+                    },
+                    APIV2: {
+                        Internal: {
+                            TestServer,
+                            SupportedMethod: SupportedMethodValues,
+                        },
+                    },
+                },
+                Utils: {
+                    Converter,
+                },
             };
             _exports = exports;
-            globalThis.Utils.Converter = exports.Converter;
-            globalThis.Networking.API.HTTPServer = exports.HTTPServer;
-            globalThis.Networking.APIV2.Internal.TestServer = exports.TestServer;
+            globalThis.Utils.Converter = exports.Utils.Converter;
+            globalThis.Networking.API.HTTPServer = exports.Networking.API.HTTPServer;
+            globalThis.Networking.APIV2.Internal.TestServer = exports.Networking.APIV2.Internal.TestServer;
             return exports;
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.d.ts
@@ -50,16 +50,28 @@ export interface UUID extends SwiftHeapObject {
     uuidString(): string;
 }
 export type Exports = {
-    Greeter: {
-        new(name: string): Greeter;
-    }
-    Converter: {
-        new(): Converter;
-    }
-    UUID: {
-    }
     plainFunction(): string;
-    namespacedFunction(): string;
+    MyModule: {
+        Utils: {
+            namespacedFunction(): string;
+        },
+    },
+    Utils: {
+        Converters: {
+            Converter: {
+                new(): Converter;
+            }
+        },
+    },
+    __Swift: {
+        Foundation: {
+            Greeter: {
+                new(name: string): Greeter;
+            }
+            UUID: {
+            }
+        },
+    },
 }
 export type Imports = {
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.js
@@ -294,27 +294,39 @@ export async function createInstantiator(options, swift) {
                 globalThis.__Swift.Foundation = {};
             }
             const exports = {
-                Greeter,
-                Converter,
-                UUID,
                 plainFunction: function bjs_plainFunction() {
                     instance.exports.bjs_plainFunction();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 },
-                namespacedFunction: function bjs_MyModule_Utils_namespacedFunction() {
-                    instance.exports.bjs_MyModule_Utils_namespacedFunction();
-                    const ret = tmpRetString;
-                    tmpRetString = undefined;
-                    return ret;
+                MyModule: {
+                    Utils: {
+                        namespacedFunction: function bjs_MyModule_Utils_namespacedFunction() {
+                            instance.exports.bjs_MyModule_Utils_namespacedFunction();
+                            const ret = tmpRetString;
+                            tmpRetString = undefined;
+                            return ret;
+                        },
+                    },
+                },
+                Utils: {
+                    Converters: {
+                        Converter,
+                    },
+                },
+                __Swift: {
+                    Foundation: {
+                        Greeter,
+                        UUID,
+                    },
                 },
             };
             _exports = exports;
-            globalThis.__Swift.Foundation.Greeter = exports.Greeter;
-            globalThis.Utils.Converters.Converter = exports.Converter;
-            globalThis.__Swift.Foundation.UUID = exports.UUID;
-            globalThis.MyModule.Utils.namespacedFunction = exports.namespacedFunction;
+            globalThis.__Swift.Foundation.Greeter = exports.__Swift.Foundation.Greeter;
+            globalThis.Utils.Converters.Converter = exports.Utils.Converters.Converter;
+            globalThis.__Swift.Foundation.UUID = exports.__Swift.Foundation.UUID;
+            globalThis.MyModule.Utils.namespacedFunction = exports.MyModule.Utils.namespacedFunction;
             return exports;
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Export.d.ts
@@ -56,6 +56,11 @@ export type Exports = {
     }
     Calculator: CalculatorObject
     APIResult: APIResultObject
+    Utils: {
+        String: {
+            uppercase(text: string): string;
+        },
+    },
 }
 export type Imports = {
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Export.js
@@ -305,15 +305,6 @@ export async function createInstantiator(options, swift) {
             }
             const exports = {
                 MathUtils,
-                uppercase: function bjs_Utils_String_static_uppercase(text) {
-                    const textBytes = textEncoder.encode(text);
-                    const textId = swift.memory.retain(textBytes);
-                    instance.exports.bjs_Utils_String_static_uppercase(textId, textBytes.length);
-                    const ret = tmpRetString;
-                    tmpRetString = undefined;
-                    swift.memory.release(textId);
-                    return ret;
-                },
                 Calculator: {
                     ...CalculatorValues,
                     square: function(value) {
@@ -331,9 +322,22 @@ export async function createInstantiator(options, swift) {
                         return ret;
                     }
                 },
+                Utils: {
+                    String: {
+                        uppercase: function bjs_Utils_String_static_uppercase(text) {
+                            const textBytes = textEncoder.encode(text);
+                            const textId = swift.memory.retain(textBytes);
+                            instance.exports.bjs_Utils_String_static_uppercase(textId, textBytes.length);
+                            const ret = tmpRetString;
+                            tmpRetString = undefined;
+                            swift.memory.release(textId);
+                            return ret;
+                        },
+                    },
+                },
             };
             _exports = exports;
-            globalThis.Utils.String.uppercase = exports.uppercase;
+            globalThis.Utils.String.uppercase = exports.Utils.String.uppercase;
             return exports;
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Export.d.ts
@@ -51,6 +51,15 @@ export type Exports = {
         optionalProperty: string | null;
     }
     PropertyEnum: PropertyEnumObject
+    PropertyNamespace: {
+        readonly namespaceConstant: string;
+        namespaceProperty: string;
+        Nested: {
+            readonly nestedConstant: string;
+            nestedDouble: number;
+            nestedProperty: number;
+        },
+    },
 }
 export type Imports = {
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Export.js
@@ -303,41 +303,12 @@ export async function createInstantiator(options, swift) {
                     }
                 }
             }
-            Object.defineProperty(globalThis.PropertyNamespace, 'namespaceProperty', { get: function() {
-                instance.exports.bjs_PropertyNamespace_static_namespaceProperty_get();
-                const ret = tmpRetString;
-                tmpRetString = undefined;
-                return ret;
-            }, set: function(value) {
-                const valueBytes = textEncoder.encode(value);
-                const valueId = swift.memory.retain(valueBytes);
-                instance.exports.bjs_PropertyNamespace_static_namespaceProperty_set(valueId, valueBytes.length);
-                swift.memory.release(valueId);
-            } });
-            Object.defineProperty(globalThis.PropertyNamespace, 'namespaceConstant', { get: function() {
-                instance.exports.bjs_PropertyNamespace_static_namespaceConstant_get();
-                const ret = tmpRetString;
-                tmpRetString = undefined;
-                return ret;
-            } });
-            Object.defineProperty(globalThis.PropertyNamespace.Nested, 'nestedProperty', { get: function() {
-                const ret = instance.exports.bjs_PropertyNamespace_Nested_static_nestedProperty_get();
-                return ret;
-            }, set: function(value) {
-                instance.exports.bjs_PropertyNamespace_Nested_static_nestedProperty_set(value);
-            } });
-            Object.defineProperty(globalThis.PropertyNamespace.Nested, 'nestedConstant', { get: function() {
-                instance.exports.bjs_PropertyNamespace_Nested_static_nestedConstant_get();
-                const ret = tmpRetString;
-                tmpRetString = undefined;
-                return ret;
-            } });
-            Object.defineProperty(globalThis.PropertyNamespace.Nested, 'nestedDouble', { get: function() {
-                const ret = instance.exports.bjs_PropertyNamespace_Nested_static_nestedDouble_get();
-                return ret;
-            }, set: function(value) {
-                instance.exports.bjs_PropertyNamespace_Nested_static_nestedDouble_set(value);
-            } });
+            if (typeof globalThis.PropertyNamespace === 'undefined') {
+                globalThis.PropertyNamespace = {};
+            }
+            if (typeof globalThis.PropertyNamespace.Nested === 'undefined') {
+                globalThis.PropertyNamespace.Nested = {};
+            }
             const exports = {
                 PropertyClass,
                 PropertyEnum: {
@@ -371,8 +342,68 @@ export async function createInstantiator(options, swift) {
                         swift.memory.release(valueId);
                     }
                 },
+                PropertyNamespace: {
+                    get namespaceProperty() {
+                        instance.exports.bjs_PropertyNamespace_static_namespaceProperty_get();
+                        const ret = tmpRetString;
+                        tmpRetString = undefined;
+                        return ret;
+                    },
+                    set namespaceProperty(value) {
+                        const valueBytes = textEncoder.encode(value);
+                        const valueId = swift.memory.retain(valueBytes);
+                        instance.exports.bjs_PropertyNamespace_static_namespaceProperty_set(valueId, valueBytes.length);
+                        swift.memory.release(valueId);
+                    },
+                    get namespaceConstant() {
+                        instance.exports.bjs_PropertyNamespace_static_namespaceConstant_get();
+                        const ret = tmpRetString;
+                        tmpRetString = undefined;
+                        return ret;
+                    },
+                    Nested: {
+                        get nestedProperty() {
+                            const ret = instance.exports.bjs_PropertyNamespace_Nested_static_nestedProperty_get();
+                            return ret;
+                        },
+                        set nestedProperty(value) {
+                            instance.exports.bjs_PropertyNamespace_Nested_static_nestedProperty_set(value);
+                        },
+                        get nestedConstant() {
+                            instance.exports.bjs_PropertyNamespace_Nested_static_nestedConstant_get();
+                            const ret = tmpRetString;
+                            tmpRetString = undefined;
+                            return ret;
+                        },
+                        get nestedDouble() {
+                            const ret = instance.exports.bjs_PropertyNamespace_Nested_static_nestedDouble_get();
+                            return ret;
+                        },
+                        set nestedDouble(value) {
+                            instance.exports.bjs_PropertyNamespace_Nested_static_nestedDouble_set(value);
+                        },
+                    },
+                },
             };
             _exports = exports;
+            Object.defineProperty(globalThis.PropertyNamespace, 'namespaceProperty', {
+                get: () => exports.PropertyNamespace.namespaceProperty,
+                set: (value) => { exports.PropertyNamespace.namespaceProperty = value; }
+            });
+            Object.defineProperty(globalThis.PropertyNamespace, 'namespaceConstant', {
+                get: () => exports.PropertyNamespace.namespaceConstant,
+            });
+            Object.defineProperty(globalThis.PropertyNamespace.Nested, 'nestedProperty', {
+                get: () => exports.PropertyNamespace.Nested.nestedProperty,
+                set: (value) => { exports.PropertyNamespace.Nested.nestedProperty = value; }
+            });
+            Object.defineProperty(globalThis.PropertyNamespace.Nested, 'nestedConstant', {
+                get: () => exports.PropertyNamespace.Nested.nestedConstant,
+            });
+            Object.defineProperty(globalThis.PropertyNamespace.Nested, 'nestedDouble', {
+                get: () => exports.PropertyNamespace.Nested.nestedDouble,
+                set: (value) => { exports.PropertyNamespace.Nested.nestedDouble = value; }
+            });
             return exports;
         },
     }

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Using-Namespace.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Using-Namespace.md
@@ -21,10 +21,18 @@ import JavaScriptKit
 }
 ```
 
-This function will be accessible in JavaScript through its namespace hierarchy:
+This function will be accessible in JavaScript through its namespace hierarchy in two ways:
 
 ```javascript
-// Access the function through its namespace
+// Recommended: Access via the exports object (supports multiple WASM instances)
+const { createInstantiator } = await import('./path/to/bridge-js.js');
+const instantiator = await createInstantiator(options, swift);
+const exports = instantiator.createExports(instance);
+
+const result = exports.MyModule.Utils.namespacedFunction();
+console.log(result); // "namespaced"
+
+// Alternative: Access via globalThis
 const result = globalThis.MyModule.Utils.namespacedFunction();
 console.log(result); // "namespaced"
 ```
@@ -65,10 +73,14 @@ import JavaScriptKit
 }
 ```
 
-In JavaScript, this class is accessible through its namespace:
+In JavaScript, this class is accessible through its namespace in two ways:
 
 ```javascript
-// Create instances through namespaced constructors
+// Recommended: Access via the exports object (supports multiple WASM instances)
+const greeter = new exports.__Swift.Foundation.Greeter("World");
+console.log(greeter.greet()); // "Hello, World!"
+
+// Alternative: Access via globalThis and through its namespace
 const greeter = new globalThis.__Swift.Foundation.Greeter("World");
 console.log(greeter.greet()); // "Hello, World!"
 ```
@@ -82,6 +94,16 @@ declare global {
             class Greeter {
                 constructor(name: string);
                 greet(): string;
+            }
+        }
+    }
+}
+
+export type Exports = {
+    __Swift: {
+        Foundation: {
+            Greeter: {
+                new(name: string): Greeter;
             }
         }
     }

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -356,6 +356,22 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     assert.equal(globalThis.StaticPropertyNamespace.NestedProperties.nestedProperty, 1000);
     assert.equal(globalThis.StaticPropertyNamespace.NestedProperties.nestedDouble, 2.828);
 
+    assert.equal(exports.StaticPropertyNamespace.namespaceProperty, "modified namespace");
+    assert.equal(exports.StaticPropertyNamespace.namespaceConstant, "constant");
+    exports.StaticPropertyNamespace.namespaceProperty = "exports modified";
+    assert.equal(exports.StaticPropertyNamespace.namespaceProperty, "exports modified");
+    assert.equal(globalThis.StaticPropertyNamespace.namespaceProperty, "exports modified");
+
+    assert.equal(exports.StaticPropertyNamespace.NestedProperties.nestedProperty, 1000);
+    assert.equal(exports.StaticPropertyNamespace.NestedProperties.nestedConstant, "nested");
+    assert.equal(exports.StaticPropertyNamespace.NestedProperties.nestedDouble, 2.828);
+    exports.StaticPropertyNamespace.NestedProperties.nestedProperty = 2000;
+    exports.StaticPropertyNamespace.NestedProperties.nestedDouble = 3.14;
+    assert.equal(exports.StaticPropertyNamespace.NestedProperties.nestedProperty, 2000);
+    assert.equal(exports.StaticPropertyNamespace.NestedProperties.nestedDouble, 3.14);
+    assert.equal(globalThis.StaticPropertyNamespace.NestedProperties.nestedProperty, 2000);
+    assert.equal(globalThis.StaticPropertyNamespace.NestedProperties.nestedDouble, 3.14);
+
     // Test class without @JS init constructor
     const calc = exports.createCalculator();
     assert.equal(calc.square(5), 25);
@@ -428,6 +444,10 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     assert.equal(globalThis.Networking.API.MethodValues.Post, 1);
     assert.equal(globalThis.Networking.API.MethodValues.Put, 2);
     assert.equal(globalThis.Networking.API.MethodValues.Delete, 3);
+    assert.equal(exports.Networking.API.Method.Get, 0);
+    assert.equal(exports.Networking.API.Method.Post, 1);
+    assert.equal(exports.Networking.API.Method.Put, 2);
+    assert.equal(exports.Networking.API.Method.Delete, 3);
     assert.equal(globalThis.Configuration.LogLevelValues.Debug, "debug");
     assert.equal(globalThis.Configuration.LogLevelValues.Info, "info");
     assert.equal(globalThis.Configuration.LogLevelValues.Warning, "warning");
@@ -435,8 +455,17 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     assert.equal(globalThis.Configuration.PortValues.Http, 80);
     assert.equal(globalThis.Configuration.PortValues.Https, 443);
     assert.equal(globalThis.Configuration.PortValues.Development, 3000);
+    assert.equal(exports.Configuration.LogLevel.Debug, "debug");
+    assert.equal(exports.Configuration.LogLevel.Info, "info");
+    assert.equal(exports.Configuration.LogLevel.Warning, "warning");
+    assert.equal(exports.Configuration.LogLevel.Error, "error");
+    assert.equal(exports.Configuration.Port.Http, 80);
+    assert.equal(exports.Configuration.Port.Https, 443);
+    assert.equal(exports.Configuration.Port.Development, 3000);
     assert.equal(globalThis.Networking.APIV2.Internal.SupportedMethodValues.Get, 0);
     assert.equal(globalThis.Networking.APIV2.Internal.SupportedMethodValues.Post, 1);
+    assert.equal(exports.Networking.APIV2.Internal.SupportedMethod.Get, 0);
+    assert.equal(exports.Networking.APIV2.Internal.SupportedMethod.Post, 1);
 
     assert.equal(exports.roundtripNetworkingAPIMethod(globalThis.Networking.API.MethodValues.Get), globalThis.Networking.API.MethodValues.Get);
     assert.equal(exports.roundtripConfigurationLogLevel(globalThis.Configuration.LogLevelValues.Debug), globalThis.Configuration.LogLevelValues.Debug);
@@ -447,17 +476,17 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     assert.equal(exports.processConfigurationLogLevel(globalThis.Configuration.LogLevelValues.Error), globalThis.Configuration.PortValues.Development);
     assert.equal(exports.roundtripInternalSupportedMethod(globalThis.Networking.APIV2.Internal.SupportedMethodValues.Get), globalThis.Networking.APIV2.Internal.SupportedMethodValues.Get);
 
-    const converter = new exports.Converter();
+    const converter = new exports.Utils.Converter();
     assert.equal(converter.toString(42), "42");
     assert.equal(converter.toString(123), "123");
     converter.release();
 
-    const httpServer = new exports.HTTPServer();
+    const httpServer = new exports.Networking.API.HTTPServer();
     httpServer.call(globalThis.Networking.API.MethodValues.Get);
     httpServer.call(globalThis.Networking.API.MethodValues.Post);
     httpServer.release();
 
-    const testServer = new exports.TestServer();
+    const testServer = new exports.Networking.APIV2.Internal.TestServer();
     testServer.call(globalThis.Networking.APIV2.Internal.SupportedMethodValues.Get);
     testServer.call(globalThis.Networking.APIV2.Internal.SupportedMethodValues.Post);
     testServer.release();
@@ -643,6 +672,8 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     assert.equal(StaticCalculatorValues.Scientific, exports.StaticCalculator.Scientific);
     assert.equal(StaticCalculatorValues.Basic, exports.StaticCalculator.Basic);
     assert.equal(globalThis.StaticUtils.Nested.roundtrip("hello world"), "hello world");
+    assert.equal(exports.StaticUtils.Nested.roundtrip("test"), "test");
+    assert.equal(exports.StaticUtils.Nested.roundtrip("exports api"), "exports api");
 
     // Test default parameters
     assert.equal(exports.testStringDefault(), "Hello World");
@@ -1034,8 +1065,8 @@ function testProtocolSupport(exports) {
         getAPIResult() { return lastAPIResult; }
     };
 
-    const successResult = { tag: exports.Result.Tag.Success, param0: "Operation completed" };
-    const failureResult = { tag: exports.Result.Tag.Failure, param0: 500 };
+    const successResult = { tag: exports.Utilities.Result.Tag.Success, param0: "Operation completed" };
+    const failureResult = { tag: exports.Utilities.Result.Tag.Failure, param0: 500 };
 
     const jsManager = new exports.DataProcessorManager(jsProcessor);
 


### PR DESCRIPTION
##  Introduction
First part of improvements to address https://github.com/swiftwasm/JavaScriptKit/issues/451 and discussions from: https://github.com/swiftwasm/JavaScriptKit/pull/448#discussion_r2365900916

## Overview
- Namespacing structure is properly reflected in Exports
- Access to namespaced static properties is finally available via Exports
- Static properties implementation is improved; `Object.defineProperty` now only global this only references export's implementation

## Testing
Some additional tests to check extended exports access 

## Next steps
Next PR will include:
- optional `namespace global` 
- `{ "exposeToGlobal": true }` in `bridge-js.config.json`