### PR TITLE
build: Allow swift-syntax 6.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         .plugin(name: "BridgeJSCommandPlugin", targets: ["BridgeJSCommandPlugin"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"602.0.0")
+        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"603.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
This allows packages consuming JavaScriptKit to use swift-syntax versions for Swift 6.2.x. Currently, any packages consuming JavaScriptKit are limited to using swift-syntax 6.1.x and earlier.

This does not require anyone to raise their swift versions or swift-syntax versions, just allows later swift-syntax versions to be used.