### PR TITLE
BridgeJS: Struct and struct vs classes benchmarks

### DIFF
--- a/Benchmarks/Sources/Benchmarks.swift
+++ b/Benchmarks/Sources/Benchmarks.swift
@@ -111,6 +111,136 @@ enum ComplexResult {
     }
 }
 
+// MARK: - Struct Performance Tests
+
+@JS struct SimpleStruct {
+    var name: String
+    var count: Int
+    var flag: Bool
+    var rate: Float
+    var precise: Double
+}
+
+@JS struct Address {
+    var street: String
+    var city: String
+    var zipCode: Int
+}
+
+@JS struct Person {
+    var name: String
+    var age: Int
+    var address: Address
+    var email: String?
+}
+
+@JS struct ComplexStruct {
+    var id: Int
+    var title: String
+    var active: Bool
+    var score: Double
+    var tags: String
+    var metadata: String
+}
+
+@JS class StructRoundtrip {
+    @JS init() {}
+
+    @JS func takeSimple(_ value: SimpleStruct) {}
+    @JS func makeSimple() -> SimpleStruct {
+        return SimpleStruct(name: "Hello", count: 42, flag: true, rate: 0.5, precise: 3.14159)
+    }
+    @JS func roundtripSimple(_ value: SimpleStruct) -> SimpleStruct {
+        return value
+    }
+
+    @JS func takeAddress(_ value: Address) {}
+    @JS func makeAddress() -> Address {
+        return Address(street: "123 Main St", city: "San Francisco", zipCode: 94102)
+    }
+    @JS func roundtripAddress(_ value: Address) -> Address {
+        return value
+    }
+
+    @JS func takePerson(_ value: Person) {}
+    @JS func makePerson() -> Person {
+        return Person(
+            name: "John Doe",
+            age: 30,
+            address: Address(street: "456 Oak Ave", city: "New York", zipCode: 10001),
+            email: "john@example.com"
+        )
+    }
+    @JS func roundtripPerson(_ value: Person) -> Person {
+        return value
+    }
+
+    @JS func takeComplex(_ value: ComplexStruct) {}
+    @JS func makeComplex() -> ComplexStruct {
+        return ComplexStruct(
+            id: 12345,
+            title: "Test Item",
+            active: true,
+            score: 98.6,
+            tags: "swift,wasm,benchmark",
+            metadata: "{\"version\":1}"
+        )
+    }
+    @JS func roundtripComplex(_ value: ComplexStruct) -> ComplexStruct {
+        return value
+    }
+}
+
+// MARK: - Class vs Struct Comparison Tests
+
+@JS class SimpleClass {
+    @JS var name: String
+    @JS var count: Int
+    @JS var flag: Bool
+    @JS var rate: Float
+    @JS var precise: Double
+
+    @JS init(name: String, count: Int, flag: Bool, rate: Float, precise: Double) {
+        self.name = name
+        self.count = count
+        self.flag = flag
+        self.rate = rate
+        self.precise = precise
+    }
+}
+
+@JS class AddressClass {
+    @JS var street: String
+    @JS var city: String
+    @JS var zipCode: Int
+
+    @JS init(street: String, city: String, zipCode: Int) {
+        self.street = street
+        self.city = city
+        self.zipCode = zipCode
+    }
+}
+
+@JS class ClassRoundtrip {
+    @JS init() {}
+
+    @JS func takeSimpleClass(_ value: SimpleClass) {}
+    @JS func makeSimpleClass() -> SimpleClass {
+        return SimpleClass(name: "Hello", count: 42, flag: true, rate: 0.5, precise: 3.14159)
+    }
+    @JS func roundtripSimpleClass(_ value: SimpleClass) -> SimpleClass {
+        return value
+    }
+
+    @JS func takeAddressClass(_ value: AddressClass) {}
+    @JS func makeAddressClass() -> AddressClass {
+        return AddressClass(street: "123 Main St", city: "San Francisco", zipCode: 94102)
+    }
+    @JS func roundtripAddressClass(_ value: AddressClass) -> AddressClass {
+        return value
+    }
+}
+
 @JS func run() {
 
     let call = Benchmark("Call")

--- a/Benchmarks/Sources/Generated/BridgeJS.ExportSwift.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.ExportSwift.swift
@@ -246,6 +246,106 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
+extension SimpleStruct: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> SimpleStruct {
+        let precise = Double.bridgeJSLiftParameter(_swift_js_pop_param_f64())
+        let rate = Float.bridgeJSLiftParameter(_swift_js_pop_param_f32())
+        let flag = Bool.bridgeJSLiftParameter(_swift_js_pop_param_int32())
+        let count = Int.bridgeJSLiftParameter(_swift_js_pop_param_int32())
+        let name = String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32())
+        return SimpleStruct(name: name, count: count, flag: flag, rate: rate, precise: precise)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        var __bjs_name = self.name
+        __bjs_name.withUTF8 { ptr in
+            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+        }
+        _swift_js_push_int(Int32(self.count))
+        _swift_js_push_int(self.flag ? 1 : 0)
+        _swift_js_push_f32(self.rate)
+        _swift_js_push_f64(self.precise)
+    }
+}
+
+extension Address: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Address {
+        let zipCode = Int.bridgeJSLiftParameter(_swift_js_pop_param_int32())
+        let city = String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32())
+        let street = String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32())
+        return Address(street: street, city: city, zipCode: zipCode)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        var __bjs_street = self.street
+        __bjs_street.withUTF8 { ptr in
+            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+        }
+        var __bjs_city = self.city
+        __bjs_city.withUTF8 { ptr in
+            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+        }
+        _swift_js_push_int(Int32(self.zipCode))
+    }
+}
+
+extension Person: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Person {
+        let email = Optional<String>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32(), _swift_js_pop_param_int32())
+        let address = Address.bridgeJSLiftParameter()
+        let age = Int.bridgeJSLiftParameter(_swift_js_pop_param_int32())
+        let name = String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32())
+        return Person(name: name, age: age, address: address, email: email)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        var __bjs_name = self.name
+        __bjs_name.withUTF8 { ptr in
+            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+        }
+        _swift_js_push_int(Int32(self.age))
+        self.address.bridgeJSLowerReturn()
+        let __bjs_isSome_email = self.email != nil
+        if let __bjs_unwrapped_email = self.email {
+            var __bjs_str_email = __bjs_unwrapped_email
+            __bjs_str_email.withUTF8 { ptr in
+                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+            }
+        }
+        _swift_js_push_int(__bjs_isSome_email ? 1 : 0)
+    }
+}
+
+extension ComplexStruct: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ComplexStruct {
+        let metadata = String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32())
+        let tags = String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32())
+        let score = Double.bridgeJSLiftParameter(_swift_js_pop_param_f64())
+        let active = Bool.bridgeJSLiftParameter(_swift_js_pop_param_int32())
+        let title = String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32())
+        let id = Int.bridgeJSLiftParameter(_swift_js_pop_param_int32())
+        return ComplexStruct(id: id, title: title, active: active, score: score, tags: tags, metadata: metadata)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        _swift_js_push_int(Int32(self.id))
+        var __bjs_title = self.title
+        __bjs_title.withUTF8 { ptr in
+            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+        }
+        _swift_js_push_int(self.active ? 1 : 0)
+        _swift_js_push_f64(self.score)
+        var __bjs_tags = self.tags
+        __bjs_tags.withUTF8 { ptr in
+            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+        }
+        var __bjs_metadata = self.metadata
+        __bjs_metadata.withUTF8 { ptr in
+            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+        }
+    }
+}
+
 @_expose(wasm, "bjs_run")
 @_cdecl("bjs_run")
 public func _bjs_run() -> Void {
@@ -554,6 +654,494 @@ extension StringRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject {
 fileprivate func _bjs_StringRoundtrip_wrap(_: UnsafeMutableRawPointer) -> Int32
 #else
 fileprivate func _bjs_StringRoundtrip_wrap(_: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_StructRoundtrip_init")
+@_cdecl("bjs_StructRoundtrip_init")
+public func _bjs_StructRoundtrip_init() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = StructRoundtrip()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_takeSimple")
+@_cdecl("bjs_StructRoundtrip_takeSimple")
+public func _bjs_StructRoundtrip_takeSimple(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    StructRoundtrip.bridgeJSLiftParameter(_self).takeSimple(_: SimpleStruct.bridgeJSLiftParameter())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_makeSimple")
+@_cdecl("bjs_StructRoundtrip_makeSimple")
+public func _bjs_StructRoundtrip_makeSimple(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).makeSimple()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_roundtripSimple")
+@_cdecl("bjs_StructRoundtrip_roundtripSimple")
+public func _bjs_StructRoundtrip_roundtripSimple(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).roundtripSimple(_: SimpleStruct.bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_takeAddress")
+@_cdecl("bjs_StructRoundtrip_takeAddress")
+public func _bjs_StructRoundtrip_takeAddress(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    StructRoundtrip.bridgeJSLiftParameter(_self).takeAddress(_: Address.bridgeJSLiftParameter())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_makeAddress")
+@_cdecl("bjs_StructRoundtrip_makeAddress")
+public func _bjs_StructRoundtrip_makeAddress(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).makeAddress()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_roundtripAddress")
+@_cdecl("bjs_StructRoundtrip_roundtripAddress")
+public func _bjs_StructRoundtrip_roundtripAddress(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).roundtripAddress(_: Address.bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_takePerson")
+@_cdecl("bjs_StructRoundtrip_takePerson")
+public func _bjs_StructRoundtrip_takePerson(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    StructRoundtrip.bridgeJSLiftParameter(_self).takePerson(_: Person.bridgeJSLiftParameter())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_makePerson")
+@_cdecl("bjs_StructRoundtrip_makePerson")
+public func _bjs_StructRoundtrip_makePerson(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).makePerson()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_roundtripPerson")
+@_cdecl("bjs_StructRoundtrip_roundtripPerson")
+public func _bjs_StructRoundtrip_roundtripPerson(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).roundtripPerson(_: Person.bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_takeComplex")
+@_cdecl("bjs_StructRoundtrip_takeComplex")
+public func _bjs_StructRoundtrip_takeComplex(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    StructRoundtrip.bridgeJSLiftParameter(_self).takeComplex(_: ComplexStruct.bridgeJSLiftParameter())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_makeComplex")
+@_cdecl("bjs_StructRoundtrip_makeComplex")
+public func _bjs_StructRoundtrip_makeComplex(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).makeComplex()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_roundtripComplex")
+@_cdecl("bjs_StructRoundtrip_roundtripComplex")
+public func _bjs_StructRoundtrip_roundtripComplex(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).roundtripComplex(_: ComplexStruct.bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_StructRoundtrip_deinit")
+@_cdecl("bjs_StructRoundtrip_deinit")
+public func _bjs_StructRoundtrip_deinit(pointer: UnsafeMutableRawPointer) {
+    Unmanaged<StructRoundtrip>.fromOpaque(pointer).release()
+}
+
+extension StructRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_StructRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "Benchmarks", name: "bjs_StructRoundtrip_wrap")
+fileprivate func _bjs_StructRoundtrip_wrap(_: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_StructRoundtrip_wrap(_: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_SimpleClass_init")
+@_cdecl("bjs_SimpleClass_init")
+public func _bjs_SimpleClass_init(nameBytes: Int32, nameLength: Int32, count: Int32, flag: Int32, rate: Float32, precise: Float64) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = SimpleClass(name: String.bridgeJSLiftParameter(nameBytes, nameLength), count: Int.bridgeJSLiftParameter(count), flag: Bool.bridgeJSLiftParameter(flag), rate: Float.bridgeJSLiftParameter(rate), precise: Double.bridgeJSLiftParameter(precise))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SimpleClass_name_get")
+@_cdecl("bjs_SimpleClass_name_get")
+public func _bjs_SimpleClass_name_get(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = SimpleClass.bridgeJSLiftParameter(_self).name
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SimpleClass_name_set")
+@_cdecl("bjs_SimpleClass_name_set")
+public func _bjs_SimpleClass_name_set(_self: UnsafeMutableRawPointer, valueBytes: Int32, valueLength: Int32) -> Void {
+    #if arch(wasm32)
+    SimpleClass.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SimpleClass_count_get")
+@_cdecl("bjs_SimpleClass_count_get")
+public func _bjs_SimpleClass_count_get(_self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = SimpleClass.bridgeJSLiftParameter(_self).count
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SimpleClass_count_set")
+@_cdecl("bjs_SimpleClass_count_set")
+public func _bjs_SimpleClass_count_set(_self: UnsafeMutableRawPointer, value: Int32) -> Void {
+    #if arch(wasm32)
+    SimpleClass.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SimpleClass_flag_get")
+@_cdecl("bjs_SimpleClass_flag_get")
+public func _bjs_SimpleClass_flag_get(_self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = SimpleClass.bridgeJSLiftParameter(_self).flag
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SimpleClass_flag_set")
+@_cdecl("bjs_SimpleClass_flag_set")
+public func _bjs_SimpleClass_flag_set(_self: UnsafeMutableRawPointer, value: Int32) -> Void {
+    #if arch(wasm32)
+    SimpleClass.bridgeJSLiftParameter(_self).flag = Bool.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SimpleClass_rate_get")
+@_cdecl("bjs_SimpleClass_rate_get")
+public func _bjs_SimpleClass_rate_get(_self: UnsafeMutableRawPointer) -> Float32 {
+    #if arch(wasm32)
+    let ret = SimpleClass.bridgeJSLiftParameter(_self).rate
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SimpleClass_rate_set")
+@_cdecl("bjs_SimpleClass_rate_set")
+public func _bjs_SimpleClass_rate_set(_self: UnsafeMutableRawPointer, value: Float32) -> Void {
+    #if arch(wasm32)
+    SimpleClass.bridgeJSLiftParameter(_self).rate = Float.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SimpleClass_precise_get")
+@_cdecl("bjs_SimpleClass_precise_get")
+public func _bjs_SimpleClass_precise_get(_self: UnsafeMutableRawPointer) -> Float64 {
+    #if arch(wasm32)
+    let ret = SimpleClass.bridgeJSLiftParameter(_self).precise
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SimpleClass_precise_set")
+@_cdecl("bjs_SimpleClass_precise_set")
+public func _bjs_SimpleClass_precise_set(_self: UnsafeMutableRawPointer, value: Float64) -> Void {
+    #if arch(wasm32)
+    SimpleClass.bridgeJSLiftParameter(_self).precise = Double.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SimpleClass_deinit")
+@_cdecl("bjs_SimpleClass_deinit")
+public func _bjs_SimpleClass_deinit(pointer: UnsafeMutableRawPointer) {
+    Unmanaged<SimpleClass>.fromOpaque(pointer).release()
+}
+
+extension SimpleClass: ConvertibleToJSValue, _BridgedSwiftHeapObject {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_SimpleClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "Benchmarks", name: "bjs_SimpleClass_wrap")
+fileprivate func _bjs_SimpleClass_wrap(_: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_SimpleClass_wrap(_: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_AddressClass_init")
+@_cdecl("bjs_AddressClass_init")
+public func _bjs_AddressClass_init(streetBytes: Int32, streetLength: Int32, cityBytes: Int32, cityLength: Int32, zipCode: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = AddressClass(street: String.bridgeJSLiftParameter(streetBytes, streetLength), city: String.bridgeJSLiftParameter(cityBytes, cityLength), zipCode: Int.bridgeJSLiftParameter(zipCode))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_AddressClass_street_get")
+@_cdecl("bjs_AddressClass_street_get")
+public func _bjs_AddressClass_street_get(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = AddressClass.bridgeJSLiftParameter(_self).street
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_AddressClass_street_set")
+@_cdecl("bjs_AddressClass_street_set")
+public func _bjs_AddressClass_street_set(_self: UnsafeMutableRawPointer, valueBytes: Int32, valueLength: Int32) -> Void {
+    #if arch(wasm32)
+    AddressClass.bridgeJSLiftParameter(_self).street = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_AddressClass_city_get")
+@_cdecl("bjs_AddressClass_city_get")
+public func _bjs_AddressClass_city_get(_self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = AddressClass.bridgeJSLiftParameter(_self).city
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_AddressClass_city_set")
+@_cdecl("bjs_AddressClass_city_set")
+public func _bjs_AddressClass_city_set(_self: UnsafeMutableRawPointer, valueBytes: Int32, valueLength: Int32) -> Void {
+    #if arch(wasm32)
+    AddressClass.bridgeJSLiftParameter(_self).city = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_AddressClass_zipCode_get")
+@_cdecl("bjs_AddressClass_zipCode_get")
+public func _bjs_AddressClass_zipCode_get(_self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = AddressClass.bridgeJSLiftParameter(_self).zipCode
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_AddressClass_zipCode_set")
+@_cdecl("bjs_AddressClass_zipCode_set")
+public func _bjs_AddressClass_zipCode_set(_self: UnsafeMutableRawPointer, value: Int32) -> Void {
+    #if arch(wasm32)
+    AddressClass.bridgeJSLiftParameter(_self).zipCode = Int.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_AddressClass_deinit")
+@_cdecl("bjs_AddressClass_deinit")
+public func _bjs_AddressClass_deinit(pointer: UnsafeMutableRawPointer) {
+    Unmanaged<AddressClass>.fromOpaque(pointer).release()
+}
+
+extension AddressClass: ConvertibleToJSValue, _BridgedSwiftHeapObject {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_AddressClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "Benchmarks", name: "bjs_AddressClass_wrap")
+fileprivate func _bjs_AddressClass_wrap(_: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_AddressClass_wrap(_: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_ClassRoundtrip_init")
+@_cdecl("bjs_ClassRoundtrip_init")
+public func _bjs_ClassRoundtrip_init() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = ClassRoundtrip()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ClassRoundtrip_takeSimpleClass")
+@_cdecl("bjs_ClassRoundtrip_takeSimpleClass")
+public func _bjs_ClassRoundtrip_takeSimpleClass(_self: UnsafeMutableRawPointer, value: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    ClassRoundtrip.bridgeJSLiftParameter(_self).takeSimpleClass(_: SimpleClass.bridgeJSLiftParameter(value))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ClassRoundtrip_makeSimpleClass")
+@_cdecl("bjs_ClassRoundtrip_makeSimpleClass")
+public func _bjs_ClassRoundtrip_makeSimpleClass(_self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = ClassRoundtrip.bridgeJSLiftParameter(_self).makeSimpleClass()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ClassRoundtrip_roundtripSimpleClass")
+@_cdecl("bjs_ClassRoundtrip_roundtripSimpleClass")
+public func _bjs_ClassRoundtrip_roundtripSimpleClass(_self: UnsafeMutableRawPointer, value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = ClassRoundtrip.bridgeJSLiftParameter(_self).roundtripSimpleClass(_: SimpleClass.bridgeJSLiftParameter(value))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ClassRoundtrip_takeAddressClass")
+@_cdecl("bjs_ClassRoundtrip_takeAddressClass")
+public func _bjs_ClassRoundtrip_takeAddressClass(_self: UnsafeMutableRawPointer, value: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    ClassRoundtrip.bridgeJSLiftParameter(_self).takeAddressClass(_: AddressClass.bridgeJSLiftParameter(value))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ClassRoundtrip_makeAddressClass")
+@_cdecl("bjs_ClassRoundtrip_makeAddressClass")
+public func _bjs_ClassRoundtrip_makeAddressClass(_self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = ClassRoundtrip.bridgeJSLiftParameter(_self).makeAddressClass()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ClassRoundtrip_roundtripAddressClass")
+@_cdecl("bjs_ClassRoundtrip_roundtripAddressClass")
+public func _bjs_ClassRoundtrip_roundtripAddressClass(_self: UnsafeMutableRawPointer, value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = ClassRoundtrip.bridgeJSLiftParameter(_self).roundtripAddressClass(_: AddressClass.bridgeJSLiftParameter(value))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ClassRoundtrip_deinit")
+@_cdecl("bjs_ClassRoundtrip_deinit")
+public func _bjs_ClassRoundtrip_deinit(pointer: UnsafeMutableRawPointer) {
+    Unmanaged<ClassRoundtrip>.fromOpaque(pointer).release()
+}
+
+extension ClassRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_ClassRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "Benchmarks", name: "bjs_ClassRoundtrip_wrap")
+fileprivate func _bjs_ClassRoundtrip_wrap(_: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_ClassRoundtrip_wrap(_: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Benchmarks/Sources/Generated/JavaScript/BridgeJS.ExportSwift.json
+++ b/Benchmarks/Sources/Generated/JavaScript/BridgeJS.ExportSwift.json
@@ -422,6 +422,638 @@
 
       ],
       "swiftCallName" : "StringRoundtrip"
+    },
+    {
+      "constructor" : {
+        "abiName" : "bjs_StructRoundtrip_init",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "parameters" : [
+
+        ]
+      },
+      "methods" : [
+        {
+          "abiName" : "bjs_StructRoundtrip_takeSimple",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "takeSimple",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "swiftStruct" : {
+                  "_0" : "SimpleStruct"
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_StructRoundtrip_makeSimple",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "makeSimple",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "swiftStruct" : {
+              "_0" : "SimpleStruct"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_StructRoundtrip_roundtripSimple",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "roundtripSimple",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "swiftStruct" : {
+                  "_0" : "SimpleStruct"
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "swiftStruct" : {
+              "_0" : "SimpleStruct"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_StructRoundtrip_takeAddress",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "takeAddress",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "swiftStruct" : {
+                  "_0" : "Address"
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_StructRoundtrip_makeAddress",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "makeAddress",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "swiftStruct" : {
+              "_0" : "Address"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_StructRoundtrip_roundtripAddress",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "roundtripAddress",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "swiftStruct" : {
+                  "_0" : "Address"
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "swiftStruct" : {
+              "_0" : "Address"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_StructRoundtrip_takePerson",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "takePerson",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "swiftStruct" : {
+                  "_0" : "Person"
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_StructRoundtrip_makePerson",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "makePerson",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "swiftStruct" : {
+              "_0" : "Person"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_StructRoundtrip_roundtripPerson",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "roundtripPerson",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "swiftStruct" : {
+                  "_0" : "Person"
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "swiftStruct" : {
+              "_0" : "Person"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_StructRoundtrip_takeComplex",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "takeComplex",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "swiftStruct" : {
+                  "_0" : "ComplexStruct"
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_StructRoundtrip_makeComplex",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "makeComplex",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "swiftStruct" : {
+              "_0" : "ComplexStruct"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_StructRoundtrip_roundtripComplex",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "roundtripComplex",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "swiftStruct" : {
+                  "_0" : "ComplexStruct"
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "swiftStruct" : {
+              "_0" : "ComplexStruct"
+            }
+          }
+        }
+      ],
+      "name" : "StructRoundtrip",
+      "properties" : [
+
+      ],
+      "swiftCallName" : "StructRoundtrip"
+    },
+    {
+      "constructor" : {
+        "abiName" : "bjs_SimpleClass_init",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "parameters" : [
+          {
+            "label" : "name",
+            "name" : "name",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "label" : "count",
+            "name" : "count",
+            "type" : {
+              "int" : {
+
+              }
+            }
+          },
+          {
+            "label" : "flag",
+            "name" : "flag",
+            "type" : {
+              "bool" : {
+
+              }
+            }
+          },
+          {
+            "label" : "rate",
+            "name" : "rate",
+            "type" : {
+              "float" : {
+
+              }
+            }
+          },
+          {
+            "label" : "precise",
+            "name" : "precise",
+            "type" : {
+              "double" : {
+
+              }
+            }
+          }
+        ]
+      },
+      "methods" : [
+
+      ],
+      "name" : "SimpleClass",
+      "properties" : [
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "name",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "count",
+          "type" : {
+            "int" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "flag",
+          "type" : {
+            "bool" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "rate",
+          "type" : {
+            "float" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "precise",
+          "type" : {
+            "double" : {
+
+            }
+          }
+        }
+      ],
+      "swiftCallName" : "SimpleClass"
+    },
+    {
+      "constructor" : {
+        "abiName" : "bjs_AddressClass_init",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "parameters" : [
+          {
+            "label" : "street",
+            "name" : "street",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "label" : "city",
+            "name" : "city",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "label" : "zipCode",
+            "name" : "zipCode",
+            "type" : {
+              "int" : {
+
+              }
+            }
+          }
+        ]
+      },
+      "methods" : [
+
+      ],
+      "name" : "AddressClass",
+      "properties" : [
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "street",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "city",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "zipCode",
+          "type" : {
+            "int" : {
+
+            }
+          }
+        }
+      ],
+      "swiftCallName" : "AddressClass"
+    },
+    {
+      "constructor" : {
+        "abiName" : "bjs_ClassRoundtrip_init",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "parameters" : [
+
+        ]
+      },
+      "methods" : [
+        {
+          "abiName" : "bjs_ClassRoundtrip_takeSimpleClass",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "takeSimpleClass",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "swiftHeapObject" : {
+                  "_0" : "SimpleClass"
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_ClassRoundtrip_makeSimpleClass",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "makeSimpleClass",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "swiftHeapObject" : {
+              "_0" : "SimpleClass"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_ClassRoundtrip_roundtripSimpleClass",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "roundtripSimpleClass",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "swiftHeapObject" : {
+                  "_0" : "SimpleClass"
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "swiftHeapObject" : {
+              "_0" : "SimpleClass"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_ClassRoundtrip_takeAddressClass",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "takeAddressClass",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "swiftHeapObject" : {
+                  "_0" : "AddressClass"
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_ClassRoundtrip_makeAddressClass",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "makeAddressClass",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "swiftHeapObject" : {
+              "_0" : "AddressClass"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_ClassRoundtrip_roundtripAddressClass",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "roundtripAddressClass",
+          "parameters" : [
+            {
+              "label" : "_",
+              "name" : "value",
+              "type" : {
+                "swiftHeapObject" : {
+                  "_0" : "AddressClass"
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "swiftHeapObject" : {
+              "_0" : "AddressClass"
+            }
+          }
+        }
+      ],
+      "name" : "ClassRoundtrip",
+      "properties" : [
+
+      ],
+      "swiftCallName" : "ClassRoundtrip"
     }
   ],
   "enums" : [
@@ -728,6 +1360,225 @@
 
   ],
   "structs" : [
+    {
+      "methods" : [
 
+      ],
+      "name" : "SimpleStruct",
+      "properties" : [
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "name",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "count",
+          "type" : {
+            "int" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "flag",
+          "type" : {
+            "bool" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "rate",
+          "type" : {
+            "float" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "precise",
+          "type" : {
+            "double" : {
+
+            }
+          }
+        }
+      ],
+      "swiftCallName" : "SimpleStruct"
+    },
+    {
+      "methods" : [
+
+      ],
+      "name" : "Address",
+      "properties" : [
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "street",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "city",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "zipCode",
+          "type" : {
+            "int" : {
+
+            }
+          }
+        }
+      ],
+      "swiftCallName" : "Address"
+    },
+    {
+      "methods" : [
+
+      ],
+      "name" : "Person",
+      "properties" : [
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "name",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "age",
+          "type" : {
+            "int" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "address",
+          "type" : {
+            "swiftStruct" : {
+              "_0" : "Address"
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "email",
+          "type" : {
+            "optional" : {
+              "_0" : {
+                "string" : {
+
+                }
+              }
+            }
+          }
+        }
+      ],
+      "swiftCallName" : "Person"
+    },
+    {
+      "methods" : [
+
+      ],
+      "name" : "ComplexStruct",
+      "properties" : [
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "id",
+          "type" : {
+            "int" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "title",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "active",
+          "type" : {
+            "bool" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "score",
+          "type" : {
+            "double" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "tags",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "metadata",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        }
+      ],
+      "swiftCallName" : "ComplexStruct"
+    }
   ]
 }

--- a/Benchmarks/run.js
+++ b/Benchmarks/run.js
@@ -3,7 +3,7 @@ import { defaultNodeSetup } from "./.build/plugins/PackageToJS/outputs/Package/p
 import fs from 'fs';
 import path from 'path';
 import { parseArgs } from "util";
-import { APIResult, ComplexResult } from "./.build/plugins/PackageToJS/outputs/Package/bridge-js.js";
+import { APIResultValues as APIResult, ComplexResultValues as ComplexResult } from "./.build/plugins/PackageToJS/outputs/Package/bridge-js.js";
 
 /**
  * Update progress bar on the current line
@@ -452,6 +452,136 @@ async function singleRun(results, nameFilter) {
     benchmarkRunner("StringRoundtrip/makeString", () => {
         for (let i = 0; i < iterations; i++) {
             stringRoundtrip.make()
+        }
+    })
+
+    // Struct performance tests
+    const structRoundtrip = new exports.StructRoundtrip();
+
+    benchmarkRunner("StructRoundtrip/takeSimple", () => {
+        for (let i = 0; i < iterations; i++) {
+            structRoundtrip.takeSimple({ name: "Hello", count: 42, flag: true, rate: 0.5, precise: 3.14159 })
+        }
+    })
+    benchmarkRunner("StructRoundtrip/makeSimple", () => {
+        for (let i = 0; i < iterations; i++) {
+            structRoundtrip.makeSimple()
+        }
+    })
+    benchmarkRunner("StructRoundtrip/roundtripSimple", () => {
+        for (let i = 0; i < iterations; i++) {
+            structRoundtrip.roundtripSimple({ name: "Hello", count: 42, flag: true, rate: 0.5, precise: 3.14159 })
+        }
+    })
+
+    benchmarkRunner("StructRoundtrip/takeAddress", () => {
+        for (let i = 0; i < iterations; i++) {
+            structRoundtrip.takeAddress({ street: "123 Main St", city: "San Francisco", zipCode: 94102 })
+        }
+    })
+    benchmarkRunner("StructRoundtrip/makeAddress", () => {
+        for (let i = 0; i < iterations; i++) {
+            structRoundtrip.makeAddress()
+        }
+    })
+    benchmarkRunner("StructRoundtrip/roundtripAddress", () => {
+        for (let i = 0; i < iterations; i++) {
+            structRoundtrip.roundtripAddress({ street: "123 Main St", city: "San Francisco", zipCode: 94102 })
+        }
+    })
+
+    benchmarkRunner("StructRoundtrip/takePerson", () => {
+        for (let i = 0; i < iterations; i++) {
+            structRoundtrip.takePerson({
+                name: "John Doe",
+                age: 30,
+                address: { street: "456 Oak Ave", city: "New York", zipCode: 10001 },
+                email: "john@example.com"
+            })
+        }
+    })
+    benchmarkRunner("StructRoundtrip/makePerson", () => {
+        for (let i = 0; i < iterations; i++) {
+            structRoundtrip.makePerson()
+        }
+    })
+    benchmarkRunner("StructRoundtrip/roundtripPerson", () => {
+        for (let i = 0; i < iterations; i++) {
+            structRoundtrip.roundtripPerson({
+                name: "John Doe",
+                age: 30,
+                address: { street: "456 Oak Ave", city: "New York", zipCode: 10001 },
+                email: "john@example.com"
+            })
+        }
+    })
+
+    benchmarkRunner("StructRoundtrip/takeComplex", () => {
+        for (let i = 0; i < iterations; i++) {
+            structRoundtrip.takeComplex({
+                id: 12345,
+                title: "Test Item",
+                active: true,
+                score: 98.6,
+                tags: "swift,wasm,benchmark",
+                metadata: "{\"version\":1}"
+            })
+        }
+    })
+    benchmarkRunner("StructRoundtrip/makeComplex", () => {
+        for (let i = 0; i < iterations; i++) {
+            structRoundtrip.makeComplex()
+        }
+    })
+    benchmarkRunner("StructRoundtrip/roundtripComplex", () => {
+        for (let i = 0; i < iterations; i++) {
+            structRoundtrip.roundtripComplex({
+                id: 12345,
+                title: "Test Item",
+                active: true,
+                score: 98.6,
+                tags: "swift,wasm,benchmark",
+                metadata: "{\"version\":1}"
+            })
+        }
+    })
+
+    // Class vs Struct comparison tests
+    const classRoundtrip = new exports.ClassRoundtrip();
+
+    benchmarkRunner("ClassRoundtrip/takeSimpleClass", () => {
+        const simple = new exports.SimpleClass("Hello", 42, true, 0.5, 3.14159)
+        for (let i = 0; i < iterations; i++) {
+            classRoundtrip.takeSimpleClass(simple)
+        }
+    })
+    benchmarkRunner("ClassRoundtrip/makeSimpleClass", () => {
+        for (let i = 0; i < iterations; i++) {
+            classRoundtrip.makeSimpleClass()
+        }
+    })
+    benchmarkRunner("ClassRoundtrip/roundtripSimpleClass", () => {
+        const simple = new exports.SimpleClass("Hello", 42, true, 0.5, 3.14159)
+        for (let i = 0; i < iterations; i++) {
+            classRoundtrip.roundtripSimpleClass(simple)
+        }
+    })
+
+    benchmarkRunner("ClassRoundtrip/takeAddressClass", () => {
+        const address = new exports.AddressClass("123 Main St", "San Francisco", 94102)
+        for (let i = 0; i < iterations; i++) {
+            classRoundtrip.takeAddressClass(address)
+        }
+    })
+    benchmarkRunner("ClassRoundtrip/makeAddressClass", () => {
+        for (let i = 0; i < iterations; i++) {
+            classRoundtrip.makeAddressClass()
+        }
+    })
+    benchmarkRunner("ClassRoundtrip/roundtripAddressClass", () => {
+        const address = new exports.AddressClass("123 Main St", "San Francisco", 94102)
+        for (let i = 0; i < iterations; i++) {
+            classRoundtrip.roundtripAddressClass(address)
         }
     })
 }


### PR DESCRIPTION
## Overview

This PR adds performance benchmarks for Swift structs, similar to the existing enum benchmarks. 
Also added some class equivalents for direct struct vs class comparison.

## Benchmark Coverage

  **Structs:**
  - `SimpleStruct` - 5 fields (String, Int, Bool, Float, Double)
  - `Address` - 3 fields (strings + int)
  - `Person` - nested struct with optional
  - `ComplexStruct` - 6 fields

  **Classes (for comparison with structs):**
  - `SimpleClass` - equivalent to SimpleStruct
  - `AddressClass` - equivalent to Address

 ## Results

 ### Struct Benchmarks

`node run.js --adaptive --filter=StructRoundtrip`

<img width="1832" height="554" alt="CleanShot 2025-12-23 at 19 06 44@2x" src="https://github.com/user-attachments/assets/e8f81952-621d-4155-a1b3-4ae698bc0d0e" />

  ### Struct vs Class Comparison

 `node run.js --adaptive '--filter=/Simple|Address/'`

<img width="1918" height="540" alt="CleanShot 2025-12-23 at 19 04 57@2x" src="https://github.com/user-attachments/assets/eb10f2fa-36ff-47ea-8306-82000379b8e0" />
