### PR TITLE
[NFC] BridgeJS: Codegen code organisation and minor cleanups

### DIFF
--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import JavaScriptKit
+import JavaScriptEventLoop
 
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "runJsWorks")
 @_extern(c)
@@ -1383,7 +1384,7 @@ class ExportAPITests: XCTestCase {
         XCTAssertTrue(hasDeinitCalculator, "Calculator (without @JS init) should have been deinitialized")
     }
 
-    // func testAllAsync() async throws {
-    //     _ = try await runAsyncWorks().value()
-    // }
+    func testAllAsync() async throws {
+        _ = try await runAsyncWorks().value()
+    }
 }


### PR DESCRIPTION
## Overview 

This PR extracts some codegen code from ExportSwift, as it became a bit large due to new types introduction. Some additional minor cleanup introduced along the way.

## Technical changes

- extracted specialized code generators into `ExportSwiftCodegens.swift` with updated and a bit more consistent naming
- added protocols codegen
- unified thunk body rendering (`renderFunctionBody(into:returnExpr:)` helper)
- shared property rendering for instance and static ones
- removed some unused parameters
 
## Testing 
I've fixed testing regression I've introduced [here](https://github.com/swiftwasm/JavaScriptKit/pull/480/changes#diff-fd034a6b3245c6475995a7497846e184065bf873d332a0bfbe4f2ad476356e74L1376) when I was trying to run some tests on macOS with Swift 6.2.1 and disabled async tests, sorry for that 🙇🏻  🙏🏻 
