### PR TITLE
Drop Swift 6.0 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,6 @@ jobs:
         entry:
           - os: ubuntu-22.04
             toolchain:
-              download-url: https://download.swift.org/swift-6.0.2-release/ubuntu2204/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE-ubuntu22.04.tar.gz
-            wasi-backend: Node
-            target: "wasm32-unknown-wasi"
-          - os: ubuntu-22.04
-            toolchain:
               download-url: https://download.swift.org/swift-6.1-release/ubuntu2204/swift-6.1-RELEASE/swift-6.1-RELEASE-ubuntu22.04.tar.gz
             wasi-backend: Node
             target: "wasm32-unknown-wasi"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 
 import CompilerPluginSupport
 import PackageDescription

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/Deploying-Pages.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/Deploying-Pages.md
@@ -63,7 +63,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    container: swift:6.0.3
+    container: swift:6.2
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Swift 6.0 has issues with macro usage in cross-compilation scenarios, which blocks https://github.com/swiftwasm/JavaScriptKit/pull/499