### PR TITLE
BridgeJS: Remove adhoc `exportedProtocolNameByKey` recording

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -26,7 +26,6 @@ public class ExportSwift {
     private var exportedEnums: [ExportedEnum] = []
     private var exportedStructs: [ExportedStruct] = []
     private var exportedProtocols: [ExportedProtocol] = []
-    private var exportedProtocolNameByKey: [String: String] = [:]
     private var typeDeclResolver: TypeDeclResolver = TypeDeclResolver()
     private var sourceFiles: [(sourceFile: SourceFileSyntax, inputFilePath: String)] = []
 
@@ -1136,8 +1135,6 @@ public class ExportSwift {
 
             stateStack.pop()
 
-            parent.exportedProtocolNameByKey[protocolUniqueKey] = name
-
             return .skipChildren
         }
 
@@ -1596,11 +1593,6 @@ public class ExportSwift {
         let typeName = type.trimmedDescription
         if let primitiveType = BridgeType(swiftType: typeName) {
             return primitiveType
-        }
-
-        let protocolKey = typeName
-        if let protocolName = exportedProtocolNameByKey[protocolKey] {
-            return .swiftProtocol(protocolName)
         }
 
         guard let typeDecl = typeDeclResolver.resolve(type) else {

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/TypeDeclResolver.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/TypeDeclResolver.swift
@@ -63,6 +63,12 @@ class TypeDeclResolver {
         override func visitPost(_ node: EnumDeclSyntax) {
             visitPostNominalDecl()
         }
+        override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+            return visitNominalDecl(node)
+        }
+        override func visitPost(_ node: ProtocolDeclSyntax) {
+            visitPostNominalDecl()
+        }
 
         override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
             let name = node.name.text


### PR DESCRIPTION
TypeDeclResolver should be responsible for handling this