### PR TITLE
BridgeJS: Unify Swift type lookup logic between import/export

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -25,6 +25,13 @@ public final class SwiftToSkeleton {
         self.moduleName = moduleName
         self.exposeToGlobal = exposeToGlobal
         self.typeDeclResolver = TypeDeclResolver()
+
+        // Index known types provided by JavaScriptKit
+        self.typeDeclResolver.addSourceFile(
+            """
+            @JSClass struct JSPromise {}
+            """
+        )
     }
 
     public func addSourceFile(_ sourceFile: SourceFileSyntax, inputFilePath: String) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.d.ts
@@ -7,6 +7,13 @@
 export type Exports = {
 }
 export type Imports = {
+    asyncReturnVoid(): JSPromise;
+    asyncRoundTripInt(v: number): JSPromise;
+    asyncRoundTripString(v: string): JSPromise;
+    asyncRoundTripBool(v: boolean): JSPromise;
+    asyncRoundTripFloat(v: number): JSPromise;
+    asyncRoundTripDouble(v: number): JSPromise;
+    asyncRoundTripJSObject(v: any): JSPromise;
 }
 export function createInstantiator(options: {
     imports: Imports;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.js
@@ -41,6 +41,7 @@ export async function createInstantiator(options, swift) {
         addImports: (importObject, importsContext) => {
             bjs = {};
             importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
             bjs["swift_js_return_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
                 tmpRetString = textDecoder.decode(bytes);
@@ -189,6 +190,72 @@ export async function createInstantiator(options, swift) {
                 const pointer = tmpRetOptionalHeapObject;
                 tmpRetOptionalHeapObject = undefined;
                 return pointer || 0;
+            }
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
+            TestModule["bjs_asyncReturnVoid"] = function bjs_asyncReturnVoid() {
+                try {
+                    let ret = imports.asyncReturnVoid();
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_asyncRoundTripInt"] = function bjs_asyncRoundTripInt(v) {
+                try {
+                    let ret = imports.asyncRoundTripInt(v);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_asyncRoundTripString"] = function bjs_asyncRoundTripString(v) {
+                try {
+                    const vObject = swift.memory.getObject(v);
+                    swift.memory.release(v);
+                    let ret = imports.asyncRoundTripString(vObject);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_asyncRoundTripBool"] = function bjs_asyncRoundTripBool(v) {
+                try {
+                    let ret = imports.asyncRoundTripBool(v !== 0);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_asyncRoundTripFloat"] = function bjs_asyncRoundTripFloat(v) {
+                try {
+                    let ret = imports.asyncRoundTripFloat(v);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_asyncRoundTripDouble"] = function bjs_asyncRoundTripDouble(v) {
+                try {
+                    let ret = imports.asyncRoundTripDouble(v);
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_asyncRoundTripJSObject"] = function bjs_asyncRoundTripJSObject(v) {
+                try {
+                    let ret = imports.asyncRoundTripJSObject(swift.memory.getObject(v));
+                    return swift.memory.retain(ret);
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
             }
         },
         setInstance: (i) => {


### PR DESCRIPTION
Importing-side signature type resolution now uses the same logic with ExportSwift.