### PR TITLE
Restrict @JSClass to structs

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSMacros/JSClassMacro.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSMacros/JSClassMacro.swift
@@ -12,6 +12,13 @@ extension JSClassMacro: MemberMacro {
         conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
+        guard declaration.is(StructDeclSyntax.self) else {
+            context.diagnose(
+                Diagnostic(node: Syntax(declaration), message: JSMacroMessage.unsupportedJSClassDeclaration)
+            )
+            return []
+        }
+
         var members: [DeclSyntax] = []
 
         let existingMembers = declaration.memberBlock.members
@@ -59,6 +66,7 @@ extension JSClassMacro: ExtensionMacro {
         conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
+        guard declaration.is(StructDeclSyntax.self) else { return [] }
         guard !protocols.isEmpty else { return [] }
 
         let conformanceList = protocols.map { $0.trimmed.description }.joined(separator: ", ")

--- a/Plugins/BridgeJS/Sources/BridgeJSMacros/JSMacroSupport.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSMacros/JSMacroSupport.swift
@@ -5,6 +5,7 @@ import SwiftDiagnostics
 
 enum JSMacroMessage: String, DiagnosticMessage {
     case unsupportedDeclaration = "@JSFunction can only be applied to functions or initializers."
+    case unsupportedJSClassDeclaration = "@JSClass can only be applied to structs."
     case unsupportedVariable = "@JSGetter can only be applied to single-variable declarations."
     case unsupportedSetterDeclaration = "@JSSetter can only be applied to functions."
     case invalidSetterName =

--- a/Plugins/BridgeJS/Tests/BridgeJSMacrosTests/JSClassMacroTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSMacrosTests/JSClassMacroTests.swift
@@ -153,16 +153,15 @@ import BridgeJSMacros
             """,
             expandedSource: """
                 class MyClass {
-                    let jsObject: JSObject
-
-                    init(unsafelyWrapping jsObject: JSObject) {
-                        self.jsObject = jsObject
-                    }
-                }
-
-                extension MyClass: _JSBridgedClass {
                 }
                 """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "@JSClass can only be applied to structs.",
+                    line: 1,
+                    column: 1
+                )
+            ],
             macroSpecs: macroSpecs,
             indentationWidth: indentationWidth
         )
@@ -177,16 +176,15 @@ import BridgeJSMacros
             """,
             expandedSource: """
                 enum MyEnum {
-                    let jsObject: JSObject
-
-                    init(unsafelyWrapping jsObject: JSObject) {
-                        self.jsObject = jsObject
-                    }
-                }
-
-                extension MyEnum: _JSBridgedClass {
                 }
                 """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "@JSClass can only be applied to structs.",
+                    line: 1,
+                    column: 1
+                )
+            ],
             macroSpecs: macroSpecs,
             indentationWidth: indentationWidth
         )
@@ -201,16 +199,15 @@ import BridgeJSMacros
             """,
             expandedSource: """
                 actor MyActor {
-                    let jsObject: JSObject
-
-                    init(unsafelyWrapping jsObject: JSObject) {
-                        self.jsObject = jsObject
-                    }
-                }
-
-                extension MyActor: _JSBridgedClass {
                 }
                 """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "@JSClass can only be applied to structs.",
+                    line: 1,
+                    column: 1
+                )
+            ],
             macroSpecs: macroSpecs,
             indentationWidth: indentationWidth
         )


### PR DESCRIPTION
BridgeJS uses @JSClass to model JS objects as value types, but the macro could be applied to other declaration kinds.

Make @JSClass emit a diagnostic unless it’s attached to a struct, and adjust macro tests accordingly.