### PR TITLE
BridgeJS: add init(unsafelyCopying:) for @JS structs

### DIFF
--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -267,7 +267,49 @@ extension SimpleStruct: _BridgedSwiftStruct {
         _swift_js_push_f32(self.rate)
         _swift_js_push_f64(self.precise)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _SimpleStructHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _SimpleStructHelpers.raise()
+    }
 }
+
+fileprivate enum _SimpleStructHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_SimpleStruct(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_SimpleStruct()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_SimpleStruct")
+fileprivate func _bjs_struct_lower_SimpleStruct(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_SimpleStruct(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_SimpleStruct")
+fileprivate func _bjs_struct_raise_SimpleStruct() -> Int32
+#else
+fileprivate func _bjs_struct_raise_SimpleStruct() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 extension Address: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Address {
@@ -288,7 +330,49 @@ extension Address: _BridgedSwiftStruct {
         }
         _swift_js_push_int(Int32(self.zipCode))
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _AddressHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _AddressHelpers.raise()
+    }
 }
+
+fileprivate enum _AddressHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Address()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Address")
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Address")
+fileprivate func _bjs_struct_raise_Address() -> Int32
+#else
+fileprivate func _bjs_struct_raise_Address() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 extension Person: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Person {
@@ -315,7 +399,49 @@ extension Person: _BridgedSwiftStruct {
         }
         _swift_js_push_int(__bjs_isSome_email ? 1 : 0)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _PersonHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _PersonHelpers.raise()
+    }
 }
+
+fileprivate enum _PersonHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_Person(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Person()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Person")
+fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Person")
+fileprivate func _bjs_struct_raise_Person() -> Int32
+#else
+fileprivate func _bjs_struct_raise_Person() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 extension ComplexStruct: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ComplexStruct {
@@ -345,7 +471,49 @@ extension ComplexStruct: _BridgedSwiftStruct {
             _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
         }
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _ComplexStructHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _ComplexStructHelpers.raise()
+    }
 }
+
+fileprivate enum _ComplexStructHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_ComplexStruct(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_ComplexStruct()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ComplexStruct")
+fileprivate func _bjs_struct_lower_ComplexStruct(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_ComplexStruct(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_ComplexStruct")
+fileprivate func _bjs_struct_raise_ComplexStruct() -> Int32
+#else
+fileprivate func _bjs_struct_raise_ComplexStruct() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 @_expose(wasm, "bjs_run")
 @_cdecl("bjs_run")

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -74,7 +74,7 @@ public class ExportSwift {
 
         let structCodegen = StructCodegen()
         for structDef in skeleton.structs {
-            decls.append(structCodegen.renderStructHelpers(structDef))
+            decls.append(contentsOf: structCodegen.renderStructHelpers(structDef))
             decls.append(contentsOf: try renderSingleExportedStruct(struct: structDef))
         }
 
@@ -1147,12 +1147,19 @@ struct EnumCodegen {
 struct StructCodegen {
     private let stackCodegen = StackCodegen()
 
-    func renderStructHelpers(_ structDef: ExportedStruct) -> DeclSyntax {
+    func renderStructHelpers(_ structDef: ExportedStruct) -> [DeclSyntax] {
         let typeName = structDef.swiftCallName
         let liftCode = generateStructLiftCode(structDef: structDef)
         let lowerCode = generateStructLowerCode(structDef: structDef)
+        let accessControl = structDef.explicitAccessControl.map { "\($0) " } ?? ""
 
-        return """
+        let helpersTypeName = "_\(structDef.name)Helpers"
+        let lowerExternName = "swift_js_struct_lower_\(structDef.name)"
+        let raiseExternName = "swift_js_struct_raise_\(structDef.name)"
+        let lowerFunctionName = "_bjs_struct_lower_\(structDef.name)"
+        let raiseFunctionName = "_bjs_struct_raise_\(structDef.name)"
+
+        let bridgedStructExtension: DeclSyntax = """
             extension \(raw: typeName): _BridgedSwiftStruct {
                 @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> \(raw: typeName) {
                     \(raw: liftCode.joined(separator: "\n"))
@@ -1161,8 +1168,83 @@ struct StructCodegen {
                 @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
                     \(raw: lowerCode.joined(separator: "\n"))
                 }
+
+                \(raw: accessControl)init(unsafelyCopying jsObject: JSObject) {
+                    let __bjs_cleanupId = \(raw: helpersTypeName).lower(jsObject)
+                    defer { _swift_js_struct_cleanup(__bjs_cleanupId) }
+                    self = Self.bridgeJSLiftParameter()
+                }
+
+                \(raw: accessControl)func toJSObject() -> JSObject {
+                    var __bjs_self = self
+                    __bjs_self.bridgeJSLowerReturn()
+                    return \(raw: helpersTypeName).raise()
+                }
             }
             """
+
+        let helpersType: DeclSyntax = """
+            fileprivate enum \(raw: helpersTypeName) {
+                static func lower(_ jsObject: JSObject) -> Int32 {
+                    return \(raw: lowerFunctionName)(jsObject.bridgeJSLowerParameter())
+                }
+
+                static func raise() -> JSObject {
+                    return JSObject(id: UInt32(bitPattern: \(raw: raiseFunctionName)()))
+                }
+            }
+            """
+
+        let lowerExternDecl = Self.renderStructExtern(
+            externName: lowerExternName,
+            functionName: lowerFunctionName,
+            signature: SwiftSignatureBuilder.buildABIFunctionSignature(
+                abiParameters: [("objectId", .i32)],
+                returnType: .i32
+            )
+        )
+        let raiseExternDecl = Self.renderStructExtern(
+            externName: raiseExternName,
+            functionName: raiseFunctionName,
+            signature: SwiftSignatureBuilder.buildABIFunctionSignature(
+                abiParameters: [],
+                returnType: .i32
+            )
+        )
+
+        return [bridgedStructExtension, helpersType, lowerExternDecl, raiseExternDecl]
+    }
+
+    private static func renderStructExtern(
+        externName: String,
+        functionName: String,
+        signature: FunctionSignatureSyntax
+    ) -> DeclSyntax {
+        let externFuncDecl = SwiftCodePattern.buildExternFunctionDecl(
+            moduleName: "bjs",
+            abiName: externName,
+            functionName: functionName,
+            signature: signature
+        )
+
+        let stubFuncDecl = FunctionDeclSyntax(
+            modifiers: DeclModifierListSyntax {
+                DeclModifierSyntax(name: .keyword(.fileprivate))
+            },
+            funcKeyword: .keyword(.func),
+            name: .identifier(functionName),
+            signature: signature,
+            body: CodeBlockSyntax {
+                "fatalError(\"Only available on WebAssembly\")"
+            }
+        )
+
+        return DeclSyntax(
+            SwiftCodePattern.buildWasmConditionalCompilationDecls(
+                wasmDecl: DeclSyntax(externFuncDecl),
+                elseDecl: DeclSyntax(stubFuncDecl)
+            )
+        )
     }
 
     private func generateStructLiftCode(structDef: ExportedStruct) -> [String] {

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -30,6 +30,7 @@ final class JSGlueVariableScope {
     static let reservedTmpParamF64s = "tmpParamF64s"
     static let reservedTmpRetPointers = "tmpRetPointers"
     static let reservedTmpParamPointers = "tmpParamPointers"
+    static let reservedTmpStructCleanups = "tmpStructCleanups"
     static let reservedEnumHelpers = "enumHelpers"
     static let reservedStructHelpers = "structHelpers"
 
@@ -58,6 +59,7 @@ final class JSGlueVariableScope {
         reservedTmpParamF64s,
         reservedTmpRetPointers,
         reservedTmpParamPointers,
+        reservedTmpStructCleanups,
         reservedEnumHelpers,
         reservedStructHelpers,
     ]

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayParameter.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayParameter.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.Export.js
@@ -503,6 +503,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -574,6 +575,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.Export.js
@@ -52,6 +52,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -123,6 +124,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.js
@@ -53,6 +53,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -124,6 +125,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.Export.js
@@ -72,6 +72,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -143,6 +144,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.Export.js
@@ -103,6 +103,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -174,6 +175,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.ImportMacros.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.ImportMacros.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Interface.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Interface.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.Export.js
@@ -92,6 +92,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -163,6 +164,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ReExportFrom.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ReExportFrom.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Export.js
@@ -79,6 +79,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -150,6 +151,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.Export.js
@@ -79,6 +79,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -150,6 +151,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Export.js
@@ -33,6 +33,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -104,6 +105,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.Export.js
@@ -33,6 +33,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -104,6 +105,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringEnum.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringEnum.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.Export.js
@@ -130,6 +130,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -201,6 +202,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.ImportMacros.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.ImportMacros.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -259,6 +260,71 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
+            }
+            bjs["swift_js_struct_lower_DataPoint"] = function(objectId) {
+                const { cleanup: cleanup } = structHelpers.DataPoint.lower(swift.memory.getObject(objectId));
+                if (cleanup) {
+                    return tmpStructCleanups.push(cleanup);
+                }
+                return 0;
+            }
+            bjs["swift_js_struct_raise_DataPoint"] = function() {
+                const value = structHelpers.DataPoint.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                return swift.memory.retain(value);
+            }
+            bjs["swift_js_struct_lower_Address"] = function(objectId) {
+                const { cleanup: cleanup } = structHelpers.Address.lower(swift.memory.getObject(objectId));
+                if (cleanup) {
+                    return tmpStructCleanups.push(cleanup);
+                }
+                return 0;
+            }
+            bjs["swift_js_struct_raise_Address"] = function() {
+                const value = structHelpers.Address.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                return swift.memory.retain(value);
+            }
+            bjs["swift_js_struct_lower_Person"] = function(objectId) {
+                const { cleanup: cleanup } = structHelpers.Person.lower(swift.memory.getObject(objectId));
+                if (cleanup) {
+                    return tmpStructCleanups.push(cleanup);
+                }
+                return 0;
+            }
+            bjs["swift_js_struct_raise_Person"] = function() {
+                const value = structHelpers.Person.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                return swift.memory.retain(value);
+            }
+            bjs["swift_js_struct_lower_Session"] = function(objectId) {
+                const { cleanup: cleanup } = structHelpers.Session.lower(swift.memory.getObject(objectId));
+                if (cleanup) {
+                    return tmpStructCleanups.push(cleanup);
+                }
+                return 0;
+            }
+            bjs["swift_js_struct_raise_Session"] = function() {
+                const value = structHelpers.Session.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                return swift.memory.retain(value);
+            }
+            bjs["swift_js_struct_lower_ConfigStruct"] = function(objectId) {
+                const { cleanup: cleanup } = structHelpers.ConfigStruct.lower(swift.memory.getObject(objectId));
+                if (cleanup) {
+                    return tmpStructCleanups.push(cleanup);
+                }
+                return 0;
+            }
+            bjs["swift_js_struct_raise_ConfigStruct"] = function() {
+                const value = structHelpers.ConfigStruct.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeAlias.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeAlias.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeScriptClass.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeScriptClass.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Export.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -99,6 +100,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Import.js
@@ -28,6 +28,7 @@ export async function createInstantiator(options, swift) {
     let tmpParamF64s = [];
     let tmpRetPointers = [];
     let tmpParamPointers = [];
+    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +101,16 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.swift
@@ -53,7 +53,49 @@ extension Config: _BridgedSwiftStruct {
         _swift_js_push_int(Int32(self.value))
         _swift_js_push_int(self.enabled ? 1 : 0)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _ConfigHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _ConfigHelpers.raise()
+    }
 }
+
+fileprivate enum _ConfigHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_Config(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Config()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Config")
+fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Config")
+fileprivate func _bjs_struct_raise_Config() -> Int32
+#else
+fileprivate func _bjs_struct_raise_Config() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 extension MathOperations: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> MathOperations {
@@ -64,7 +106,49 @@ extension MathOperations: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
         _swift_js_push_f64(self.baseValue)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _MathOperationsHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _MathOperationsHelpers.raise()
+    }
 }
+
+fileprivate enum _MathOperationsHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_MathOperations(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_MathOperations()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_MathOperations")
+fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_MathOperations")
+fileprivate func _bjs_struct_raise_MathOperations() -> Int32
+#else
+fileprivate func _bjs_struct_raise_MathOperations() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 @_expose(wasm, "bjs_MathOperations_init")
 @_cdecl("bjs_MathOperations_init")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftStruct.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftStruct.swift
@@ -26,7 +26,49 @@ extension DataPoint: _BridgedSwiftStruct {
         }
         _swift_js_push_int(__bjs_isSome_optFlag ? 1 : 0)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _DataPointHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _DataPointHelpers.raise()
+    }
 }
+
+fileprivate enum _DataPointHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_DataPoint(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_DataPoint()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_DataPoint")
+fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_DataPoint")
+fileprivate func _bjs_struct_raise_DataPoint() -> Int32
+#else
+fileprivate func _bjs_struct_raise_DataPoint() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 @_expose(wasm, "bjs_DataPoint_init")
 @_cdecl("bjs_DataPoint_init")
@@ -62,7 +104,49 @@ extension Address: _BridgedSwiftStruct {
         }
         _swift_js_push_int(__bjs_isSome_zipCode ? 1 : 0)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _AddressHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _AddressHelpers.raise()
+    }
 }
+
+fileprivate enum _AddressHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Address()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Address")
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Address")
+fileprivate func _bjs_struct_raise_Address() -> Int32
+#else
+fileprivate func _bjs_struct_raise_Address() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 extension Person: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Person {
@@ -89,7 +173,49 @@ extension Person: _BridgedSwiftStruct {
         }
         _swift_js_push_int(__bjs_isSome_email ? 1 : 0)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _PersonHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _PersonHelpers.raise()
+    }
 }
+
+fileprivate enum _PersonHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_Person(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Person()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Person")
+fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Person")
+fileprivate func _bjs_struct_raise_Person() -> Int32
+#else
+fileprivate func _bjs_struct_raise_Person() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 extension Session: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Session {
@@ -102,7 +228,49 @@ extension Session: _BridgedSwiftStruct {
         _swift_js_push_int(Int32(self.id))
         _swift_js_push_pointer(self.owner.bridgeJSLowerReturn())
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _SessionHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _SessionHelpers.raise()
+    }
 }
+
+fileprivate enum _SessionHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_Session(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Session()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Session")
+fileprivate func _bjs_struct_lower_Session(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_Session(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Session")
+fileprivate func _bjs_struct_raise_Session() -> Int32
+#else
+fileprivate func _bjs_struct_raise_Session() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 extension ConfigStruct: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ConfigStruct {
@@ -112,7 +280,49 @@ extension ConfigStruct: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
 
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _ConfigStructHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _ConfigStructHelpers.raise()
+    }
 }
+
+fileprivate enum _ConfigStructHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_ConfigStruct(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_ConfigStruct()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ConfigStruct")
+fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_ConfigStruct")
+fileprivate func _bjs_struct_raise_ConfigStruct() -> Int32
+#else
+fileprivate func _bjs_struct_raise_ConfigStruct() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 @_expose(wasm, "bjs_ConfigStruct_static_maxRetries_get")
 @_cdecl("bjs_ConfigStruct_static_maxRetries_get")

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -441,6 +441,17 @@ where Self: RawRepresentable, RawValue: _BridgedSwiftTypeLoweredIntoSingleWasmCo
 }
 #endif
 
+// MARK: Struct bridging helpers (JS-side lowering/raising)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_cleanup")
+@_spi(BridgeJS) public func _swift_js_struct_cleanup(_ cleanupId: Int32)
+#else
+@_spi(BridgeJS) public func _swift_js_struct_cleanup(_ cleanupId: Int32) {
+    _onlyAvailableOnWasm()
+}
+#endif
+
 // MARK: Wasm externs used by type lowering/lifting
 
 #if arch(wasm32)

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -1318,6 +1318,38 @@ enum APIOptionalResult {
     return "\(point.x),\(point.y),\(point.label)"
 }
 
+@JS struct CopyableCart {
+    var x: Int
+    var note: String?
+
+    @JS static func fromJSObject(_ object: JSObject) -> CopyableCart {
+        CopyableCart(unsafelyCopying: object)
+    }
+}
+
+@JS func cartToJSObject(_ cart: CopyableCart) -> JSObject {
+    cart.toJSObject()
+}
+
+@JS struct CopyableCartItem {
+    var sku: String
+    var quantity: Int
+}
+
+@JS struct CopyableNestedCart {
+    var id: Int
+    var item: CopyableCartItem
+    var shippingAddress: Address?
+
+    @JS static func fromJSObject(_ object: JSObject) -> CopyableNestedCart {
+        CopyableNestedCart(unsafelyCopying: object)
+    }
+}
+
+@JS func nestedCartToJSObject(_ cart: CopyableNestedCart) -> JSObject {
+    cart.toJSObject()
+}
+
 @JS struct ConfigStruct {
     var name: String
     var value: Int

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -2240,7 +2240,49 @@ extension DataPoint: _BridgedSwiftStruct {
         }
         _swift_js_push_int(__bjs_isSome_optFlag ? 1 : 0)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _DataPointHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _DataPointHelpers.raise()
+    }
 }
+
+fileprivate enum _DataPointHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_DataPoint(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_DataPoint()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_DataPoint")
+fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_DataPoint")
+fileprivate func _bjs_struct_raise_DataPoint() -> Int32
+#else
+fileprivate func _bjs_struct_raise_DataPoint() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 @_expose(wasm, "bjs_DataPoint_init")
 @_cdecl("bjs_DataPoint_init")
@@ -2276,7 +2318,49 @@ extension Address: _BridgedSwiftStruct {
         }
         _swift_js_push_int(__bjs_isSome_zipCode ? 1 : 0)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _AddressHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _AddressHelpers.raise()
+    }
 }
+
+fileprivate enum _AddressHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Address()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Address")
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Address")
+fileprivate func _bjs_struct_raise_Address() -> Int32
+#else
+fileprivate func _bjs_struct_raise_Address() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 extension Contact: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Contact {
@@ -2309,7 +2393,49 @@ extension Contact: _BridgedSwiftStruct {
         }
         _swift_js_push_int(__bjs_isSome_secondaryAddress ? 1 : 0)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _ContactHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _ContactHelpers.raise()
+    }
 }
+
+fileprivate enum _ContactHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_Contact(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Contact()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Contact")
+fileprivate func _bjs_struct_lower_Contact(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_Contact(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Contact")
+fileprivate func _bjs_struct_raise_Contact() -> Int32
+#else
+fileprivate func _bjs_struct_raise_Contact() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 extension Config: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Config {
@@ -2340,7 +2466,49 @@ extension Config: _BridgedSwiftStruct {
         _swift_js_push_int(__bjs_isSome_direction ? 1 : 0)
         _swift_js_push_int(Int32(self.status.bridgeJSLowerParameter()))
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _ConfigHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _ConfigHelpers.raise()
+    }
 }
+
+fileprivate enum _ConfigHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_Config(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Config()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Config")
+fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Config")
+fileprivate func _bjs_struct_raise_Config() -> Int32
+#else
+fileprivate func _bjs_struct_raise_Config() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 extension SessionData: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> SessionData {
@@ -2357,7 +2525,49 @@ extension SessionData: _BridgedSwiftStruct {
         }
         _swift_js_push_int(__bjs_isSome_owner ? 1 : 0)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _SessionDataHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _SessionDataHelpers.raise()
+    }
 }
+
+fileprivate enum _SessionDataHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_SessionData(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_SessionData()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_SessionData")
+fileprivate func _bjs_struct_lower_SessionData(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_SessionData(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_SessionData")
+fileprivate func _bjs_struct_raise_SessionData() -> Int32
+#else
+fileprivate func _bjs_struct_raise_SessionData() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 extension ValidationReport: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ValidationReport {
@@ -2382,7 +2592,49 @@ extension ValidationReport: _BridgedSwiftStruct {
         }
         _swift_js_push_int(__bjs_isSome_outcome ? 1 : 0)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _ValidationReportHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _ValidationReportHelpers.raise()
+    }
 }
+
+fileprivate enum _ValidationReportHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_ValidationReport(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_ValidationReport()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ValidationReport")
+fileprivate func _bjs_struct_lower_ValidationReport(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_ValidationReport(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_ValidationReport")
+fileprivate func _bjs_struct_raise_ValidationReport() -> Int32
+#else
+fileprivate func _bjs_struct_raise_ValidationReport() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 extension MathOperations: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> MathOperations {
@@ -2393,7 +2645,49 @@ extension MathOperations: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
         _swift_js_push_f64(self.baseValue)
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _MathOperationsHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _MathOperationsHelpers.raise()
+    }
 }
+
+fileprivate enum _MathOperationsHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_MathOperations(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_MathOperations()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_MathOperations")
+fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_MathOperations")
+fileprivate func _bjs_struct_raise_MathOperations() -> Int32
+#else
+fileprivate func _bjs_struct_raise_MathOperations() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 @_expose(wasm, "bjs_MathOperations_init")
 @_cdecl("bjs_MathOperations_init")
@@ -2439,6 +2733,209 @@ public func _bjs_MathOperations_static_subtract(_ a: Float64, _ b: Float64) -> F
     #endif
 }
 
+extension CopyableCart: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> CopyableCart {
+        let note = Optional<String>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32(), _swift_js_pop_param_int32())
+        let x = Int.bridgeJSLiftParameter(_swift_js_pop_param_int32())
+        return CopyableCart(x: x, note: note)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        _swift_js_push_int(Int32(self.x))
+        let __bjs_isSome_note = self.note != nil
+        if let __bjs_unwrapped_note = self.note {
+            var __bjs_str_note = __bjs_unwrapped_note
+            __bjs_str_note.withUTF8 { ptr in
+                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+            }
+        }
+        _swift_js_push_int(__bjs_isSome_note ? 1 : 0)
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _CopyableCartHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _CopyableCartHelpers.raise()
+    }
+}
+
+fileprivate enum _CopyableCartHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_CopyableCart(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_CopyableCart()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_CopyableCart")
+fileprivate func _bjs_struct_lower_CopyableCart(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_CopyableCart(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_CopyableCart")
+fileprivate func _bjs_struct_raise_CopyableCart() -> Int32
+#else
+fileprivate func _bjs_struct_raise_CopyableCart() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_CopyableCart_static_fromJSObject")
+@_cdecl("bjs_CopyableCart_static_fromJSObject")
+public func _bjs_CopyableCart_static_fromJSObject(_ object: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = CopyableCart.fromJSObject(_: JSObject.bridgeJSLiftParameter(object))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension CopyableCartItem: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> CopyableCartItem {
+        let quantity = Int.bridgeJSLiftParameter(_swift_js_pop_param_int32())
+        let sku = String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32())
+        return CopyableCartItem(sku: sku, quantity: quantity)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        var __bjs_sku = self.sku
+        __bjs_sku.withUTF8 { ptr in
+            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+        }
+        _swift_js_push_int(Int32(self.quantity))
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _CopyableCartItemHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _CopyableCartItemHelpers.raise()
+    }
+}
+
+fileprivate enum _CopyableCartItemHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_CopyableCartItem(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_CopyableCartItem()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_CopyableCartItem")
+fileprivate func _bjs_struct_lower_CopyableCartItem(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_CopyableCartItem(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_CopyableCartItem")
+fileprivate func _bjs_struct_raise_CopyableCartItem() -> Int32
+#else
+fileprivate func _bjs_struct_raise_CopyableCartItem() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+extension CopyableNestedCart: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> CopyableNestedCart {
+        let shippingAddress = Optional<Address>.bridgeJSLiftParameter(_swift_js_pop_param_int32())
+        let item = CopyableCartItem.bridgeJSLiftParameter()
+        let id = Int.bridgeJSLiftParameter(_swift_js_pop_param_int32())
+        return CopyableNestedCart(id: id, item: item, shippingAddress: shippingAddress)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        _swift_js_push_int(Int32(self.id))
+        self.item.bridgeJSLowerReturn()
+        let __bjs_isSome_shippingAddress = self.shippingAddress != nil
+        if let __bjs_unwrapped_shippingAddress = self.shippingAddress {
+            __bjs_unwrapped_shippingAddress.bridgeJSLowerReturn()
+        }
+        _swift_js_push_int(__bjs_isSome_shippingAddress ? 1 : 0)
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _CopyableNestedCartHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _CopyableNestedCartHelpers.raise()
+    }
+}
+
+fileprivate enum _CopyableNestedCartHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_CopyableNestedCart(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_CopyableNestedCart()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_CopyableNestedCart")
+fileprivate func _bjs_struct_lower_CopyableNestedCart(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_CopyableNestedCart(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_CopyableNestedCart")
+fileprivate func _bjs_struct_raise_CopyableNestedCart() -> Int32
+#else
+fileprivate func _bjs_struct_raise_CopyableNestedCart() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_CopyableNestedCart_static_fromJSObject")
+@_cdecl("bjs_CopyableNestedCart_static_fromJSObject")
+public func _bjs_CopyableNestedCart_static_fromJSObject(_ object: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = CopyableNestedCart.fromJSObject(_: JSObject.bridgeJSLiftParameter(object))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 extension ConfigStruct: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ConfigStruct {
         let value = Int.bridgeJSLiftParameter(_swift_js_pop_param_int32())
@@ -2453,7 +2950,49 @@ extension ConfigStruct: _BridgedSwiftStruct {
         }
         _swift_js_push_int(Int32(self.value))
     }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _ConfigStructHelpers.lower(jsObject)
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        var __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return _ConfigStructHelpers.raise()
+    }
 }
+
+fileprivate enum _ConfigStructHelpers {
+    static func lower(_ jsObject: JSObject) -> Int32 {
+        return _bjs_struct_lower_ConfigStruct(jsObject.bridgeJSLowerParameter())
+    }
+
+    static func raise() -> JSObject {
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_ConfigStruct()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ConfigStruct")
+fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_ConfigStruct")
+fileprivate func _bjs_struct_raise_ConfigStruct() -> Int32
+#else
+fileprivate func _bjs_struct_raise_ConfigStruct() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
 
 @_expose(wasm, "bjs_ConfigStruct_static_defaultConfig_get")
 @_cdecl("bjs_ConfigStruct_static_defaultConfig_get")
@@ -3852,6 +4391,28 @@ public func _bjs_makeAdder(_ base: Int32) -> UnsafeMutableRawPointer {
 public func _bjs_testStructDefault() -> Void {
     #if arch(wasm32)
     let ret = testStructDefault(point: DataPoint.bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_cartToJSObject")
+@_cdecl("bjs_cartToJSObject")
+public func _bjs_cartToJSObject() -> Int32 {
+    #if arch(wasm32)
+    let ret = cartToJSObject(_: CopyableCart.bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_nestedCartToJSObject")
+@_cdecl("bjs_nestedCartToJSObject")
+public func _bjs_nestedCartToJSObject() -> Int32 {
+    #if arch(wasm32)
+    let ret = nestedCartToJSObject(_: CopyableNestedCart.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -7743,6 +7743,56 @@
         }
       },
       {
+        "abiName" : "bjs_cartToJSObject",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "cartToJSObject",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "cart",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "CopyableCart"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "jsObject" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_nestedCartToJSObject",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "nestedCartToJSObject",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "cart",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "CopyableNestedCart"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "jsObject" : {
+
+          }
+        }
+      },
+      {
         "abiName" : "bjs_roundTripDataPoint",
         "effects" : {
           "isAsync" : false,
@@ -8854,6 +8904,169 @@
           }
         ],
         "swiftCallName" : "MathOperations"
+      },
+      {
+        "methods" : [
+          {
+            "abiName" : "bjs_CopyableCart_static_fromJSObject",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "fromJSObject",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "object",
+                "type" : {
+                  "jsObject" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "swiftStruct" : {
+                "_0" : "CopyableCart"
+              }
+            },
+            "staticContext" : {
+              "structName" : {
+                "_0" : "CopyableCart"
+              }
+            }
+          }
+        ],
+        "name" : "CopyableCart",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "x",
+            "type" : {
+              "int" : {
+
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "note",
+            "type" : {
+              "optional" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "CopyableCart"
+      },
+      {
+        "methods" : [
+
+        ],
+        "name" : "CopyableCartItem",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "sku",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "quantity",
+            "type" : {
+              "int" : {
+
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "CopyableCartItem"
+      },
+      {
+        "methods" : [
+          {
+            "abiName" : "bjs_CopyableNestedCart_static_fromJSObject",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "fromJSObject",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "object",
+                "type" : {
+                  "jsObject" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "swiftStruct" : {
+                "_0" : "CopyableNestedCart"
+              }
+            },
+            "staticContext" : {
+              "structName" : {
+                "_0" : "CopyableNestedCart"
+              }
+            }
+          }
+        ],
+        "name" : "CopyableNestedCart",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "id",
+            "type" : {
+              "int" : {
+
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "item",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "CopyableCartItem"
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "shippingAddress",
+            "type" : {
+              "optional" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "Address"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "CopyableNestedCart"
       },
       {
         "methods" : [

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -1032,6 +1032,31 @@ function testStructSupport(exports) {
     const customPoint = { x: 10.0, y: 20.0, label: "custom", optCount: null, optFlag: null };
     assert.equal(exports.testStructDefault(customPoint), "10.0,20.0,custom");
 
+    // Test @JS struct init(unsafelyCopying:) + toJSObject()
+    const cart1 = { x: 123, note: "hello" };
+    assert.deepEqual(exports.CopyableCart.fromJSObject(cart1), cart1);
+    assert.deepEqual(exports.cartToJSObject(cart1), cart1);
+
+    const cart2 = { x: 1 };
+    assert.deepEqual(exports.CopyableCart.fromJSObject(cart2), { x: 1, note: null });
+    assert.deepEqual(exports.cartToJSObject(cart2), { x: 1, note: null });
+
+    const nestedCart1 = {
+        id: 7,
+        item: { sku: "ABC-123", quantity: 2 },
+        shippingAddress: { street: "1 Swift Way", city: "WasmCity", zipCode: 12345 },
+    };
+    assert.deepEqual(exports.CopyableNestedCart.fromJSObject(nestedCart1), nestedCart1);
+    assert.deepEqual(exports.nestedCartToJSObject(nestedCart1), nestedCart1);
+
+    const nestedCart2 = {
+        id: 8,
+        item: { sku: "XYZ-999", quantity: 0 },
+        shippingAddress: null,
+    };
+    assert.deepEqual(exports.CopyableNestedCart.fromJSObject(nestedCart2), nestedCart2);
+    assert.deepEqual(exports.nestedCartToJSObject(nestedCart2), nestedCart2);
+
     const container = exports.testContainerWithStruct({ x: 5.0, y: 10.0, label: "test", optCount: null, optFlag: true });
     assert.equal(container.location.x, 5.0);
     assert.equal(container.config, null);


### PR DESCRIPTION
Motivation: enable ergonomic interop with JSON-style plain objects (e.g. JSON.parse results) without hand-written field mapping, while keeping exported structs as value types.

Changes:
- Generate init(unsafelyCopying:) and toJSObject() for @JS struct via per-struct JS helper shims.
- Add JS glue support for struct lower/raise, plus a cleanup hook for temporary allocations created during lowering.
- Add runtime unit tests for nested structs and optionals; update generated artifacts and snapshots.
