### PR TITLE
Turn JSValue from enum to struct to have flexibility for future changes

### DIFF
--- a/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSPromise.swift
@@ -31,7 +31,7 @@ public final class JSPromise: JSBridgedClass {
     /// is not an object and is not an instance of JavaScript `Promise`, this function will
     /// return `nil`.
     public static func construct(from value: JSValue) -> Self? {
-        guard case .object(let jsObject) = value else { return nil }
+        guard let jsObject = value.object else { return nil }
         return Self(jsObject)
     }
 

--- a/Sources/JavaScriptKit/ConvertibleToJSValue.swift
+++ b/Sources/JavaScriptKit/ConvertibleToJSValue.swift
@@ -222,7 +222,7 @@ extension JSValue {
         let kind: JavaScriptValueKind
         let payload1: JavaScriptPayload1
         var payload2: JavaScriptPayload2 = 0
-        switch self {
+        switch self.storage {
         case .boolean(let boolValue):
             kind = .boolean
             payload1 = boolValue ? 1 : 0

--- a/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
+++ b/Sources/JavaScriptKit/FundamentalObjects/JSObject.swift
@@ -249,7 +249,7 @@ public class JSObject: Equatable, ExpressibleByDictionaryLiteral {
     }
 
     public static func construct(from value: JSValue) -> Self? {
-        switch value {
+        switch value.storage {
         case .boolean,
             .string,
             .number,

--- a/Sources/JavaScriptKit/JSValueDecoder.swift
+++ b/Sources/JavaScriptKit/JSValueDecoder.swift
@@ -159,7 +159,11 @@ private struct _UnkeyedDecodingContainer: UnkeyedDecodingContainer {
 
     init(decoder: _Decoder, ref: JSObject) {
         self.decoder = decoder
-        count = ref.length.number.map(Int.init)
+        if let count = ref.length.number {
+            self.count = Int(count)
+        } else {
+            self.count = nil
+        }
         self.ref = ref
     }
 

--- a/Tests/JavaScriptKitTests/JavaScriptKitTests.swift
+++ b/Tests/JavaScriptKitTests/JavaScriptKitTests.swift
@@ -21,8 +21,8 @@ class JavaScriptKitTests: XCTestCase {
             let prop = JSString("prop_\(index)")
             setJSValue(this: global, name: prop, value: input)
             let got = getJSValue(this: global, name: prop)
-            switch (got, input) {
-            case (.number(let lhs), .number(let rhs)):
+            switch (got.number, input.number) {
+            case (let lhs?, let rhs?):
                 // Compare bitPattern because nan == nan is always false
                 XCTAssertEqual(lhs.bitPattern, rhs.bitPattern)
             default:


### PR DESCRIPTION
Let's hide the internal storage to have more flexibility for future changes like unifying `symbol` and `object` cases into a single case