### PR TITLE
BridgeJS: Use let for non-mutated __bjs_self in generated toJSObject()

### DIFF
--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -277,7 +277,7 @@ extension SimpleStruct: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_SimpleStruct()))
     }
@@ -330,7 +330,7 @@ extension Address: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Address()))
     }
@@ -389,7 +389,7 @@ extension Person: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Person()))
     }
@@ -451,7 +451,7 @@ extension ComplexStruct: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_ComplexStruct()))
     }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -1179,7 +1179,7 @@ struct StructCodegen {
                 }
 
                 \(raw: accessControl)func toJSObject() -> JSObject {
-                    var __bjs_self = self
+                    let __bjs_self = self
                     __bjs_self.bridgeJSLowerReturn()
                     return JSObject(id: UInt32(bitPattern: \(raw: raiseFunctionName)()))
                 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.swift
@@ -63,7 +63,7 @@ extension Config: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Config()))
     }
@@ -106,7 +106,7 @@ extension MathOperations: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_MathOperations()))
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftStruct.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftStruct.swift
@@ -36,7 +36,7 @@ extension DataPoint: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_DataPoint()))
     }
@@ -104,7 +104,7 @@ extension Address: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Address()))
     }
@@ -163,7 +163,7 @@ extension Person: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Person()))
     }
@@ -208,7 +208,7 @@ extension Session: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Session()))
     }
@@ -250,7 +250,7 @@ extension ConfigStruct: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_ConfigStruct()))
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/UnsafePointer.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/UnsafePointer.swift
@@ -25,7 +25,7 @@ extension PointerFields: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_PointerFields()))
     }

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -2239,7 +2239,7 @@ extension PointerFields: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_PointerFields()))
     }
@@ -2312,7 +2312,7 @@ extension DataPoint: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_DataPoint()))
     }
@@ -2380,7 +2380,7 @@ extension Address: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Address()))
     }
@@ -2445,7 +2445,7 @@ extension Contact: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Contact()))
     }
@@ -2508,7 +2508,7 @@ extension Config: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Config()))
     }
@@ -2557,7 +2557,7 @@ extension SessionData: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_SessionData()))
     }
@@ -2614,7 +2614,7 @@ extension ValidationReport: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_ValidationReport()))
     }
@@ -2657,7 +2657,7 @@ extension MathOperations: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_MathOperations()))
     }
@@ -2753,7 +2753,7 @@ extension CopyableCart: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_CopyableCart()))
     }
@@ -2812,7 +2812,7 @@ extension CopyableCartItem: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_CopyableCartItem()))
     }
@@ -2863,7 +2863,7 @@ extension CopyableNestedCart: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_CopyableNestedCart()))
     }
@@ -2922,7 +2922,7 @@ extension ConfigStruct: _BridgedSwiftStruct {
     }
 
     func toJSObject() -> JSObject {
-        var __bjs_self = self
+        let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_ConfigStruct()))
     }


### PR DESCRIPTION
## Overview

Aims to remove following warning from `toJSObject()` method.
```
  func toJSObject() -> JSObject {
      var __bjs_self = self          // `- warning: variable '__bjs_self' was never mutated; consider changing to 'let' constant
      __bjs_self.bridgeJSLowerReturn()
      return _FooHelpers.raise()
  }
```
Since `toJSObject()` borrows `self`, the local copy exists to give `bridgeJSLowerReturn()` something to consume. That copy is never mutated, just consumed, hence we can use `let`.