### PR TITLE
NFC: BridgeJS: Rename raise to lift in struct and enum helpers

### DIFF
--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -279,7 +279,7 @@ extension SimpleStruct: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_SimpleStruct()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_SimpleStruct()))
     }
 }
 
@@ -293,10 +293,10 @@ fileprivate func _bjs_struct_lower_SimpleStruct(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_SimpleStruct")
-fileprivate func _bjs_struct_raise_SimpleStruct() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_SimpleStruct")
+fileprivate func _bjs_struct_lift_SimpleStruct() -> Int32
 #else
-fileprivate func _bjs_struct_raise_SimpleStruct() -> Int32 {
+fileprivate func _bjs_struct_lift_SimpleStruct() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -332,7 +332,7 @@ extension Address: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Address()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Address()))
     }
 }
 
@@ -346,10 +346,10 @@ fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Address")
-fileprivate func _bjs_struct_raise_Address() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Address")
+fileprivate func _bjs_struct_lift_Address() -> Int32
 #else
-fileprivate func _bjs_struct_raise_Address() -> Int32 {
+fileprivate func _bjs_struct_lift_Address() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -391,7 +391,7 @@ extension Person: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Person()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Person()))
     }
 }
 
@@ -405,10 +405,10 @@ fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Person")
-fileprivate func _bjs_struct_raise_Person() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Person")
+fileprivate func _bjs_struct_lift_Person() -> Int32
 #else
-fileprivate func _bjs_struct_raise_Person() -> Int32 {
+fileprivate func _bjs_struct_lift_Person() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -453,7 +453,7 @@ extension ComplexStruct: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_ComplexStruct()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ComplexStruct()))
     }
 }
 
@@ -467,10 +467,10 @@ fileprivate func _bjs_struct_lower_ComplexStruct(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_ComplexStruct")
-fileprivate func _bjs_struct_raise_ComplexStruct() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ComplexStruct")
+fileprivate func _bjs_struct_lift_ComplexStruct() -> Int32
 #else
-fileprivate func _bjs_struct_raise_ComplexStruct() -> Int32 {
+fileprivate func _bjs_struct_lift_ComplexStruct() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -1184,9 +1184,9 @@ struct StructCodegen {
         let accessControl = structDef.explicitAccessControl.map { "\($0) " } ?? ""
 
         let lowerExternName = "swift_js_struct_lower_\(structDef.name)"
-        let raiseExternName = "swift_js_struct_raise_\(structDef.name)"
+        let liftExternName = "swift_js_struct_lift_\(structDef.name)"
         let lowerFunctionName = "_bjs_struct_lower_\(structDef.name)"
-        let raiseFunctionName = "_bjs_struct_raise_\(structDef.name)"
+        let liftFunctionName = "_bjs_struct_lift_\(structDef.name)"
 
         let bridgedStructExtension: DeclSyntax = """
             extension \(raw: typeName): _BridgedSwiftStruct {
@@ -1207,7 +1207,7 @@ struct StructCodegen {
                 \(raw: accessControl)func toJSObject() -> JSObject {
                     let __bjs_self = self
                     __bjs_self.bridgeJSLowerReturn()
-                    return JSObject(id: UInt32(bitPattern: \(raw: raiseFunctionName)()))
+                    return JSObject(id: UInt32(bitPattern: \(raw: liftFunctionName)()))
                 }
             }
             """
@@ -1220,16 +1220,16 @@ struct StructCodegen {
                 returnType: .i32
             )
         )
-        let raiseExternDecl = Self.renderStructExtern(
-            externName: raiseExternName,
-            functionName: raiseFunctionName,
+        let liftExternDecl = Self.renderStructExtern(
+            externName: liftExternName,
+            functionName: liftFunctionName,
             signature: SwiftSignatureBuilder.buildABIFunctionSignature(
                 abiParameters: [],
                 returnType: .i32
             )
         )
 
-        return [bridgedStructExtension, lowerExternDecl, raiseExternDecl]
+        return [bridgedStructExtension, lowerExternDecl, liftExternDecl]
     }
 
     private static func renderStructExtern(

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -475,10 +475,10 @@ public struct BridgeJSLink {
                         }
                         printer.write("}")
 
-                        printer.write("bjs[\"swift_js_struct_raise_\(structDef.name)\"] = function() {")
+                        printer.write("bjs[\"swift_js_struct_lift_\(structDef.name)\"] = function() {")
                         printer.indent {
                             printer.write(
-                                "const value = \(JSGlueVariableScope.reservedStructHelpers).\(structDef.name).raise(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                                "const value = \(JSGlueVariableScope.reservedStructHelpers).\(structDef.name).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
                             )
                             printer.write("return \(JSGlueVariableScope.reservedSwift).memory.retain(value);")
                         }

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -280,7 +280,7 @@ struct IntrinsicJSFragment: Sendable {
             printCode: { _, scope, printer, _ in
                 let retName = scope.variable("ret")
                 printer.write(
-                    "const \(retName) = \(JSGlueVariableScope.reservedEnumHelpers).\(enumBase).raise(\(JSGlueVariableScope.reservedTmpRetTag), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
+                    "const \(retName) = \(JSGlueVariableScope.reservedEnumHelpers).\(enumBase).lift(\(JSGlueVariableScope.reservedTmpRetTag), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
                 )
                 return [retName]
             }
@@ -343,7 +343,7 @@ struct IntrinsicJSFragment: Sendable {
                     printer.write("if (\(isSome)) {")
                     printer.indent {
                         printer.write(
-                            "\(enumVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).raise(\(wrappedValue), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
+                            "\(enumVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(wrappedValue), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
                         )
                     }
                     printer.write("}")
@@ -355,7 +355,7 @@ struct IntrinsicJSFragment: Sendable {
                     printer.write("if (\(isSome)) {")
                     printer.indent {
                         printer.write(
-                            "\(structVar) = \(JSGlueVariableScope.reservedStructHelpers).\(base).raise(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                            "\(structVar) = \(JSGlueVariableScope.reservedStructHelpers).\(base).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
                         )
                     }
                     printer.write("} else {")
@@ -547,7 +547,7 @@ struct IntrinsicJSFragment: Sendable {
                     printer.write("} else {")
                     printer.indent {
                         printer.write(
-                            "\(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).raise(\(JSGlueVariableScope.reservedTmpRetTag), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
+                            "\(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(JSGlueVariableScope.reservedTmpRetTag), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
                         )
                     }
                     printer.write("}")
@@ -559,7 +559,7 @@ struct IntrinsicJSFragment: Sendable {
                     printer.write("if (\(isSomeVar)) {")
                     printer.indent {
                         printer.write(
-                            "\(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(base).raise(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                            "\(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(base).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
                         )
                     }
                     printer.write("} else {")
@@ -839,7 +839,7 @@ struct IntrinsicJSFragment: Sendable {
                     let targetVar = arguments[1]
                     let base = fullName.components(separatedBy: ".").last ?? fullName
                     printer.write(
-                        "let \(targetVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).raise(\(caseId), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
+                        "let \(targetVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(caseId), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
                     )
                     return []
                 }
@@ -906,7 +906,7 @@ struct IntrinsicJSFragment: Sendable {
                 case .associatedValueEnum(let fullName):
                     let base = fullName.components(separatedBy: ".").last ?? fullName
                     printer.write(
-                        "\(targetVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).raise(\(value), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
+                        "\(targetVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(value), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
                     )
                 default:
                     fatalError("Unsupported optional wrapped type in closure parameter lifting: \(wrappedType)")
@@ -1234,7 +1234,7 @@ struct IntrinsicJSFragment: Sendable {
                     let base = fullName.components(separatedBy: ".").last ?? fullName
                     let resultVar = scope.variable("result")
                     printer.write(
-                        "const \(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).raise(\(JSGlueVariableScope.reservedTmpRetTag), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
+                        "const \(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(JSGlueVariableScope.reservedTmpRetTag), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
                     )
                     printer.write("return \(resultVar);")
                     return []
@@ -1449,7 +1449,7 @@ struct IntrinsicJSFragment: Sendable {
                         let caseId = arguments[0]
                         let resultVar = scope.variable("enumValue")
                         printer.write(
-                            "const \(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).raise(\(caseId), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
+                            "const \(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(caseId), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
                         )
                         return [resultVar]
                     }
@@ -1466,7 +1466,7 @@ struct IntrinsicJSFragment: Sendable {
                     printCode: { arguments, scope, printer, cleanupCode in
                         let resultVar = scope.variable("structValue")
                         printer.write(
-                            "const \(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(base).raise(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                            "const \(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(base).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
                         )
                         return [resultVar]
                     }
@@ -1636,25 +1636,25 @@ struct IntrinsicJSFragment: Sendable {
                 }
                 printer.write("},")
 
-                // Generate raise function
+                // Generate lift function
                 printer.write(
-                    "raise: (\(JSGlueVariableScope.reservedTmpRetTag), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s)) => {"
+                    "lift: (\(JSGlueVariableScope.reservedTmpRetTag), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s)) => {"
                 )
                 printer.indent {
                     printer.write("const tag = tmpRetTag | 0;")
                     printer.write("switch (tag) {")
                     printer.indent {
-                        let raisePrinter = CodeFragmentPrinter()
+                        let liftPrinter = CodeFragmentPrinter()
                         for enumCase in enumDefinition.cases {
                             let caseName = enumCase.name.capitalizedFirstLetter
                             let caseScope = JSGlueVariableScope()
                             let caseCleanup = CodeFragmentPrinter()
 
                             let fragment = IntrinsicJSFragment.associatedValuePopPayload(enumCase: enumCase)
-                            _ = fragment.printCode([enumName, caseName], caseScope, raisePrinter, caseCleanup)
+                            _ = fragment.printCode([enumName, caseName], caseScope, liftPrinter, caseCleanup)
                         }
 
-                        for line in raisePrinter.lines {
+                        for line in liftPrinter.lines {
                             printer.write(line)
                         }
 
@@ -2048,7 +2048,7 @@ struct IntrinsicJSFragment: Sendable {
             printCode: { arguments, scope, printer, cleanupCode in
                 let resultVar = scope.variable("structValue")
                 printer.write(
-                    "const \(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(structBase).raise(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                    "const \(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(structBase).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
                 )
                 return [resultVar]
             }
@@ -2081,10 +2081,10 @@ struct IntrinsicJSFragment: Sendable {
                 printer.write("},")
 
                 printer.write(
-                    "raise: (\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers)) => {"
+                    "lift: (\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers)) => {"
                 )
                 printer.indent {
-                    generateStructRaiseCode(
+                    generateStructLiftCode(
                         structDef: capturedStructDef,
                         allStructs: capturedAllStructs,
                         printer: printer,
@@ -2137,21 +2137,21 @@ struct IntrinsicJSFragment: Sendable {
         }
     }
 
-    private static func generateStructRaiseCode(
+    private static func generateStructLiftCode(
         structDef: ExportedStruct,
         allStructs: [ExportedStruct],
         printer: CodeFragmentPrinter,
         attachMethods: Bool = false
     ) {
-        let raiseScope = JSGlueVariableScope()
-        let raiseCleanup = CodeFragmentPrinter()
+        let liftScope = JSGlueVariableScope()
+        let liftCleanup = CodeFragmentPrinter()
 
         var fieldExpressions: [(name: String, expression: String)] = []
 
         let instanceProps = structDef.properties.filter { !$0.isStatic }
         for property in instanceProps.reversed() {
-            let fragment = structFieldRaiseFragment(field: property, allStructs: allStructs)
-            let results = fragment.printCode([], raiseScope, printer, raiseCleanup)
+            let fragment = structFieldLiftFragment(field: property, allStructs: allStructs)
+            let results = fragment.printCode([], liftScope, printer, liftCleanup)
 
             if let resultExpr = results.first {
                 fieldExpressions.append((property.name, resultExpr))
@@ -2167,7 +2167,7 @@ struct IntrinsicJSFragment: Sendable {
         }
 
         if attachMethods && !structDef.methods.filter({ !$0.effects.isStatic }).isEmpty {
-            let instanceVar = raiseScope.variable("instance")
+            let instanceVar = liftScope.variable("instance")
             printer.write("const \(instanceVar) = { \(reconstructedFields.joined(separator: ", ")) };")
 
             // Attach instance methods to the struct instance
@@ -2710,7 +2710,7 @@ struct IntrinsicJSFragment: Sendable {
         case tmpParamF64s
     }
 
-    private static func structFieldRaiseFragment(
+    private static func structFieldLiftFragment(
         field: ExportedProperty,
         allStructs: [ExportedStruct]
     ) -> IntrinsicJSFragment {
@@ -2785,10 +2785,10 @@ struct IntrinsicJSFragment: Sendable {
                             let caseIdVar = scope.variable("enumCaseId")
                             printer.write("const \(caseIdVar) = \(JSGlueVariableScope.reservedTmpRetInts).pop();")
                             printer.write(
-                                "\(optVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).raise(\(caseIdVar), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
+                                "\(optVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(caseIdVar), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
                             )
                         } else {
-                            let wrappedFragment = structFieldRaiseFragment(
+                            let wrappedFragment = structFieldLiftFragment(
                                 field: ExportedProperty(
                                     name: field.name,
                                     type: wrappedType,
@@ -2819,7 +2819,7 @@ struct IntrinsicJSFragment: Sendable {
                 printCode: { arguments, scope, printer, cleanup in
                     let structVar = scope.variable("struct")
                     printer.write(
-                        "const \(structVar) = \(JSGlueVariableScope.reservedStructHelpers).\(nestedName).raise(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                        "const \(structVar) = \(JSGlueVariableScope.reservedStructHelpers).\(nestedName).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
                     )
                     return [structVar]
                 }
@@ -2913,7 +2913,7 @@ struct IntrinsicJSFragment: Sendable {
                 printCode: { arguments, scope, printer, cleanup in
                     let varName = scope.variable("value")
                     printer.write(
-                        "const \(varName) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).raise(\(JSGlueVariableScope.reservedTmpRetTag), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
+                        "const \(varName) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(JSGlueVariableScope.reservedTmpRetTag), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s));"
                     )
                     return [varName]
                 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.Export.js
@@ -54,7 +54,7 @@ export async function createInstantiator(options, swift) {
                 };
                 return { cleanup };
             },
-            raise: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
                 const bool = tmpRetInts.pop() !== 0;
                 const int = tmpRetInts.pop();
                 const string = tmpRetStrings.pop();
@@ -68,7 +68,7 @@ export async function createInstantiator(options, swift) {
                 tmpParamF64s.push(value.baseValue);
                 return { cleanup: undefined };
             },
-            raise: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
                 const f64 = tmpRetF64s.pop();
                 const instance1 = { baseValue: f64 };
                 instance1.add = function(a, b = 10.0) {
@@ -171,8 +171,8 @@ export async function createInstantiator(options, swift) {
                 }
                 return 0;
             }
-            bjs["swift_js_struct_raise_Config"] = function() {
-                const value = structHelpers.Config.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+            bjs["swift_js_struct_lift_Config"] = function() {
+                const value = structHelpers.Config.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_MathOperations"] = function(objectId) {
@@ -182,8 +182,8 @@ export async function createInstantiator(options, swift) {
                 }
                 return 0;
             }
-            bjs["swift_js_struct_raise_MathOperations"] = function() {
-                const value = structHelpers.MathOperations.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+            bjs["swift_js_struct_lift_MathOperations"] = function() {
+                const value = structHelpers.MathOperations.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                 return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
@@ -528,7 +528,7 @@ export async function createInstantiator(options, swift) {
                     const isSome1 = tmpRetInts.pop();
                     let optResult;
                     if (isSome1) {
-                        optResult = structHelpers.Config.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = structHelpers.Config.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                     } else {
                         optResult = null;
                     }
@@ -546,7 +546,7 @@ export async function createInstantiator(options, swift) {
                     const isSome1 = tmpRetInts.pop();
                     let optResult;
                     if (isSome1) {
-                        optResult = structHelpers.Config.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = structHelpers.Config.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                     } else {
                         optResult = null;
                     }
@@ -557,7 +557,7 @@ export async function createInstantiator(options, swift) {
                 MathOperations: {
                     init: function(baseValue = 0.0) {
                         instance.exports.bjs_MathOperations_init(baseValue);
-                        const structValue = structHelpers.MathOperations.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        const structValue = structHelpers.MathOperations.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                         return structValue;
                     },
                     subtract: function(a, b) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.Export.js
@@ -57,7 +57,7 @@ const __bjs_createAPIResultValuesHelpers = () => {
                 default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
             }
         },
-        raise: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
+        lift: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
             const tag = tmpRetTag | 0;
             switch (tag) {
                 case APIResultValues.Tag.Success: {
@@ -175,7 +175,7 @@ const __bjs_createComplexResultValuesHelpers = () => {
                 default: throw new Error("Unknown ComplexResultValues tag: " + String(enumTag));
             }
         },
-        raise: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
+        lift: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
             const tag = tmpRetTag | 0;
             switch (tag) {
                 case ComplexResultValues.Tag.Success: {
@@ -266,7 +266,7 @@ const __bjs_createResultValuesHelpers = () => {
                 default: throw new Error("Unknown ResultValues tag: " + String(enumTag));
             }
         },
-        raise: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
+        lift: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
             const tag = tmpRetTag | 0;
             switch (tag) {
                 case ResultValues.Tag.Success: {
@@ -325,7 +325,7 @@ const __bjs_createNetworkingResultValuesHelpers = () => {
                 default: throw new Error("Unknown NetworkingResultValues tag: " + String(enumTag));
             }
         },
-        raise: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
+        lift: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
             const tag = tmpRetTag | 0;
             switch (tag) {
                 case NetworkingResultValues.Tag.Success: {
@@ -414,7 +414,7 @@ const __bjs_createAPIOptionalResultValuesHelpers = () => {
                 default: throw new Error("Unknown APIOptionalResultValues tag: " + String(enumTag));
             }
         },
-        raise: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
+        lift: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
             const tag = tmpRetTag | 0;
             switch (tag) {
                 case APIOptionalResultValues.Tag.Success: {
@@ -711,13 +711,13 @@ export async function createInstantiator(options, swift) {
                 },
                 getResult: function bjs_getResult() {
                     instance.exports.bjs_getResult();
-                    const ret = enumHelpers.APIResult.raise(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                    const ret = enumHelpers.APIResult.lift(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     return ret;
                 },
                 roundtripAPIResult: function bjs_roundtripAPIResult(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.APIResult.lower(result);
                     instance.exports.bjs_roundtripAPIResult(resultCaseId);
-                    const ret = enumHelpers.APIResult.raise(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                    const ret = enumHelpers.APIResult.lift(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
@@ -735,7 +735,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.APIResult.raise(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                        optResult = enumHelpers.APIResult.lift(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;
@@ -747,13 +747,13 @@ export async function createInstantiator(options, swift) {
                 },
                 getComplexResult: function bjs_getComplexResult() {
                     instance.exports.bjs_getComplexResult();
-                    const ret = enumHelpers.ComplexResult.raise(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                    const ret = enumHelpers.ComplexResult.lift(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     return ret;
                 },
                 roundtripComplexResult: function bjs_roundtripComplexResult(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.ComplexResult.lower(result);
                     instance.exports.bjs_roundtripComplexResult(resultCaseId);
-                    const ret = enumHelpers.ComplexResult.raise(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                    const ret = enumHelpers.ComplexResult.lift(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
@@ -771,7 +771,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.ComplexResult.raise(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                        optResult = enumHelpers.ComplexResult.lift(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;
@@ -790,7 +790,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.Result.raise(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                        optResult = enumHelpers.Result.lift(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;
@@ -809,7 +809,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.NetworkingResult.raise(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                        optResult = enumHelpers.NetworkingResult.lift(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;
@@ -828,7 +828,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.APIOptionalResult.raise(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                        optResult = enumHelpers.APIOptionalResult.lift(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;
@@ -854,7 +854,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.APIOptionalResult.raise(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                        optResult = enumHelpers.APIOptionalResult.lift(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     }
                     if (result1Cleanup) { result1Cleanup(); }
                     if (result2Cleanup) { result2Cleanup(); }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.Export.js
@@ -46,7 +46,7 @@ const __bjs_createResultValuesHelpers = () => {
                 default: throw new Error("Unknown ResultValues tag: " + String(enumTag));
             }
         },
-        raise: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
+        lift: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
             const tag = tmpRetTag | 0;
             switch (tag) {
                 case ResultValues.Tag.Success: {
@@ -372,7 +372,7 @@ export async function createInstantiator(options, swift) {
             }
             TestModule["bjs_MyViewControllerDelegate_result_set"] = function bjs_MyViewControllerDelegate_result_set(self, value) {
                 try {
-                    const enumValue = enumHelpers.Result.raise(value, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                    const enumValue = enumHelpers.Result.lift(value, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     swift.memory.getObject(self).result = enumValue;
                 } catch (error) {
                     setException(error);
@@ -396,7 +396,7 @@ export async function createInstantiator(options, swift) {
                 try {
                     let enumValue;
                     if (valueIsSome) {
-                        enumValue = enumHelpers.Result.raise(valueWrappedValue, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                        enumValue = enumHelpers.Result.lift(valueWrappedValue, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     }
                     swift.memory.getObject(self).optionalResult = valueIsSome ? enumValue : null;
                 } catch (error) {
@@ -553,7 +553,7 @@ export async function createInstantiator(options, swift) {
             }
             TestModule["bjs_MyViewControllerDelegate_handleResult"] = function bjs_MyViewControllerDelegate_handleResult(self, result) {
                 try {
-                    const enumValue = enumHelpers.Result.raise(result, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                    const enumValue = enumHelpers.Result.lift(result, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     swift.memory.getObject(self).handleResult(enumValue);
                 } catch (error) {
                     setException(error);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Export.js
@@ -39,7 +39,7 @@ const __bjs_createAPIResultValuesHelpers = () => {
                 default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
             }
         },
-        raise: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
+        lift: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
             const tag = tmpRetTag | 0;
             switch (tag) {
                 case APIResultValues.Tag.Success: {
@@ -330,7 +330,7 @@ export async function createInstantiator(options, swift) {
                     roundtrip: function(value) {
                         const { caseId: valueCaseId, cleanup: valueCleanup } = enumHelpers.APIResult.lower(value);
                         instance.exports.bjs_APIResult_static_roundtrip(valueCaseId);
-                        const ret = enumHelpers.APIResult.raise(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                        const ret = enumHelpers.APIResult.lift(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                         if (valueCleanup) { valueCleanup(); }
                         return ret;
                     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.Export.js
@@ -39,7 +39,7 @@ const __bjs_createAPIResultValuesHelpers = () => {
                 default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
             }
         },
-        raise: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
+        lift: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
             const tag = tmpRetTag | 0;
             switch (tag) {
                 case APIResultValues.Tag.Success: {
@@ -336,7 +336,7 @@ export async function createInstantiator(options, swift) {
                     roundtrip: function(value) {
                         const { caseId: valueCaseId, cleanup: valueCleanup } = enumHelpers.APIResult.lower(value);
                         instance.exports.bjs_APIResult_static_roundtrip(valueCaseId);
-                        const ret = enumHelpers.APIResult.raise(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                        const ret = enumHelpers.APIResult.lift(tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                         if (valueCleanup) { valueCleanup(); }
                         return ret;
                     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.Export.js
@@ -77,7 +77,7 @@ const __bjs_createAPIResultValuesHelpers = () => {
                 default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
             }
         },
-        raise: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
+        lift: (tmpRetTag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s) => {
             const tag = tmpRetTag | 0;
             switch (tag) {
                 case APIResultValues.Tag.Success: {
@@ -423,7 +423,7 @@ export async function createInstantiator(options, swift) {
             bjs["invoke_js_callback_TestModule_10TestModule9APIResultO_SS"] = function(callbackId, param0Id) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
-                    let param0 = enumHelpers.APIResult.raise(param0Id, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                    let param0 = enumHelpers.APIResult.lift(param0Id, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     const result = callback(param0);
                     if (typeof result !== "string") {
                         throw new TypeError("Callback must return a string");
@@ -685,7 +685,7 @@ export async function createInstantiator(options, swift) {
                     const callback = swift.memory.getObject(callbackId);
                     let param0;
                     if (param0IsSome) {
-                        param0 = enumHelpers.APIResult.raise(param0Value, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                        param0 = enumHelpers.APIResult.lift(param0Value, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
                     } else {
                         param0 = null;
                     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.Export.js
@@ -67,7 +67,7 @@ export async function createInstantiator(options, swift) {
                 };
                 return { cleanup };
             },
-            raise: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
                 const isSome = tmpRetInts.pop();
                 let optional;
                 if (isSome) {
@@ -115,7 +115,7 @@ export async function createInstantiator(options, swift) {
                 };
                 return { cleanup };
             },
-            raise: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
                 const isSome = tmpRetInts.pop();
                 let optional;
                 if (isSome) {
@@ -158,7 +158,7 @@ export async function createInstantiator(options, swift) {
                 };
                 return { cleanup };
             },
-            raise: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
                 const isSome = tmpRetInts.pop();
                 let optional;
                 if (isSome) {
@@ -167,7 +167,7 @@ export async function createInstantiator(options, swift) {
                 } else {
                     optional = null;
                 }
-                const struct = structHelpers.Address.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const struct = structHelpers.Address.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                 const int = tmpRetInts.pop();
                 const string1 = tmpRetStrings.pop();
                 return { name: string1, age: int, address: struct, email: optional };
@@ -181,7 +181,7 @@ export async function createInstantiator(options, swift) {
                 tmpParamPointers.push(value.owner.pointer);
                 return { cleanup: undefined };
             },
-            raise: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
                 const ptr = tmpRetPointers.pop();
                 const value = _exports['Greeter'].__construct(ptr);
                 const int = tmpRetInts.pop();
@@ -203,7 +203,7 @@ export async function createInstantiator(options, swift) {
                 tmpParamInts.push(isSome ? 1 : 0);
                 return { cleanup: undefined };
             },
-            raise: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
                 const isSome = tmpRetInts.pop();
                 let optional;
                 if (isSome) {
@@ -223,7 +223,7 @@ export async function createInstantiator(options, swift) {
             lower: (value) => {
                 return { cleanup: undefined };
             },
-            raise: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
                 return {  };
             }
         });
@@ -312,8 +312,8 @@ export async function createInstantiator(options, swift) {
                 }
                 return 0;
             }
-            bjs["swift_js_struct_raise_DataPoint"] = function() {
-                const value = structHelpers.DataPoint.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+            bjs["swift_js_struct_lift_DataPoint"] = function() {
+                const value = structHelpers.DataPoint.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Address"] = function(objectId) {
@@ -323,8 +323,8 @@ export async function createInstantiator(options, swift) {
                 }
                 return 0;
             }
-            bjs["swift_js_struct_raise_Address"] = function() {
-                const value = structHelpers.Address.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+            bjs["swift_js_struct_lift_Address"] = function() {
+                const value = structHelpers.Address.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Person"] = function(objectId) {
@@ -334,8 +334,8 @@ export async function createInstantiator(options, swift) {
                 }
                 return 0;
             }
-            bjs["swift_js_struct_raise_Person"] = function() {
-                const value = structHelpers.Person.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+            bjs["swift_js_struct_lift_Person"] = function() {
+                const value = structHelpers.Person.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Session"] = function(objectId) {
@@ -345,8 +345,8 @@ export async function createInstantiator(options, swift) {
                 }
                 return 0;
             }
-            bjs["swift_js_struct_raise_Session"] = function() {
-                const value = structHelpers.Session.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+            bjs["swift_js_struct_lift_Session"] = function() {
+                const value = structHelpers.Session.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Measurement"] = function(objectId) {
@@ -356,8 +356,8 @@ export async function createInstantiator(options, swift) {
                 }
                 return 0;
             }
-            bjs["swift_js_struct_raise_Measurement"] = function() {
-                const value = structHelpers.Measurement.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+            bjs["swift_js_struct_lift_Measurement"] = function() {
+                const value = structHelpers.Measurement.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_ConfigStruct"] = function(objectId) {
@@ -367,8 +367,8 @@ export async function createInstantiator(options, swift) {
                 }
                 return 0;
             }
-            bjs["swift_js_struct_raise_ConfigStruct"] = function() {
-                const value = structHelpers.ConfigStruct.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+            bjs["swift_js_struct_lift_ConfigStruct"] = function() {
+                const value = structHelpers.ConfigStruct.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                 return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
@@ -554,7 +554,7 @@ export async function createInstantiator(options, swift) {
                 roundtrip: function bjs_roundtrip(session) {
                     const { cleanup: cleanup } = structHelpers.Person.lower(session);
                     instance.exports.bjs_roundtrip();
-                    const structValue = structHelpers.Person.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const structValue = structHelpers.Person.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                     if (cleanup) { cleanup(); }
                     return structValue;
                 },
@@ -566,7 +566,7 @@ export async function createInstantiator(options, swift) {
                         const isSome = optCount != null;
                         const isSome1 = optFlag != null;
                         instance.exports.bjs_DataPoint_init(x, y, labelId, labelBytes.length, +isSome, isSome ? optCount : 0, +isSome1, isSome1 ? optFlag : 0);
-                        const structValue = structHelpers.DataPoint.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        const structValue = structHelpers.DataPoint.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                         swift.memory.release(labelId);
                         return structValue;
                     },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.ImportMacros.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.ImportMacros.js
@@ -41,7 +41,7 @@ export async function createInstantiator(options, swift) {
                 tmpParamInts.push((value.y | 0));
                 return { cleanup: undefined };
             },
-            raise: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
                 const int = tmpRetInts.pop();
                 const int1 = tmpRetInts.pop();
                 return { x: int1, y: int };
@@ -133,8 +133,8 @@ export async function createInstantiator(options, swift) {
                 }
                 return 0;
             }
-            bjs["swift_js_struct_raise_Point"] = function() {
-                const value = structHelpers.Point.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+            bjs["swift_js_struct_lift_Point"] = function() {
+                const value = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                 return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.Export.js
@@ -44,7 +44,7 @@ export async function createInstantiator(options, swift) {
                 tmpParamPointers.push((value.mutPtr | 0));
                 return { cleanup: undefined };
             },
-            raise: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
                 const pointer = tmpRetPointers.pop();
                 const pointer1 = tmpRetPointers.pop();
                 const pointer2 = tmpRetPointers.pop();
@@ -138,8 +138,8 @@ export async function createInstantiator(options, swift) {
                 }
                 return 0;
             }
-            bjs["swift_js_struct_raise_PointerFields"] = function() {
-                const value = structHelpers.PointerFields.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+            bjs["swift_js_struct_lift_PointerFields"] = function() {
+                const value = structHelpers.PointerFields.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                 return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
@@ -286,14 +286,14 @@ export async function createInstantiator(options, swift) {
                 roundTripPointerFields: function bjs_roundTripPointerFields(value) {
                     const { cleanup: cleanup } = structHelpers.PointerFields.lower(value);
                     instance.exports.bjs_roundTripPointerFields();
-                    const structValue = structHelpers.PointerFields.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const structValue = structHelpers.PointerFields.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                     if (cleanup) { cleanup(); }
                     return structValue;
                 },
                 PointerFields: {
                     init: function(raw, mutRaw, opaque, ptr, mutPtr) {
                         instance.exports.bjs_PointerFields_init(raw, mutRaw, opaque, ptr, mutPtr);
-                        const structValue = structHelpers.PointerFields.raise(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        const structValue = structHelpers.PointerFields.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
                         return structValue;
                     },
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.swift
@@ -65,7 +65,7 @@ extension Config: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Config()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Config()))
     }
 }
 
@@ -79,10 +79,10 @@ fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Config")
-fileprivate func _bjs_struct_raise_Config() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Config")
+fileprivate func _bjs_struct_lift_Config() -> Int32
 #else
-fileprivate func _bjs_struct_raise_Config() -> Int32 {
+fileprivate func _bjs_struct_lift_Config() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -108,7 +108,7 @@ extension MathOperations: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_MathOperations()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_MathOperations()))
     }
 }
 
@@ -122,10 +122,10 @@ fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_MathOperations")
-fileprivate func _bjs_struct_raise_MathOperations() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_MathOperations")
+fileprivate func _bjs_struct_lift_MathOperations() -> Int32
 #else
-fileprivate func _bjs_struct_raise_MathOperations() -> Int32 {
+fileprivate func _bjs_struct_lift_MathOperations() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftStruct.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftStruct.swift
@@ -41,7 +41,7 @@ extension DataPoint: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_DataPoint()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_DataPoint()))
     }
 }
 
@@ -55,10 +55,10 @@ fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_DataPoint")
-fileprivate func _bjs_struct_raise_DataPoint() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_DataPoint")
+fileprivate func _bjs_struct_lift_DataPoint() -> Int32
 #else
-fileprivate func _bjs_struct_raise_DataPoint() -> Int32 {
+fileprivate func _bjs_struct_lift_DataPoint() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -109,7 +109,7 @@ extension Address: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Address()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Address()))
     }
 }
 
@@ -123,10 +123,10 @@ fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Address")
-fileprivate func _bjs_struct_raise_Address() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Address")
+fileprivate func _bjs_struct_lift_Address() -> Int32
 #else
-fileprivate func _bjs_struct_raise_Address() -> Int32 {
+fileprivate func _bjs_struct_lift_Address() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -168,7 +168,7 @@ extension Person: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Person()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Person()))
     }
 }
 
@@ -182,10 +182,10 @@ fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Person")
-fileprivate func _bjs_struct_raise_Person() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Person")
+fileprivate func _bjs_struct_lift_Person() -> Int32
 #else
-fileprivate func _bjs_struct_raise_Person() -> Int32 {
+fileprivate func _bjs_struct_lift_Person() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -213,7 +213,7 @@ extension Session: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Session()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Session()))
     }
 }
 
@@ -227,10 +227,10 @@ fileprivate func _bjs_struct_lower_Session(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Session")
-fileprivate func _bjs_struct_raise_Session() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Session")
+fileprivate func _bjs_struct_lift_Session() -> Int32
 #else
-fileprivate func _bjs_struct_raise_Session() -> Int32 {
+fileprivate func _bjs_struct_lift_Session() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -264,7 +264,7 @@ extension Measurement: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Measurement()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Measurement()))
     }
 }
 
@@ -278,10 +278,10 @@ fileprivate func _bjs_struct_lower_Measurement(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Measurement")
-fileprivate func _bjs_struct_raise_Measurement() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Measurement")
+fileprivate func _bjs_struct_lift_Measurement() -> Int32
 #else
-fileprivate func _bjs_struct_raise_Measurement() -> Int32 {
+fileprivate func _bjs_struct_lift_Measurement() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -306,7 +306,7 @@ extension ConfigStruct: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_ConfigStruct()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ConfigStruct()))
     }
 }
 
@@ -320,10 +320,10 @@ fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_ConfigStruct")
-fileprivate func _bjs_struct_raise_ConfigStruct() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ConfigStruct")
+fileprivate func _bjs_struct_lift_ConfigStruct() -> Int32
 #else
-fileprivate func _bjs_struct_raise_ConfigStruct() -> Int32 {
+fileprivate func _bjs_struct_lift_ConfigStruct() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/UnsafePointer.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/UnsafePointer.swift
@@ -27,7 +27,7 @@ extension PointerFields: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_PointerFields()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PointerFields()))
     }
 }
 
@@ -41,10 +41,10 @@ fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_PointerFields")
-fileprivate func _bjs_struct_raise_PointerFields() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_PointerFields")
+fileprivate func _bjs_struct_lift_PointerFields() -> Int32
 #else
-fileprivate func _bjs_struct_raise_PointerFields() -> Int32 {
+fileprivate func _bjs_struct_lift_PointerFields() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -2241,7 +2241,7 @@ extension Point: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Point()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
     }
 }
 
@@ -2255,10 +2255,10 @@ fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Point")
-fileprivate func _bjs_struct_raise_Point() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Point")
+fileprivate func _bjs_struct_lift_Point() -> Int32
 #else
-fileprivate func _bjs_struct_raise_Point() -> Int32 {
+fileprivate func _bjs_struct_lift_Point() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2292,7 +2292,7 @@ extension PointerFields: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_PointerFields()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PointerFields()))
     }
 }
 
@@ -2306,10 +2306,10 @@ fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_PointerFields")
-fileprivate func _bjs_struct_raise_PointerFields() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_PointerFields")
+fileprivate func _bjs_struct_lift_PointerFields() -> Int32
 #else
-fileprivate func _bjs_struct_raise_PointerFields() -> Int32 {
+fileprivate func _bjs_struct_lift_PointerFields() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2365,7 +2365,7 @@ extension DataPoint: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_DataPoint()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_DataPoint()))
     }
 }
 
@@ -2379,10 +2379,10 @@ fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_DataPoint")
-fileprivate func _bjs_struct_raise_DataPoint() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_DataPoint")
+fileprivate func _bjs_struct_lift_DataPoint() -> Int32
 #else
-fileprivate func _bjs_struct_raise_DataPoint() -> Int32 {
+fileprivate func _bjs_struct_lift_DataPoint() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2433,7 +2433,7 @@ extension Address: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Address()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Address()))
     }
 }
 
@@ -2447,10 +2447,10 @@ fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Address")
-fileprivate func _bjs_struct_raise_Address() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Address")
+fileprivate func _bjs_struct_lift_Address() -> Int32
 #else
-fileprivate func _bjs_struct_raise_Address() -> Int32 {
+fileprivate func _bjs_struct_lift_Address() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2498,7 +2498,7 @@ extension Contact: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Contact()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Contact()))
     }
 }
 
@@ -2512,10 +2512,10 @@ fileprivate func _bjs_struct_lower_Contact(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Contact")
-fileprivate func _bjs_struct_raise_Contact() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Contact")
+fileprivate func _bjs_struct_lift_Contact() -> Int32
 #else
-fileprivate func _bjs_struct_raise_Contact() -> Int32 {
+fileprivate func _bjs_struct_lift_Contact() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2561,7 +2561,7 @@ extension Config: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_Config()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Config()))
     }
 }
 
@@ -2575,10 +2575,10 @@ fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_Config")
-fileprivate func _bjs_struct_raise_Config() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Config")
+fileprivate func _bjs_struct_lift_Config() -> Int32
 #else
-fileprivate func _bjs_struct_raise_Config() -> Int32 {
+fileprivate func _bjs_struct_lift_Config() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2610,7 +2610,7 @@ extension SessionData: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_SessionData()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_SessionData()))
     }
 }
 
@@ -2624,10 +2624,10 @@ fileprivate func _bjs_struct_lower_SessionData(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_SessionData")
-fileprivate func _bjs_struct_raise_SessionData() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_SessionData")
+fileprivate func _bjs_struct_lift_SessionData() -> Int32
 #else
-fileprivate func _bjs_struct_raise_SessionData() -> Int32 {
+fileprivate func _bjs_struct_lift_SessionData() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2667,7 +2667,7 @@ extension ValidationReport: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_ValidationReport()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ValidationReport()))
     }
 }
 
@@ -2681,10 +2681,10 @@ fileprivate func _bjs_struct_lower_ValidationReport(_ objectId: Int32) -> Int32 
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_ValidationReport")
-fileprivate func _bjs_struct_raise_ValidationReport() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ValidationReport")
+fileprivate func _bjs_struct_lift_ValidationReport() -> Int32
 #else
-fileprivate func _bjs_struct_raise_ValidationReport() -> Int32 {
+fileprivate func _bjs_struct_lift_ValidationReport() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2750,7 +2750,7 @@ extension AdvancedConfig: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_AdvancedConfig()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_AdvancedConfig()))
     }
 }
 
@@ -2764,10 +2764,10 @@ fileprivate func _bjs_struct_lower_AdvancedConfig(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_AdvancedConfig")
-fileprivate func _bjs_struct_raise_AdvancedConfig() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_AdvancedConfig")
+fileprivate func _bjs_struct_lift_AdvancedConfig() -> Int32
 #else
-fileprivate func _bjs_struct_raise_AdvancedConfig() -> Int32 {
+fileprivate func _bjs_struct_lift_AdvancedConfig() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2807,7 +2807,7 @@ extension MeasurementConfig: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_MeasurementConfig()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_MeasurementConfig()))
     }
 }
 
@@ -2821,10 +2821,10 @@ fileprivate func _bjs_struct_lower_MeasurementConfig(_ objectId: Int32) -> Int32
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_MeasurementConfig")
-fileprivate func _bjs_struct_raise_MeasurementConfig() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_MeasurementConfig")
+fileprivate func _bjs_struct_lift_MeasurementConfig() -> Int32
 #else
-fileprivate func _bjs_struct_raise_MeasurementConfig() -> Int32 {
+fileprivate func _bjs_struct_lift_MeasurementConfig() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2850,7 +2850,7 @@ extension MathOperations: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_MathOperations()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_MathOperations()))
     }
 }
 
@@ -2864,10 +2864,10 @@ fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_MathOperations")
-fileprivate func _bjs_struct_raise_MathOperations() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_MathOperations")
+fileprivate func _bjs_struct_lift_MathOperations() -> Int32
 #else
-fileprivate func _bjs_struct_raise_MathOperations() -> Int32 {
+fileprivate func _bjs_struct_lift_MathOperations() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2946,7 +2946,7 @@ extension CopyableCart: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_CopyableCart()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_CopyableCart()))
     }
 }
 
@@ -2960,10 +2960,10 @@ fileprivate func _bjs_struct_lower_CopyableCart(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_CopyableCart")
-fileprivate func _bjs_struct_raise_CopyableCart() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_CopyableCart")
+fileprivate func _bjs_struct_lift_CopyableCart() -> Int32
 #else
-fileprivate func _bjs_struct_raise_CopyableCart() -> Int32 {
+fileprivate func _bjs_struct_lift_CopyableCart() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3005,7 +3005,7 @@ extension CopyableCartItem: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_CopyableCartItem()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_CopyableCartItem()))
     }
 }
 
@@ -3019,10 +3019,10 @@ fileprivate func _bjs_struct_lower_CopyableCartItem(_ objectId: Int32) -> Int32 
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_CopyableCartItem")
-fileprivate func _bjs_struct_raise_CopyableCartItem() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_CopyableCartItem")
+fileprivate func _bjs_struct_lift_CopyableCartItem() -> Int32
 #else
-fileprivate func _bjs_struct_raise_CopyableCartItem() -> Int32 {
+fileprivate func _bjs_struct_lift_CopyableCartItem() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3056,7 +3056,7 @@ extension CopyableNestedCart: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_CopyableNestedCart()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_CopyableNestedCart()))
     }
 }
 
@@ -3070,10 +3070,10 @@ fileprivate func _bjs_struct_lower_CopyableNestedCart(_ objectId: Int32) -> Int3
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_CopyableNestedCart")
-fileprivate func _bjs_struct_raise_CopyableNestedCart() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_CopyableNestedCart")
+fileprivate func _bjs_struct_lift_CopyableNestedCart() -> Int32
 #else
-fileprivate func _bjs_struct_raise_CopyableNestedCart() -> Int32 {
+fileprivate func _bjs_struct_lift_CopyableNestedCart() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3115,7 +3115,7 @@ extension ConfigStruct: _BridgedSwiftStruct {
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSLowerReturn()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_raise_ConfigStruct()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ConfigStruct()))
     }
 }
 
@@ -3129,10 +3129,10 @@ fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32 {
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_raise_ConfigStruct")
-fileprivate func _bjs_struct_raise_ConfigStruct() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ConfigStruct")
+fileprivate func _bjs_struct_lift_ConfigStruct() -> Int32
 #else
-fileprivate func _bjs_struct_raise_ConfigStruct() -> Int32 {
+fileprivate func _bjs_struct_lift_ConfigStruct() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif


### PR DESCRIPTION
## Overview
 
Renames the raise method on struct and enum helpers to lift, aligning with the naming convention used throughout the rest of the codebase (`liftReturn`, `liftParameter`, `bridgeJSLiftParameter`, etc.).
