### PR TITLE
BridgeJS: Swift Array support

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -933,6 +933,13 @@ extension BridgeType {
                 params.append(contentsOf: wrappedInfo.loweredParameters)
                 return LoweringParameterInfo(loweredParameters: params)
             }
+        case .array:
+            switch context {
+            case .importTS:
+                throw BridgeJSCoreError("Array types are not yet supported in TypeScript imports")
+            case .exportSwift:
+                return LoweringParameterInfo(loweredParameters: [])
+            }
         }
     }
 
@@ -1017,6 +1024,13 @@ extension BridgeType {
             case .exportSwift:
                 let wrappedInfo = try wrappedType.liftingReturnInfo(context: context)
                 return LiftingReturnInfo(valueToLift: wrappedInfo.valueToLift)
+            }
+        case .array:
+            switch context {
+            case .importTS:
+                throw BridgeJSCoreError("Array types are not yet supported in TypeScript imports")
+            case .exportSwift:
+                return LiftingReturnInfo(valueToLift: nil)
             }
         }
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/ArrayTypes.swift
@@ -1,0 +1,56 @@
+@JS struct Point {
+    var x: Double
+    var y: Double
+}
+
+@JS enum Direction {
+    case north
+    case south
+    case east
+    case west
+}
+
+@JS enum Status: Int {
+    case pending = 0
+    case active = 1
+    case completed = 2
+}
+
+@JS class Item {
+    var name: String
+
+    init(name: String) {
+        self.name = name
+    }
+}
+
+@JS func processIntArray(_ values: [Int]) -> [Int]
+@JS func processStringArray(_ values: [String]) -> [String]
+@JS func processDoubleArray(_ values: [Double]) -> [Double]
+@JS func processBoolArray(_ values: [Bool]) -> [Bool]
+
+@JS func processPointArray(_ points: [Point]) -> [Point]
+
+@JS func processDirectionArray(_ directions: [Direction]) -> [Direction]
+@JS func processStatusArray(_ statuses: [Status]) -> [Status]
+
+@JS func sumIntArray(_ values: [Int]) -> Int
+@JS func findFirstPoint(_ points: [Point], matching: String) -> Point
+
+@JS func processUnsafeRawPointerArray(_ values: [UnsafeRawPointer]) -> [UnsafeRawPointer]
+@JS func processUnsafeMutableRawPointerArray(_ values: [UnsafeMutableRawPointer]) -> [UnsafeMutableRawPointer]
+@JS func processOpaquePointerArray(_ values: [OpaquePointer]) -> [OpaquePointer]
+
+@JS func processOptionalIntArray(_ values: [Int?]) -> [Int?]
+@JS func processOptionalStringArray(_ values: [String?]) -> [String?]
+@JS func processOptionalArray(_ values: [Int]?) -> [Int]?
+@JS func processOptionalPointArray(_ points: [Point?]) -> [Point?]
+@JS func processOptionalDirectionArray(_ directions: [Direction?]) -> [Direction?]
+@JS func processOptionalStatusArray(_ statuses: [Status?]) -> [Status?]
+
+@JS func processNestedIntArray(_ values: [[Int]]) -> [[Int]]
+@JS func processNestedStringArray(_ values: [[String]]) -> [[String]]
+@JS func processNestedPointArray(_ points: [[Point]]) -> [[Point]]
+
+@JS func processItemArray(_ items: [Item]) -> [Item]
+@JS func processNestedItemArray(_ items: [[Item]]) -> [[Item]]

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/DefaultParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/DefaultParameters.swift
@@ -73,3 +73,15 @@
     @JS func multiply(a: Double, b: Double) -> Double
     @JS static func subtract(a: Double, b: Double = 5.0) -> Double
 }
+
+// Array default values
+@JS public func testIntArrayDefault(values: [Int] = [1, 2, 3]) -> [Int]
+@JS public func testStringArrayDefault(names: [String] = ["a", "b", "c"]) -> [String]
+@JS public func testDoubleArrayDefault(values: [Double] = [1.5, 2.5, 3.5]) -> [Double]
+@JS public func testBoolArrayDefault(flags: [Bool] = [true, false, true]) -> [Bool]
+@JS public func testEmptyArrayDefault(items: [Int] = []) -> [Int]
+@JS public func testMixedWithArrayDefault(
+    name: String = "test",
+    values: [Int] = [10, 20, 30],
+    enabled: Bool = true
+) -> String

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/Protocol.swift
@@ -96,3 +96,21 @@ import JavaScriptKit
         delegate.onHelperUpdated(helper)
     }
 }
+
+// Protocol array support
+@JS class DelegateManager {
+    @JS
+    var delegates: [MyViewControllerDelegate]
+
+    @JS init(delegates: [MyViewControllerDelegate]) {
+        self.delegates = delegates
+    }
+
+    @JS func notifyAll() {
+        for delegate in delegates {
+            delegate.onSomethingHappened()
+        }
+    }
+}
+
+@JS func processDelegates(_ delegates: [MyViewControllerDelegate]) -> [MyViewControllerDelegate]

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayParameter.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayParameter.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.Export.d.ts
@@ -1,0 +1,76 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export const DirectionValues: {
+    readonly North: 0;
+    readonly South: 1;
+    readonly East: 2;
+    readonly West: 3;
+};
+export type DirectionTag = typeof DirectionValues[keyof typeof DirectionValues];
+
+export const StatusValues: {
+    readonly Pending: 0;
+    readonly Active: 1;
+    readonly Completed: 2;
+};
+export type StatusTag = typeof StatusValues[keyof typeof StatusValues];
+
+export interface Point {
+    x: number;
+    y: number;
+}
+export type DirectionObject = typeof DirectionValues;
+
+export type StatusObject = typeof StatusValues;
+
+/// Represents a Swift heap object like a class instance or an actor instance.
+export interface SwiftHeapObject {
+    /// Release the heap object.
+    ///
+    /// Note: Calling this method will release the heap object and it will no longer be accessible.
+    release(): void;
+}
+export interface Item extends SwiftHeapObject {
+}
+export type Exports = {
+    Item: {
+    }
+    processIntArray(values: number[]): number[];
+    processStringArray(values: string[]): string[];
+    processDoubleArray(values: number[]): number[];
+    processBoolArray(values: boolean[]): boolean[];
+    processPointArray(points: Point[]): Point[];
+    processDirectionArray(directions: DirectionTag[]): DirectionTag[];
+    processStatusArray(statuses: StatusTag[]): StatusTag[];
+    sumIntArray(values: number[]): number;
+    findFirstPoint(points: Point[], matching: string): Point;
+    processUnsafeRawPointerArray(values: number[]): number[];
+    processUnsafeMutableRawPointerArray(values: number[]): number[];
+    processOpaquePointerArray(values: number[]): number[];
+    processOptionalIntArray(values: (number | null)[]): (number | null)[];
+    processOptionalStringArray(values: (string | null)[]): (string | null)[];
+    processOptionalArray(values: number[] | null): number[] | null;
+    processOptionalPointArray(points: (Point | null)[]): (Point | null)[];
+    processOptionalDirectionArray(directions: (DirectionTag | null)[]): (DirectionTag | null)[];
+    processOptionalStatusArray(statuses: (StatusTag | null)[]): (StatusTag | null)[];
+    processNestedIntArray(values: number[][]): number[][];
+    processNestedStringArray(values: string[][]): string[][];
+    processNestedPointArray(points: Point[][]): Point[][];
+    processItemArray(items: Item[]): Item[];
+    processNestedItemArray(items: Item[][]): Item[][];
+    Direction: DirectionObject
+    Status: StatusObject
+}
+export type Imports = {
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.Export.js
@@ -1,0 +1,845 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export const DirectionValues = {
+    North: 0,
+    South: 1,
+    East: 2,
+    West: 3,
+};
+
+export const StatusValues = {
+    Pending: 0,
+    Active: 1,
+    Completed: 2,
+};
+
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let tmpRetTag;
+    let tmpRetStrings = [];
+    let tmpRetInts = [];
+    let tmpRetF32s = [];
+    let tmpRetF64s = [];
+    let tmpParamInts = [];
+    let tmpParamF32s = [];
+    let tmpParamF64s = [];
+    let tmpRetPointers = [];
+    let tmpParamPointers = [];
+    let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
+    const enumHelpers = {};
+    const structHelpers = {};
+    
+    let _exports = null;
+    let bjs = null;
+    const __bjs_createPointHelpers = () => {
+        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+            lower: (value) => {
+                tmpParamF64s.push(value.x);
+                tmpParamF64s.push(value.y);
+                return { cleanup: undefined };
+            },
+            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+                const f64 = tmpRetF64s.pop();
+                const f641 = tmpRetF64s.pop();
+                return { x: f641, y: f64 };
+            }
+        });
+    };
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            bjs = {};
+            importObject["bjs"] = bjs;
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                tmpRetString = textDecoder.decode(bytes);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                return swift.memory.retain(textDecoder.decode(bytes));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr, len);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_tag"] = function(tag) {
+                tmpRetTag = tag;
+            }
+            bjs["swift_js_push_int"] = function(v) {
+                tmpRetInts.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                tmpRetF32s.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                tmpRetF64s.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                const value = textDecoder.decode(bytes);
+                tmpRetStrings.push(value);
+            }
+            bjs["swift_js_pop_param_int32"] = function() {
+                return tmpParamInts.pop();
+            }
+            bjs["swift_js_pop_param_f32"] = function() {
+                return tmpParamF32s.pop();
+            }
+            bjs["swift_js_pop_param_f64"] = function() {
+                return tmpParamF64s.pop();
+            }
+            bjs["swift_js_push_pointer"] = function(pointer) {
+                tmpRetPointers.push(pointer);
+            }
+            bjs["swift_js_pop_param_pointer"] = function() {
+                return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
+            }
+            bjs["swift_js_struct_lower_Point"] = function(objectId) {
+                const { cleanup: cleanup } = structHelpers.Point.lower(swift.memory.getObject(objectId));
+                if (cleanup) {
+                    return tmpStructCleanups.push(cleanup);
+                }
+                return 0;
+            }
+            bjs["swift_js_struct_lift_Point"] = function() {
+                const value = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                return swift.memory.retain(value);
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    const bytes = new Uint8Array(memory.buffer, ptr, len);
+                    tmpRetString = textDecoder.decode(bytes);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            bjs["swift_js_get_optional_int_presence"] = function() {
+                return tmpRetOptionalInt != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_int_value"] = function() {
+                const value = tmpRetOptionalInt;
+                tmpRetOptionalInt = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_string"] = function() {
+                const str = tmpRetString;
+                tmpRetString = undefined;
+                if (str == null) {
+                    return -1;
+                } else {
+                    const bytes = textEncoder.encode(str);
+                    tmpRetBytes = bytes;
+                    return bytes.length;
+                }
+            }
+            bjs["swift_js_get_optional_float_presence"] = function() {
+                return tmpRetOptionalFloat != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_float_value"] = function() {
+                const value = tmpRetOptionalFloat;
+                tmpRetOptionalFloat = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_double_presence"] = function() {
+                return tmpRetOptionalDouble != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_double_value"] = function() {
+                const value = tmpRetOptionalDouble;
+                tmpRetOptionalDouble = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_heap_object_pointer"] = function() {
+                const pointer = tmpRetOptionalHeapObject;
+                tmpRetOptionalHeapObject = undefined;
+                return pointer || 0;
+            }
+            // Wrapper functions for module: TestModule
+            if (!importObject["TestModule"]) {
+                importObject["TestModule"] = {};
+            }
+            importObject["TestModule"]["bjs_Item_wrap"] = function(pointer) {
+                const obj = Item.__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            /// Represents a Swift heap object like a class instance or an actor instance.
+            class SwiftHeapObject {
+                static __wrap(pointer, deinit, prototype) {
+                    const obj = Object.create(prototype);
+                    obj.pointer = pointer;
+                    obj.hasReleased = false;
+                    obj.deinit = deinit;
+                    obj.registry = new FinalizationRegistry((pointer) => {
+                        deinit(pointer);
+                    });
+                    obj.registry.register(this, obj.pointer);
+                    return obj;
+                }
+            
+                release() {
+                    this.registry.unregister(this);
+                    this.deinit(this.pointer);
+                }
+            }
+            class Item extends SwiftHeapObject {
+                static __construct(ptr) {
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Item_deinit, Item.prototype);
+                }
+            
+            }
+            const PointHelpers = __bjs_createPointHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            structHelpers.Point = PointHelpers;
+            
+            const exports = {
+                Item,
+                processIntArray: function bjs_processIntArray(values) {
+                    const arrayCleanups = [];
+                    for (const elem of values) {
+                        tmpParamInts.push((elem | 0));
+                    }
+                    tmpParamArrayLengths.push(values.length);
+                    instance.exports.bjs_processIntArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const int = tmpRetInts.pop();
+                        arrayResult.push(int);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processStringArray: function bjs_processStringArray(values) {
+                    const arrayCleanups = [];
+                    for (const elem of values) {
+                        const bytes = textEncoder.encode(elem);
+                        const id = swift.memory.retain(bytes);
+                        tmpParamInts.push(bytes.length);
+                        tmpParamInts.push(id);
+                        arrayCleanups.push(() => {
+                            swift.memory.release(id);
+                        });
+                    }
+                    tmpParamArrayLengths.push(values.length);
+                    instance.exports.bjs_processStringArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const string = tmpRetStrings.pop();
+                        arrayResult.push(string);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processDoubleArray: function bjs_processDoubleArray(values) {
+                    const arrayCleanups = [];
+                    for (const elem of values) {
+                        tmpParamF64s.push(elem);
+                    }
+                    tmpParamArrayLengths.push(values.length);
+                    instance.exports.bjs_processDoubleArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const f64 = tmpRetF64s.pop();
+                        arrayResult.push(f64);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processBoolArray: function bjs_processBoolArray(values) {
+                    const arrayCleanups = [];
+                    for (const elem of values) {
+                        tmpParamInts.push(elem ? 1 : 0);
+                    }
+                    tmpParamArrayLengths.push(values.length);
+                    instance.exports.bjs_processBoolArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const bool = tmpRetInts.pop() !== 0;
+                        arrayResult.push(bool);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processPointArray: function bjs_processPointArray(points) {
+                    const arrayCleanups = [];
+                    for (const elem of points) {
+                        const { cleanup: cleanup } = structHelpers.Point.lower(elem);
+                        arrayCleanups.push(() => {
+                            if (cleanup) { cleanup(); }
+                        });
+                    }
+                    tmpParamArrayLengths.push(points.length);
+                    instance.exports.bjs_processPointArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const struct = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        arrayResult.push(struct);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processDirectionArray: function bjs_processDirectionArray(directions) {
+                    const arrayCleanups = [];
+                    for (const elem of directions) {
+                        tmpParamInts.push((elem | 0));
+                    }
+                    tmpParamArrayLengths.push(directions.length);
+                    instance.exports.bjs_processDirectionArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const caseId = tmpRetInts.pop();
+                        arrayResult.push(caseId);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processStatusArray: function bjs_processStatusArray(statuses) {
+                    const arrayCleanups = [];
+                    for (const elem of statuses) {
+                        tmpParamInts.push((elem | 0));
+                    }
+                    tmpParamArrayLengths.push(statuses.length);
+                    instance.exports.bjs_processStatusArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const rawValue = tmpRetInts.pop();
+                        arrayResult.push(rawValue);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                sumIntArray: function bjs_sumIntArray(values) {
+                    const arrayCleanups = [];
+                    for (const elem of values) {
+                        tmpParamInts.push((elem | 0));
+                    }
+                    tmpParamArrayLengths.push(values.length);
+                    const ret = instance.exports.bjs_sumIntArray();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return ret;
+                },
+                findFirstPoint: function bjs_findFirstPoint(points, matching) {
+                    const arrayCleanups = [];
+                    for (const elem of points) {
+                        const { cleanup: cleanup } = structHelpers.Point.lower(elem);
+                        arrayCleanups.push(() => {
+                            if (cleanup) { cleanup(); }
+                        });
+                    }
+                    tmpParamArrayLengths.push(points.length);
+                    const matchingBytes = textEncoder.encode(matching);
+                    const matchingId = swift.memory.retain(matchingBytes);
+                    instance.exports.bjs_findFirstPoint(matchingId, matchingBytes.length);
+                    const structValue = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    swift.memory.release(matchingId);
+                    return structValue;
+                },
+                processUnsafeRawPointerArray: function bjs_processUnsafeRawPointerArray(values) {
+                    const arrayCleanups = [];
+                    for (const elem of values) {
+                        tmpParamPointers.push((elem | 0));
+                    }
+                    tmpParamArrayLengths.push(values.length);
+                    instance.exports.bjs_processUnsafeRawPointerArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const pointer = tmpRetPointers.pop();
+                        arrayResult.push(pointer);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processUnsafeMutableRawPointerArray: function bjs_processUnsafeMutableRawPointerArray(values) {
+                    const arrayCleanups = [];
+                    for (const elem of values) {
+                        tmpParamPointers.push((elem | 0));
+                    }
+                    tmpParamArrayLengths.push(values.length);
+                    instance.exports.bjs_processUnsafeMutableRawPointerArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const pointer = tmpRetPointers.pop();
+                        arrayResult.push(pointer);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processOpaquePointerArray: function bjs_processOpaquePointerArray(values) {
+                    const arrayCleanups = [];
+                    for (const elem of values) {
+                        tmpParamPointers.push((elem | 0));
+                    }
+                    tmpParamArrayLengths.push(values.length);
+                    instance.exports.bjs_processOpaquePointerArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const pointer = tmpRetPointers.pop();
+                        arrayResult.push(pointer);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processOptionalIntArray: function bjs_processOptionalIntArray(values) {
+                    const arrayCleanups = [];
+                    for (const elem of values) {
+                        const isSome = elem != null ? 1 : 0;
+                        if (isSome) {
+                            tmpParamInts.push((elem | 0));
+                        } else {
+                            tmpParamInts.push(0);
+                        }
+                        tmpParamInts.push(isSome);
+                    }
+                    tmpParamArrayLengths.push(values.length);
+                    instance.exports.bjs_processOptionalIntArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const isSome1 = tmpRetInts.pop();
+                        let optValue;
+                        if (isSome1 === 0) {
+                            optValue = null;
+                        } else {
+                            const int = tmpRetInts.pop();
+                            optValue = int;
+                        }
+                        arrayResult.push(optValue);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processOptionalStringArray: function bjs_processOptionalStringArray(values) {
+                    const arrayCleanups = [];
+                    for (const elem of values) {
+                        const isSome = elem != null ? 1 : 0;
+                        if (isSome) {
+                            const bytes = textEncoder.encode(elem);
+                            const id = swift.memory.retain(bytes);
+                            tmpParamInts.push(bytes.length);
+                            tmpParamInts.push(id);
+                            arrayCleanups.push(() => { swift.memory.release(id); });
+                        } else {
+                            tmpParamInts.push(0);
+                            tmpParamInts.push(0);
+                        }
+                        tmpParamInts.push(isSome);
+                    }
+                    tmpParamArrayLengths.push(values.length);
+                    instance.exports.bjs_processOptionalStringArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const isSome1 = tmpRetInts.pop();
+                        let optValue;
+                        if (isSome1 === 0) {
+                            optValue = null;
+                        } else {
+                            const string = tmpRetStrings.pop();
+                            optValue = string;
+                        }
+                        arrayResult.push(optValue);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processOptionalArray: function bjs_processOptionalArray(values) {
+                    const isSome = values != null;
+                    const valuesCleanups = [];
+                    if (isSome) {
+                        const arrayCleanups = [];
+                        for (const elem of values) {
+                            tmpParamInts.push((elem | 0));
+                        }
+                        tmpParamArrayLengths.push(values.length);
+                        valuesCleanups.push(() => { for (const cleanup of arrayCleanups) { cleanup(); } });
+                    }
+                    instance.exports.bjs_processOptionalArray(+isSome);
+                    const isSome1 = tmpRetInts.pop();
+                    let optResult;
+                    if (isSome1) {
+                        const arrayLen = tmpRetArrayLengths.pop();
+                        const arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const int = tmpRetInts.pop();
+                            arrayResult.push(int);
+                        }
+                        arrayResult.reverse();
+                        optResult = arrayResult;
+                    } else {
+                        optResult = null;
+                    }
+                    for (const cleanup of valuesCleanups) { cleanup(); }
+                    return optResult;
+                },
+                processOptionalPointArray: function bjs_processOptionalPointArray(points) {
+                    const arrayCleanups = [];
+                    for (const elem of points) {
+                        const isSome = elem != null ? 1 : 0;
+                        if (isSome) {
+                            const { cleanup: cleanup } = structHelpers.Point.lower(elem);
+                            arrayCleanups.push(() => { if (cleanup) { cleanup(); } });
+                        } else {
+                        }
+                        tmpParamInts.push(isSome);
+                    }
+                    tmpParamArrayLengths.push(points.length);
+                    instance.exports.bjs_processOptionalPointArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const isSome1 = tmpRetInts.pop();
+                        let optValue;
+                        if (isSome1 === 0) {
+                            optValue = null;
+                        } else {
+                            const struct = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                            optValue = struct;
+                        }
+                        arrayResult.push(optValue);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processOptionalDirectionArray: function bjs_processOptionalDirectionArray(directions) {
+                    const arrayCleanups = [];
+                    for (const elem of directions) {
+                        const isSome = elem != null ? 1 : 0;
+                        if (isSome) {
+                            tmpParamInts.push((elem | 0));
+                        } else {
+                            tmpParamInts.push(0);
+                        }
+                        tmpParamInts.push(isSome);
+                    }
+                    tmpParamArrayLengths.push(directions.length);
+                    instance.exports.bjs_processOptionalDirectionArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const isSome1 = tmpRetInts.pop();
+                        let optValue;
+                        if (isSome1 === 0) {
+                            optValue = null;
+                        } else {
+                            const caseId = tmpRetInts.pop();
+                            optValue = caseId;
+                        }
+                        arrayResult.push(optValue);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processOptionalStatusArray: function bjs_processOptionalStatusArray(statuses) {
+                    const arrayCleanups = [];
+                    for (const elem of statuses) {
+                        const isSome = elem != null ? 1 : 0;
+                        if (isSome) {
+                            tmpParamInts.push((elem | 0));
+                        } else {
+                            tmpParamInts.push(0);
+                        }
+                        tmpParamInts.push(isSome);
+                    }
+                    tmpParamArrayLengths.push(statuses.length);
+                    instance.exports.bjs_processOptionalStatusArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const isSome1 = tmpRetInts.pop();
+                        let optValue;
+                        if (isSome1 === 0) {
+                            optValue = null;
+                        } else {
+                            const rawValue = tmpRetInts.pop();
+                            optValue = rawValue;
+                        }
+                        arrayResult.push(optValue);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processNestedIntArray: function bjs_processNestedIntArray(values) {
+                    const arrayCleanups = [];
+                    for (const elem of values) {
+                        const arrayCleanups1 = [];
+                        for (const elem1 of elem) {
+                            tmpParamInts.push((elem1 | 0));
+                        }
+                        tmpParamArrayLengths.push(elem.length);
+                        arrayCleanups.push(() => {
+                            for (const cleanup of arrayCleanups1) { cleanup(); }
+                        });
+                    }
+                    tmpParamArrayLengths.push(values.length);
+                    instance.exports.bjs_processNestedIntArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const arrayLen1 = tmpRetArrayLengths.pop();
+                        const arrayResult1 = [];
+                        for (let i1 = 0; i1 < arrayLen1; i1++) {
+                            const int = tmpRetInts.pop();
+                            arrayResult1.push(int);
+                        }
+                        arrayResult1.reverse();
+                        arrayResult.push(arrayResult1);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processNestedStringArray: function bjs_processNestedStringArray(values) {
+                    const arrayCleanups = [];
+                    for (const elem of values) {
+                        const arrayCleanups1 = [];
+                        for (const elem1 of elem) {
+                            const bytes = textEncoder.encode(elem1);
+                            const id = swift.memory.retain(bytes);
+                            tmpParamInts.push(bytes.length);
+                            tmpParamInts.push(id);
+                            arrayCleanups1.push(() => {
+                                swift.memory.release(id);
+                            });
+                        }
+                        tmpParamArrayLengths.push(elem.length);
+                        arrayCleanups.push(() => {
+                            for (const cleanup of arrayCleanups1) { cleanup(); }
+                        });
+                    }
+                    tmpParamArrayLengths.push(values.length);
+                    instance.exports.bjs_processNestedStringArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const arrayLen1 = tmpRetArrayLengths.pop();
+                        const arrayResult1 = [];
+                        for (let i1 = 0; i1 < arrayLen1; i1++) {
+                            const string = tmpRetStrings.pop();
+                            arrayResult1.push(string);
+                        }
+                        arrayResult1.reverse();
+                        arrayResult.push(arrayResult1);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processNestedPointArray: function bjs_processNestedPointArray(points) {
+                    const arrayCleanups = [];
+                    for (const elem of points) {
+                        const arrayCleanups1 = [];
+                        for (const elem1 of elem) {
+                            const { cleanup: cleanup } = structHelpers.Point.lower(elem1);
+                            arrayCleanups1.push(() => {
+                                if (cleanup) { cleanup(); }
+                            });
+                        }
+                        tmpParamArrayLengths.push(elem.length);
+                        arrayCleanups.push(() => {
+                            for (const cleanup of arrayCleanups1) { cleanup(); }
+                        });
+                    }
+                    tmpParamArrayLengths.push(points.length);
+                    instance.exports.bjs_processNestedPointArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const arrayLen1 = tmpRetArrayLengths.pop();
+                        const arrayResult1 = [];
+                        for (let i1 = 0; i1 < arrayLen1; i1++) {
+                            const struct = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                            arrayResult1.push(struct);
+                        }
+                        arrayResult1.reverse();
+                        arrayResult.push(arrayResult1);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processItemArray: function bjs_processItemArray(items) {
+                    const arrayCleanups = [];
+                    for (const elem of items) {
+                        tmpParamPointers.push(elem.pointer);
+                    }
+                    tmpParamArrayLengths.push(items.length);
+                    instance.exports.bjs_processItemArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const ptr = tmpRetPointers.pop();
+                        const obj = Item.__construct(ptr);
+                        arrayResult.push(obj);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                processNestedItemArray: function bjs_processNestedItemArray(items) {
+                    const arrayCleanups = [];
+                    for (const elem of items) {
+                        const arrayCleanups1 = [];
+                        for (const elem1 of elem) {
+                            tmpParamPointers.push(elem1.pointer);
+                        }
+                        tmpParamArrayLengths.push(elem.length);
+                        arrayCleanups.push(() => {
+                            for (const cleanup of arrayCleanups1) { cleanup(); }
+                        });
+                    }
+                    tmpParamArrayLengths.push(items.length);
+                    instance.exports.bjs_processNestedItemArray();
+                    const arrayLen = tmpRetArrayLengths.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const arrayLen1 = tmpRetArrayLengths.pop();
+                        const arrayResult1 = [];
+                        for (let i1 = 0; i1 < arrayLen1; i1++) {
+                            const ptr = tmpRetPointers.pop();
+                            const obj = Item.__construct(ptr);
+                            arrayResult1.push(obj);
+                        }
+                        arrayResult1.reverse();
+                        arrayResult.push(arrayResult1);
+                    }
+                    arrayResult.reverse();
+                    for (const cleanup of arrayCleanups) { cleanup(); }
+                    return arrayResult;
+                },
+                Direction: DirectionValues,
+                Status: StatusValues,
+            };
+            _exports = exports;
+            return exports;
+        },
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.Export.d.ts
@@ -116,6 +116,32 @@ export type Exports = {
      * @param point - Optional parameter (default: { name: "default", value: 42, enabled: true })
      */
     testOptionalStructWithValueDefault(point?: Config | null): Config | null;
+    /**
+     * @param values - Optional parameter (default: [1, 2, 3])
+     */
+    testIntArrayDefault(values?: number[]): number[];
+    /**
+     * @param names - Optional parameter (default: ["a", "b", "c"])
+     */
+    testStringArrayDefault(names?: string[]): string[];
+    /**
+     * @param values - Optional parameter (default: [1.5, 2.5, 3.5])
+     */
+    testDoubleArrayDefault(values?: number[]): number[];
+    /**
+     * @param flags - Optional parameter (default: [true, false, true])
+     */
+    testBoolArrayDefault(flags?: boolean[]): boolean[];
+    /**
+     * @param items - Optional parameter (default: [])
+     */
+    testEmptyArrayDefault(items?: number[]): number[];
+    /**
+     * @param name - Optional parameter (default: "test")
+     * @param values - Optional parameter (default: [10, 20, 30])
+     * @param enabled - Optional parameter (default: true)
+     */
+    testMixedWithArrayDefault(name?: string, values?: number[], enabled?: boolean): string;
     Status: StatusObject
     MathOperations: {
         /**

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.Export.js
@@ -504,6 +504,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -575,6 +577,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.Export.js
@@ -53,6 +53,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -124,6 +126,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.js
@@ -54,6 +54,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -125,6 +127,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.Export.js
@@ -73,6 +73,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -144,6 +146,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.Export.js
@@ -104,6 +104,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -175,6 +177,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.ImportMacros.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.ImportMacros.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.ImportMacros.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.ImportMacros.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Interface.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Interface.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MultipleImportedTypes.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.Export.d.ts
@@ -90,6 +90,10 @@ export interface MyViewController extends SwiftHeapObject {
     delegate: MyViewControllerDelegate;
     secondDelegate: MyViewControllerDelegate | null;
 }
+export interface DelegateManager extends SwiftHeapObject {
+    notifyAll(): void;
+    delegates: MyViewControllerDelegate[];
+}
 export type Exports = {
     Helper: {
         new(value: number): Helper;
@@ -97,6 +101,10 @@ export type Exports = {
     MyViewController: {
         new(delegate: MyViewControllerDelegate): MyViewController;
     }
+    DelegateManager: {
+        new(delegates: MyViewControllerDelegate[]): DelegateManager;
+    }
+    processDelegates(delegates: MyViewControllerDelegate[]): MyViewControllerDelegate[];
     Direction: DirectionObject
     ExampleEnum: ExampleEnumObject
     Result: ResultObject

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ReExportFrom.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ReExportFrom.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Export.js
@@ -80,6 +80,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -151,6 +153,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.Export.js
@@ -80,6 +80,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -151,6 +153,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Export.js
@@ -34,6 +34,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -105,6 +107,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.Export.js
@@ -34,6 +34,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -105,6 +107,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringEnum.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringEnum.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.Export.js
@@ -131,6 +131,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -202,6 +204,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.ImportMacros.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.ImportMacros.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.Export.js
@@ -34,6 +34,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -294,6 +296,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.ImportMacros.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.ImportMacros.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -115,6 +117,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TS2SkeletonLike.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeAlias.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeAlias.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeScriptClass.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/TypeScriptClass.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -120,6 +122,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Export.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -100,6 +102,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Import.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.Import.js
@@ -29,6 +29,8 @@ export async function createInstantiator(options, swift) {
     let tmpRetPointers = [];
     let tmpParamPointers = [];
     let tmpStructCleanups = [];
+    let tmpRetArrayLengths = [];
+    let tmpParamArrayLengths = [];
     const enumHelpers = {};
     const structHelpers = {};
     
@@ -101,6 +103,12 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_param_pointer"] = function() {
                 return tmpParamPointers.pop();
+            }
+            bjs["swift_js_push_array_length"] = function(len) {
+                tmpRetArrayLengths.push(len | 0);
+            }
+            bjs["swift_js_pop_param_array_length"] = function() {
+                return tmpParamArrayLengths.pop();
             }
             bjs["swift_js_struct_cleanup"] = function(cleanupId) {
                 if (cleanupId === 0) { return; }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/ArrayTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/ArrayTypes.json
@@ -1,0 +1,983 @@
+{
+  "classes" : [
+    {
+      "methods" : [
+
+      ],
+      "name" : "Item",
+      "properties" : [
+
+      ],
+      "swiftCallName" : "Item"
+    }
+  ],
+  "enums" : [
+    {
+      "cases" : [
+        {
+          "associatedValues" : [
+
+          ],
+          "name" : "north"
+        },
+        {
+          "associatedValues" : [
+
+          ],
+          "name" : "south"
+        },
+        {
+          "associatedValues" : [
+
+          ],
+          "name" : "east"
+        },
+        {
+          "associatedValues" : [
+
+          ],
+          "name" : "west"
+        }
+      ],
+      "emitStyle" : "const",
+      "name" : "Direction",
+      "staticMethods" : [
+
+      ],
+      "staticProperties" : [
+
+      ],
+      "swiftCallName" : "Direction",
+      "tsFullPath" : "Direction"
+    },
+    {
+      "cases" : [
+        {
+          "associatedValues" : [
+
+          ],
+          "name" : "pending",
+          "rawValue" : "0"
+        },
+        {
+          "associatedValues" : [
+
+          ],
+          "name" : "active",
+          "rawValue" : "1"
+        },
+        {
+          "associatedValues" : [
+
+          ],
+          "name" : "completed",
+          "rawValue" : "2"
+        }
+      ],
+      "emitStyle" : "const",
+      "name" : "Status",
+      "rawType" : "Int",
+      "staticMethods" : [
+
+      ],
+      "staticProperties" : [
+
+      ],
+      "swiftCallName" : "Status",
+      "tsFullPath" : "Status"
+    }
+  ],
+  "exposeToGlobal" : false,
+  "functions" : [
+    {
+      "abiName" : "bjs_processIntArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processIntArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "int" : {
+
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "int" : {
+
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processStringArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processStringArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "string" : {
+
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "string" : {
+
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processDoubleArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processDoubleArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "double" : {
+
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "double" : {
+
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processBoolArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processBoolArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "bool" : {
+
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "bool" : {
+
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processPointArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processPointArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "points",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "swiftStruct" : {
+                  "_0" : "Point"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "swiftStruct" : {
+              "_0" : "Point"
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processDirectionArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processDirectionArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "directions",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "caseEnum" : {
+                  "_0" : "Direction"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "caseEnum" : {
+              "_0" : "Direction"
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processStatusArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processStatusArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "statuses",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "rawValueEnum" : {
+                  "_0" : "Status",
+                  "_1" : "Int"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "rawValueEnum" : {
+              "_0" : "Status",
+              "_1" : "Int"
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_sumIntArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "sumIntArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "int" : {
+
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "int" : {
+
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_findFirstPoint",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "findFirstPoint",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "points",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "swiftStruct" : {
+                  "_0" : "Point"
+                }
+              }
+            }
+          }
+        },
+        {
+          "label" : "matching",
+          "name" : "matching",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "swiftStruct" : {
+          "_0" : "Point"
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processUnsafeRawPointerArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processUnsafeRawPointerArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "unsafePointer" : {
+                  "_0" : {
+                    "kind" : "unsafeRawPointer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "unsafePointer" : {
+              "_0" : {
+                "kind" : "unsafeRawPointer"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processUnsafeMutableRawPointerArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processUnsafeMutableRawPointerArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "unsafePointer" : {
+                  "_0" : {
+                    "kind" : "unsafeMutableRawPointer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "unsafePointer" : {
+              "_0" : {
+                "kind" : "unsafeMutableRawPointer"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processOpaquePointerArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processOpaquePointerArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "unsafePointer" : {
+                  "_0" : {
+                    "kind" : "opaquePointer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "unsafePointer" : {
+              "_0" : {
+                "kind" : "opaquePointer"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processOptionalIntArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processOptionalIntArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "optional" : {
+                  "_0" : {
+                    "int" : {
+
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "optional" : {
+              "_0" : {
+                "int" : {
+
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processOptionalStringArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processOptionalStringArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "optional" : {
+                  "_0" : {
+                    "string" : {
+
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "optional" : {
+              "_0" : {
+                "string" : {
+
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processOptionalArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processOptionalArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "optional" : {
+              "_0" : {
+                "array" : {
+                  "_0" : {
+                    "int" : {
+
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "optional" : {
+          "_0" : {
+            "array" : {
+              "_0" : {
+                "int" : {
+
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processOptionalPointArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processOptionalPointArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "points",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "optional" : {
+                  "_0" : {
+                    "swiftStruct" : {
+                      "_0" : "Point"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "optional" : {
+              "_0" : {
+                "swiftStruct" : {
+                  "_0" : "Point"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processOptionalDirectionArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processOptionalDirectionArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "directions",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "optional" : {
+                  "_0" : {
+                    "caseEnum" : {
+                      "_0" : "Direction"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "optional" : {
+              "_0" : {
+                "caseEnum" : {
+                  "_0" : "Direction"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processOptionalStatusArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processOptionalStatusArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "statuses",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "optional" : {
+                  "_0" : {
+                    "rawValueEnum" : {
+                      "_0" : "Status",
+                      "_1" : "Int"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "optional" : {
+              "_0" : {
+                "rawValueEnum" : {
+                  "_0" : "Status",
+                  "_1" : "Int"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processNestedIntArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processNestedIntArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "array" : {
+                  "_0" : {
+                    "int" : {
+
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "array" : {
+              "_0" : {
+                "int" : {
+
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processNestedStringArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processNestedStringArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "array" : {
+                  "_0" : {
+                    "string" : {
+
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "array" : {
+              "_0" : {
+                "string" : {
+
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processNestedPointArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processNestedPointArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "points",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "array" : {
+                  "_0" : {
+                    "swiftStruct" : {
+                      "_0" : "Point"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "array" : {
+              "_0" : {
+                "swiftStruct" : {
+                  "_0" : "Point"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processItemArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processItemArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "items",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "swiftHeapObject" : {
+                  "_0" : "Item"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "swiftHeapObject" : {
+              "_0" : "Item"
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_processNestedItemArray",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processNestedItemArray",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "items",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "array" : {
+                  "_0" : {
+                    "swiftHeapObject" : {
+                      "_0" : "Item"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "array" : {
+              "_0" : {
+                "swiftHeapObject" : {
+                  "_0" : "Item"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "protocols" : [
+
+  ],
+  "structs" : [
+    {
+      "methods" : [
+
+      ],
+      "name" : "Point",
+      "properties" : [
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "x",
+          "type" : {
+            "double" : {
+
+            }
+          }
+        },
+        {
+          "isReadonly" : true,
+          "isStatic" : false,
+          "name" : "y",
+          "type" : {
+            "double" : {
+
+            }
+          }
+        }
+      ],
+      "swiftCallName" : "Point"
+    }
+  ]
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/ArrayTypes.swift
@@ -1,0 +1,694 @@
+extension Direction: _BridgedSwiftCaseEnum {
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
+        return bridgeJSRawValue
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Direction {
+        return bridgeJSLiftParameter(value)
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Direction {
+        return Direction(bridgeJSRawValue: value)!
+    }
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
+        return bridgeJSLowerParameter()
+    }
+
+    private init?(bridgeJSRawValue: Int32) {
+        switch bridgeJSRawValue {
+        case 0:
+            self = .north
+        case 1:
+            self = .south
+        case 2:
+            self = .east
+        case 3:
+            self = .west
+        default:
+            return nil
+        }
+    }
+
+    private var bridgeJSRawValue: Int32 {
+        switch self {
+        case .north:
+            return 0
+        case .south:
+            return 1
+        case .east:
+            return 2
+        case .west:
+            return 3
+        }
+    }
+}
+
+extension Status: _BridgedSwiftEnumNoPayload {
+}
+
+extension Point: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Point {
+        let y = Double.bridgeJSLiftParameter(_swift_js_pop_param_f64())
+        let x = Double.bridgeJSLiftParameter(_swift_js_pop_param_f64())
+        return Point(x: x, y: y)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        _swift_js_push_f64(self.x)
+        _swift_js_push_f64(self.y)
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Point")
+fileprivate func _bjs_struct_lift_Point() -> Int32
+#else
+fileprivate func _bjs_struct_lift_Point() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_processIntArray")
+@_cdecl("bjs_processIntArray")
+public func _bjs_processIntArray() -> Void {
+    #if arch(wasm32)
+    let ret = processIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processStringArray")
+@_cdecl("bjs_processStringArray")
+public func _bjs_processStringArray() -> Void {
+    #if arch(wasm32)
+    let ret = processStringArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [String] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    var __bjs_ret_elem = __bjs_elem_ret
+    __bjs_ret_elem.withUTF8 { ptr in
+        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+    }}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processDoubleArray")
+@_cdecl("bjs_processDoubleArray")
+public func _bjs_processDoubleArray() -> Void {
+    #if arch(wasm32)
+    let ret = processDoubleArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Double] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Double.bridgeJSLiftParameter(_swift_js_pop_param_f64()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_f64(__bjs_elem_ret)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processBoolArray")
+@_cdecl("bjs_processBoolArray")
+public func _bjs_processBoolArray() -> Void {
+    #if arch(wasm32)
+    let ret = processBoolArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Bool] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Bool.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(__bjs_elem_ret ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processPointArray")
+@_cdecl("bjs_processPointArray")
+public func _bjs_processPointArray() -> Void {
+    #if arch(wasm32)
+    let ret = processPointArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Point] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Point.bridgeJSLiftParameter())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    __bjs_elem_ret.bridgeJSLowerReturn()}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processDirectionArray")
+@_cdecl("bjs_processDirectionArray")
+public func _bjs_processDirectionArray() -> Void {
+    #if arch(wasm32)
+    let ret = processDirectionArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Direction] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Direction.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret.bridgeJSLowerParameter()))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processStatusArray")
+@_cdecl("bjs_processStatusArray")
+public func _bjs_processStatusArray() -> Void {
+    #if arch(wasm32)
+    let ret = processStatusArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Status] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Status.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret.bridgeJSLowerParameter()))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_sumIntArray")
+@_cdecl("bjs_sumIntArray")
+public func _bjs_sumIntArray() -> Int32 {
+    #if arch(wasm32)
+    let ret = sumIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_findFirstPoint")
+@_cdecl("bjs_findFirstPoint")
+public func _bjs_findFirstPoint(_ matchingBytes: Int32, _ matchingLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = findFirstPoint(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Point] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Point.bridgeJSLiftParameter())
+        }
+        __result.reverse()
+        return __result
+        }(), matching: String.bridgeJSLiftParameter(matchingBytes, matchingLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processUnsafeRawPointerArray")
+@_cdecl("bjs_processUnsafeRawPointerArray")
+public func _bjs_processUnsafeRawPointerArray() -> Void {
+    #if arch(wasm32)
+    let ret = processUnsafeRawPointerArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [UnsafeRawPointer] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(UnsafeRawPointer.bridgeJSLiftParameter(_swift_js_pop_param_pointer()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processUnsafeMutableRawPointerArray")
+@_cdecl("bjs_processUnsafeMutableRawPointerArray")
+public func _bjs_processUnsafeMutableRawPointerArray() -> Void {
+    #if arch(wasm32)
+    let ret = processUnsafeMutableRawPointerArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [UnsafeMutableRawPointer] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(UnsafeMutableRawPointer.bridgeJSLiftParameter(_swift_js_pop_param_pointer()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processOpaquePointerArray")
+@_cdecl("bjs_processOpaquePointerArray")
+public func _bjs_processOpaquePointerArray() -> Void {
+    #if arch(wasm32)
+    let ret = processOpaquePointerArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [OpaquePointer] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(OpaquePointer.bridgeJSLiftParameter(_swift_js_pop_param_pointer()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processOptionalIntArray")
+@_cdecl("bjs_processOptionalIntArray")
+public func _bjs_processOptionalIntArray() -> Void {
+    #if arch(wasm32)
+    let ret = processOptionalIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<Int>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    _swift_js_push_int(Int32(__bjs_unwrapped_ret_elem))}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processOptionalStringArray")
+@_cdecl("bjs_processOptionalStringArray")
+public func _bjs_processOptionalStringArray() -> Void {
+    #if arch(wasm32)
+    let ret = processOptionalStringArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<String>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<String>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    var __bjs_str_ret_elem = __bjs_unwrapped_ret_elem
+    __bjs_str_ret_elem.withUTF8 { ptr in
+        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+    }}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processOptionalArray")
+@_cdecl("bjs_processOptionalArray")
+public func _bjs_processOptionalArray(_ values: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = processOptionalArray(_: {
+        if values == 0 {
+            return Optional<[Int]>.none
+        } else {
+            return {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                }()
+        }
+        }())
+    let __bjs_isSome_ret = ret != nil
+    if let __bjs_unwrapped_ret = ret {
+    for __bjs_elem_ret in __bjs_unwrapped_ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret))}
+    _swift_js_push_array_length(Int32(__bjs_unwrapped_ret.count))}
+    _swift_js_push_int(__bjs_isSome_ret ? 1 : 0)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processOptionalPointArray")
+@_cdecl("bjs_processOptionalPointArray")
+public func _bjs_processOptionalPointArray() -> Void {
+    #if arch(wasm32)
+    let ret = processOptionalPointArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<Point>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<Point>.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    __bjs_unwrapped_ret_elem.bridgeJSLowerReturn()}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processOptionalDirectionArray")
+@_cdecl("bjs_processOptionalDirectionArray")
+public func _bjs_processOptionalDirectionArray() -> Void {
+    #if arch(wasm32)
+    let ret = processOptionalDirectionArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<Direction>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<Direction>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    _swift_js_push_int(__bjs_unwrapped_ret_elem.bridgeJSLowerParameter())}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processOptionalStatusArray")
+@_cdecl("bjs_processOptionalStatusArray")
+public func _bjs_processOptionalStatusArray() -> Void {
+    #if arch(wasm32)
+    let ret = processOptionalStatusArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<Status>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<Status>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    _swift_js_push_int(__bjs_unwrapped_ret_elem.bridgeJSLowerParameter())}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processNestedIntArray")
+@_cdecl("bjs_processNestedIntArray")
+public func _bjs_processNestedIntArray() -> Void {
+    #if arch(wasm32)
+    let ret = processNestedIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[Int]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret_elem))}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processNestedStringArray")
+@_cdecl("bjs_processNestedStringArray")
+public func _bjs_processNestedStringArray() -> Void {
+    #if arch(wasm32)
+    let ret = processNestedStringArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[String]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [String] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    var __bjs_ret_elem_elem = __bjs_elem_ret_elem
+    __bjs_ret_elem_elem.withUTF8 { ptr in
+        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+    }}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processNestedPointArray")
+@_cdecl("bjs_processNestedPointArray")
+public func _bjs_processNestedPointArray() -> Void {
+    #if arch(wasm32)
+    let ret = processNestedPointArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[Point]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Point] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Point.bridgeJSLiftParameter())
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    __bjs_elem_ret_elem.bridgeJSLowerReturn()}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processItemArray")
+@_cdecl("bjs_processItemArray")
+public func _bjs_processItemArray() -> Void {
+    #if arch(wasm32)
+    let ret = processItemArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Item] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Item.bridgeJSLiftParameter(_swift_js_pop_param_pointer()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processNestedItemArray")
+@_cdecl("bjs_processNestedItemArray")
+public func _bjs_processNestedItemArray() -> Void {
+    #if arch(wasm32)
+    let ret = processNestedItemArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[Item]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Item] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Item.bridgeJSLiftParameter(_swift_js_pop_param_pointer()))
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    _swift_js_push_pointer(__bjs_elem_ret_elem.bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_Item_deinit")
+@_cdecl("bjs_Item_deinit")
+public func _bjs_Item_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<Item>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension Item: ConvertibleToJSValue, _BridgedSwiftHeapObject {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Item_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_Item_wrap")
+fileprivate func _bjs_Item_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_Item_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.json
@@ -728,6 +728,340 @@
           }
         }
       }
+    },
+    {
+      "abiName" : "bjs_testIntArrayDefault",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "testIntArrayDefault",
+      "parameters" : [
+        {
+          "defaultValue" : {
+            "array" : {
+              "_0" : [
+                {
+                  "int" : {
+                    "_0" : 1
+                  }
+                },
+                {
+                  "int" : {
+                    "_0" : 2
+                  }
+                },
+                {
+                  "int" : {
+                    "_0" : 3
+                  }
+                }
+              ]
+            }
+          },
+          "label" : "values",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "int" : {
+
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "int" : {
+
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_testStringArrayDefault",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "testStringArrayDefault",
+      "parameters" : [
+        {
+          "defaultValue" : {
+            "array" : {
+              "_0" : [
+                {
+                  "string" : {
+                    "_0" : "a"
+                  }
+                },
+                {
+                  "string" : {
+                    "_0" : "b"
+                  }
+                },
+                {
+                  "string" : {
+                    "_0" : "c"
+                  }
+                }
+              ]
+            }
+          },
+          "label" : "names",
+          "name" : "names",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "string" : {
+
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "string" : {
+
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_testDoubleArrayDefault",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "testDoubleArrayDefault",
+      "parameters" : [
+        {
+          "defaultValue" : {
+            "array" : {
+              "_0" : [
+                {
+                  "double" : {
+                    "_0" : 1.5
+                  }
+                },
+                {
+                  "double" : {
+                    "_0" : 2.5
+                  }
+                },
+                {
+                  "double" : {
+                    "_0" : 3.5
+                  }
+                }
+              ]
+            }
+          },
+          "label" : "values",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "double" : {
+
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "double" : {
+
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_testBoolArrayDefault",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "testBoolArrayDefault",
+      "parameters" : [
+        {
+          "defaultValue" : {
+            "array" : {
+              "_0" : [
+                {
+                  "bool" : {
+                    "_0" : true
+                  }
+                },
+                {
+                  "bool" : {
+                    "_0" : false
+                  }
+                },
+                {
+                  "bool" : {
+                    "_0" : true
+                  }
+                }
+              ]
+            }
+          },
+          "label" : "flags",
+          "name" : "flags",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "bool" : {
+
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "bool" : {
+
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_testEmptyArrayDefault",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "testEmptyArrayDefault",
+      "parameters" : [
+        {
+          "defaultValue" : {
+            "array" : {
+              "_0" : [
+
+              ]
+            }
+          },
+          "label" : "items",
+          "name" : "items",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "int" : {
+
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "int" : {
+
+            }
+          }
+        }
+      }
+    },
+    {
+      "abiName" : "bjs_testMixedWithArrayDefault",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "testMixedWithArrayDefault",
+      "parameters" : [
+        {
+          "defaultValue" : {
+            "string" : {
+              "_0" : "test"
+            }
+          },
+          "label" : "name",
+          "name" : "name",
+          "type" : {
+            "string" : {
+
+            }
+          }
+        },
+        {
+          "defaultValue" : {
+            "array" : {
+              "_0" : [
+                {
+                  "int" : {
+                    "_0" : 10
+                  }
+                },
+                {
+                  "int" : {
+                    "_0" : 20
+                  }
+                },
+                {
+                  "int" : {
+                    "_0" : 30
+                  }
+                }
+              ]
+            }
+          },
+          "label" : "values",
+          "name" : "values",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "int" : {
+
+                }
+              }
+            }
+          }
+        },
+        {
+          "defaultValue" : {
+            "bool" : {
+              "_0" : true
+            }
+          },
+          "label" : "enabled",
+          "name" : "enabled",
+          "type" : {
+            "bool" : {
+
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "string" : {
+
+        }
+      }
     }
   ],
   "protocols" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.swift
@@ -317,6 +317,139 @@ public func _bjs_testOptionalStructWithValueDefault(_ point: Int32) -> Void {
     #endif
 }
 
+@_expose(wasm, "bjs_testIntArrayDefault")
+@_cdecl("bjs_testIntArrayDefault")
+public func _bjs_testIntArrayDefault() -> Void {
+    #if arch(wasm32)
+    let ret = testIntArrayDefault(values: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_testStringArrayDefault")
+@_cdecl("bjs_testStringArrayDefault")
+public func _bjs_testStringArrayDefault() -> Void {
+    #if arch(wasm32)
+    let ret = testStringArrayDefault(names: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [String] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    var __bjs_ret_elem = __bjs_elem_ret
+    __bjs_ret_elem.withUTF8 { ptr in
+        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+    }}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_testDoubleArrayDefault")
+@_cdecl("bjs_testDoubleArrayDefault")
+public func _bjs_testDoubleArrayDefault() -> Void {
+    #if arch(wasm32)
+    let ret = testDoubleArrayDefault(values: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Double] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Double.bridgeJSLiftParameter(_swift_js_pop_param_f64()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_f64(__bjs_elem_ret)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_testBoolArrayDefault")
+@_cdecl("bjs_testBoolArrayDefault")
+public func _bjs_testBoolArrayDefault() -> Void {
+    #if arch(wasm32)
+    let ret = testBoolArrayDefault(flags: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Bool] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Bool.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(__bjs_elem_ret ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_testEmptyArrayDefault")
+@_cdecl("bjs_testEmptyArrayDefault")
+public func _bjs_testEmptyArrayDefault() -> Void {
+    #if arch(wasm32)
+    let ret = testEmptyArrayDefault(items: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_testMixedWithArrayDefault")
+@_cdecl("bjs_testMixedWithArrayDefault")
+public func _bjs_testMixedWithArrayDefault(_ nameBytes: Int32, _ nameLength: Int32, _ enabled: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = testMixedWithArrayDefault(name: String.bridgeJSLiftParameter(nameBytes, nameLength), values: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }(), enabled: Bool.bridgeJSLiftParameter(enabled))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_DefaultGreeter_init")
 @_cdecl("bjs_DefaultGreeter_init")
 public func _bjs_DefaultGreeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Protocol.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Protocol.json
@@ -247,6 +247,68 @@
         }
       ],
       "swiftCallName" : "MyViewController"
+    },
+    {
+      "constructor" : {
+        "abiName" : "bjs_DelegateManager_init",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "parameters" : [
+          {
+            "label" : "delegates",
+            "name" : "delegates",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "swiftProtocol" : {
+                    "_0" : "MyViewControllerDelegate"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "methods" : [
+        {
+          "abiName" : "bjs_DelegateManager_notifyAll",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "name" : "notifyAll",
+          "parameters" : [
+
+          ],
+          "returnType" : {
+            "void" : {
+
+            }
+          }
+        }
+      ],
+      "name" : "DelegateManager",
+      "properties" : [
+        {
+          "isReadonly" : false,
+          "isStatic" : false,
+          "name" : "delegates",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "swiftProtocol" : {
+                  "_0" : "MyViewControllerDelegate"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "swiftCallName" : "DelegateManager"
     }
   ],
   "enums" : [
@@ -394,7 +456,39 @@
   ],
   "exposeToGlobal" : false,
   "functions" : [
-
+    {
+      "abiName" : "bjs_processDelegates",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "processDelegates",
+      "parameters" : [
+        {
+          "label" : "_",
+          "name" : "delegates",
+          "type" : {
+            "array" : {
+              "_0" : {
+                "swiftProtocol" : {
+                  "_0" : "MyViewControllerDelegate"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returnType" : {
+        "array" : {
+          "_0" : {
+            "swiftProtocol" : {
+              "_0" : "MyViewControllerDelegate"
+            }
+          }
+        }
+      }
+    }
   ],
   "protocols" : [
     {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Protocol.swift
@@ -418,6 +418,28 @@ extension Result: _BridgedSwiftAssociatedValueEnum {
 extension Priority: _BridgedSwiftEnumNoPayload {
 }
 
+@_expose(wasm, "bjs_processDelegates")
+@_cdecl("bjs_processDelegates")
+public func _bjs_processDelegates() -> Void {
+    #if arch(wasm32)
+    let ret = processDelegates(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [AnyMyViewControllerDelegate] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(AnyMyViewControllerDelegate.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int((__bjs_elem_ret as! AnyMyViewControllerDelegate).bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_Helper_init")
 @_cdecl("bjs_Helper_init")
 public func _bjs_Helper_init(_ value: Int32) -> UnsafeMutableRawPointer {
@@ -623,6 +645,93 @@ extension MyViewController: ConvertibleToJSValue, _BridgedSwiftHeapObject {
 fileprivate func _bjs_MyViewController_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
 fileprivate func _bjs_MyViewController_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_DelegateManager_init")
+@_cdecl("bjs_DelegateManager_init")
+public func _bjs_DelegateManager_init() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = DelegateManager(delegates: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [AnyMyViewControllerDelegate] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(AnyMyViewControllerDelegate.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_DelegateManager_notifyAll")
+@_cdecl("bjs_DelegateManager_notifyAll")
+public func _bjs_DelegateManager_notifyAll(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    DelegateManager.bridgeJSLiftParameter(_self).notifyAll()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_DelegateManager_delegates_get")
+@_cdecl("bjs_DelegateManager_delegates_get")
+public func _bjs_DelegateManager_delegates_get(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = DelegateManager.bridgeJSLiftParameter(_self).delegates
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int((__bjs_elem_ret as! AnyMyViewControllerDelegate).bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_DelegateManager_delegates_set")
+@_cdecl("bjs_DelegateManager_delegates_set")
+public func _bjs_DelegateManager_delegates_set(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    DelegateManager.bridgeJSLiftParameter(_self).delegates = {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [AnyMyViewControllerDelegate] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(AnyMyViewControllerDelegate.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+    }()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_DelegateManager_deinit")
+@_cdecl("bjs_DelegateManager_deinit")
+public func _bjs_DelegateManager_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<DelegateManager>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension DelegateManager: ConvertibleToJSValue, _BridgedSwiftHeapObject {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_DelegateManager_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_DelegateManager_wrap")
+fileprivate func _bjs_DelegateManager_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_DelegateManager_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -282,6 +282,10 @@ extension _BridgedSwiftProtocolWrapper {
     @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Int32 {
         jsObject.bridgeJSLowerReturn()
     }
+
+    @_spi(BridgeJS) public consuming func bridgeJSLowerParameter() -> Int32 {
+        jsObject.bridgeJSLowerParameter()
+    }
 }
 
 /// A protocol that Swift enum types that do not have a payload can conform to.
@@ -453,6 +457,26 @@ where Self: RawRepresentable, RawValue: _BridgedSwiftTypeLoweredIntoSingleWasmCo
 @_spi(BridgeJS) public func _swift_js_pop_param_f64() -> Float64
 #else
 @_spi(BridgeJS) public func _swift_js_pop_param_f64() -> Float64 {
+    _onlyAvailableOnWasm()
+}
+#endif
+
+// MARK: Array length operations
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_push_array_length")
+@_spi(BridgeJS) public func _swift_js_push_array_length(_ length: Int32)
+#else
+@_spi(BridgeJS) public func _swift_js_push_array_length(_ length: Int32) {
+    _onlyAvailableOnWasm()
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_pop_param_array_length")
+@_spi(BridgeJS) public func _swift_js_pop_param_array_length() -> Int32
+#else
+@_spi(BridgeJS) public func _swift_js_pop_param_array_length() -> Int32 {
     _onlyAvailableOnWasm()
 }
 #endif

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift-to-JavaScript.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift-to-JavaScript.md
@@ -66,6 +66,7 @@ This command will:
 - <doc:Exporting-Swift-Function>
 - <doc:Exporting-Swift-Class>
 - <doc:Exporting-Swift-Struct>
+- <doc:Exporting-Swift-Array>
 - <doc:Exporting-Swift-Enum>
 - <doc:Exporting-Swift-Closure>
 - <doc:Exporting-Swift-Protocols>

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Array.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Array.md
@@ -1,0 +1,132 @@
+# Exporting Swift Arrays to JS
+
+Learn how to pass Swift arrays to and from JavaScript.
+
+## Overview
+
+> Tip: You can quickly preview what interfaces will be exposed on the Swift/TypeScript sides using the [BridgeJS Playground](https://swiftwasm.org/JavaScriptKit/PlayBridgeJS/).
+
+BridgeJS allows you to pass Swift arrays as function parameters and return values.
+
+```swift
+import JavaScriptKit
+
+@JS func processNumbers(_ values: [Int]) -> [Int] {
+    return values.map { $0 * 2 }
+}
+
+@JS func getGreeting() -> [String] {
+    return ["Hello", "World", "from", "Swift"]
+}
+```
+
+In JavaScript:
+
+```javascript
+import { init } from "./.build/plugins/PackageToJS/outputs/Package/index.js";
+const { exports } = await init({});
+
+const doubled = exports.processNumbers([1, 2, 3, 4, 5]);
+console.log(doubled); // [2, 4, 6, 8, 10]
+
+const greeting = exports.getGreeting();
+console.log(greeting.join(" ")); // "Hello World from Swift"
+```
+
+The generated TypeScript declarations:
+
+```typescript
+export type Exports = {
+    processNumbers(values: number[]): number[];
+    getGreeting(): string[];
+}
+```
+
+## Arrays of Custom Types
+
+Arrays work with `@JS` marked structs, classes, and enums:
+
+```swift
+@JS struct Point {
+    var x: Double
+    var y: Double
+}
+
+@JS func scalePoints(_ points: [Point], by factor: Double) -> [Point] {
+    return points.map { Point(x: $0.x * factor, y: $0.y * factor) }
+}
+```
+
+In JavaScript:
+
+```javascript
+const points = [{ x: 1.0, y: 2.0 }, { x: 3.0, y: 4.0 }];
+const scaled = exports.scalePoints(points, 2.0);
+console.log(scaled); // [{ x: 2.0, y: 4.0 }, { x: 6.0, y: 8.0 }]
+```
+
+## Optional and Nested Arrays
+
+BridgeJS supports optional arrays (`[T]?`), arrays of optionals (`[T?]`), and nested arrays (`[[T]]`):
+
+```swift
+@JS func processOptionalInts(_ values: [Int?]) -> [Int?] {
+    return values.map { $0.map { $0 * 2 } }
+}
+
+@JS func processMatrix(_ matrix: [[Int]]) -> [[Int]] {
+    return matrix.map { row in row.map { $0 * 2 } }
+}
+```
+
+In JavaScript:
+
+```javascript
+const mixed = [1, null, 3];
+console.log(exports.processOptionalInts(mixed)); // [2, null, 6]
+
+const matrix = [[1, 2], [3, 4]];
+console.log(exports.processMatrix(matrix)); // [[2, 4], [6, 8]]
+```
+
+TypeScript definitions:
+
+- `[Int?]` becomes `(number | null)[]`
+- `[Int]?` becomes `number[] | null`
+- `[[Int]]` becomes `number[][]`
+
+## How It Works
+
+Arrays use **copy semantics** when crossing the Swift/JavaScript boundary:
+
+1. **Data Transfer**: Array elements are pushed to type-specific stacks and reconstructed as JavaScript arrays
+2. **No Shared State**: Each side has its own copy - modifications don't affect the original
+3. **Element Handling**: Primitive elements are copied by value; class elements copy their references (the objects remain shared)
+
+This differs from classes, which use reference semantics and share state across the boundary.
+
+```javascript
+const original = [1, 2, 3];
+const result = exports.processNumbers(original);
+// original is unchanged - Swift received a copy
+```
+
+## Supported Features
+
+| Swift Feature | Status |
+|:--------------|:-------|
+| Primitive arrays: `[Int]`, `[Double]`, `[Bool]`, `[String]` | ✅ |
+| Struct arrays: `[MyStruct]` | ✅ |
+| Class arrays: `[MyClass]` | ✅ |
+| Enum arrays (case, raw value, associated value) | ✅ |
+| Nested arrays: `[[Int]]` | ✅ |
+| Optional arrays: `[Int]?` | ✅ |
+| Arrays of optionals: `[Int?]` | ✅ |
+| Protocol arrays: `[MyProtocol]` | ✅ |
+| UnsafePointer-family arrays: `[UnsafeRawPointer]`, `[OpaquePointer]`, etc. | ✅ |
+
+> Note: Array element type support matches that of regular `@JS func` parameters and return values.
+
+## See Also
+
+- <doc:Supported-Types>

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Default-Parameters.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Default-Parameters.md
@@ -110,6 +110,7 @@ The following default value types are supported for both function and constructo
 | Class initialization (no args) | `MyClass()` | `new MyClass()` |
 | Class initialization (literal args) | `MyClass("value", 42)` | `new MyClass("value", 42)` |
 | Struct initialization | `Point(x: 1.0, y: 2.0)` | `{ x: 1.0, y: 2.0 }` |
+| Array literals | `[1, 2, 3]` | `[1, 2, 3]` |
 
 ## Working with Class and Struct Defaults
 
@@ -156,7 +157,6 @@ The following expressions are **not supported** as default parameter values:
 |:----------------|:--------|:-------|
 | Method calls | `Date().description` | ❌ |
 | Closures | `{ "computed" }()` | ❌ |
-| Array literals | `[1, 2, 3]` | ❌ |
 | Dictionary literals | `["key": "value"]` | ❌ |
 | Binary operations | `10 + 20` | ❌ |
 | Complex member access | `Config.shared.value` | ❌ |

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -864,6 +864,22 @@ enum APIOptionalResult {
     }
 }
 
+@JS func arrayWithDefault(_ values: [Int] = [1, 2, 3]) -> Int {
+    return values.reduce(0, +)
+}
+
+@JS func arrayWithOptionalDefault(_ values: [Int]? = nil) -> Int {
+    return values?.reduce(0, +) ?? -1
+}
+
+@JS func arrayMixedDefaults(
+    prefix: String = "Sum",
+    values: [Int] = [10, 20],
+    suffix: String = "!"
+) -> String {
+    return "\(prefix): \(values.reduce(0, +))\(suffix)"
+}
+
 // MARK: - Static Properties
 
 @JS class StaticPropertyHolder {
@@ -1267,6 +1283,134 @@ enum APIOptionalResult {
             }
         }
     }
+}
+
+// MARK: - Array Tests
+
+// Primitive arrays
+@JS func roundTripIntArray(_ values: [Int]) -> [Int] {
+    return values
+}
+
+@JS func roundTripStringArray(_ values: [String]) -> [String] {
+    return values
+}
+
+@JS func roundTripDoubleArray(_ values: [Double]) -> [Double] {
+    return values
+}
+
+@JS func roundTripBoolArray(_ values: [Bool]) -> [Bool] {
+    return values
+}
+
+// Enum arrays
+@JS func roundTripDirectionArray(_ values: [Direction]) -> [Direction] {
+    return values
+}
+
+@JS func roundTripStatusArray(_ values: [Status]) -> [Status] {
+    return values
+}
+
+@JS func roundTripThemeArray(_ values: [Theme]) -> [Theme] {
+    return values
+}
+
+@JS func roundTripHttpStatusArray(_ values: [HttpStatus]) -> [HttpStatus] {
+    return values
+}
+
+// Struct arrays
+@JS func roundTripDataPointArray(_ points: [DataPoint]) -> [DataPoint] {
+    return points
+}
+
+// Class arrays
+@JS func roundTripGreeterArray(_ greeters: [Greeter]) -> [Greeter] {
+    return greeters
+}
+
+// Arrays of optional elements
+@JS func roundTripOptionalIntArray(_ values: [Int?]) -> [Int?] {
+    return values
+}
+
+@JS func roundTripOptionalStringArray(_ values: [String?]) -> [String?] {
+    return values
+}
+
+@JS func roundTripOptionalDataPointArray(_ points: [DataPoint?]) -> [DataPoint?] {
+    return points
+}
+
+@JS func roundTripOptionalDirectionArray(_ directions: [Direction?]) -> [Direction?] {
+    return directions
+}
+
+@JS func roundTripOptionalStatusArray(_ statuses: [Status?]) -> [Status?] {
+    return statuses
+}
+
+// Optional arrays
+@JS func roundTripOptionalIntArrayType(_ values: [Int]?) -> [Int]? {
+    return values
+}
+
+@JS func roundTripOptionalStringArrayType(_ values: [String]?) -> [String]? {
+    return values
+}
+
+@JS func roundTripOptionalGreeterArrayType(_ greeters: [Greeter]?) -> [Greeter]? {
+    return greeters
+}
+
+// Nested arrays
+
+@JS func roundTripNestedIntArray(_ values: [[Int]]) -> [[Int]] {
+    return values
+}
+
+@JS func roundTripNestedStringArray(_ values: [[String]]) -> [[String]] {
+    return values
+}
+
+@JS func roundTripNestedDoubleArray(_ values: [[Double]]) -> [[Double]] {
+    return values
+}
+
+@JS func roundTripNestedBoolArray(_ values: [[Bool]]) -> [[Bool]] {
+    return values
+}
+
+@JS func roundTripNestedDataPointArray(_ points: [[DataPoint]]) -> [[DataPoint]] {
+    return points
+}
+
+@JS func roundTripNestedDirectionArray(_ directions: [[Direction]]) -> [[Direction]] {
+    return directions
+}
+
+@JS func roundTripNestedGreeterArray(_ greeters: [[Greeter]]) -> [[Greeter]] {
+    return greeters
+}
+
+@JS func roundTripUnsafeRawPointerArray(_ values: [UnsafeRawPointer]) -> [UnsafeRawPointer] {
+    return values
+}
+@JS func roundTripUnsafeMutableRawPointerArray(_ values: [UnsafeMutableRawPointer]) -> [UnsafeMutableRawPointer] {
+    return values
+}
+@JS func roundTripOpaquePointerArray(_ values: [OpaquePointer]) -> [OpaquePointer] {
+    return values
+}
+
+@JS func consumeDataProcessorArrayType(_ processors: [DataProcessor]) -> Int {
+    return processors.count
+}
+
+@JS func roundTripDataProcessorArrayType(_ processors: [DataProcessor]) -> [DataProcessor] {
+    return processors
 }
 
 class ExportAPITests: XCTestCase {

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -4551,6 +4551,72 @@ public func _bjs_testEmptyInit(_ object: UnsafeMutableRawPointer) -> UnsafeMutab
     #endif
 }
 
+@_expose(wasm, "bjs_arrayWithDefault")
+@_cdecl("bjs_arrayWithDefault")
+public func _bjs_arrayWithDefault() -> Int32 {
+    #if arch(wasm32)
+    let ret = arrayWithDefault(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_arrayWithOptionalDefault")
+@_cdecl("bjs_arrayWithOptionalDefault")
+public func _bjs_arrayWithOptionalDefault(_ values: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = arrayWithOptionalDefault(_: {
+        if values == 0 {
+            return Optional<[Int]>.none
+        } else {
+            return {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                }()
+        }
+        }())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_arrayMixedDefaults")
+@_cdecl("bjs_arrayMixedDefaults")
+public func _bjs_arrayMixedDefaults(_ prefixBytes: Int32, _ prefixLength: Int32, _ suffixBytes: Int32, _ suffixLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = arrayMixedDefaults(prefix: String.bridgeJSLiftParameter(prefixBytes, prefixLength), values: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }(), suffix: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_formatName")
 @_cdecl("bjs_formatName")
 public func _bjs_formatName(_ nameBytes: Int32, _ nameLength: Int32, _ transform: Int32) -> Void {
@@ -4579,6 +4645,798 @@ public func _bjs_makeAdder(_ base: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = makeAdder(base: Int.bridgeJSLiftParameter(base))
     return _BJS_Closure_20BridgeJSRuntimeTestsSi_Si.bridgeJSLower(ret)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripIntArray")
+@_cdecl("bjs_roundTripIntArray")
+public func _bjs_roundTripIntArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripStringArray")
+@_cdecl("bjs_roundTripStringArray")
+public func _bjs_roundTripStringArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripStringArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [String] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    var __bjs_ret_elem = __bjs_elem_ret
+    __bjs_ret_elem.withUTF8 { ptr in
+        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+    }}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripDoubleArray")
+@_cdecl("bjs_roundTripDoubleArray")
+public func _bjs_roundTripDoubleArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripDoubleArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Double] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Double.bridgeJSLiftParameter(_swift_js_pop_param_f64()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_f64(__bjs_elem_ret)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripBoolArray")
+@_cdecl("bjs_roundTripBoolArray")
+public func _bjs_roundTripBoolArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripBoolArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Bool] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Bool.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(__bjs_elem_ret ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripDirectionArray")
+@_cdecl("bjs_roundTripDirectionArray")
+public func _bjs_roundTripDirectionArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripDirectionArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Direction] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Direction.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret.bridgeJSLowerParameter()))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripStatusArray")
+@_cdecl("bjs_roundTripStatusArray")
+public func _bjs_roundTripStatusArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripStatusArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Status] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Status.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret.bridgeJSLowerParameter()))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripThemeArray")
+@_cdecl("bjs_roundTripThemeArray")
+public func _bjs_roundTripThemeArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripThemeArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Theme] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Theme.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    var __bjs_ret_elem = __bjs_elem_ret.rawValue
+    __bjs_ret_elem.withUTF8 { ptr in
+        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+    }}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripHttpStatusArray")
+@_cdecl("bjs_roundTripHttpStatusArray")
+public func _bjs_roundTripHttpStatusArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripHttpStatusArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [HttpStatus] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(HttpStatus.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret.bridgeJSLowerParameter()))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripDataPointArray")
+@_cdecl("bjs_roundTripDataPointArray")
+public func _bjs_roundTripDataPointArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripDataPointArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [DataPoint] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(DataPoint.bridgeJSLiftParameter())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    __bjs_elem_ret.bridgeJSLowerReturn()}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripGreeterArray")
+@_cdecl("bjs_roundTripGreeterArray")
+public func _bjs_roundTripGreeterArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripGreeterArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Greeter] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Greeter.bridgeJSLiftParameter(_swift_js_pop_param_pointer()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalIntArray")
+@_cdecl("bjs_roundTripOptionalIntArray")
+public func _bjs_roundTripOptionalIntArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<Int>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    _swift_js_push_int(Int32(__bjs_unwrapped_ret_elem))}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalStringArray")
+@_cdecl("bjs_roundTripOptionalStringArray")
+public func _bjs_roundTripOptionalStringArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalStringArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<String>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<String>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    var __bjs_str_ret_elem = __bjs_unwrapped_ret_elem
+    __bjs_str_ret_elem.withUTF8 { ptr in
+        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+    }}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalDataPointArray")
+@_cdecl("bjs_roundTripOptionalDataPointArray")
+public func _bjs_roundTripOptionalDataPointArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalDataPointArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<DataPoint>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<DataPoint>.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    __bjs_unwrapped_ret_elem.bridgeJSLowerReturn()}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalDirectionArray")
+@_cdecl("bjs_roundTripOptionalDirectionArray")
+public func _bjs_roundTripOptionalDirectionArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalDirectionArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<Direction>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<Direction>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    _swift_js_push_int(__bjs_unwrapped_ret_elem.bridgeJSLowerParameter())}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalStatusArray")
+@_cdecl("bjs_roundTripOptionalStatusArray")
+public func _bjs_roundTripOptionalStatusArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalStatusArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<Status>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<Status>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    _swift_js_push_int(__bjs_unwrapped_ret_elem.bridgeJSLowerParameter())}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalIntArrayType")
+@_cdecl("bjs_roundTripOptionalIntArrayType")
+public func _bjs_roundTripOptionalIntArrayType(_ values: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalIntArrayType(_: {
+        if values == 0 {
+            return Optional<[Int]>.none
+        } else {
+            return {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                }()
+        }
+        }())
+    let __bjs_isSome_ret = ret != nil
+    if let __bjs_unwrapped_ret = ret {
+    for __bjs_elem_ret in __bjs_unwrapped_ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret))}
+    _swift_js_push_array_length(Int32(__bjs_unwrapped_ret.count))}
+    _swift_js_push_int(__bjs_isSome_ret ? 1 : 0)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalStringArrayType")
+@_cdecl("bjs_roundTripOptionalStringArrayType")
+public func _bjs_roundTripOptionalStringArrayType(_ values: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalStringArrayType(_: {
+        if values == 0 {
+            return Optional<[String]>.none
+        } else {
+            return {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [String] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                }()
+        }
+        }())
+    let __bjs_isSome_ret = ret != nil
+    if let __bjs_unwrapped_ret = ret {
+    for __bjs_elem_ret in __bjs_unwrapped_ret {
+    var __bjs_ret_elem = __bjs_elem_ret
+    __bjs_ret_elem.withUTF8 { ptr in
+        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+    }}
+    _swift_js_push_array_length(Int32(__bjs_unwrapped_ret.count))}
+    _swift_js_push_int(__bjs_isSome_ret ? 1 : 0)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalGreeterArrayType")
+@_cdecl("bjs_roundTripOptionalGreeterArrayType")
+public func _bjs_roundTripOptionalGreeterArrayType(_ greeters: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalGreeterArrayType(_: {
+        if greeters == 0 {
+            return Optional<[Greeter]>.none
+        } else {
+            return {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Greeter] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Greeter.bridgeJSLiftParameter(_swift_js_pop_param_pointer()))
+        }
+        __result.reverse()
+        return __result
+                }()
+        }
+        }())
+    let __bjs_isSome_ret = ret != nil
+    if let __bjs_unwrapped_ret = ret {
+    for __bjs_elem_ret in __bjs_unwrapped_ret {
+    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(__bjs_unwrapped_ret.count))}
+    _swift_js_push_int(__bjs_isSome_ret ? 1 : 0)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripNestedIntArray")
+@_cdecl("bjs_roundTripNestedIntArray")
+public func _bjs_roundTripNestedIntArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripNestedIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[Int]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret_elem))}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripNestedStringArray")
+@_cdecl("bjs_roundTripNestedStringArray")
+public func _bjs_roundTripNestedStringArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripNestedStringArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[String]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [String] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    var __bjs_ret_elem_elem = __bjs_elem_ret_elem
+    __bjs_ret_elem_elem.withUTF8 { ptr in
+        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+    }}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripNestedDoubleArray")
+@_cdecl("bjs_roundTripNestedDoubleArray")
+public func _bjs_roundTripNestedDoubleArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripNestedDoubleArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[Double]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Double] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Double.bridgeJSLiftParameter(_swift_js_pop_param_f64()))
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    _swift_js_push_f64(__bjs_elem_ret_elem)}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripNestedBoolArray")
+@_cdecl("bjs_roundTripNestedBoolArray")
+public func _bjs_roundTripNestedBoolArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripNestedBoolArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[Bool]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Bool] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Bool.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    _swift_js_push_int(__bjs_elem_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripNestedDataPointArray")
+@_cdecl("bjs_roundTripNestedDataPointArray")
+public func _bjs_roundTripNestedDataPointArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripNestedDataPointArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[DataPoint]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [DataPoint] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(DataPoint.bridgeJSLiftParameter())
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    __bjs_elem_ret_elem.bridgeJSLowerReturn()}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripNestedDirectionArray")
+@_cdecl("bjs_roundTripNestedDirectionArray")
+public func _bjs_roundTripNestedDirectionArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripNestedDirectionArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[Direction]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Direction] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Direction.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret_elem.bridgeJSLowerParameter()))}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripNestedGreeterArray")
+@_cdecl("bjs_roundTripNestedGreeterArray")
+public func _bjs_roundTripNestedGreeterArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripNestedGreeterArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[Greeter]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Greeter] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Greeter.bridgeJSLiftParameter(_swift_js_pop_param_pointer()))
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    _swift_js_push_pointer(__bjs_elem_ret_elem.bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripUnsafeRawPointerArray")
+@_cdecl("bjs_roundTripUnsafeRawPointerArray")
+public func _bjs_roundTripUnsafeRawPointerArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripUnsafeRawPointerArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [UnsafeRawPointer] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(UnsafeRawPointer.bridgeJSLiftParameter(_swift_js_pop_param_pointer()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripUnsafeMutableRawPointerArray")
+@_cdecl("bjs_roundTripUnsafeMutableRawPointerArray")
+public func _bjs_roundTripUnsafeMutableRawPointerArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripUnsafeMutableRawPointerArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [UnsafeMutableRawPointer] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(UnsafeMutableRawPointer.bridgeJSLiftParameter(_swift_js_pop_param_pointer()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOpaquePointerArray")
+@_cdecl("bjs_roundTripOpaquePointerArray")
+public func _bjs_roundTripOpaquePointerArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOpaquePointerArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [OpaquePointer] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(OpaquePointer.bridgeJSLiftParameter(_swift_js_pop_param_pointer()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_consumeDataProcessorArrayType")
+@_cdecl("bjs_consumeDataProcessorArrayType")
+public func _bjs_consumeDataProcessorArrayType() -> Int32 {
+    #if arch(wasm32)
+    let ret = consumeDataProcessorArrayType(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [AnyDataProcessor] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(AnyDataProcessor.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripDataProcessorArrayType")
+@_cdecl("bjs_roundTripDataProcessorArrayType")
+public func _bjs_roundTripDataProcessorArrayType() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripDataProcessorArrayType(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [AnyDataProcessor] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(AnyDataProcessor.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int((__bjs_elem_ret as! AnyDataProcessor).bridgeJSLowerReturn())}
+    _swift_js_push_array_length(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -7757,6 +7757,167 @@
         }
       },
       {
+        "abiName" : "bjs_arrayWithDefault",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "arrayWithDefault",
+        "parameters" : [
+          {
+            "defaultValue" : {
+              "array" : {
+                "_0" : [
+                  {
+                    "int" : {
+                      "_0" : 1
+                    }
+                  },
+                  {
+                    "int" : {
+                      "_0" : 2
+                    }
+                  },
+                  {
+                    "int" : {
+                      "_0" : 3
+                    }
+                  }
+                ]
+              }
+            },
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "int" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_arrayWithOptionalDefault",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "arrayWithOptionalDefault",
+        "parameters" : [
+          {
+            "defaultValue" : {
+              "null" : {
+
+              }
+            },
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "optional" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "int" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_arrayMixedDefaults",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "arrayMixedDefaults",
+        "parameters" : [
+          {
+            "defaultValue" : {
+              "string" : {
+                "_0" : "Sum"
+              }
+            },
+            "label" : "prefix",
+            "name" : "prefix",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "defaultValue" : {
+              "array" : {
+                "_0" : [
+                  {
+                    "int" : {
+                      "_0" : 10
+                    }
+                  },
+                  {
+                    "int" : {
+                      "_0" : 20
+                    }
+                  }
+                ]
+              }
+            },
+            "label" : "values",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "defaultValue" : {
+              "string" : {
+                "_0" : "!"
+              }
+            },
+            "label" : "suffix",
+            "name" : "suffix",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
         "abiName" : "bjs_formatName",
         "effects" : {
           "isAsync" : false,
@@ -7886,6 +8047,1128 @@
                 "int" : {
 
                 }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripIntArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripIntArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "int" : {
+
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripStringArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripStringArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "string" : {
+
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripDoubleArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripDoubleArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "double" : {
+
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "double" : {
+
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripBoolArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripBoolArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "bool" : {
+
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "bool" : {
+
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripDirectionArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripDirectionArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Direction"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "Direction"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripStatusArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripStatusArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Status"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "Status"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripThemeArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripThemeArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "Theme",
+                    "_1" : "String"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "Theme",
+                "_1" : "String"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripHttpStatusArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripHttpStatusArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "HttpStatus",
+                    "_1" : "Int"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "HttpStatus",
+                "_1" : "Int"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripDataPointArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripDataPointArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "points",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "DataPoint"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "swiftStruct" : {
+                "_0" : "DataPoint"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripGreeterArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripGreeterArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "greeters",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "swiftHeapObject" : {
+                    "_0" : "Greeter"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "swiftHeapObject" : {
+                "_0" : "Greeter"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalIntArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalIntArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "optional" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "optional" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalStringArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalStringArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "optional" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "optional" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalDataPointArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalDataPointArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "points",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "optional" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "DataPoint"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "optional" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "DataPoint"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalDirectionArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalDirectionArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "directions",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "optional" : {
+                    "_0" : {
+                      "caseEnum" : {
+                        "_0" : "Direction"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "optional" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Direction"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalStatusArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalStatusArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "statuses",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "optional" : {
+                    "_0" : {
+                      "caseEnum" : {
+                        "_0" : "Status"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "optional" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Status"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalIntArrayType",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalIntArrayType",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "optional" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "optional" : {
+            "_0" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalStringArrayType",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalStringArrayType",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "optional" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "optional" : {
+            "_0" : {
+              "array" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalGreeterArrayType",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalGreeterArrayType",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "greeters",
+            "type" : {
+              "optional" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "swiftHeapObject" : {
+                        "_0" : "Greeter"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "optional" : {
+            "_0" : {
+              "array" : {
+                "_0" : {
+                  "swiftHeapObject" : {
+                    "_0" : "Greeter"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripNestedIntArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripNestedIntArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripNestedStringArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripNestedStringArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "array" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripNestedDoubleArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripNestedDoubleArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "double" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "array" : {
+                "_0" : {
+                  "double" : {
+
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripNestedBoolArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripNestedBoolArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "bool" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "array" : {
+                "_0" : {
+                  "bool" : {
+
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripNestedDataPointArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripNestedDataPointArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "points",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "DataPoint"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "array" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "DataPoint"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripNestedDirectionArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripNestedDirectionArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "directions",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "caseEnum" : {
+                        "_0" : "Direction"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "array" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Direction"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripNestedGreeterArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripNestedGreeterArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "greeters",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "swiftHeapObject" : {
+                        "_0" : "Greeter"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "array" : {
+                "_0" : {
+                  "swiftHeapObject" : {
+                    "_0" : "Greeter"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripUnsafeRawPointerArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripUnsafeRawPointerArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "unsafePointer" : {
+                    "_0" : {
+                      "kind" : "unsafeRawPointer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "unsafePointer" : {
+                "_0" : {
+                  "kind" : "unsafeRawPointer"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripUnsafeMutableRawPointerArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripUnsafeMutableRawPointerArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "unsafePointer" : {
+                    "_0" : {
+                      "kind" : "unsafeMutableRawPointer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "unsafePointer" : {
+                "_0" : {
+                  "kind" : "unsafeMutableRawPointer"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOpaquePointerArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOpaquePointerArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "unsafePointer" : {
+                    "_0" : {
+                      "kind" : "opaquePointer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "unsafePointer" : {
+                "_0" : {
+                  "kind" : "opaquePointer"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_consumeDataProcessorArrayType",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "consumeDataProcessorArrayType",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "processors",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "swiftProtocol" : {
+                    "_0" : "DataProcessor"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "int" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripDataProcessorArrayType",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripDataProcessorArrayType",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "processors",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "swiftProtocol" : {
+                    "_0" : "DataProcessor"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "swiftProtocol" : {
+                "_0" : "DataProcessor"
               }
             }
           }


### PR DESCRIPTION
# BridgeJS: Swift Array Support

This PR adds the ability to pass Swift arrays to and from JavaScript using the BridgeJS plugin.

## Example

**Swift:**
```swift
@JS func processNumbers(_ values: [Int]) -> [Int] {
    return values.map { $0 * 2 }
}

@JS func getGreeting() -> [String] {
    return ["Hello", "World", "from", "Swift"]
}
```

**JavaScript:**
```javascript
const doubled = exports.processNumbers([1, 2, 3, 4, 5]);
console.log(doubled); // [2, 4, 6, 8, 10]

const greeting = exports.getGreeting();
console.log(greeting.join(" ")); // "Hello World from Swift"
```

**Generated TypeScript:**
```typescript
export type Exports = {
    processNumbers(values: number[]): number[];
    getGreeting(): string[];
}
```

## Supported Array Types / Features

| Swift Feature | Status |
|:--------------|:-------|
| Primitive arrays: `[Int]`, `[Double]`, `[Bool]`, `[String]` | Supported |
| Struct arrays: `[MyStruct]` | Supported |
| Class arrays: `[MyClass]` | Supported |
| Enum arrays (case, raw value, associated value) | Supported |
| Nested arrays: `[[Int]]` | Supported |
| Optional arrays: `[Int]?` | Supported |
| Arrays of optionals: `[Int?]` | Supported |
| Protocol arrays: `[MyProtocol]` | Supported |
| UnsafePointer-family arrays | Supported |
| Default Values | Supported |

## How It Works

Arrays use **copy semantics** when crossing the Swift/JavaScript boundary:
- Array elements are pushed to type-specific stacks and reconstructed as JavaScript arrays
- Each side has its own copy - modifications don't affect the original
- Primitive elements are copied by value; class elements copy their references

## Testing

- Comprehensive snapshot tests for array codegen
- Runtime tests covering primitive, struct, class, enum, optional, and nested arrays

## Documentation

- Added `Exporting-Swift-Array.md` covering array usage, supported types, and copy semantics
