### PR TITLE
BridgeJS: Array benchmarks

### DIFF
--- a/Benchmarks/Sources/Benchmarks.swift
+++ b/Benchmarks/Sources/Benchmarks.swift
@@ -257,6 +257,134 @@ enum ComplexResult {
     }
 }
 
+// MARK: - Array Performance Tests
+
+@JS struct Point {
+    var x: Double
+    var y: Double
+}
+
+@JS class ArrayRoundtrip {
+    @JS init() {}
+
+    // MARK: Primitive Arrays - Int
+
+    @JS func takeIntArray(_ values: [Int]) {}
+    @JS func makeIntArray() -> [Int] {
+        return Array(1...1000)
+    }
+    @JS func roundtripIntArray(_ values: [Int]) -> [Int] {
+        return values
+    }
+
+    @JS func makeIntArrayLarge() -> [Int] {
+        return Array(1...10000)
+    }
+
+    // MARK: Primitive Arrays - Double
+
+    @JS func takeDoubleArray(_ values: [Double]) {}
+    @JS func makeDoubleArray() -> [Double] {
+        return (1...1000).map { Double($0) * 1.1 }
+    }
+    @JS func roundtripDoubleArray(_ values: [Double]) -> [Double] {
+        return values
+    }
+
+    // MARK: Primitive Arrays - String
+
+    @JS func takeStringArray(_ values: [String]) {}
+    @JS func makeStringArray() -> [String] {
+        return ["one", "two", "three", "four", "five"]
+    }
+    @JS func roundtripStringArray(_ values: [String]) -> [String] {
+        return values
+    }
+
+    // MARK: Struct Arrays
+
+    @JS func takePointArray(_ points: [Point]) {}
+    @JS func makePointArray() -> [Point] {
+        return [
+            Point(x: 0.0, y: 0.0),
+            Point(x: 1.0, y: 1.0),
+            Point(x: 2.0, y: 2.0),
+            Point(x: 3.0, y: 3.0),
+            Point(x: 4.0, y: 4.0),
+        ]
+    }
+    @JS func roundtripPointArray(_ points: [Point]) -> [Point] {
+        return points
+    }
+
+    @JS func makePointArrayLarge() -> [Point] {
+        return (0..<50).map { Point(x: Double($0), y: Double($0)) }
+    }
+
+    // MARK: Nested Arrays
+
+    @JS func takeNestedIntArray(_ values: [[Int]]) {}
+    @JS func makeNestedIntArray() -> [[Int]] {
+        return [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+        ]
+    }
+    @JS func roundtripNestedIntArray(_ values: [[Int]]) -> [[Int]] {
+        return values
+    }
+
+    @JS func takeNestedPointArray(_ points: [[Point]]) {}
+    @JS func makeNestedPointArray() -> [[Point]] {
+        return [
+            [Point(x: 0.0, y: 0.0), Point(x: 1.0, y: 1.0)],
+            [Point(x: 2.0, y: 2.0), Point(x: 3.0, y: 3.0)],
+            [Point(x: 4.0, y: 4.0), Point(x: 5.0, y: 5.0)],
+        ]
+    }
+    @JS func roundtripNestedPointArray(_ points: [[Point]]) -> [[Point]] {
+        return points
+    }
+
+    // MARK: Optional Element Arrays
+
+    @JS func takeOptionalIntArray(_ values: [Int?]) {}
+    @JS func makeOptionalIntArray() -> [Int?] {
+        return [1, nil, 3, nil, 5, nil, 7, nil, 9, nil]
+    }
+    @JS func roundtripOptionalIntArray(_ values: [Int?]) -> [Int?] {
+        return values
+    }
+
+    @JS func takeOptionalPointArray(_ points: [Point?]) {}
+    @JS func makeOptionalPointArray() -> [Point?] {
+        return [
+            Point(x: 0.0, y: 0.0),
+            nil,
+            Point(x: 2.0, y: 2.0),
+            nil,
+            Point(x: 4.0, y: 4.0),
+        ]
+    }
+    @JS func roundtripOptionalPointArray(_ points: [Point?]) -> [Point?] {
+        return points
+    }
+
+    // MARK: Optional Arrays
+
+    @JS func takeOptionalArray(_ values: [Int]?) {}
+    @JS func makeOptionalArraySome() -> [Int]? {
+        return [1, 2, 3, 4, 5]
+    }
+    @JS func makeOptionalArrayNone() -> [Int]? {
+        return nil
+    }
+    @JS func roundtripOptionalArray(_ values: [Int]?) -> [Int]? {
+        return values
+    }
+}
+
 @JS func run() {
 
     let call = Benchmark("Call")

--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -475,6 +475,51 @@ fileprivate func _bjs_struct_lift_ComplexStruct() -> Int32 {
 }
 #endif
 
+extension Point: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Point {
+        let y = Double.bridgeJSLiftParameter(_swift_js_pop_param_f64())
+        let x = Double.bridgeJSLiftParameter(_swift_js_pop_param_f64())
+        return Point(x: x, y: y)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        _swift_js_push_f64(self.x)
+        _swift_js_push_f64(self.y)
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Point")
+fileprivate func _bjs_struct_lift_Point() -> Int32
+#else
+fileprivate func _bjs_struct_lift_Point() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
 @_expose(wasm, "bjs_run")
 @_cdecl("bjs_run")
 public func _bjs_run() -> Void {
@@ -1423,6 +1468,650 @@ extension ClassRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject {
 fileprivate func _bjs_ClassRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
 fileprivate func _bjs_ClassRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_ArrayRoundtrip_init")
+@_cdecl("bjs_ArrayRoundtrip_init")
+public func _bjs_ArrayRoundtrip_init() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_takeIntArray")
+@_cdecl("bjs_ArrayRoundtrip_takeIntArray")
+public func _bjs_ArrayRoundtrip_takeIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_makeIntArray")
+@_cdecl("bjs_ArrayRoundtrip_makeIntArray")
+public func _bjs_ArrayRoundtrip_makeIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeIntArray()
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_roundtripIntArray")
+@_cdecl("bjs_ArrayRoundtrip_roundtripIntArray")
+public func _bjs_ArrayRoundtrip_roundtripIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_makeIntArrayLarge")
+@_cdecl("bjs_ArrayRoundtrip_makeIntArrayLarge")
+public func _bjs_ArrayRoundtrip_makeIntArrayLarge(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeIntArrayLarge()
+    for __bjs_elem_ret in ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_takeDoubleArray")
+@_cdecl("bjs_ArrayRoundtrip_takeDoubleArray")
+public func _bjs_ArrayRoundtrip_takeDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeDoubleArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Double] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Double.bridgeJSLiftParameter(_swift_js_pop_param_f64()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_makeDoubleArray")
+@_cdecl("bjs_ArrayRoundtrip_makeDoubleArray")
+public func _bjs_ArrayRoundtrip_makeDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeDoubleArray()
+    for __bjs_elem_ret in ret {
+    _swift_js_push_f64(__bjs_elem_ret)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_roundtripDoubleArray")
+@_cdecl("bjs_ArrayRoundtrip_roundtripDoubleArray")
+public func _bjs_ArrayRoundtrip_roundtripDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripDoubleArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Double] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Double.bridgeJSLiftParameter(_swift_js_pop_param_f64()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    _swift_js_push_f64(__bjs_elem_ret)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_takeStringArray")
+@_cdecl("bjs_ArrayRoundtrip_takeStringArray")
+public func _bjs_ArrayRoundtrip_takeStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeStringArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [String] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_makeStringArray")
+@_cdecl("bjs_ArrayRoundtrip_makeStringArray")
+public func _bjs_ArrayRoundtrip_makeStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeStringArray()
+    for __bjs_elem_ret in ret {
+    var __bjs_ret_elem = __bjs_elem_ret
+    __bjs_ret_elem.withUTF8 { ptr in
+        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+    }}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_roundtripStringArray")
+@_cdecl("bjs_ArrayRoundtrip_roundtripStringArray")
+public func _bjs_ArrayRoundtrip_roundtripStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripStringArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [String] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    var __bjs_ret_elem = __bjs_elem_ret
+    __bjs_ret_elem.withUTF8 { ptr in
+        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
+    }}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_takePointArray")
+@_cdecl("bjs_ArrayRoundtrip_takePointArray")
+public func _bjs_ArrayRoundtrip_takePointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takePointArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Point] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Point.bridgeJSLiftParameter())
+        }
+        __result.reverse()
+        return __result
+        }())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_makePointArray")
+@_cdecl("bjs_ArrayRoundtrip_makePointArray")
+public func _bjs_ArrayRoundtrip_makePointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makePointArray()
+    for __bjs_elem_ret in ret {
+    __bjs_elem_ret.bridgeJSLowerReturn()}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_roundtripPointArray")
+@_cdecl("bjs_ArrayRoundtrip_roundtripPointArray")
+public func _bjs_ArrayRoundtrip_roundtripPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripPointArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Point] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Point.bridgeJSLiftParameter())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    __bjs_elem_ret.bridgeJSLowerReturn()}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_makePointArrayLarge")
+@_cdecl("bjs_ArrayRoundtrip_makePointArrayLarge")
+public func _bjs_ArrayRoundtrip_makePointArrayLarge(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makePointArrayLarge()
+    for __bjs_elem_ret in ret {
+    __bjs_elem_ret.bridgeJSLowerReturn()}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_takeNestedIntArray")
+@_cdecl("bjs_ArrayRoundtrip_takeNestedIntArray")
+public func _bjs_ArrayRoundtrip_takeNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[Int]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_makeNestedIntArray")
+@_cdecl("bjs_ArrayRoundtrip_makeNestedIntArray")
+public func _bjs_ArrayRoundtrip_makeNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeNestedIntArray()
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret_elem))}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_roundtripNestedIntArray")
+@_cdecl("bjs_ArrayRoundtrip_roundtripNestedIntArray")
+public func _bjs_ArrayRoundtrip_roundtripNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[Int]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret_elem))}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_takeNestedPointArray")
+@_cdecl("bjs_ArrayRoundtrip_takeNestedPointArray")
+public func _bjs_ArrayRoundtrip_takeNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedPointArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[Point]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Point] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Point.bridgeJSLiftParameter())
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_makeNestedPointArray")
+@_cdecl("bjs_ArrayRoundtrip_makeNestedPointArray")
+public func _bjs_ArrayRoundtrip_makeNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeNestedPointArray()
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    __bjs_elem_ret_elem.bridgeJSLowerReturn()}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_roundtripNestedPointArray")
+@_cdecl("bjs_ArrayRoundtrip_roundtripNestedPointArray")
+public func _bjs_ArrayRoundtrip_roundtripNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedPointArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [[Point]] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append({
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Point] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Point.bridgeJSLiftParameter())
+        }
+        __result.reverse()
+        return __result
+                    }())
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    for __bjs_elem_ret_elem in __bjs_elem_ret {
+    __bjs_elem_ret_elem.bridgeJSLowerReturn()}
+    _swift_js_push_array_length(Int32(__bjs_elem_ret.count))}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_takeOptionalIntArray")
+@_cdecl("bjs_ArrayRoundtrip_takeOptionalIntArray")
+public func _bjs_ArrayRoundtrip_takeOptionalIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeOptionalIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<Int>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_makeOptionalIntArray")
+@_cdecl("bjs_ArrayRoundtrip_makeOptionalIntArray")
+public func _bjs_ArrayRoundtrip_makeOptionalIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalIntArray()
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    _swift_js_push_int(Int32(__bjs_unwrapped_ret_elem))}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_roundtripOptionalIntArray")
+@_cdecl("bjs_ArrayRoundtrip_roundtripOptionalIntArray")
+public func _bjs_ArrayRoundtrip_roundtripOptionalIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripOptionalIntArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<Int>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    _swift_js_push_int(Int32(__bjs_unwrapped_ret_elem))}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_takeOptionalPointArray")
+@_cdecl("bjs_ArrayRoundtrip_takeOptionalPointArray")
+public func _bjs_ArrayRoundtrip_takeOptionalPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeOptionalPointArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<Point>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<Point>.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_makeOptionalPointArray")
+@_cdecl("bjs_ArrayRoundtrip_makeOptionalPointArray")
+public func _bjs_ArrayRoundtrip_makeOptionalPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalPointArray()
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    __bjs_unwrapped_ret_elem.bridgeJSLowerReturn()}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_roundtripOptionalPointArray")
+@_cdecl("bjs_ArrayRoundtrip_roundtripOptionalPointArray")
+public func _bjs_ArrayRoundtrip_roundtripOptionalPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripOptionalPointArray(_: {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Optional<Point>] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Optional<Point>.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+        }())
+    for __bjs_elem_ret in ret {
+    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
+    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
+    __bjs_unwrapped_ret_elem.bridgeJSLowerReturn()}
+    _swift_js_push_int(__bjs_isSome_ret_elem ? 1 : 0)}
+    _swift_js_push_array_length(Int32(ret.count))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_takeOptionalArray")
+@_cdecl("bjs_ArrayRoundtrip_takeOptionalArray")
+public func _bjs_ArrayRoundtrip_takeOptionalArray(_ _self: UnsafeMutableRawPointer, _ values: Int32) -> Void {
+    #if arch(wasm32)
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeOptionalArray(_: {
+        if values == 0 {
+            return Optional<[Int]>.none
+        } else {
+            return {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                }()
+        }
+        }())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_makeOptionalArraySome")
+@_cdecl("bjs_ArrayRoundtrip_makeOptionalArraySome")
+public func _bjs_ArrayRoundtrip_makeOptionalArraySome(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalArraySome()
+    let __bjs_isSome_ret = ret != nil
+    if let __bjs_unwrapped_ret = ret {
+    for __bjs_elem_ret in __bjs_unwrapped_ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret))}
+    _swift_js_push_array_length(Int32(__bjs_unwrapped_ret.count))}
+    _swift_js_push_int(__bjs_isSome_ret ? 1 : 0)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_makeOptionalArrayNone")
+@_cdecl("bjs_ArrayRoundtrip_makeOptionalArrayNone")
+public func _bjs_ArrayRoundtrip_makeOptionalArrayNone(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalArrayNone()
+    let __bjs_isSome_ret = ret != nil
+    if let __bjs_unwrapped_ret = ret {
+    for __bjs_elem_ret in __bjs_unwrapped_ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret))}
+    _swift_js_push_array_length(Int32(__bjs_unwrapped_ret.count))}
+    _swift_js_push_int(__bjs_isSome_ret ? 1 : 0)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_roundtripOptionalArray")
+@_cdecl("bjs_ArrayRoundtrip_roundtripOptionalArray")
+public func _bjs_ArrayRoundtrip_roundtripOptionalArray(_ _self: UnsafeMutableRawPointer, _ values: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripOptionalArray(_: {
+        if values == 0 {
+            return Optional<[Int]>.none
+        } else {
+            return {
+        let __count = Int(_swift_js_pop_param_array_length())
+        var __result: [Int] = []
+        __result.reserveCapacity(__count)
+        for _ in 0 ..< __count {
+            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_param_int32()))
+        }
+        __result.reverse()
+        return __result
+                }()
+        }
+        }())
+    let __bjs_isSome_ret = ret != nil
+    if let __bjs_unwrapped_ret = ret {
+    for __bjs_elem_ret in __bjs_unwrapped_ret {
+    _swift_js_push_int(Int32(__bjs_elem_ret))}
+    _swift_js_push_array_length(Int32(__bjs_unwrapped_ret.count))}
+    _swift_js_push_int(__bjs_isSome_ret ? 1 : 0)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayRoundtrip_deinit")
+@_cdecl("bjs_ArrayRoundtrip_deinit")
+public func _bjs_ArrayRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<ArrayRoundtrip>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension ArrayRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_ArrayRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "Benchmarks", name: "bjs_ArrayRoundtrip_wrap")
+fileprivate func _bjs_ArrayRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_ArrayRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Benchmarks/Sources/Generated/JavaScript/BridgeJS.json
+++ b/Benchmarks/Sources/Generated/JavaScript/BridgeJS.json
@@ -1243,6 +1243,920 @@
 
         ],
         "swiftCallName" : "ClassRoundtrip"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_ArrayRoundtrip_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+
+          ]
+        },
+        "methods" : [
+          {
+            "abiName" : "bjs_ArrayRoundtrip_takeIntArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "takeIntArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_makeIntArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "makeIntArray",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_roundtripIntArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "roundtripIntArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_makeIntArrayLarge",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "makeIntArrayLarge",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_takeDoubleArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "takeDoubleArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "double" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_makeDoubleArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "makeDoubleArray",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "double" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_roundtripDoubleArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "roundtripDoubleArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "double" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "double" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_takeStringArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "takeStringArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_makeStringArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "makeStringArray",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_roundtripStringArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "roundtripStringArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_takePointArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "takePointArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "points",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "Point"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_makePointArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "makePointArray",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "Point"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_roundtripPointArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "roundtripPointArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "points",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "Point"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "Point"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_makePointArrayLarge",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "makePointArrayLarge",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "Point"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_takeNestedIntArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "takeNestedIntArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "array" : {
+                        "_0" : {
+                          "int" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_makeNestedIntArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "makeNestedIntArray",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_roundtripNestedIntArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "roundtripNestedIntArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "array" : {
+                        "_0" : {
+                          "int" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_takeNestedPointArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "takeNestedPointArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "points",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "array" : {
+                        "_0" : {
+                          "swiftStruct" : {
+                            "_0" : "Point"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_makeNestedPointArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "makeNestedPointArray",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "Point"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_roundtripNestedPointArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "roundtripNestedPointArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "points",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "array" : {
+                        "_0" : {
+                          "swiftStruct" : {
+                            "_0" : "Point"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "Point"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_takeOptionalIntArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "takeOptionalIntArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "optional" : {
+                        "_0" : {
+                          "int" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_makeOptionalIntArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "makeOptionalIntArray",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "optional" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_roundtripOptionalIntArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "roundtripOptionalIntArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "optional" : {
+                        "_0" : {
+                          "int" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "optional" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_takeOptionalPointArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "takeOptionalPointArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "points",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "optional" : {
+                        "_0" : {
+                          "swiftStruct" : {
+                            "_0" : "Point"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_makeOptionalPointArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "makeOptionalPointArray",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "optional" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "Point"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_roundtripOptionalPointArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "roundtripOptionalPointArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "points",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "optional" : {
+                        "_0" : {
+                          "swiftStruct" : {
+                            "_0" : "Point"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "optional" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "Point"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_takeOptionalArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "takeOptionalArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "array" : {
+                        "_0" : {
+                          "int" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_makeOptionalArraySome",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "makeOptionalArraySome",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "optional" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_makeOptionalArrayNone",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "makeOptionalArrayNone",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "optional" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayRoundtrip_roundtripOptionalArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "roundtripOptionalArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "array" : {
+                        "_0" : {
+                          "int" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "optional" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "name" : "ArrayRoundtrip",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "ArrayRoundtrip"
       }
     ],
     "enums" : [
@@ -1767,6 +2681,35 @@
           }
         ],
         "swiftCallName" : "ComplexStruct"
+      },
+      {
+        "methods" : [
+
+        ],
+        "name" : "Point",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "x",
+            "type" : {
+              "double" : {
+
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "y",
+            "type" : {
+              "double" : {
+
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "Point"
       }
     ]
   },

--- a/Benchmarks/run.js
+++ b/Benchmarks/run.js
@@ -640,6 +640,235 @@ async function singleRun(results, nameFilter, iterations) {
             classRoundtrip.roundtripAddressClass(address)
         }
     })
+
+    // Array performance tests
+    const arrayRoundtrip = new exports.ArrayRoundtrip();
+
+    // Primitive Arrays - Int
+    benchmarkRunner("ArrayRoundtrip/takeIntArray", () => {
+        const arr = Array.from({length: 1000}, (_, i) => i + 1)
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.takeIntArray(arr)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/makeIntArray", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.makeIntArray()
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/roundtripIntArray", () => {
+        const arr = Array.from({length: 1000}, (_, i) => i + 1)
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.roundtripIntArray(arr)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/makeIntArrayLarge", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.makeIntArrayLarge()
+        }
+    })
+
+    // Primitive Arrays - Double
+    benchmarkRunner("ArrayRoundtrip/takeDoubleArray", () => {
+        const arr = Array.from({length: 1000}, (_, i) => (i + 1) * 1.1)
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.takeDoubleArray(arr)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/makeDoubleArray", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.makeDoubleArray()
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/roundtripDoubleArray", () => {
+        const arr = Array.from({length: 1000}, (_, i) => (i + 1) * 1.1)
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.roundtripDoubleArray(arr)
+        }
+    })
+
+    // Primitive Arrays - String
+    benchmarkRunner("ArrayRoundtrip/takeStringArray", () => {
+        const arr = ["one", "two", "three", "four", "five"]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.takeStringArray(arr)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/makeStringArray", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.makeStringArray()
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/roundtripStringArray", () => {
+        const arr = ["one", "two", "three", "four", "five"]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.roundtripStringArray(arr)
+        }
+    })
+
+    // Struct Arrays
+    benchmarkRunner("ArrayRoundtrip/takePointArray", () => {
+        const arr = [
+            { x: 0.0, y: 0.0 },
+            { x: 1.0, y: 1.0 },
+            { x: 2.0, y: 2.0 },
+            { x: 3.0, y: 3.0 },
+            { x: 4.0, y: 4.0 }
+        ]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.takePointArray(arr)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/makePointArray", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.makePointArray()
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/roundtripPointArray", () => {
+        const arr = [
+            { x: 0.0, y: 0.0 },
+            { x: 1.0, y: 1.0 },
+            { x: 2.0, y: 2.0 },
+            { x: 3.0, y: 3.0 },
+            { x: 4.0, y: 4.0 }
+        ]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.roundtripPointArray(arr)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/makePointArrayLarge", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.makePointArrayLarge()
+        }
+    })
+
+    // Nested Arrays
+    benchmarkRunner("ArrayRoundtrip/takeNestedIntArray", () => {
+        const arr = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.takeNestedIntArray(arr)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/makeNestedIntArray", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.makeNestedIntArray()
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/roundtripNestedIntArray", () => {
+        const arr = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.roundtripNestedIntArray(arr)
+        }
+    })
+
+    benchmarkRunner("ArrayRoundtrip/takeNestedPointArray", () => {
+        const arr = [
+            [{ x: 0.0, y: 0.0 }, { x: 1.0, y: 1.0 }],
+            [{ x: 2.0, y: 2.0 }, { x: 3.0, y: 3.0 }],
+            [{ x: 4.0, y: 4.0 }, { x: 5.0, y: 5.0 }]
+        ]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.takeNestedPointArray(arr)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/makeNestedPointArray", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.makeNestedPointArray()
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/roundtripNestedPointArray", () => {
+        const arr = [
+            [{ x: 0.0, y: 0.0 }, { x: 1.0, y: 1.0 }],
+            [{ x: 2.0, y: 2.0 }, { x: 3.0, y: 3.0 }],
+            [{ x: 4.0, y: 4.0 }, { x: 5.0, y: 5.0 }]
+        ]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.roundtripNestedPointArray(arr)
+        }
+    })
+
+    // Optional Element Arrays
+    benchmarkRunner("ArrayRoundtrip/takeOptionalIntArray", () => {
+        const arr = [1, null, 3, null, 5, null, 7, null, 9, null]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.takeOptionalIntArray(arr)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/makeOptionalIntArray", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.makeOptionalIntArray()
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/roundtripOptionalIntArray", () => {
+        const arr = [1, null, 3, null, 5, null, 7, null, 9, null]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.roundtripOptionalIntArray(arr)
+        }
+    })
+
+    benchmarkRunner("ArrayRoundtrip/takeOptionalPointArray", () => {
+        const arr = [
+            { x: 0.0, y: 0.0 },
+            null,
+            { x: 2.0, y: 2.0 },
+            null,
+            { x: 4.0, y: 4.0 }
+        ]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.takeOptionalPointArray(arr)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/makeOptionalPointArray", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.makeOptionalPointArray()
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/roundtripOptionalPointArray", () => {
+        const arr = [
+            { x: 0.0, y: 0.0 },
+            null,
+            { x: 2.0, y: 2.0 },
+            null,
+            { x: 4.0, y: 4.0 }
+        ]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.roundtripOptionalPointArray(arr)
+        }
+    })
+
+    // Optional Arrays
+    benchmarkRunner("ArrayRoundtrip/takeOptionalArraySome", () => {
+        const arr = [1, 2, 3, 4, 5]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.takeOptionalArray(arr)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/takeOptionalArrayNone", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.takeOptionalArray(null)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/makeOptionalArraySome", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.makeOptionalArraySome()
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/makeOptionalArrayNone", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.makeOptionalArrayNone()
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/roundtripOptionalArraySome", () => {
+        const arr = [1, 2, 3, 4, 5]
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.roundtripOptionalArray(arr)
+        }
+    })
+    benchmarkRunner("ArrayRoundtrip/roundtripOptionalArrayNone", () => {
+        for (let i = 0; i < iterations; i++) {
+            arrayRoundtrip.roundtripOptionalArray(null)
+        }
+    })
 }
 
 /**


### PR DESCRIPTION
## Overview

This PR adds performance benchmarks for Swift array, similar to the existing enum benchmarks.

 ## Results

`node run.js --filter=Array --adaptive`

<img width="2092" height="1296" alt="CleanShot 2026-01-30 at 17 00 27@2x" src="https://github.com/user-attachments/assets/877a9601-85fc-402f-bb5e-cb67c33cfd75" />