### PR TITLE
BridgeJS: Add UInt support

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -800,7 +800,7 @@ struct StackCodegen {
         switch type {
         case .string:
             return "String.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32())"
-        case .int:
+        case .int, .uint:
             return "Int.bridgeJSLiftParameter(_swift_js_pop_param_int32())"
         case .bool:
             return "Bool.bridgeJSLiftParameter(_swift_js_pop_param_int32())"
@@ -873,7 +873,7 @@ struct StackCodegen {
         case .string:
             return
                 "Optional<String>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32(), _swift_js_pop_param_int32())"
-        case .int:
+        case .int, .uint:
             return "Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32())"
         case .bool:
             return "Optional<Bool>.bridgeJSLiftParameter(_swift_js_pop_param_int32(), _swift_js_pop_param_int32())"
@@ -945,7 +945,7 @@ struct StackCodegen {
                 "var __bjs_\(raw: varPrefix) = \(raw: accessor)",
                 "__bjs_\(raw: varPrefix).withUTF8 { ptr in _swift_js_push_string(ptr.baseAddress, Int32(ptr.count)) }",
             ]
-        case .int:
+        case .int, .uint:
             return ["_swift_js_push_int(Int32(\(raw: accessor)))"]
         case .bool:
             return ["_swift_js_push_int(\(raw: accessor) ? 1 : 0)"]
@@ -1052,7 +1052,7 @@ struct StackCodegen {
                 "var __bjs_str_\(raw: varPrefix) = \(raw: unwrappedVar)",
                 "__bjs_str_\(raw: varPrefix).withUTF8 { ptr in _swift_js_push_string(ptr.baseAddress, Int32(ptr.count)) }",
             ]
-        case .int:
+        case .int, .uint:
             return ["_swift_js_push_int(Int32(\(raw: unwrappedVar)))"]
         case .bool:
             return ["_swift_js_push_int(\(raw: unwrappedVar) ? 1 : 0)"]
@@ -1643,6 +1643,7 @@ extension BridgeType {
         switch self {
         case .bool: return "Bool"
         case .int: return "Int"
+        case .uint: return "UInt"
         case .float: return "Float"
         case .double: return "Double"
         case .string: return "String"
@@ -1687,7 +1688,7 @@ extension BridgeType {
     func liftParameterInfo() throws -> LiftingIntrinsicInfo {
         switch self {
         case .bool: return .bool
-        case .int: return .int
+        case .int, .uint: return .int
         case .float: return .float
         case .double: return .double
         case .string: return .string
@@ -1739,7 +1740,7 @@ extension BridgeType {
     func loweringReturnInfo() throws -> LoweringIntrinsicInfo {
         switch self {
         case .bool: return .bool
-        case .int: return .int
+        case .int, .uint: return .int
         case .float: return .float
         case .double: return .double
         case .string: return .string

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -866,7 +866,7 @@ extension BridgeType {
     func loweringParameterInfo(context: BridgeContext = .importTS) throws -> LoweringParameterInfo {
         switch self {
         case .bool: return .bool
-        case .int: return .int
+        case .int, .uint: return .int
         case .float: return .float
         case .double: return .double
         case .string: return .string
@@ -960,7 +960,7 @@ extension BridgeType {
     ) throws -> LiftingReturnInfo {
         switch self {
         case .bool: return .bool
-        case .int: return .int
+        case .int, .uint: return .int
         case .float: return .float
         case .double: return .double
         case .string: return .string

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -3401,7 +3401,7 @@ extension BridgeType {
             return "void"
         case .string:
             return "string"
-        case .int:
+        case .int, .uint:
             return "number"
         case .float:
             return "number"

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -127,7 +127,7 @@ public struct UnsafePointerType: Codable, Equatable, Hashable, Sendable {
 }
 
 public enum BridgeType: Codable, Equatable, Hashable, Sendable {
-    case int, float, double, string, bool, jsObject(String?), swiftHeapObject(String), void
+    case int, uint, float, double, string, bool, jsObject(String?), swiftHeapObject(String), void
     case unsafePointer(UnsafePointerType)
     indirect case optional(BridgeType)
     indirect case array(BridgeType)
@@ -860,6 +860,8 @@ extension BridgeType {
         switch swiftType {
         case "Int":
             self = .int
+        case "UInt":
+            self = .uint
         case "Float":
             self = .float
         case "Double":
@@ -887,7 +889,7 @@ extension BridgeType {
         switch self {
         case .void: return nil
         case .bool: return .i32
-        case .int: return .i32
+        case .int, .uint: return .i32
         case .float: return .f32
         case .double: return .f64
         case .string: return nil
@@ -933,6 +935,7 @@ extension BridgeType {
     public var mangleTypeName: String {
         switch self {
         case .int: return "Si"
+        case .uint: return "Su"
         case .float: return "Sf"
         case .double: return "Sd"
         case .string: return "SS"

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/PrimitiveParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/PrimitiveParameters.swift
@@ -1,1 +1,1 @@
-@JS func check(a: Int, b: Float, c: Double, d: Bool) {}
+@JS func check(a: Int, b: UInt, c: Float, d: Double, e: Bool) {}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/PrimitiveReturn.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/PrimitiveReturn.swift
@@ -1,4 +1,5 @@
 @JS func checkInt() -> Int { fatalError() }
+@JS func checkUInt() -> UInt { fatalError() }
 @JS func checkFloat() -> Float { fatalError() }
 @JS func checkDouble() -> Double { fatalError() }
 @JS func checkBool() -> Bool { fatalError() }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.d.ts
@@ -5,7 +5,7 @@
 // `swift package bridge-js`.
 
 export type Exports = {
-    check(a: number, b: number, c: number, d: boolean): void;
+    check(a: number, b: number, c: number, d: number, e: boolean): void;
 }
 export type Imports = {
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.Export.js
@@ -222,8 +222,8 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
-                check: function bjs_check(a, b, c, d) {
-                    instance.exports.bjs_check(a, b, c, d);
+                check: function bjs_check(a, b, c, d, e) {
+                    instance.exports.bjs_check(a, b, c, d, e);
                 },
             };
             _exports = exports;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.d.ts
@@ -6,6 +6,7 @@
 
 export type Exports = {
     checkInt(): number;
+    checkUInt(): number;
     checkFloat(): number;
     checkDouble(): number;
     checkBool(): boolean;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.Export.js
@@ -226,6 +226,10 @@ export async function createInstantiator(options, swift) {
                     const ret = instance.exports.bjs_checkInt();
                     return ret;
                 },
+                checkUInt: function bjs_checkUInt() {
+                    const ret = instance.exports.bjs_checkUInt();
+                    return ret >>> 0;
+                },
                 checkFloat: function bjs_checkFloat() {
                     const ret = instance.exports.bjs_checkFloat();
                     return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveParameters.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveParameters.json
@@ -29,7 +29,7 @@
           "label" : "b",
           "name" : "b",
           "type" : {
-            "float" : {
+            "uint" : {
 
             }
           }
@@ -38,7 +38,7 @@
           "label" : "c",
           "name" : "c",
           "type" : {
-            "double" : {
+            "float" : {
 
             }
           }
@@ -46,6 +46,15 @@
         {
           "label" : "d",
           "name" : "d",
+          "type" : {
+            "double" : {
+
+            }
+          }
+        },
+        {
+          "label" : "e",
+          "name" : "e",
           "type" : {
             "bool" : {
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveParameters.swift
@@ -1,8 +1,8 @@
 @_expose(wasm, "bjs_check")
 @_cdecl("bjs_check")
-public func _bjs_check(_ a: Int32, _ b: Float32, _ c: Float64, _ d: Int32) -> Void {
+public func _bjs_check(_ a: Int32, _ b: Int32, _ c: Float32, _ d: Float64, _ e: Int32) -> Void {
     #if arch(wasm32)
-    check(a: Int.bridgeJSLiftParameter(a), b: Float.bridgeJSLiftParameter(b), c: Double.bridgeJSLiftParameter(c), d: Bool.bridgeJSLiftParameter(d))
+    check(a: Int.bridgeJSLiftParameter(a), b: UInt.bridgeJSLiftParameter(b), c: Float.bridgeJSLiftParameter(c), d: Double.bridgeJSLiftParameter(d), e: Bool.bridgeJSLiftParameter(e))
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveReturn.json
@@ -25,6 +25,23 @@
       }
     },
     {
+      "abiName" : "bjs_checkUInt",
+      "effects" : {
+        "isAsync" : false,
+        "isStatic" : false,
+        "isThrows" : false
+      },
+      "name" : "checkUInt",
+      "parameters" : [
+
+      ],
+      "returnType" : {
+        "uint" : {
+
+        }
+      }
+    },
+    {
       "abiName" : "bjs_checkFloat",
       "effects" : {
         "isAsync" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveReturn.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/PrimitiveReturn.swift
@@ -9,6 +9,17 @@ public func _bjs_checkInt() -> Int32 {
     #endif
 }
 
+@_expose(wasm, "bjs_checkUInt")
+@_cdecl("bjs_checkUInt")
+public func _bjs_checkUInt() -> Int32 {
+    #if arch(wasm32)
+    let ret = checkUInt()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_checkFloat")
 @_cdecl("bjs_checkFloat")
 public func _bjs_checkFloat() -> Float32 {

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -13,6 +13,9 @@ func runJsWorks() -> Void
 @JS func roundTripInt(v: Int) -> Int {
     return v
 }
+@JS func roundTripUInt(v: UInt) -> UInt {
+    return v
+}
 @JS func roundTripFloat(v: Float) -> Float {
     return v
 }

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -3222,6 +3222,17 @@ public func _bjs_roundTripInt(_ v: Int32) -> Int32 {
     #endif
 }
 
+@_expose(wasm, "bjs_roundTripUInt")
+@_cdecl("bjs_roundTripUInt")
+public func _bjs_roundTripUInt(_ v: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = roundTripUInt(v: UInt.bridgeJSLiftParameter(v))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_roundTripFloat")
 @_cdecl("bjs_roundTripFloat")
 public func _bjs_roundTripFloat(_ v: Float32) -> Float32 {

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -4652,6 +4652,31 @@
         }
       },
       {
+        "abiName" : "bjs_roundTripUInt",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripUInt",
+        "parameters" : [
+          {
+            "label" : "v",
+            "name" : "v",
+            "type" : {
+              "uint" : {
+
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "uint" : {
+
+          }
+        }
+      },
+      {
         "abiName" : "bjs_roundTripFloat",
         "effects" : {
           "isAsync" : false,

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -155,6 +155,9 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     for (const v of [0, 1, -1, 2147483647, -2147483648]) {
         assert.equal(exports.roundTripInt(v), v);
     }
+    for (const v of [0, 1, 2147483647, 4294967295]) {
+        assert.equal(exports.roundTripUInt(v), v);
+    }
     for (const v of [
         0.0, 1.0, -1.0,
         NaN,


### PR DESCRIPTION
## Introduction

Adds `UInt` type support to BridgeJS, allowing Swift functions using `UInt` parameters and return values to be exported to JavaScript.

**Motivation**: Enable developers to use existing Swift code with `UInt` types without requiring modifications to use `Int` instead.

## Example

```swift
@JS func processUnsigned(_ value: UInt) -> UInt {
    return value * 2
}
```

TypeScript:
```typescript
export function processUnsigned(value: number): number;
```

## Implementation Notes
- `UInt` maps to `number` in TypeScript (same as `Int`)
- Uses bitwise conversion to preserve the full UInt32 range (0 to 4,294,967,295)
- On the JS side, return values use `>>> 0` to convert signed Int32 back to unsigned

This approach is consistent with how `Int` supports its full range (-2^31 to 2^31-1) — `UInt` also supports its full range. But if we'd rather just not handle this case and return `.identity`, just let me know.

## Testing
- Added `UInt` to primitive type snapshot tests
- Added E2E round-trip tests including edge case `4294967295` (max UInt32)
