### PR TITLE
BridgeJS: Add intrinsic extensions for stack-based lifting and refactor Swift glue code generation to use them

### DIFF
--- a/Benchmarks/Sources/Generated/BridgeJS.Macros.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func benchmarkHelperNoop() throws (JSException) -> Void
 

--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -11,15 +11,15 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> APIResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .failure(Int.bridgeJSLiftParameter())
         case 2:
-            return .flag(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .flag(Bool.bridgeJSLiftParameter())
         case 3:
-            return .rate(Float.bridgeJSLiftParameter(_swift_js_pop_f32()))
+            return .rate(Float.bridgeJSLiftParameter())
         case 4:
-            return .precise(Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
+            return .precise(Double.bridgeJSLiftParameter())
         case 5:
             return .info
         default:
@@ -32,22 +32,19 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .failure(let param0):
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
             return Int32(1)
         case .flag(let param0):
-            _swift_js_push_i32(param0 ? 1 : 0)
+            param0.bridgeJSLowerStackReturn()
             return Int32(2)
         case .rate(let param0):
-            _swift_js_push_f32(param0)
+            param0.bridgeJSLowerStackReturn()
             return Int32(3)
         case .precise(let param0):
-            _swift_js_push_f64(param0)
+            param0.bridgeJSLowerStackReturn()
             return Int32(4)
         case .info:
             return Int32(5)
@@ -68,22 +65,19 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .failure(let param0):
             _swift_js_push_tag(Int32(1))
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
         case .flag(let param0):
             _swift_js_push_tag(Int32(2))
-            _swift_js_push_i32(param0 ? 1 : 0)
+            param0.bridgeJSLowerStackReturn()
         case .rate(let param0):
             _swift_js_push_tag(Int32(3))
-            _swift_js_push_f32(param0)
+            param0.bridgeJSLowerStackReturn()
         case .precise(let param0):
             _swift_js_push_tag(Int32(4))
-            _swift_js_push_f64(param0)
+            param0.bridgeJSLowerStackReturn()
         case .info:
             _swift_js_push_tag(Int32(5))
         }
@@ -94,17 +88,17 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> ComplexResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .error(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .error(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
         case 2:
-            return .location(Double.bridgeJSLiftParameter(_swift_js_pop_f64()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .location(Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
         case 3:
-            return .status(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .status(Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
         case 4:
-            return .coordinates(Double.bridgeJSLiftParameter(_swift_js_pop_f64()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
+            return .coordinates(Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter())
         case 5:
-            return .comprehensive(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()), Bool.bridgeJSLiftParameter(_swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .comprehensive(Bool.bridgeJSLiftParameter(), Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), String.bridgeJSLiftParameter(), String.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
         case 6:
             return .info
         default:
@@ -117,58 +111,37 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .error(let param0, let param1):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
             return Int32(1)
         case .location(let param0, let param1, let param2):
-            _swift_js_push_f64(param0)
-            _swift_js_push_f64(param1)
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
             return Int32(2)
         case .status(let param0, let param1, let param2):
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(Int32(param1))
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
             return Int32(3)
         case .coordinates(let param0, let param1, let param2):
-            _swift_js_push_f64(param0)
-            _swift_js_push_f64(param1)
-            _swift_js_push_f64(param2)
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
             return Int32(4)
         case .comprehensive(let param0, let param1, let param2, let param3, let param4, let param5, let param6, let param7, let param8):
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(param1 ? 1 : 0)
-            _swift_js_push_i32(Int32(param2))
-            _swift_js_push_i32(Int32(param3))
-            _swift_js_push_f64(param4)
-            _swift_js_push_f64(param5)
-            var __bjs_param6 = param6
-            __bjs_param6.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            var __bjs_param7 = param7
-            __bjs_param7.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            var __bjs_param8 = param8
-            __bjs_param8.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
+            param3.bridgeJSLowerStackReturn()
+            param4.bridgeJSLowerStackReturn()
+            param5.bridgeJSLowerStackReturn()
+            param6.bridgeJSLowerStackReturn()
+            param7.bridgeJSLowerStackReturn()
+            param8.bridgeJSLowerStackReturn()
             return Int32(5)
         case .info:
             return Int32(6)
@@ -189,58 +162,37 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .error(let param0, let param1):
             _swift_js_push_tag(Int32(1))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
         case .location(let param0, let param1, let param2):
             _swift_js_push_tag(Int32(2))
-            _swift_js_push_f64(param0)
-            _swift_js_push_f64(param1)
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
         case .status(let param0, let param1, let param2):
             _swift_js_push_tag(Int32(3))
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(Int32(param1))
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
         case .coordinates(let param0, let param1, let param2):
             _swift_js_push_tag(Int32(4))
-            _swift_js_push_f64(param0)
-            _swift_js_push_f64(param1)
-            _swift_js_push_f64(param2)
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
         case .comprehensive(let param0, let param1, let param2, let param3, let param4, let param5, let param6, let param7, let param8):
             _swift_js_push_tag(Int32(5))
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(param1 ? 1 : 0)
-            _swift_js_push_i32(Int32(param2))
-            _swift_js_push_i32(Int32(param3))
-            _swift_js_push_f64(param4)
-            _swift_js_push_f64(param5)
-            var __bjs_param6 = param6
-            __bjs_param6.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            var __bjs_param7 = param7
-            __bjs_param7.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            var __bjs_param8 = param8
-            __bjs_param8.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
+            param3.bridgeJSLowerStackReturn()
+            param4.bridgeJSLowerStackReturn()
+            param5.bridgeJSLowerStackReturn()
+            param6.bridgeJSLowerStackReturn()
+            param7.bridgeJSLowerStackReturn()
+            param8.bridgeJSLowerStackReturn()
         case .info:
             _swift_js_push_tag(Int32(6))
         }
@@ -249,23 +201,20 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
 
 extension SimpleStruct: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> SimpleStruct {
-        let precise = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
-        let rate = Float.bridgeJSLiftParameter(_swift_js_pop_f32())
-        let flag = Bool.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let count = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let name = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let precise = Double.bridgeJSLiftParameter()
+        let rate = Float.bridgeJSLiftParameter()
+        let flag = Bool.bridgeJSLiftParameter()
+        let count = Int.bridgeJSLiftParameter()
+        let name = String.bridgeJSLiftParameter()
         return SimpleStruct(name: name, count: count, flag: flag, rate: rate, precise: precise)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        var __bjs_name = self.name
-        __bjs_name.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        _swift_js_push_i32(Int32(self.count))
-        _swift_js_push_i32(self.flag ? 1 : 0)
-        _swift_js_push_f32(self.rate)
-        _swift_js_push_f64(self.precise)
+        self.name.bridgeJSLowerStackReturn()
+        self.count.bridgeJSLowerStackReturn()
+        self.flag.bridgeJSLowerStackReturn()
+        self.rate.bridgeJSLowerStackReturn()
+        self.precise.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -303,22 +252,16 @@ fileprivate func _bjs_struct_lift_SimpleStruct() -> Int32 {
 
 extension Address: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Address {
-        let zipCode = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let city = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let street = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let zipCode = Int.bridgeJSLiftParameter()
+        let city = String.bridgeJSLiftParameter()
+        let street = String.bridgeJSLiftParameter()
         return Address(street: street, city: city, zipCode: zipCode)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        var __bjs_street = self.street
-        __bjs_street.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        var __bjs_city = self.city
-        __bjs_city.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        _swift_js_push_i32(Int32(self.zipCode))
+        self.street.bridgeJSLowerStackReturn()
+        self.city.bridgeJSLowerStackReturn()
+        self.zipCode.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -356,26 +299,20 @@ fileprivate func _bjs_struct_lift_Address() -> Int32 {
 
 extension Person: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Person {
-        let email = Optional<String>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32())
+        let email = Optional<String>.bridgeJSLiftParameter()
         let address = Address.bridgeJSLiftParameter()
-        let age = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let name = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let age = Int.bridgeJSLiftParameter()
+        let name = String.bridgeJSLiftParameter()
         return Person(name: name, age: age, address: address, email: email)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        var __bjs_name = self.name
-        __bjs_name.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        _swift_js_push_i32(Int32(self.age))
+        self.name.bridgeJSLowerStackReturn()
+        self.age.bridgeJSLowerStackReturn()
         self.address.bridgeJSLowerReturn()
         let __bjs_isSome_email = self.email != nil
         if let __bjs_unwrapped_email = self.email {
-            var __bjs_str_email = __bjs_unwrapped_email
-            __bjs_str_email.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            __bjs_unwrapped_email.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_email ? 1 : 0)
     }
@@ -415,31 +352,22 @@ fileprivate func _bjs_struct_lift_Person() -> Int32 {
 
 extension ComplexStruct: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ComplexStruct {
-        let metadata = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let tags = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let score = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
-        let active = Bool.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let title = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let id = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
+        let metadata = String.bridgeJSLiftParameter()
+        let tags = String.bridgeJSLiftParameter()
+        let score = Double.bridgeJSLiftParameter()
+        let active = Bool.bridgeJSLiftParameter()
+        let title = String.bridgeJSLiftParameter()
+        let id = Int.bridgeJSLiftParameter()
         return ComplexStruct(id: id, title: title, active: active, score: score, tags: tags, metadata: metadata)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_i32(Int32(self.id))
-        var __bjs_title = self.title
-        __bjs_title.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        _swift_js_push_i32(self.active ? 1 : 0)
-        _swift_js_push_f64(self.score)
-        var __bjs_tags = self.tags
-        __bjs_tags.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        var __bjs_metadata = self.metadata
-        __bjs_metadata.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
+        self.id.bridgeJSLowerStackReturn()
+        self.title.bridgeJSLowerStackReturn()
+        self.active.bridgeJSLowerStackReturn()
+        self.score.bridgeJSLowerStackReturn()
+        self.tags.bridgeJSLowerStackReturn()
+        self.metadata.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -477,14 +405,14 @@ fileprivate func _bjs_struct_lift_ComplexStruct() -> Int32 {
 
 extension Point: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Point {
-        let y = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
-        let x = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
+        let y = Double.bridgeJSLiftParameter()
+        let x = Double.bridgeJSLiftParameter()
         return Point(x: x, y: y)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_f64(self.x)
-        _swift_js_push_f64(self.y)
+        self.x.bridgeJSLowerStackReturn()
+        self.y.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -1487,16 +1415,7 @@ public func _bjs_ArrayRoundtrip_init() -> UnsafeMutableRawPointer {
 @_cdecl("bjs_ArrayRoundtrip_takeIntArray")
 public func _bjs_ArrayRoundtrip_takeIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeIntArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeIntArray(_: [Int].bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1507,9 +1426,7 @@ public func _bjs_ArrayRoundtrip_takeIntArray(_ _self: UnsafeMutableRawPointer) -
 public func _bjs_ArrayRoundtrip_makeIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeIntArray()
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret))}
-    _swift_js_push_i32(Int32(ret.count))
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1519,19 +1436,8 @@ public func _bjs_ArrayRoundtrip_makeIntArray(_ _self: UnsafeMutableRawPointer) -
 @_cdecl("bjs_ArrayRoundtrip_roundtripIntArray")
 public func _bjs_ArrayRoundtrip_roundtripIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripIntArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret))}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripIntArray(_: [Int].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1542,9 +1448,7 @@ public func _bjs_ArrayRoundtrip_roundtripIntArray(_ _self: UnsafeMutableRawPoint
 public func _bjs_ArrayRoundtrip_makeIntArrayLarge(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeIntArrayLarge()
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret))}
-    _swift_js_push_i32(Int32(ret.count))
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1554,16 +1458,7 @@ public func _bjs_ArrayRoundtrip_makeIntArrayLarge(_ _self: UnsafeMutableRawPoint
 @_cdecl("bjs_ArrayRoundtrip_takeDoubleArray")
 public func _bjs_ArrayRoundtrip_takeDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeDoubleArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Double] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
-        }
-        __result.reverse()
-        return __result
-        }())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeDoubleArray(_: [Double].bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1574,9 +1469,7 @@ public func _bjs_ArrayRoundtrip_takeDoubleArray(_ _self: UnsafeMutableRawPointer
 public func _bjs_ArrayRoundtrip_makeDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeDoubleArray()
-    for __bjs_elem_ret in ret {
-    _swift_js_push_f64(__bjs_elem_ret)}
-    _swift_js_push_i32(Int32(ret.count))
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1586,19 +1479,8 @@ public func _bjs_ArrayRoundtrip_makeDoubleArray(_ _self: UnsafeMutableRawPointer
 @_cdecl("bjs_ArrayRoundtrip_roundtripDoubleArray")
 public func _bjs_ArrayRoundtrip_roundtripDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripDoubleArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Double] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_f64(__bjs_elem_ret)}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripDoubleArray(_: [Double].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1608,16 +1490,7 @@ public func _bjs_ArrayRoundtrip_roundtripDoubleArray(_ _self: UnsafeMutableRawPo
 @_cdecl("bjs_ArrayRoundtrip_takeStringArray")
 public func _bjs_ArrayRoundtrip_takeStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeStringArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [String] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeStringArray(_: [String].bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1628,12 +1501,7 @@ public func _bjs_ArrayRoundtrip_takeStringArray(_ _self: UnsafeMutableRawPointer
 public func _bjs_ArrayRoundtrip_makeStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeStringArray()
-    for __bjs_elem_ret in ret {
-    var __bjs_ret_elem = __bjs_elem_ret
-    __bjs_ret_elem.withUTF8 { ptr in
-        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-    }}
-    _swift_js_push_i32(Int32(ret.count))
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1643,22 +1511,8 @@ public func _bjs_ArrayRoundtrip_makeStringArray(_ _self: UnsafeMutableRawPointer
 @_cdecl("bjs_ArrayRoundtrip_roundtripStringArray")
 public func _bjs_ArrayRoundtrip_roundtripStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripStringArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [String] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    var __bjs_ret_elem = __bjs_elem_ret
-    __bjs_ret_elem.withUTF8 { ptr in
-        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-    }}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripStringArray(_: [String].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1668,16 +1522,7 @@ public func _bjs_ArrayRoundtrip_roundtripStringArray(_ _self: UnsafeMutableRawPo
 @_cdecl("bjs_ArrayRoundtrip_takePointArray")
 public func _bjs_ArrayRoundtrip_takePointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takePointArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Point] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Point.bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-        }())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takePointArray(_: [Point].bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1688,9 +1533,7 @@ public func _bjs_ArrayRoundtrip_takePointArray(_ _self: UnsafeMutableRawPointer)
 public func _bjs_ArrayRoundtrip_makePointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makePointArray()
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()}
-    _swift_js_push_i32(Int32(ret.count))
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1700,19 +1543,8 @@ public func _bjs_ArrayRoundtrip_makePointArray(_ _self: UnsafeMutableRawPointer)
 @_cdecl("bjs_ArrayRoundtrip_roundtripPointArray")
 public func _bjs_ArrayRoundtrip_roundtripPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripPointArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Point] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Point.bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripPointArray(_: [Point].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1723,9 +1555,7 @@ public func _bjs_ArrayRoundtrip_roundtripPointArray(_ _self: UnsafeMutableRawPoi
 public func _bjs_ArrayRoundtrip_makePointArrayLarge(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makePointArrayLarge()
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()}
-    _swift_js_push_i32(Int32(ret.count))
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1740,16 +1570,7 @@ public func _bjs_ArrayRoundtrip_takeNestedIntArray(_ _self: UnsafeMutableRawPoin
         var __result: [[Int]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([Int].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -1765,9 +1586,7 @@ public func _bjs_ArrayRoundtrip_makeNestedIntArray(_ _self: UnsafeMutableRawPoin
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeNestedIntArray()
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret_elem))}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -1783,24 +1602,13 @@ public func _bjs_ArrayRoundtrip_roundtripNestedIntArray(_ _self: UnsafeMutableRa
         var __result: [[Int]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([Int].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret_elem))}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -1816,16 +1624,7 @@ public func _bjs_ArrayRoundtrip_takeNestedPointArray(_ _self: UnsafeMutableRawPo
         var __result: [[Point]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Point] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Point.bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([Point].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -1841,9 +1640,7 @@ public func _bjs_ArrayRoundtrip_makeNestedPointArray(_ _self: UnsafeMutableRawPo
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeNestedPointArray()
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    __bjs_elem_ret_elem.bridgeJSLowerReturn()}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -1859,24 +1656,13 @@ public func _bjs_ArrayRoundtrip_roundtripNestedPointArray(_ _self: UnsafeMutable
         var __result: [[Point]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Point] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Point.bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([Point].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    __bjs_elem_ret_elem.bridgeJSLowerReturn()}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -1892,7 +1678,7 @@ public func _bjs_ArrayRoundtrip_takeOptionalIntArray(_ _self: UnsafeMutableRawPo
         var __result: [Optional<Int>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            __result.append(Optional<Int>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -1910,7 +1696,7 @@ public func _bjs_ArrayRoundtrip_makeOptionalIntArray(_ _self: UnsafeMutableRawPo
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    _swift_js_push_i32(Int32(__bjs_unwrapped_ret_elem))}
+    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()}
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)}
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -1927,7 +1713,7 @@ public func _bjs_ArrayRoundtrip_roundtripOptionalIntArray(_ _self: UnsafeMutable
         var __result: [Optional<Int>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            __result.append(Optional<Int>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -1935,7 +1721,7 @@ public func _bjs_ArrayRoundtrip_roundtripOptionalIntArray(_ _self: UnsafeMutable
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    _swift_js_push_i32(Int32(__bjs_unwrapped_ret_elem))}
+    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()}
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)}
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -1952,7 +1738,7 @@ public func _bjs_ArrayRoundtrip_takeOptionalPointArray(_ _self: UnsafeMutableRaw
         var __result: [Optional<Point>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<Point>.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            __result.append(Optional<Point>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -1987,7 +1773,7 @@ public func _bjs_ArrayRoundtrip_roundtripOptionalPointArray(_ _self: UnsafeMutab
         var __result: [Optional<Point>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<Point>.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            __result.append(Optional<Point>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -2011,16 +1797,7 @@ public func _bjs_ArrayRoundtrip_takeOptionalArray(_ _self: UnsafeMutableRawPoint
         if values == 0 {
             return Optional<[Int]>.none
         } else {
-            return {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                }()
+            return [Int].bridgeJSLiftParameter()
         }
         }())
     #else
@@ -2035,9 +1812,7 @@ public func _bjs_ArrayRoundtrip_makeOptionalArraySome(_ _self: UnsafeMutableRawP
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalArraySome()
     let __bjs_isSome_ret = ret != nil
     if let __bjs_unwrapped_ret = ret {
-    for __bjs_elem_ret in __bjs_unwrapped_ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret))}
-    _swift_js_push_i32(Int32(__bjs_unwrapped_ret.count))}
+    __bjs_unwrapped_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
     #else
     fatalError("Only available on WebAssembly")
@@ -2051,9 +1826,7 @@ public func _bjs_ArrayRoundtrip_makeOptionalArrayNone(_ _self: UnsafeMutableRawP
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalArrayNone()
     let __bjs_isSome_ret = ret != nil
     if let __bjs_unwrapped_ret = ret {
-    for __bjs_elem_ret in __bjs_unwrapped_ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret))}
-    _swift_js_push_i32(Int32(__bjs_unwrapped_ret.count))}
+    __bjs_unwrapped_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
     #else
     fatalError("Only available on WebAssembly")
@@ -2068,23 +1841,12 @@ public func _bjs_ArrayRoundtrip_roundtripOptionalArray(_ _self: UnsafeMutableRaw
         if values == 0 {
             return Optional<[Int]>.none
         } else {
-            return {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                }()
+            return [Int].bridgeJSLiftParameter()
         }
         }())
     let __bjs_isSome_ret = ret != nil
     if let __bjs_unwrapped_ret = ret {
-    for __bjs_elem_ret in __bjs_unwrapped_ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret))}
-    _swift_js_push_i32(Int32(__bjs_unwrapped_ret.count))}
+    __bjs_unwrapped_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
     #else
     fatalError("Only available on WebAssembly")

--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.Macros.swift
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func createTS2Swift() throws (JSException) -> TS2Swift
 

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -798,60 +798,56 @@ struct StackCodegen {
     /// - Returns: An ExprSyntax representing the lift expression
     func liftExpression(for type: BridgeType) -> ExprSyntax {
         switch type {
-        case .string:
-            return "String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())"
-        case .int, .uint:
-            return "Int.bridgeJSLiftParameter(_swift_js_pop_i32())"
-        case .bool:
-            return "Bool.bridgeJSLiftParameter(_swift_js_pop_i32())"
-        case .float:
-            return "Float.bridgeJSLiftParameter(_swift_js_pop_f32())"
-        case .double:
-            return "Double.bridgeJSLiftParameter(_swift_js_pop_f64())"
-        case .jsObject:
-            return "JSObject.bridgeJSLiftParameter(_swift_js_pop_i32())"
-        case .swiftHeapObject(let className):
-            return "\(raw: className).bridgeJSLiftParameter(_swift_js_pop_pointer())"
+        case .string, .int, .uint, .bool, .float, .double,
+            .jsObject, .swiftStruct, .swiftHeapObject:
+            return "\(raw: type.swiftType).bridgeJSLiftParameter()"
         case .unsafePointer:
-            return "\(raw: type.swiftType).bridgeJSLiftParameter(_swift_js_pop_pointer())"
+            return "\(raw: type.swiftType).bridgeJSLiftParameter()"
         case .swiftProtocol(let protocolName):
-            // Protocols use their Any wrapper type for lifting
-            let wrapperName = "Any\(protocolName)"
-            return "\(raw: wrapperName).bridgeJSLiftParameter(_swift_js_pop_i32())"
-        case .caseEnum(let enumName):
-            return "\(raw: enumName).bridgeJSLiftParameter(_swift_js_pop_i32())"
-        case .rawValueEnum(let enumName, let rawType):
+            return "Any\(raw: protocolName).bridgeJSLiftParameter(_swift_js_pop_i32())"
+        case .caseEnum:
+            return "\(raw: type.swiftType).bridgeJSLiftParameter(_swift_js_pop_i32())"
+        case .rawValueEnum(_, let rawType):
             switch rawType {
             case .string:
                 return
-                    "\(raw: enumName).bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())"
+                    "\(raw: type.swiftType).bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())"
             case .float:
-                return "\(raw: enumName).bridgeJSLiftParameter(_swift_js_pop_f32())"
+                return "\(raw: type.swiftType).bridgeJSLiftParameter(_swift_js_pop_f32())"
             case .double:
-                return "\(raw: enumName).bridgeJSLiftParameter(_swift_js_pop_f64())"
+                return "\(raw: type.swiftType).bridgeJSLiftParameter(_swift_js_pop_f64())"
             case .bool, .int, .int32, .int64, .uint, .uint32, .uint64:
-                return "\(raw: enumName).bridgeJSLiftParameter(_swift_js_pop_i32())"
+                return "\(raw: type.swiftType).bridgeJSLiftParameter(_swift_js_pop_i32())"
             }
-        case .associatedValueEnum(let enumName):
-            return "\(raw: enumName).bridgeJSLiftParameter(_swift_js_pop_i32())"
-        case .swiftStruct(let structName):
-            return "\(raw: structName).bridgeJSLiftParameter()"
+        case .associatedValueEnum:
+            return "\(raw: type.swiftType).bridgeJSLiftParameter(_swift_js_pop_i32())"
         case .optional(let wrappedType):
             return liftOptionalExpression(wrappedType: wrappedType)
-        case .void:
-            // Void shouldn't be lifted, but return a placeholder
-            return "()"
-        case .namespaceEnum:
-            // Namespace enums are not passed as values
-            return "()"
-        case .closure:
-            return "JSObject.bridgeJSLiftParameter(_swift_js_pop_i32())"
         case .array(let elementType):
             return liftArrayExpression(elementType: elementType)
+        case .closure:
+            return "JSObject.bridgeJSLiftParameter()"
+        case .void, .namespaceEnum:
+            return "()"
         }
     }
 
     func liftArrayExpression(elementType: BridgeType) -> ExprSyntax {
+        switch elementType {
+        case .int, .uint, .float, .double, .string, .bool,
+            .jsObject, .swiftStruct, .caseEnum, .swiftHeapObject,
+            .unsafePointer, .rawValueEnum, .associatedValueEnum:
+            return "[\(raw: elementType.swiftType)].bridgeJSLiftParameter()"
+        case .swiftProtocol(let protocolName):
+            return "[Any\(raw: protocolName)].bridgeJSLiftParameter()"
+        case .optional, .array, .closure:
+            return liftArrayExpressionInline(elementType: elementType)
+        case .void, .namespaceEnum:
+            fatalError("Invalid array element type: \(elementType)")
+        }
+    }
+
+    private func liftArrayExpressionInline(elementType: BridgeType) -> ExprSyntax {
         let elementLift = liftExpression(for: elementType)
         let swiftTypeName = elementType.swiftType
         return """
@@ -870,45 +866,9 @@ struct StackCodegen {
 
     private func liftOptionalExpression(wrappedType: BridgeType) -> ExprSyntax {
         switch wrappedType {
-        case .string:
-            return
-                "Optional<String>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32())"
-        case .int, .uint:
-            return "Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())"
-        case .bool:
-            return "Optional<Bool>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())"
-        case .float:
-            return "Optional<Float>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_f32())"
-        case .double:
-            return "Optional<Double>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_f64())"
-        case .caseEnum(let enumName):
-            return
-                "Optional<\(raw: enumName)>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())"
-        case .rawValueEnum(let enumName, let rawType):
-            switch rawType {
-            case .string:
-                return
-                    "Optional<\(raw: enumName)>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32())"
-            case .float:
-                return
-                    "Optional<\(raw: enumName)>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_f32())"
-            case .double:
-                return
-                    "Optional<\(raw: enumName)>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_f64())"
-            case .bool, .int, .int32, .int64, .uint, .uint32, .uint64:
-                return
-                    "Optional<\(raw: enumName)>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())"
-            }
-        case .swiftStruct(let nestedName):
-            return "Optional<\(raw: nestedName)>.bridgeJSLiftParameter(_swift_js_pop_i32())"
-        case .swiftHeapObject(let className):
-            return
-                "Optional<\(raw: className)>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_pointer())"
-        case .associatedValueEnum(let enumName):
-            return
-                "Optional<\(raw: enumName)>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())"
-        case .jsObject:
-            return "Optional<JSObject>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())"
+        case .string, .int, .uint, .bool, .float, .double, .jsObject,
+            .swiftStruct, .swiftHeapObject, .caseEnum, .associatedValueEnum, .rawValueEnum:
+            return "Optional<\(raw: wrappedType.swiftType)>.bridgeJSLiftParameter()"
         case .array(let elementType):
             let arrayLift = liftArrayExpression(elementType: elementType)
             let swiftTypeName = elementType.swiftType
@@ -922,9 +882,8 @@ struct StackCodegen {
                     }
                 }()
                 """
-        default:
-            // Fallback for other optional types
-            return "Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())"
+        case .void, .namespaceEnum, .closure, .optional, .unsafePointer, .swiftProtocol:
+            fatalError("Invalid optional wrapped type: \(wrappedType)")
         }
     }
 
@@ -940,62 +899,52 @@ struct StackCodegen {
         varPrefix: String
     ) -> [CodeBlockItemSyntax] {
         switch type {
-        case .string:
-            return [
-                "var __bjs_\(raw: varPrefix) = \(raw: accessor)",
-                "__bjs_\(raw: varPrefix).withUTF8 { ptr in _swift_js_push_string(ptr.baseAddress, Int32(ptr.count)) }",
-            ]
-        case .int, .uint:
-            return ["_swift_js_push_i32(Int32(\(raw: accessor)))"]
-        case .bool:
-            return ["_swift_js_push_i32(\(raw: accessor) ? 1 : 0)"]
-        case .float:
-            return ["_swift_js_push_f32(\(raw: accessor))"]
-        case .double:
-            return ["_swift_js_push_f64(\(raw: accessor))"]
+        case .string, .int, .uint, .bool, .float, .double:
+            return ["\(raw: accessor).bridgeJSLowerStackReturn()"]
         case .jsObject:
-            return ["_swift_js_push_i32(\(raw: accessor).bridgeJSLowerReturn())"]
-        case .swiftHeapObject:
-            return ["_swift_js_push_pointer(\(raw: accessor).bridgeJSLowerReturn())"]
-        case .unsafePointer:
-            return ["_swift_js_push_pointer(\(raw: accessor).bridgeJSLowerReturn())"]
+            return ["\(raw: accessor).bridgeJSLowerStackReturn()"]
+        case .swiftHeapObject, .unsafePointer, .closure:
+            return ["\(raw: accessor).bridgeJSLowerStackReturn()"]
         case .swiftProtocol(let protocolName):
             let wrapperName = "Any\(protocolName)"
-            return ["_swift_js_push_i32((\(raw: accessor) as! \(raw: wrapperName)).bridgeJSLowerReturn())"]
-        case .caseEnum:
-            return ["_swift_js_push_i32(Int32(\(raw: accessor).bridgeJSLowerParameter()))"]
-        case .rawValueEnum(_, let rawType):
-            switch rawType {
-            case .string:
-                return [
-                    "var __bjs_\(raw: varPrefix) = \(raw: accessor).rawValue",
-                    "__bjs_\(raw: varPrefix).withUTF8 { ptr in _swift_js_push_string(ptr.baseAddress, Int32(ptr.count)) }",
-                ]
-            case .float:
-                return ["_swift_js_push_f32(\(raw: accessor).bridgeJSLowerParameter())"]
-            case .double:
-                return ["_swift_js_push_f64(\(raw: accessor).bridgeJSLowerParameter())"]
-            default:
-                return ["_swift_js_push_i32(Int32(\(raw: accessor).bridgeJSLowerParameter()))"]
-            }
-        case .associatedValueEnum:
-            return ["\(raw: accessor).bridgeJSLowerReturn()"]
-        case .swiftStruct:
+            return ["(\(raw: accessor) as! \(raw: wrapperName)).bridgeJSLowerStackReturn()"]
+        case .caseEnum, .rawValueEnum:
+            return ["\(raw: accessor).bridgeJSLowerStackReturn()"]
+        case .associatedValueEnum, .swiftStruct:
             return ["\(raw: accessor).bridgeJSLowerReturn()"]
         case .optional(let wrappedType):
             return lowerOptionalStatements(wrappedType: wrappedType, accessor: accessor, varPrefix: varPrefix)
-        case .void:
+        case .void, .namespaceEnum:
             return []
-        case .namespaceEnum:
-            return []
-        case .closure:
-            return ["_swift_js_push_pointer(\(raw: accessor).bridgeJSLowerReturn())"]
         case .array(let elementType):
             return lowerArrayStatements(elementType: elementType, accessor: accessor, varPrefix: varPrefix)
         }
     }
 
     private func lowerArrayStatements(
+        elementType: BridgeType,
+        accessor: String,
+        varPrefix: String
+    ) -> [CodeBlockItemSyntax] {
+        switch elementType {
+        case .int, .uint, .float, .double, .string, .bool,
+            .jsObject, .swiftStruct, .caseEnum, .swiftHeapObject,
+            .unsafePointer, .rawValueEnum, .associatedValueEnum:
+            return ["\(raw: accessor).bridgeJSLowerReturn()"]
+        case .swiftProtocol(let protocolName):
+            return ["\(raw: accessor).map { $0 as! Any\(raw: protocolName) }.bridgeJSLowerReturn()"]
+        case .optional, .array, .closure:
+            return lowerArrayStatementsInline(
+                elementType: elementType,
+                accessor: accessor,
+                varPrefix: varPrefix
+            )
+        case .void, .namespaceEnum:
+            fatalError("Invalid array element type: \(elementType)")
+        }
+    }
+
+    private func lowerArrayStatementsInline(
         elementType: BridgeType,
         accessor: String,
         varPrefix: String
@@ -1047,43 +996,20 @@ struct StackCodegen {
         varPrefix: String
     ) -> [CodeBlockItemSyntax] {
         switch wrappedType {
-        case .string:
-            return [
-                "var __bjs_str_\(raw: varPrefix) = \(raw: unwrappedVar)",
-                "__bjs_str_\(raw: varPrefix).withUTF8 { ptr in _swift_js_push_string(ptr.baseAddress, Int32(ptr.count)) }",
-            ]
-        case .int, .uint:
-            return ["_swift_js_push_i32(Int32(\(raw: unwrappedVar)))"]
-        case .bool:
-            return ["_swift_js_push_i32(\(raw: unwrappedVar) ? 1 : 0)"]
-        case .float:
-            return ["_swift_js_push_f32(\(raw: unwrappedVar))"]
-        case .double:
-            return ["_swift_js_push_f64(\(raw: unwrappedVar))"]
-        case .caseEnum:
-            return ["_swift_js_push_i32(\(raw: unwrappedVar).bridgeJSLowerParameter())"]
-        case .rawValueEnum(_, let rawType):
-            switch rawType {
-            case .string:
-                return [
-                    "var __bjs_str_\(raw: varPrefix) = \(raw: unwrappedVar).rawValue",
-                    "__bjs_str_\(raw: varPrefix).withUTF8 { ptr in _swift_js_push_string(ptr.baseAddress, Int32(ptr.count)) }",
-                ]
-            case .float:
-                return ["_swift_js_push_f32(\(raw: unwrappedVar).bridgeJSLowerParameter())"]
-            case .double:
-                return ["_swift_js_push_f64(\(raw: unwrappedVar).bridgeJSLowerParameter())"]
-            default:
-                return ["_swift_js_push_i32(\(raw: unwrappedVar).bridgeJSLowerParameter())"]
-            }
+        case .string, .int, .uint, .bool, .float, .double:
+            return ["\(raw: unwrappedVar).bridgeJSLowerStackReturn()"]
+        case .caseEnum, .rawValueEnum:
+            // Enums conform to _BridgedSwiftStackType
+            return ["\(raw: unwrappedVar).bridgeJSLowerStackReturn()"]
         case .swiftStruct:
             return ["\(raw: unwrappedVar).bridgeJSLowerReturn()"]
         case .swiftHeapObject:
-            return ["_swift_js_push_pointer(\(raw: unwrappedVar).bridgeJSLowerReturn())"]
+            return ["\(raw: unwrappedVar).bridgeJSLowerStackReturn()"]
         case .associatedValueEnum:
+            // Push payloads via bridgeJSLowerParameter(), then push the returned case ID
             return ["_swift_js_push_i32(\(raw: unwrappedVar).bridgeJSLowerParameter())"]
         case .jsObject:
-            return ["_swift_js_push_i32(\(raw: unwrappedVar).bridgeJSLowerReturn())"]
+            return ["\(raw: unwrappedVar).bridgeJSLowerStackReturn()"]
         case .array(let elementType):
             return lowerArrayStatements(elementType: elementType, accessor: unwrappedVar, varPrefix: varPrefix)
         default:
@@ -1150,7 +1076,17 @@ struct EnumCodegen {
     }
 
     private func renderRawValueEnumHelpers(_ enumDef: ExportedEnum) -> DeclSyntax {
-        return "extension \(raw: enumDef.swiftCallName): _BridgedSwiftEnumNoPayload {}"
+        let typeName = enumDef.swiftCallName
+        guard enumDef.rawType != nil else {
+            return """
+                extension \(raw: typeName): _BridgedSwiftEnumNoPayload {}
+                """
+        }
+        // When rawType is present, conform to _BridgedSwiftRawValueEnum which provides
+        // default implementations for _BridgedSwiftStackType methods via protocol extension.
+        return """
+            extension \(raw: typeName): _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {}
+            """
     }
 
     private func renderAssociatedValueEnumHelpers(_ enumDef: ExportedEnum) -> DeclSyntax {

--- a/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/src/cli.js
+++ b/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/src/cli.js
@@ -154,7 +154,7 @@ export function main(args) {
         "// To update this file, just rebuild your project or run",
         "// `swift package bridge-js`.",
         "",
-        "@_spi(Experimental) import JavaScriptKit",
+        "@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit",
         "",
         "",
     ].join("\n");

--- a/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/src/processor.js
+++ b/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/src/processor.js
@@ -399,7 +399,7 @@ export class TypeProcessor {
                 this.swiftLines.push(`    case ${this.renderIdentifier(name)} = "${raw.replaceAll("\"", "\\\\\"")}"`);
             }
             this.swiftLines.push("}");
-            this.swiftLines.push(`extension ${swiftEnumName}: _BridgedSwiftEnumNoPayload {}`);
+            this.swiftLines.push(`extension ${swiftEnumName}: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {}`);
             this.swiftLines.push("");
             return;
         }
@@ -410,7 +410,7 @@ export class TypeProcessor {
                 this.swiftLines.push(`    case ${this.renderIdentifier(name)} = ${raw}`);
             }
             this.swiftLines.push("}");
-            this.swiftLines.push(`extension ${swiftEnumName}: _BridgedSwiftEnumNoPayload {}`);
+            this.swiftLines.push(`extension ${swiftEnumName}: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {}`);
             this.swiftLines.push("");
             return;
         }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/ArrayTypes.swift
@@ -41,19 +41,19 @@ extension Direction: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Status: _BridgedSwiftEnumNoPayload {
+extension Status: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 extension Point: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Point {
-        let y = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
-        let x = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
+        let y = Double.bridgeJSLiftParameter()
+        let x = Double.bridgeJSLiftParameter()
         return Point(x: x, y: y)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_f64(self.x)
-        _swift_js_push_f64(self.y)
+        self.x.bridgeJSLowerStackReturn()
+        self.y.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -93,19 +93,8 @@ fileprivate func _bjs_struct_lift_Point() -> Int32 {
 @_cdecl("bjs_processIntArray")
 public func _bjs_processIntArray() -> Void {
     #if arch(wasm32)
-    let ret = processIntArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret))}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processIntArray(_: [Int].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -115,22 +104,8 @@ public func _bjs_processIntArray() -> Void {
 @_cdecl("bjs_processStringArray")
 public func _bjs_processStringArray() -> Void {
     #if arch(wasm32)
-    let ret = processStringArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [String] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    var __bjs_ret_elem = __bjs_elem_ret
-    __bjs_ret_elem.withUTF8 { ptr in
-        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-    }}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processStringArray(_: [String].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -140,19 +115,8 @@ public func _bjs_processStringArray() -> Void {
 @_cdecl("bjs_processDoubleArray")
 public func _bjs_processDoubleArray() -> Void {
     #if arch(wasm32)
-    let ret = processDoubleArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Double] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_f64(__bjs_elem_ret)}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processDoubleArray(_: [Double].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -162,19 +126,8 @@ public func _bjs_processDoubleArray() -> Void {
 @_cdecl("bjs_processBoolArray")
 public func _bjs_processBoolArray() -> Void {
     #if arch(wasm32)
-    let ret = processBoolArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Bool] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(__bjs_elem_ret ? 1 : 0)}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processBoolArray(_: [Bool].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -184,19 +137,8 @@ public func _bjs_processBoolArray() -> Void {
 @_cdecl("bjs_processPointArray")
 public func _bjs_processPointArray() -> Void {
     #if arch(wasm32)
-    let ret = processPointArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Point] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Point.bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processPointArray(_: [Point].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -206,19 +148,8 @@ public func _bjs_processPointArray() -> Void {
 @_cdecl("bjs_processDirectionArray")
 public func _bjs_processDirectionArray() -> Void {
     #if arch(wasm32)
-    let ret = processDirectionArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Direction] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Direction.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret.bridgeJSLowerParameter()))}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processDirectionArray(_: [Direction].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -228,19 +159,8 @@ public func _bjs_processDirectionArray() -> Void {
 @_cdecl("bjs_processStatusArray")
 public func _bjs_processStatusArray() -> Void {
     #if arch(wasm32)
-    let ret = processStatusArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Status] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Status.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret.bridgeJSLowerParameter()))}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processStatusArray(_: [Status].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -250,16 +170,7 @@ public func _bjs_processStatusArray() -> Void {
 @_cdecl("bjs_sumIntArray")
 public func _bjs_sumIntArray() -> Int32 {
     #if arch(wasm32)
-    let ret = sumIntArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
+    let ret = sumIntArray(_: [Int].bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -270,16 +181,7 @@ public func _bjs_sumIntArray() -> Int32 {
 @_cdecl("bjs_findFirstPoint")
 public func _bjs_findFirstPoint(_ matchingBytes: Int32, _ matchingLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = findFirstPoint(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Point] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Point.bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-        }(), matching: String.bridgeJSLiftParameter(matchingBytes, matchingLength))
+    let ret = findFirstPoint(_: [Point].bridgeJSLiftParameter(), matching: String.bridgeJSLiftParameter(matchingBytes, matchingLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -290,19 +192,8 @@ public func _bjs_findFirstPoint(_ matchingBytes: Int32, _ matchingLength: Int32)
 @_cdecl("bjs_processUnsafeRawPointerArray")
 public func _bjs_processUnsafeRawPointerArray() -> Void {
     #if arch(wasm32)
-    let ret = processUnsafeRawPointerArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [UnsafeRawPointer] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(UnsafeRawPointer.bridgeJSLiftParameter(_swift_js_pop_pointer()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processUnsafeRawPointerArray(_: [UnsafeRawPointer].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -312,19 +203,8 @@ public func _bjs_processUnsafeRawPointerArray() -> Void {
 @_cdecl("bjs_processUnsafeMutableRawPointerArray")
 public func _bjs_processUnsafeMutableRawPointerArray() -> Void {
     #if arch(wasm32)
-    let ret = processUnsafeMutableRawPointerArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [UnsafeMutableRawPointer] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(UnsafeMutableRawPointer.bridgeJSLiftParameter(_swift_js_pop_pointer()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processUnsafeMutableRawPointerArray(_: [UnsafeMutableRawPointer].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -334,19 +214,8 @@ public func _bjs_processUnsafeMutableRawPointerArray() -> Void {
 @_cdecl("bjs_processOpaquePointerArray")
 public func _bjs_processOpaquePointerArray() -> Void {
     #if arch(wasm32)
-    let ret = processOpaquePointerArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [OpaquePointer] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(OpaquePointer.bridgeJSLiftParameter(_swift_js_pop_pointer()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processOpaquePointerArray(_: [OpaquePointer].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -361,7 +230,7 @@ public func _bjs_processOptionalIntArray() -> Void {
         var __result: [Optional<Int>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            __result.append(Optional<Int>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -369,7 +238,7 @@ public func _bjs_processOptionalIntArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    _swift_js_push_i32(Int32(__bjs_unwrapped_ret_elem))}
+    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()}
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)}
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -386,7 +255,7 @@ public func _bjs_processOptionalStringArray() -> Void {
         var __result: [Optional<String>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<String>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32()))
+            __result.append(Optional<String>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -394,10 +263,7 @@ public func _bjs_processOptionalStringArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    var __bjs_str_ret_elem = __bjs_unwrapped_ret_elem
-    __bjs_str_ret_elem.withUTF8 { ptr in
-        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-    }}
+    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()}
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)}
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -413,23 +279,12 @@ public func _bjs_processOptionalArray(_ values: Int32) -> Void {
         if values == 0 {
             return Optional<[Int]>.none
         } else {
-            return {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                }()
+            return [Int].bridgeJSLiftParameter()
         }
         }())
     let __bjs_isSome_ret = ret != nil
     if let __bjs_unwrapped_ret = ret {
-    for __bjs_elem_ret in __bjs_unwrapped_ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret))}
-    _swift_js_push_i32(Int32(__bjs_unwrapped_ret.count))}
+    __bjs_unwrapped_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
     #else
     fatalError("Only available on WebAssembly")
@@ -445,7 +300,7 @@ public func _bjs_processOptionalPointArray() -> Void {
         var __result: [Optional<Point>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<Point>.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            __result.append(Optional<Point>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -470,7 +325,7 @@ public func _bjs_processOptionalDirectionArray() -> Void {
         var __result: [Optional<Direction>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<Direction>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            __result.append(Optional<Direction>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -478,7 +333,7 @@ public func _bjs_processOptionalDirectionArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    _swift_js_push_i32(__bjs_unwrapped_ret_elem.bridgeJSLowerParameter())}
+    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()}
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)}
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -495,7 +350,7 @@ public func _bjs_processOptionalStatusArray() -> Void {
         var __result: [Optional<Status>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<Status>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            __result.append(Optional<Status>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -503,7 +358,7 @@ public func _bjs_processOptionalStatusArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    _swift_js_push_i32(__bjs_unwrapped_ret_elem.bridgeJSLowerParameter())}
+    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()}
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)}
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -520,24 +375,13 @@ public func _bjs_processNestedIntArray() -> Void {
         var __result: [[Int]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([Int].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret_elem))}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -553,27 +397,13 @@ public func _bjs_processNestedStringArray() -> Void {
         var __result: [[String]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [String] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([String].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    var __bjs_ret_elem_elem = __bjs_elem_ret_elem
-    __bjs_ret_elem_elem.withUTF8 { ptr in
-        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-    }}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -589,24 +419,13 @@ public func _bjs_processNestedPointArray() -> Void {
         var __result: [[Point]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Point] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Point.bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([Point].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    __bjs_elem_ret_elem.bridgeJSLowerReturn()}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -617,19 +436,8 @@ public func _bjs_processNestedPointArray() -> Void {
 @_cdecl("bjs_processItemArray")
 public func _bjs_processItemArray() -> Void {
     #if arch(wasm32)
-    let ret = processItemArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Item] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Item.bridgeJSLiftParameter(_swift_js_pop_pointer()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processItemArray(_: [Item].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -644,24 +452,13 @@ public func _bjs_processNestedItemArray() -> Void {
         var __result: [[Item]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Item] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Item.bridgeJSLiftParameter(_swift_js_pop_pointer()))
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([Item].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    _swift_js_push_pointer(__bjs_elem_ret_elem.bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/DefaultParameters.swift
@@ -39,19 +39,16 @@ extension Status: _BridgedSwiftCaseEnum {
 
 extension Config: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Config {
-        let enabled = Bool.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let value = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let name = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let enabled = Bool.bridgeJSLiftParameter()
+        let value = Int.bridgeJSLiftParameter()
+        let name = String.bridgeJSLiftParameter()
         return Config(name: name, value: value, enabled: enabled)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        var __bjs_name = self.name
-        __bjs_name.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        _swift_js_push_i32(Int32(self.value))
-        _swift_js_push_i32(self.enabled ? 1 : 0)
+        self.name.bridgeJSLowerStackReturn()
+        self.value.bridgeJSLowerStackReturn()
+        self.enabled.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -89,12 +86,12 @@ fileprivate func _bjs_struct_lift_Config() -> Int32 {
 
 extension MathOperations: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> MathOperations {
-        let baseValue = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
+        let baseValue = Double.bridgeJSLiftParameter()
         return MathOperations(baseValue: baseValue)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_f64(self.baseValue)
+        self.baseValue.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -321,19 +318,8 @@ public func _bjs_testOptionalStructWithValueDefault(_ point: Int32) -> Void {
 @_cdecl("bjs_testIntArrayDefault")
 public func _bjs_testIntArrayDefault() -> Void {
     #if arch(wasm32)
-    let ret = testIntArrayDefault(values: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret))}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = testIntArrayDefault(values: [Int].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -343,22 +329,8 @@ public func _bjs_testIntArrayDefault() -> Void {
 @_cdecl("bjs_testStringArrayDefault")
 public func _bjs_testStringArrayDefault() -> Void {
     #if arch(wasm32)
-    let ret = testStringArrayDefault(names: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [String] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    var __bjs_ret_elem = __bjs_elem_ret
-    __bjs_ret_elem.withUTF8 { ptr in
-        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-    }}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = testStringArrayDefault(names: [String].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -368,19 +340,8 @@ public func _bjs_testStringArrayDefault() -> Void {
 @_cdecl("bjs_testDoubleArrayDefault")
 public func _bjs_testDoubleArrayDefault() -> Void {
     #if arch(wasm32)
-    let ret = testDoubleArrayDefault(values: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Double] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_f64(__bjs_elem_ret)}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = testDoubleArrayDefault(values: [Double].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -390,19 +351,8 @@ public func _bjs_testDoubleArrayDefault() -> Void {
 @_cdecl("bjs_testBoolArrayDefault")
 public func _bjs_testBoolArrayDefault() -> Void {
     #if arch(wasm32)
-    let ret = testBoolArrayDefault(flags: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Bool] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(__bjs_elem_ret ? 1 : 0)}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = testBoolArrayDefault(flags: [Bool].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -412,19 +362,8 @@ public func _bjs_testBoolArrayDefault() -> Void {
 @_cdecl("bjs_testEmptyArrayDefault")
 public func _bjs_testEmptyArrayDefault() -> Void {
     #if arch(wasm32)
-    let ret = testEmptyArrayDefault(items: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret))}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = testEmptyArrayDefault(items: [Int].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -434,16 +373,7 @@ public func _bjs_testEmptyArrayDefault() -> Void {
 @_cdecl("bjs_testMixedWithArrayDefault")
 public func _bjs_testMixedWithArrayDefault(_ nameBytes: Int32, _ nameLength: Int32, _ enabled: Int32) -> Void {
     #if arch(wasm32)
-    let ret = testMixedWithArrayDefault(name: String.bridgeJSLiftParameter(nameBytes, nameLength), values: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }(), enabled: Bool.bridgeJSLiftParameter(enabled))
+    let ret = testMixedWithArrayDefault(name: String.bridgeJSLiftParameter(nameBytes, nameLength), values: [Int].bridgeJSLiftParameter(), enabled: Bool.bridgeJSLiftParameter(enabled))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumAssociatedValue.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumAssociatedValue.swift
@@ -2,15 +2,15 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> APIResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .failure(Int.bridgeJSLiftParameter())
         case 2:
-            return .flag(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .flag(Bool.bridgeJSLiftParameter())
         case 3:
-            return .rate(Float.bridgeJSLiftParameter(_swift_js_pop_f32()))
+            return .rate(Float.bridgeJSLiftParameter())
         case 4:
-            return .precise(Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
+            return .precise(Double.bridgeJSLiftParameter())
         case 5:
             return .info
         default:
@@ -23,22 +23,19 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .failure(let param0):
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
             return Int32(1)
         case .flag(let param0):
-            _swift_js_push_i32(param0 ? 1 : 0)
+            param0.bridgeJSLowerStackReturn()
             return Int32(2)
         case .rate(let param0):
-            _swift_js_push_f32(param0)
+            param0.bridgeJSLowerStackReturn()
             return Int32(3)
         case .precise(let param0):
-            _swift_js_push_f64(param0)
+            param0.bridgeJSLowerStackReturn()
             return Int32(4)
         case .info:
             return Int32(5)
@@ -59,22 +56,19 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .failure(let param0):
             _swift_js_push_tag(Int32(1))
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
         case .flag(let param0):
             _swift_js_push_tag(Int32(2))
-            _swift_js_push_i32(param0 ? 1 : 0)
+            param0.bridgeJSLowerStackReturn()
         case .rate(let param0):
             _swift_js_push_tag(Int32(3))
-            _swift_js_push_f32(param0)
+            param0.bridgeJSLowerStackReturn()
         case .precise(let param0):
             _swift_js_push_tag(Int32(4))
-            _swift_js_push_f64(param0)
+            param0.bridgeJSLowerStackReturn()
         case .info:
             _swift_js_push_tag(Int32(5))
         }
@@ -85,15 +79,15 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> ComplexResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .error(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .error(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
         case 2:
-            return .status(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .status(Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
         case 3:
-            return .coordinates(Double.bridgeJSLiftParameter(_swift_js_pop_f64()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
+            return .coordinates(Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter())
         case 4:
-            return .comprehensive(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()), Bool.bridgeJSLiftParameter(_swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .comprehensive(Bool.bridgeJSLiftParameter(), Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), String.bridgeJSLiftParameter(), String.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
         case 5:
             return .info
         default:
@@ -106,50 +100,32 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .error(let param0, let param1):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
             return Int32(1)
         case .status(let param0, let param1, let param2):
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(Int32(param1))
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
             return Int32(2)
         case .coordinates(let param0, let param1, let param2):
-            _swift_js_push_f64(param0)
-            _swift_js_push_f64(param1)
-            _swift_js_push_f64(param2)
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
             return Int32(3)
         case .comprehensive(let param0, let param1, let param2, let param3, let param4, let param5, let param6, let param7, let param8):
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(param1 ? 1 : 0)
-            _swift_js_push_i32(Int32(param2))
-            _swift_js_push_i32(Int32(param3))
-            _swift_js_push_f64(param4)
-            _swift_js_push_f64(param5)
-            var __bjs_param6 = param6
-            __bjs_param6.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            var __bjs_param7 = param7
-            __bjs_param7.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            var __bjs_param8 = param8
-            __bjs_param8.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
+            param3.bridgeJSLowerStackReturn()
+            param4.bridgeJSLowerStackReturn()
+            param5.bridgeJSLowerStackReturn()
+            param6.bridgeJSLowerStackReturn()
+            param7.bridgeJSLowerStackReturn()
+            param8.bridgeJSLowerStackReturn()
             return Int32(4)
         case .info:
             return Int32(5)
@@ -170,50 +146,32 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .error(let param0, let param1):
             _swift_js_push_tag(Int32(1))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
         case .status(let param0, let param1, let param2):
             _swift_js_push_tag(Int32(2))
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(Int32(param1))
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
         case .coordinates(let param0, let param1, let param2):
             _swift_js_push_tag(Int32(3))
-            _swift_js_push_f64(param0)
-            _swift_js_push_f64(param1)
-            _swift_js_push_f64(param2)
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
         case .comprehensive(let param0, let param1, let param2, let param3, let param4, let param5, let param6, let param7, let param8):
             _swift_js_push_tag(Int32(4))
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(param1 ? 1 : 0)
-            _swift_js_push_i32(Int32(param2))
-            _swift_js_push_i32(Int32(param3))
-            _swift_js_push_f64(param4)
-            _swift_js_push_f64(param5)
-            var __bjs_param6 = param6
-            __bjs_param6.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            var __bjs_param7 = param7
-            __bjs_param7.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            var __bjs_param8 = param8
-            __bjs_param8.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
+            param3.bridgeJSLowerStackReturn()
+            param4.bridgeJSLowerStackReturn()
+            param5.bridgeJSLowerStackReturn()
+            param6.bridgeJSLowerStackReturn()
+            param7.bridgeJSLowerStackReturn()
+            param8.bridgeJSLowerStackReturn()
         case .info:
             _swift_js_push_tag(Int32(5))
         }
@@ -224,11 +182,11 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> Utilities.Result {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .failure(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .failure(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
         case 2:
-            return .status(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .status(Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
         default:
             fatalError("Unknown Utilities.Result case ID: \(caseId)")
         }
@@ -239,25 +197,16 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .failure(let param0, let param1):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
             return Int32(1)
         case .status(let param0, let param1, let param2):
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(Int32(param1))
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
             return Int32(2)
         }
     }
@@ -276,25 +225,16 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .failure(let param0, let param1):
             _swift_js_push_tag(Int32(1))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
         case .status(let param0, let param1, let param2):
             _swift_js_push_tag(Int32(2))
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(Int32(param1))
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
         }
     }
 }
@@ -303,9 +243,9 @@ extension NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> NetworkingResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .failure(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .failure(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
         default:
             fatalError("Unknown NetworkingResult case ID: \(caseId)")
         }
@@ -316,17 +256,11 @@ extension NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .failure(let param0, let param1):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
             return Int32(1)
         }
     }
@@ -345,17 +279,11 @@ extension NetworkingResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .failure(let param0, let param1):
             _swift_js_push_tag(Int32(1))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
         }
     }
 }
@@ -364,11 +292,11 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> APIOptionalResult {
         switch caseId {
         case 0:
-            return .success(Optional<String>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(Optional<String>.bridgeJSLiftParameter())
         case 1:
-            return .failure(Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Optional<Bool>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .failure(Optional<Int>.bridgeJSLiftParameter(), Optional<Bool>.bridgeJSLiftParameter())
         case 2:
-            return .status(Optional<Bool>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Optional<String>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .status(Optional<Bool>.bridgeJSLiftParameter(), Optional<Int>.bridgeJSLiftParameter(), Optional<String>.bridgeJSLiftParameter())
         default:
             fatalError("Unknown APIOptionalResult case ID: \(caseId)")
         }
@@ -381,42 +309,36 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
         case .success(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                var __bjs_str_param0 = __bjs_unwrapped_param0
-                __bjs_str_param0.withUTF8 { ptr in
-                    _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-                }
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(0)
         case .failure(let param0, let param1):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                _swift_js_push_i32(Int32(__bjs_unwrapped_param0))
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             let __bjs_isSome_param1 = param1 != nil
             if let __bjs_unwrapped_param1 = param1 {
-                _swift_js_push_i32(__bjs_unwrapped_param1 ? 1 : 0)
+                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
             return Int32(1)
         case .status(let param0, let param1, let param2):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                _swift_js_push_i32(__bjs_unwrapped_param0 ? 1 : 0)
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             let __bjs_isSome_param1 = param1 != nil
             if let __bjs_unwrapped_param1 = param1 {
-                _swift_js_push_i32(Int32(__bjs_unwrapped_param1))
+                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
             let __bjs_isSome_param2 = param2 != nil
             if let __bjs_unwrapped_param2 = param2 {
-                var __bjs_str_param2 = __bjs_unwrapped_param2
-                __bjs_str_param2.withUTF8 { ptr in
-                    _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-                }
+                __bjs_unwrapped_param2.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param2 ? 1 : 0)
             return Int32(2)
@@ -439,42 +361,36 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
             _swift_js_push_tag(Int32(0))
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                var __bjs_str_param0 = __bjs_unwrapped_param0
-                __bjs_str_param0.withUTF8 { ptr in
-                    _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-                }
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
         case .failure(let param0, let param1):
             _swift_js_push_tag(Int32(1))
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                _swift_js_push_i32(Int32(__bjs_unwrapped_param0))
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             let __bjs_isSome_param1 = param1 != nil
             if let __bjs_unwrapped_param1 = param1 {
-                _swift_js_push_i32(__bjs_unwrapped_param1 ? 1 : 0)
+                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
         case .status(let param0, let param1, let param2):
             _swift_js_push_tag(Int32(2))
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                _swift_js_push_i32(__bjs_unwrapped_param0 ? 1 : 0)
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             let __bjs_isSome_param1 = param1 != nil
             if let __bjs_unwrapped_param1 = param1 {
-                _swift_js_push_i32(Int32(__bjs_unwrapped_param1))
+                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
             let __bjs_isSome_param2 = param2 != nil
             if let __bjs_unwrapped_param2 = param2 {
-                var __bjs_str_param2 = __bjs_unwrapped_param2
-                __bjs_str_param2.withUTF8 { ptr in
-                    _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-                }
+                __bjs_unwrapped_param2.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param2 ? 1 : 0)
         }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.Global.swift
@@ -41,10 +41,10 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Configuration.LogLevel: _BridgedSwiftEnumNoPayload {
+extension Configuration.LogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Configuration.Port: _BridgedSwiftEnumNoPayload {
+extension Configuration.Port: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.swift
@@ -41,10 +41,10 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Configuration.LogLevel: _BridgedSwiftEnumNoPayload {
+extension Configuration.LogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Configuration.Port: _BridgedSwiftEnumNoPayload {
+extension Configuration.Port: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumRawType.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumRawType.swift
@@ -1,37 +1,37 @@
-extension Theme: _BridgedSwiftEnumNoPayload {
+extension Theme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension TSTheme: _BridgedSwiftEnumNoPayload {
+extension TSTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension FeatureFlag: _BridgedSwiftEnumNoPayload {
+extension FeatureFlag: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension HttpStatus: _BridgedSwiftEnumNoPayload {
+extension HttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension TSHttpStatus: _BridgedSwiftEnumNoPayload {
+extension TSHttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Priority: _BridgedSwiftEnumNoPayload {
+extension Priority: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension FileSize: _BridgedSwiftEnumNoPayload {
+extension FileSize: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension UserId: _BridgedSwiftEnumNoPayload {
+extension UserId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension TokenId: _BridgedSwiftEnumNoPayload {
+extension TokenId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension SessionId: _BridgedSwiftEnumNoPayload {
+extension SessionId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Precision: _BridgedSwiftEnumNoPayload {
+extension Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Ratio: _BridgedSwiftEnumNoPayload {
+extension Ratio: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 @_expose(wasm, "bjs_setTheme")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/Protocol.swift
@@ -359,16 +359,16 @@ extension Direction: _BridgedSwiftCaseEnum {
     }
 }
 
-extension ExampleEnum: _BridgedSwiftEnumNoPayload {
+extension ExampleEnum: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 extension Result: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> Result {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .failure(Int.bridgeJSLiftParameter())
         default:
             fatalError("Unknown Result case ID: \(caseId)")
         }
@@ -379,13 +379,10 @@ extension Result: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .failure(let param0):
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
             return Int32(1)
         }
     }
@@ -404,37 +401,25 @@ extension Result: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .failure(let param0):
             _swift_js_push_tag(Int32(1))
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
         }
     }
 }
 
-extension Priority: _BridgedSwiftEnumNoPayload {
+extension Priority: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 @_expose(wasm, "bjs_processDelegates")
 @_cdecl("bjs_processDelegates")
 public func _bjs_processDelegates() -> Void {
     #if arch(wasm32)
-    let ret = processDelegates(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [AnyMyViewControllerDelegate] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(AnyMyViewControllerDelegate.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32((__bjs_elem_ret as! AnyMyViewControllerDelegate).bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processDelegates(_: [AnyMyViewControllerDelegate].bridgeJSLiftParameter())
+    ret.map {
+        $0 as! AnyMyViewControllerDelegate
+    } .bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -653,16 +638,7 @@ fileprivate func _bjs_MyViewController_wrap(_ pointer: UnsafeMutableRawPointer) 
 @_cdecl("bjs_DelegateManager_init")
 public func _bjs_DelegateManager_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = DelegateManager(delegates: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [AnyMyViewControllerDelegate] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(AnyMyViewControllerDelegate.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
+    let ret = DelegateManager(delegates: [AnyMyViewControllerDelegate].bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -684,9 +660,9 @@ public func _bjs_DelegateManager_notifyAll(_ _self: UnsafeMutableRawPointer) -> 
 public func _bjs_DelegateManager_delegates_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = DelegateManager.bridgeJSLiftParameter(_self).delegates
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32((__bjs_elem_ret as! AnyMyViewControllerDelegate).bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(ret.count))
+    ret.map {
+        $0 as! AnyMyViewControllerDelegate
+    } .bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -696,16 +672,7 @@ public func _bjs_DelegateManager_delegates_get(_ _self: UnsafeMutableRawPointer)
 @_cdecl("bjs_DelegateManager_delegates_set")
 public func _bjs_DelegateManager_delegates_set(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    DelegateManager.bridgeJSLiftParameter(_self).delegates = {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [AnyMyViewControllerDelegate] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(AnyMyViewControllerDelegate.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-    }()
+    DelegateManager.bridgeJSLiftParameter(_self).delegates = [AnyMyViewControllerDelegate].bridgeJSLiftParameter()
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticFunctions.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticFunctions.Global.swift
@@ -48,9 +48,9 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> APIResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .failure(Int.bridgeJSLiftParameter())
         default:
             fatalError("Unknown APIResult case ID: \(caseId)")
         }
@@ -61,13 +61,10 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .failure(let param0):
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
             return Int32(1)
         }
     }
@@ -86,13 +83,10 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .failure(let param0):
             _swift_js_push_tag(Int32(1))
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
         }
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticFunctions.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticFunctions.swift
@@ -48,9 +48,9 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> APIResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .failure(Int.bridgeJSLiftParameter())
         default:
             fatalError("Unknown APIResult case ID: \(caseId)")
         }
@@ -61,13 +61,10 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .failure(let param0):
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
             return Int32(1)
         }
     }
@@ -86,13 +83,10 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .failure(let param0):
             _swift_js_push_tag(Int32(1))
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
         }
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftClosure.swift
@@ -667,25 +667,25 @@ extension Direction: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Theme: _BridgedSwiftEnumNoPayload {
+extension Theme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension HttpStatus: _BridgedSwiftEnumNoPayload {
+extension HttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 extension APIResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> APIResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .failure(Int.bridgeJSLiftParameter())
         case 2:
-            return .flag(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .flag(Bool.bridgeJSLiftParameter())
         case 3:
-            return .rate(Float.bridgeJSLiftParameter(_swift_js_pop_f32()))
+            return .rate(Float.bridgeJSLiftParameter())
         case 4:
-            return .precise(Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
+            return .precise(Double.bridgeJSLiftParameter())
         case 5:
             return .info
         default:
@@ -698,22 +698,19 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .failure(let param0):
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
             return Int32(1)
         case .flag(let param0):
-            _swift_js_push_i32(param0 ? 1 : 0)
+            param0.bridgeJSLowerStackReturn()
             return Int32(2)
         case .rate(let param0):
-            _swift_js_push_f32(param0)
+            param0.bridgeJSLowerStackReturn()
             return Int32(3)
         case .precise(let param0):
-            _swift_js_push_f64(param0)
+            param0.bridgeJSLowerStackReturn()
             return Int32(4)
         case .info:
             return Int32(5)
@@ -734,22 +731,19 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .failure(let param0):
             _swift_js_push_tag(Int32(1))
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
         case .flag(let param0):
             _swift_js_push_tag(Int32(2))
-            _swift_js_push_i32(param0 ? 1 : 0)
+            param0.bridgeJSLowerStackReturn()
         case .rate(let param0):
             _swift_js_push_tag(Int32(3))
-            _swift_js_push_f32(param0)
+            param0.bridgeJSLowerStackReturn()
         case .precise(let param0):
             _swift_js_push_tag(Int32(4))
-            _swift_js_push_f64(param0)
+            param0.bridgeJSLowerStackReturn()
         case .info:
             _swift_js_push_tag(Int32(5))
         }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftStruct.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/SwiftStruct.swift
@@ -1,31 +1,28 @@
-extension Precision: _BridgedSwiftEnumNoPayload {
+extension Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 extension DataPoint: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> DataPoint {
-        let optFlag = Optional<Bool>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let optCount = Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let label = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let y = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
-        let x = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
+        let optFlag = Optional<Bool>.bridgeJSLiftParameter()
+        let optCount = Optional<Int>.bridgeJSLiftParameter()
+        let label = String.bridgeJSLiftParameter()
+        let y = Double.bridgeJSLiftParameter()
+        let x = Double.bridgeJSLiftParameter()
         return DataPoint(x: x, y: y, label: label, optCount: optCount, optFlag: optFlag)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_f64(self.x)
-        _swift_js_push_f64(self.y)
-        var __bjs_label = self.label
-        __bjs_label.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
+        self.x.bridgeJSLowerStackReturn()
+        self.y.bridgeJSLowerStackReturn()
+        self.label.bridgeJSLowerStackReturn()
         let __bjs_isSome_optCount = self.optCount != nil
         if let __bjs_unwrapped_optCount = self.optCount {
-            _swift_js_push_i32(Int32(__bjs_unwrapped_optCount))
+            __bjs_unwrapped_optCount.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_optCount ? 1 : 0)
         let __bjs_isSome_optFlag = self.optFlag != nil
         if let __bjs_unwrapped_optFlag = self.optFlag {
-            _swift_js_push_i32(__bjs_unwrapped_optFlag ? 1 : 0)
+            __bjs_unwrapped_optFlag.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_optFlag ? 1 : 0)
     }
@@ -76,24 +73,18 @@ public func _bjs_DataPoint_init(_ x: Float64, _ y: Float64, _ labelBytes: Int32,
 
 extension Address: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Address {
-        let zipCode = Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let city = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let street = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let zipCode = Optional<Int>.bridgeJSLiftParameter()
+        let city = String.bridgeJSLiftParameter()
+        let street = String.bridgeJSLiftParameter()
         return Address(street: street, city: city, zipCode: zipCode)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        var __bjs_street = self.street
-        __bjs_street.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        var __bjs_city = self.city
-        __bjs_city.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
+        self.street.bridgeJSLowerStackReturn()
+        self.city.bridgeJSLowerStackReturn()
         let __bjs_isSome_zipCode = self.zipCode != nil
         if let __bjs_unwrapped_zipCode = self.zipCode {
-            _swift_js_push_i32(Int32(__bjs_unwrapped_zipCode))
+            __bjs_unwrapped_zipCode.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_zipCode ? 1 : 0)
     }
@@ -133,26 +124,20 @@ fileprivate func _bjs_struct_lift_Address() -> Int32 {
 
 extension Person: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Person {
-        let email = Optional<String>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32())
+        let email = Optional<String>.bridgeJSLiftParameter()
         let address = Address.bridgeJSLiftParameter()
-        let age = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let name = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let age = Int.bridgeJSLiftParameter()
+        let name = String.bridgeJSLiftParameter()
         return Person(name: name, age: age, address: address, email: email)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        var __bjs_name = self.name
-        __bjs_name.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        _swift_js_push_i32(Int32(self.age))
+        self.name.bridgeJSLowerStackReturn()
+        self.age.bridgeJSLowerStackReturn()
         self.address.bridgeJSLowerReturn()
         let __bjs_isSome_email = self.email != nil
         if let __bjs_unwrapped_email = self.email {
-            var __bjs_str_email = __bjs_unwrapped_email
-            __bjs_str_email.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            __bjs_unwrapped_email.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_email ? 1 : 0)
     }
@@ -192,14 +177,14 @@ fileprivate func _bjs_struct_lift_Person() -> Int32 {
 
 extension Session: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Session {
-        let owner = Greeter.bridgeJSLiftParameter(_swift_js_pop_pointer())
-        let id = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
+        let owner = Greeter.bridgeJSLiftParameter()
+        let id = Int.bridgeJSLiftParameter()
         return Session(id: id, owner: owner)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_i32(Int32(self.id))
-        _swift_js_push_pointer(self.owner.bridgeJSLowerReturn())
+        self.id.bridgeJSLowerStackReturn()
+        self.owner.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -237,18 +222,18 @@ fileprivate func _bjs_struct_lift_Session() -> Int32 {
 
 extension Measurement: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Measurement {
-        let optionalPrecision = Optional<Precision>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_f32())
+        let optionalPrecision = Optional<Precision>.bridgeJSLiftParameter()
         let precision = Precision.bridgeJSLiftParameter(_swift_js_pop_f32())
-        let value = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
+        let value = Double.bridgeJSLiftParameter()
         return Measurement(value: value, precision: precision, optionalPrecision: optionalPrecision)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_f64(self.value)
-        _swift_js_push_f32(self.precision.bridgeJSLowerParameter())
+        self.value.bridgeJSLowerStackReturn()
+        self.precision.bridgeJSLowerStackReturn()
         let __bjs_isSome_optionalPrecision = self.optionalPrecision != nil
         if let __bjs_unwrapped_optionalPrecision = self.optionalPrecision {
-            _swift_js_push_f32(__bjs_unwrapped_optionalPrecision.bridgeJSLowerParameter())
+            __bjs_unwrapped_optionalPrecision.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_optionalPrecision ? 1 : 0)
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/UnsafePointer.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/UnsafePointer.swift
@@ -1,19 +1,19 @@
 extension PointerFields: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> PointerFields {
-        let mutPtr = UnsafeMutablePointer<UInt8>.bridgeJSLiftParameter(_swift_js_pop_pointer())
-        let ptr = UnsafePointer<UInt8>.bridgeJSLiftParameter(_swift_js_pop_pointer())
-        let opaque = OpaquePointer.bridgeJSLiftParameter(_swift_js_pop_pointer())
-        let mutRaw = UnsafeMutableRawPointer.bridgeJSLiftParameter(_swift_js_pop_pointer())
-        let raw = UnsafeRawPointer.bridgeJSLiftParameter(_swift_js_pop_pointer())
+        let mutPtr = UnsafeMutablePointer<UInt8>.bridgeJSLiftParameter()
+        let ptr = UnsafePointer<UInt8>.bridgeJSLiftParameter()
+        let opaque = OpaquePointer.bridgeJSLiftParameter()
+        let mutRaw = UnsafeMutableRawPointer.bridgeJSLiftParameter()
+        let raw = UnsafeRawPointer.bridgeJSLiftParameter()
         return PointerFields(raw: raw, mutRaw: mutRaw, opaque: opaque, ptr: ptr, mutPtr: mutPtr)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_pointer(self.raw.bridgeJSLowerReturn())
-        _swift_js_push_pointer(self.mutRaw.bridgeJSLowerReturn())
-        _swift_js_push_pointer(self.opaque.bridgeJSLowerReturn())
-        _swift_js_push_pointer(self.ptr.bridgeJSLowerReturn())
-        _swift_js_push_pointer(self.mutPtr.bridgeJSLowerReturn())
+        self.raw.bridgeJSLowerStackReturn()
+        self.mutRaw.bridgeJSLowerStackReturn()
+        self.opaque.bridgeJSLowerStackReturn()
+        self.ptr.bridgeJSLowerStackReturn()
+        self.mutPtr.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/ArrayParameter.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/ArrayParameter.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func checkArray(_ a: JSObject) throws (JSException) -> Void
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/Async.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/Async.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func asyncReturnVoid() throws (JSException) -> JSPromise
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/Interface.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/Interface.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func returnAnimatable() throws (JSException) -> Animatable
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/InvalidPropertyNames.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/InvalidPropertyNames.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func createArrayBuffer() throws (JSException) -> ArrayBufferLike
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/MultipleImportedTypes.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/MultipleImportedTypes.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func createDatabaseConnection(_ config: JSObject) throws (JSException) -> DatabaseConnection
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/PrimitiveParameters.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/PrimitiveParameters.Macros.swift
@@ -4,6 +4,6 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func check(_ a: Double, _ b: Bool) throws (JSException) -> Void

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/PrimitiveReturn.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/PrimitiveReturn.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func checkNumber() throws (JSException) -> Double
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/ReExportFrom.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/ReExportFrom.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func jsRoundTripNumber(_ v: Double) throws (JSException) -> Double
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/StringEnum.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/StringEnum.Macros.swift
@@ -4,13 +4,13 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 enum FeatureFlag: String {
     case foo = "foo"
     case bar = "bar"
 }
-extension FeatureFlag: _BridgedSwiftEnumNoPayload {}
+extension FeatureFlag: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {}
 
 @JSFunction func takesFeatureFlag(_ flag: FeatureFlag) throws (JSException) -> Void
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/StringParameter.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/StringParameter.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func checkString(_ a: String) throws (JSException) -> Void
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/StringReturn.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/StringReturn.Macros.swift
@@ -4,6 +4,6 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func checkString() throws (JSException) -> String

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/TS2SkeletonLike.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/TS2SkeletonLike.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func createTS2Skeleton() throws (JSException) -> TypeScriptProcessor
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/TypeAlias.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/TypeAlias.Macros.swift
@@ -4,6 +4,6 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func checkSimple(_ a: Double) throws (JSException) -> Void

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/TypeScriptClass.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/TypeScriptClass.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSClass struct Greeter {
     @JSGetter var name: String

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/VoidParameterVoidReturn.Macros.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ImportTSTests/VoidParameterVoidReturn.Macros.swift
@@ -4,6 +4,6 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func check() throws (JSException) -> Void

--- a/Plugins/PackageToJS/Templates/instantiate.js
+++ b/Plugins/PackageToJS/Templates/instantiate.js
@@ -62,6 +62,9 @@ async function createInstantiator(options, swift) {
                 swift_js_get_optional_double_presence: unexpectedBjsCall,
                 swift_js_get_optional_double_value: unexpectedBjsCall,
                 swift_js_get_optional_heap_object_pointer: unexpectedBjsCall,
+                swift_js_push_pointer: unexpectedBjsCall,
+                swift_js_pop_pointer: unexpectedBjsCall,
+                swift_js_struct_cleanup: unexpectedBjsCall,
             }
         },
         /** @param {WebAssembly.Instance} instance */

--- a/Tests/BridgeJSGlobalTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSGlobalTests/Generated/BridgeJS.swift
@@ -50,10 +50,10 @@ extension GlobalNetworking.API.CallMethod: _BridgedSwiftCaseEnum {
     }
 }
 
-extension GlobalConfiguration.PublicLogLevel: _BridgedSwiftEnumNoPayload {
+extension GlobalConfiguration.PublicLogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension GlobalConfiguration.AvailablePort: _BridgedSwiftEnumNoPayload {
+extension GlobalConfiguration.AvailablePort: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 extension Internal.SupportedServerMethod: _BridgedSwiftCaseEnum {

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -1407,6 +1407,12 @@ enum APIOptionalResult {
 @JS func roundTripOpaquePointerArray(_ values: [OpaquePointer]) -> [OpaquePointer] {
     return values
 }
+@JS func roundTripUnsafePointerArray(_ values: [UnsafePointer<UInt8>]) -> [UnsafePointer<UInt8>] {
+    return values
+}
+@JS func roundTripUnsafeMutablePointerArray(_ values: [UnsafeMutablePointer<UInt8>]) -> [UnsafeMutablePointer<UInt8>] {
+    return values
+}
 
 @JS func consumeDataProcessorArrayType(_ processors: [DataProcessor]) -> Int {
     return processors.count

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.Macros.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.Macros.swift
@@ -4,7 +4,7 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
-@_spi(Experimental) import JavaScriptKit
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
 @JSFunction func jsRoundTripVoid() throws (JSException) -> Void
 
@@ -26,7 +26,7 @@ enum FeatureFlag: String {
     case foo = "foo"
     case bar = "bar"
 }
-extension FeatureFlag: _BridgedSwiftEnumNoPayload {}
+extension FeatureFlag: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {}
 
 @JSFunction func jsRoundTripFeatureFlag(_ flag: FeatureFlag) throws (JSException) -> FeatureFlag
 

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -1292,16 +1292,16 @@ extension Status: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Theme: _BridgedSwiftEnumNoPayload {
+extension Theme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension HttpStatus: _BridgedSwiftEnumNoPayload {
+extension HttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Precision: _BridgedSwiftEnumNoPayload {
+extension Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Ratio: _BridgedSwiftEnumNoPayload {
+extension Ratio: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 extension TSDirection: _BridgedSwiftCaseEnum {
@@ -1347,7 +1347,7 @@ extension TSDirection: _BridgedSwiftCaseEnum {
     }
 }
 
-extension TSTheme: _BridgedSwiftEnumNoPayload {
+extension TSTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 extension Networking.API.Method: _BridgedSwiftCaseEnum {
@@ -1393,10 +1393,10 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Configuration.LogLevel: _BridgedSwiftEnumNoPayload {
+extension Configuration.LogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Configuration.Port: _BridgedSwiftEnumNoPayload {
+extension Configuration.Port: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
@@ -1438,15 +1438,15 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> APIResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .failure(Int.bridgeJSLiftParameter())
         case 2:
-            return .flag(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .flag(Bool.bridgeJSLiftParameter())
         case 3:
-            return .rate(Float.bridgeJSLiftParameter(_swift_js_pop_f32()))
+            return .rate(Float.bridgeJSLiftParameter())
         case 4:
-            return .precise(Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
+            return .precise(Double.bridgeJSLiftParameter())
         case 5:
             return .info
         default:
@@ -1459,22 +1459,19 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .failure(let param0):
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
             return Int32(1)
         case .flag(let param0):
-            _swift_js_push_i32(param0 ? 1 : 0)
+            param0.bridgeJSLowerStackReturn()
             return Int32(2)
         case .rate(let param0):
-            _swift_js_push_f32(param0)
+            param0.bridgeJSLowerStackReturn()
             return Int32(3)
         case .precise(let param0):
-            _swift_js_push_f64(param0)
+            param0.bridgeJSLowerStackReturn()
             return Int32(4)
         case .info:
             return Int32(5)
@@ -1495,22 +1492,19 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .failure(let param0):
             _swift_js_push_tag(Int32(1))
-            _swift_js_push_i32(Int32(param0))
+            param0.bridgeJSLowerStackReturn()
         case .flag(let param0):
             _swift_js_push_tag(Int32(2))
-            _swift_js_push_i32(param0 ? 1 : 0)
+            param0.bridgeJSLowerStackReturn()
         case .rate(let param0):
             _swift_js_push_tag(Int32(3))
-            _swift_js_push_f32(param0)
+            param0.bridgeJSLowerStackReturn()
         case .precise(let param0):
             _swift_js_push_tag(Int32(4))
-            _swift_js_push_f64(param0)
+            param0.bridgeJSLowerStackReturn()
         case .info:
             _swift_js_push_tag(Int32(5))
         }
@@ -1521,17 +1515,17 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> ComplexResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .error(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .error(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
         case 2:
-            return .location(Double.bridgeJSLiftParameter(_swift_js_pop_f64()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .location(Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
         case 3:
-            return .status(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .status(Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
         case 4:
-            return .coordinates(Double.bridgeJSLiftParameter(_swift_js_pop_f64()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
+            return .coordinates(Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter())
         case 5:
-            return .comprehensive(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()), Bool.bridgeJSLiftParameter(_swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()), Double.bridgeJSLiftParameter(_swift_js_pop_f64()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .comprehensive(Bool.bridgeJSLiftParameter(), Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), String.bridgeJSLiftParameter(), String.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
         case 6:
             return .info
         default:
@@ -1544,58 +1538,37 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .error(let param0, let param1):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
             return Int32(1)
         case .location(let param0, let param1, let param2):
-            _swift_js_push_f64(param0)
-            _swift_js_push_f64(param1)
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
             return Int32(2)
         case .status(let param0, let param1, let param2):
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(Int32(param1))
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
             return Int32(3)
         case .coordinates(let param0, let param1, let param2):
-            _swift_js_push_f64(param0)
-            _swift_js_push_f64(param1)
-            _swift_js_push_f64(param2)
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
             return Int32(4)
         case .comprehensive(let param0, let param1, let param2, let param3, let param4, let param5, let param6, let param7, let param8):
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(param1 ? 1 : 0)
-            _swift_js_push_i32(Int32(param2))
-            _swift_js_push_i32(Int32(param3))
-            _swift_js_push_f64(param4)
-            _swift_js_push_f64(param5)
-            var __bjs_param6 = param6
-            __bjs_param6.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            var __bjs_param7 = param7
-            __bjs_param7.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            var __bjs_param8 = param8
-            __bjs_param8.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
+            param3.bridgeJSLowerStackReturn()
+            param4.bridgeJSLowerStackReturn()
+            param5.bridgeJSLowerStackReturn()
+            param6.bridgeJSLowerStackReturn()
+            param7.bridgeJSLowerStackReturn()
+            param8.bridgeJSLowerStackReturn()
             return Int32(5)
         case .info:
             return Int32(6)
@@ -1616,58 +1589,37 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .error(let param0, let param1):
             _swift_js_push_tag(Int32(1))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
         case .location(let param0, let param1, let param2):
             _swift_js_push_tag(Int32(2))
-            _swift_js_push_f64(param0)
-            _swift_js_push_f64(param1)
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
         case .status(let param0, let param1, let param2):
             _swift_js_push_tag(Int32(3))
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(Int32(param1))
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
         case .coordinates(let param0, let param1, let param2):
             _swift_js_push_tag(Int32(4))
-            _swift_js_push_f64(param0)
-            _swift_js_push_f64(param1)
-            _swift_js_push_f64(param2)
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
         case .comprehensive(let param0, let param1, let param2, let param3, let param4, let param5, let param6, let param7, let param8):
             _swift_js_push_tag(Int32(5))
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(param1 ? 1 : 0)
-            _swift_js_push_i32(Int32(param2))
-            _swift_js_push_i32(Int32(param3))
-            _swift_js_push_f64(param4)
-            _swift_js_push_f64(param5)
-            var __bjs_param6 = param6
-            __bjs_param6.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            var __bjs_param7 = param7
-            __bjs_param7.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            var __bjs_param8 = param8
-            __bjs_param8.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
+            param3.bridgeJSLowerStackReturn()
+            param4.bridgeJSLowerStackReturn()
+            param5.bridgeJSLowerStackReturn()
+            param6.bridgeJSLowerStackReturn()
+            param7.bridgeJSLowerStackReturn()
+            param8.bridgeJSLowerStackReturn()
         case .info:
             _swift_js_push_tag(Int32(6))
         }
@@ -1678,11 +1630,11 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> Utilities.Result {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .failure(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .failure(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
         case 2:
-            return .status(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()), String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .status(Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
         default:
             fatalError("Unknown Utilities.Result case ID: \(caseId)")
         }
@@ -1693,25 +1645,16 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .failure(let param0, let param1):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
             return Int32(1)
         case .status(let param0, let param1, let param2):
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(Int32(param1))
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
             return Int32(2)
         }
     }
@@ -1730,25 +1673,16 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .failure(let param0, let param1):
             _swift_js_push_tag(Int32(1))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
         case .status(let param0, let param1, let param2):
             _swift_js_push_tag(Int32(2))
-            _swift_js_push_i32(param0 ? 1 : 0)
-            _swift_js_push_i32(Int32(param1))
-            var __bjs_param2 = param2
-            __bjs_param2.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
+            param2.bridgeJSLowerStackReturn()
         }
     }
 }
@@ -1757,9 +1691,9 @@ extension API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> API.NetworkingResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(String.bridgeJSLiftParameter())
         case 1:
-            return .failure(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            return .failure(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
         default:
             fatalError("Unknown API.NetworkingResult case ID: \(caseId)")
         }
@@ -1770,17 +1704,11 @@ extension API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .success(let param0):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
         case .failure(let param0, let param1):
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
             return Int32(1)
         }
     }
@@ -1799,17 +1727,11 @@ extension API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             _swift_js_push_tag(Int32(0))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            param0.bridgeJSLowerStackReturn()
         case .failure(let param0, let param1):
             _swift_js_push_tag(Int32(1))
-            var __bjs_param0 = param0
-            __bjs_param0.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
-            _swift_js_push_i32(Int32(param1))
+            param0.bridgeJSLowerStackReturn()
+            param1.bridgeJSLowerStackReturn()
         }
     }
 }
@@ -1818,11 +1740,11 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> APIOptionalResult {
         switch caseId {
         case 0:
-            return .success(Optional<String>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .success(Optional<String>.bridgeJSLiftParameter())
         case 1:
-            return .failure(Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Optional<Bool>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .failure(Optional<Int>.bridgeJSLiftParameter(), Optional<Bool>.bridgeJSLiftParameter())
         case 2:
-            return .status(Optional<Bool>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()), Optional<String>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32()))
+            return .status(Optional<Bool>.bridgeJSLiftParameter(), Optional<Int>.bridgeJSLiftParameter(), Optional<String>.bridgeJSLiftParameter())
         default:
             fatalError("Unknown APIOptionalResult case ID: \(caseId)")
         }
@@ -1835,42 +1757,36 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
         case .success(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                var __bjs_str_param0 = __bjs_unwrapped_param0
-                __bjs_str_param0.withUTF8 { ptr in
-                    _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-                }
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(0)
         case .failure(let param0, let param1):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                _swift_js_push_i32(Int32(__bjs_unwrapped_param0))
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             let __bjs_isSome_param1 = param1 != nil
             if let __bjs_unwrapped_param1 = param1 {
-                _swift_js_push_i32(__bjs_unwrapped_param1 ? 1 : 0)
+                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
             return Int32(1)
         case .status(let param0, let param1, let param2):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                _swift_js_push_i32(__bjs_unwrapped_param0 ? 1 : 0)
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             let __bjs_isSome_param1 = param1 != nil
             if let __bjs_unwrapped_param1 = param1 {
-                _swift_js_push_i32(Int32(__bjs_unwrapped_param1))
+                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
             let __bjs_isSome_param2 = param2 != nil
             if let __bjs_unwrapped_param2 = param2 {
-                var __bjs_str_param2 = __bjs_unwrapped_param2
-                __bjs_str_param2.withUTF8 { ptr in
-                    _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-                }
+                __bjs_unwrapped_param2.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param2 ? 1 : 0)
             return Int32(2)
@@ -1893,42 +1809,36 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
             _swift_js_push_tag(Int32(0))
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                var __bjs_str_param0 = __bjs_unwrapped_param0
-                __bjs_str_param0.withUTF8 { ptr in
-                    _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-                }
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
         case .failure(let param0, let param1):
             _swift_js_push_tag(Int32(1))
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                _swift_js_push_i32(Int32(__bjs_unwrapped_param0))
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             let __bjs_isSome_param1 = param1 != nil
             if let __bjs_unwrapped_param1 = param1 {
-                _swift_js_push_i32(__bjs_unwrapped_param1 ? 1 : 0)
+                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
         case .status(let param0, let param1, let param2):
             _swift_js_push_tag(Int32(2))
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                _swift_js_push_i32(__bjs_unwrapped_param0 ? 1 : 0)
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             let __bjs_isSome_param1 = param1 != nil
             if let __bjs_unwrapped_param1 = param1 {
-                _swift_js_push_i32(Int32(__bjs_unwrapped_param1))
+                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
             let __bjs_isSome_param2 = param2 != nil
             if let __bjs_unwrapped_param2 = param2 {
-                var __bjs_str_param2 = __bjs_unwrapped_param2
-                __bjs_str_param2.withUTF8 { ptr in
-                    _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-                }
+                __bjs_unwrapped_param2.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param2 ? 1 : 0)
         }
@@ -2220,14 +2130,14 @@ public func _bjs_StaticPropertyNamespace_NestedProperties_static_nestedDouble_se
 
 extension Point: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Point {
-        let y = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let x = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
+        let y = Int.bridgeJSLiftParameter()
+        let x = Int.bridgeJSLiftParameter()
         return Point(x: x, y: y)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_i32(Int32(self.x))
-        _swift_js_push_i32(Int32(self.y))
+        self.x.bridgeJSLowerStackReturn()
+        self.y.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -2265,20 +2175,20 @@ fileprivate func _bjs_struct_lift_Point() -> Int32 {
 
 extension PointerFields: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> PointerFields {
-        let mutPtr = UnsafeMutablePointer<UInt8>.bridgeJSLiftParameter(_swift_js_pop_pointer())
-        let ptr = UnsafePointer<UInt8>.bridgeJSLiftParameter(_swift_js_pop_pointer())
-        let opaque = OpaquePointer.bridgeJSLiftParameter(_swift_js_pop_pointer())
-        let mutRaw = UnsafeMutableRawPointer.bridgeJSLiftParameter(_swift_js_pop_pointer())
-        let raw = UnsafeRawPointer.bridgeJSLiftParameter(_swift_js_pop_pointer())
+        let mutPtr = UnsafeMutablePointer<UInt8>.bridgeJSLiftParameter()
+        let ptr = UnsafePointer<UInt8>.bridgeJSLiftParameter()
+        let opaque = OpaquePointer.bridgeJSLiftParameter()
+        let mutRaw = UnsafeMutableRawPointer.bridgeJSLiftParameter()
+        let raw = UnsafeRawPointer.bridgeJSLiftParameter()
         return PointerFields(raw: raw, mutRaw: mutRaw, opaque: opaque, ptr: ptr, mutPtr: mutPtr)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_pointer(self.raw.bridgeJSLowerReturn())
-        _swift_js_push_pointer(self.mutRaw.bridgeJSLowerReturn())
-        _swift_js_push_pointer(self.opaque.bridgeJSLowerReturn())
-        _swift_js_push_pointer(self.ptr.bridgeJSLowerReturn())
-        _swift_js_push_pointer(self.mutPtr.bridgeJSLowerReturn())
+        self.raw.bridgeJSLowerStackReturn()
+        self.mutRaw.bridgeJSLowerStackReturn()
+        self.opaque.bridgeJSLowerStackReturn()
+        self.ptr.bridgeJSLowerStackReturn()
+        self.mutPtr.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -2327,29 +2237,26 @@ public func _bjs_PointerFields_init(_ raw: UnsafeMutableRawPointer, _ mutRaw: Un
 
 extension DataPoint: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> DataPoint {
-        let optFlag = Optional<Bool>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let optCount = Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let label = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let y = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
-        let x = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
+        let optFlag = Optional<Bool>.bridgeJSLiftParameter()
+        let optCount = Optional<Int>.bridgeJSLiftParameter()
+        let label = String.bridgeJSLiftParameter()
+        let y = Double.bridgeJSLiftParameter()
+        let x = Double.bridgeJSLiftParameter()
         return DataPoint(x: x, y: y, label: label, optCount: optCount, optFlag: optFlag)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_f64(self.x)
-        _swift_js_push_f64(self.y)
-        var __bjs_label = self.label
-        __bjs_label.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
+        self.x.bridgeJSLowerStackReturn()
+        self.y.bridgeJSLowerStackReturn()
+        self.label.bridgeJSLowerStackReturn()
         let __bjs_isSome_optCount = self.optCount != nil
         if let __bjs_unwrapped_optCount = self.optCount {
-            _swift_js_push_i32(Int32(__bjs_unwrapped_optCount))
+            __bjs_unwrapped_optCount.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_optCount ? 1 : 0)
         let __bjs_isSome_optFlag = self.optFlag != nil
         if let __bjs_unwrapped_optFlag = self.optFlag {
-            _swift_js_push_i32(__bjs_unwrapped_optFlag ? 1 : 0)
+            __bjs_unwrapped_optFlag.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_optFlag ? 1 : 0)
     }
@@ -2400,24 +2307,18 @@ public func _bjs_DataPoint_init(_ x: Float64, _ y: Float64, _ labelBytes: Int32,
 
 extension Address: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Address {
-        let zipCode = Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let city = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let street = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let zipCode = Optional<Int>.bridgeJSLiftParameter()
+        let city = String.bridgeJSLiftParameter()
+        let street = String.bridgeJSLiftParameter()
         return Address(street: street, city: city, zipCode: zipCode)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        var __bjs_street = self.street
-        __bjs_street.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        var __bjs_city = self.city
-        __bjs_city.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
+        self.street.bridgeJSLowerStackReturn()
+        self.city.bridgeJSLowerStackReturn()
         let __bjs_isSome_zipCode = self.zipCode != nil
         if let __bjs_unwrapped_zipCode = self.zipCode {
-            _swift_js_push_i32(Int32(__bjs_unwrapped_zipCode))
+            __bjs_unwrapped_zipCode.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_zipCode ? 1 : 0)
     }
@@ -2457,27 +2358,21 @@ fileprivate func _bjs_struct_lift_Address() -> Int32 {
 
 extension Contact: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Contact {
-        let secondaryAddress = Optional<Address>.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let email = Optional<String>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32())
+        let secondaryAddress = Optional<Address>.bridgeJSLiftParameter()
+        let email = Optional<String>.bridgeJSLiftParameter()
         let address = Address.bridgeJSLiftParameter()
-        let age = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let name = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let age = Int.bridgeJSLiftParameter()
+        let name = String.bridgeJSLiftParameter()
         return Contact(name: name, age: age, address: address, email: email, secondaryAddress: secondaryAddress)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        var __bjs_name = self.name
-        __bjs_name.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        _swift_js_push_i32(Int32(self.age))
+        self.name.bridgeJSLowerStackReturn()
+        self.age.bridgeJSLowerStackReturn()
         self.address.bridgeJSLowerReturn()
         let __bjs_isSome_email = self.email != nil
         if let __bjs_unwrapped_email = self.email {
-            var __bjs_str_email = __bjs_unwrapped_email
-            __bjs_str_email.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            __bjs_unwrapped_email.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_email ? 1 : 0)
         let __bjs_isSome_secondaryAddress = self.secondaryAddress != nil
@@ -2523,31 +2418,25 @@ fileprivate func _bjs_struct_lift_Contact() -> Int32 {
 extension Config: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Config {
         let status = Status.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let direction = Optional<Direction>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let theme = Optional<Theme>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32())
-        let name = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let direction = Optional<Direction>.bridgeJSLiftParameter()
+        let theme = Optional<Theme>.bridgeJSLiftParameter()
+        let name = String.bridgeJSLiftParameter()
         return Config(name: name, theme: theme, direction: direction, status: status)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        var __bjs_name = self.name
-        __bjs_name.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
+        self.name.bridgeJSLowerStackReturn()
         let __bjs_isSome_theme = self.theme != nil
         if let __bjs_unwrapped_theme = self.theme {
-            var __bjs_str_theme = __bjs_unwrapped_theme.rawValue
-            __bjs_str_theme.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            __bjs_unwrapped_theme.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_theme ? 1 : 0)
         let __bjs_isSome_direction = self.direction != nil
         if let __bjs_unwrapped_direction = self.direction {
-            _swift_js_push_i32(__bjs_unwrapped_direction.bridgeJSLowerParameter())
+            __bjs_unwrapped_direction.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_direction ? 1 : 0)
-        _swift_js_push_i32(Int32(self.status.bridgeJSLowerParameter()))
+        self.status.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -2585,16 +2474,16 @@ fileprivate func _bjs_struct_lift_Config() -> Int32 {
 
 extension SessionData: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> SessionData {
-        let owner = Optional<Greeter>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_pointer())
-        let id = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
+        let owner = Optional<Greeter>.bridgeJSLiftParameter()
+        let id = Int.bridgeJSLiftParameter()
         return SessionData(id: id, owner: owner)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_i32(Int32(self.id))
+        self.id.bridgeJSLowerStackReturn()
         let __bjs_isSome_owner = self.owner != nil
         if let __bjs_unwrapped_owner = self.owner {
-            _swift_js_push_pointer(__bjs_unwrapped_owner.bridgeJSLowerReturn())
+            __bjs_unwrapped_owner.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_owner ? 1 : 0)
     }
@@ -2634,19 +2523,19 @@ fileprivate func _bjs_struct_lift_SessionData() -> Int32 {
 
 extension ValidationReport: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ValidationReport {
-        let outcome = Optional<APIResult>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let status = Optional<Status>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let outcome = Optional<APIResult>.bridgeJSLiftParameter()
+        let status = Optional<Status>.bridgeJSLiftParameter()
         let result = APIResult.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let id = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
+        let id = Int.bridgeJSLiftParameter()
         return ValidationReport(id: id, result: result, status: status, outcome: outcome)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_i32(Int32(self.id))
+        self.id.bridgeJSLowerStackReturn()
         self.result.bridgeJSLowerReturn()
         let __bjs_isSome_status = self.status != nil
         if let __bjs_unwrapped_status = self.status {
-            _swift_js_push_i32(__bjs_unwrapped_status.bridgeJSLowerParameter())
+            __bjs_unwrapped_status.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_status ? 1 : 0)
         let __bjs_isSome_outcome = self.outcome != nil
@@ -2691,31 +2580,25 @@ fileprivate func _bjs_struct_lift_ValidationReport() -> Int32 {
 
 extension AdvancedConfig: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> AdvancedConfig {
-        let overrideDefaults = Optional<ConfigStruct>.bridgeJSLiftParameter(_swift_js_pop_i32())
+        let overrideDefaults = Optional<ConfigStruct>.bridgeJSLiftParameter()
         let defaults = ConfigStruct.bridgeJSLiftParameter()
-        let location = Optional<DataPoint>.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let metadata = Optional<JSObject>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let result = Optional<APIResult>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let location = Optional<DataPoint>.bridgeJSLiftParameter()
+        let metadata = Optional<JSObject>.bridgeJSLiftParameter()
+        let result = Optional<APIResult>.bridgeJSLiftParameter()
         let status = Status.bridgeJSLiftParameter(_swift_js_pop_i32())
         let theme = Theme.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let enabled = Bool.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let title = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
-        let id = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
+        let enabled = Bool.bridgeJSLiftParameter()
+        let title = String.bridgeJSLiftParameter()
+        let id = Int.bridgeJSLiftParameter()
         return AdvancedConfig(id: id, title: title, enabled: enabled, theme: theme, status: status, result: result, metadata: metadata, location: location, defaults: defaults, overrideDefaults: overrideDefaults)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_i32(Int32(self.id))
-        var __bjs_title = self.title
-        __bjs_title.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        _swift_js_push_i32(self.enabled ? 1 : 0)
-        var __bjs_theme = self.theme.rawValue
-        __bjs_theme.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        _swift_js_push_i32(Int32(self.status.bridgeJSLowerParameter()))
+        self.id.bridgeJSLowerStackReturn()
+        self.title.bridgeJSLowerStackReturn()
+        self.enabled.bridgeJSLowerStackReturn()
+        self.theme.bridgeJSLowerStackReturn()
+        self.status.bridgeJSLowerStackReturn()
         let __bjs_isSome_result = self.result != nil
         if let __bjs_unwrapped_result = self.result {
             _swift_js_push_i32(__bjs_unwrapped_result.bridgeJSLowerParameter())
@@ -2723,7 +2606,7 @@ extension AdvancedConfig: _BridgedSwiftStruct {
         _swift_js_push_i32(__bjs_isSome_result ? 1 : 0)
         let __bjs_isSome_metadata = self.metadata != nil
         if let __bjs_unwrapped_metadata = self.metadata {
-            _swift_js_push_i32(__bjs_unwrapped_metadata.bridgeJSLowerReturn())
+            __bjs_unwrapped_metadata.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_metadata ? 1 : 0)
         let __bjs_isSome_location = self.location != nil
@@ -2774,24 +2657,24 @@ fileprivate func _bjs_struct_lift_AdvancedConfig() -> Int32 {
 
 extension MeasurementConfig: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> MeasurementConfig {
-        let optionalRatio = Optional<Ratio>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_f64())
-        let optionalPrecision = Optional<Precision>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_f32())
+        let optionalRatio = Optional<Ratio>.bridgeJSLiftParameter()
+        let optionalPrecision = Optional<Precision>.bridgeJSLiftParameter()
         let ratio = Ratio.bridgeJSLiftParameter(_swift_js_pop_f64())
         let precision = Precision.bridgeJSLiftParameter(_swift_js_pop_f32())
         return MeasurementConfig(precision: precision, ratio: ratio, optionalPrecision: optionalPrecision, optionalRatio: optionalRatio)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_f32(self.precision.bridgeJSLowerParameter())
-        _swift_js_push_f64(self.ratio.bridgeJSLowerParameter())
+        self.precision.bridgeJSLowerStackReturn()
+        self.ratio.bridgeJSLowerStackReturn()
         let __bjs_isSome_optionalPrecision = self.optionalPrecision != nil
         if let __bjs_unwrapped_optionalPrecision = self.optionalPrecision {
-            _swift_js_push_f32(__bjs_unwrapped_optionalPrecision.bridgeJSLowerParameter())
+            __bjs_unwrapped_optionalPrecision.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_optionalPrecision ? 1 : 0)
         let __bjs_isSome_optionalRatio = self.optionalRatio != nil
         if let __bjs_unwrapped_optionalRatio = self.optionalRatio {
-            _swift_js_push_f64(__bjs_unwrapped_optionalRatio.bridgeJSLowerParameter())
+            __bjs_unwrapped_optionalRatio.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_optionalRatio ? 1 : 0)
     }
@@ -2831,12 +2714,12 @@ fileprivate func _bjs_struct_lift_MeasurementConfig() -> Int32 {
 
 extension MathOperations: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> MathOperations {
-        let baseValue = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
+        let baseValue = Double.bridgeJSLiftParameter()
         return MathOperations(baseValue: baseValue)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_f64(self.baseValue)
+        self.baseValue.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -2918,19 +2801,16 @@ public func _bjs_MathOperations_static_subtract(_ a: Float64, _ b: Float64) -> F
 
 extension CopyableCart: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> CopyableCart {
-        let note = Optional<String>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32())
-        let x = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
+        let note = Optional<String>.bridgeJSLiftParameter()
+        let x = Int.bridgeJSLiftParameter()
         return CopyableCart(x: x, note: note)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_i32(Int32(self.x))
+        self.x.bridgeJSLowerStackReturn()
         let __bjs_isSome_note = self.note != nil
         if let __bjs_unwrapped_note = self.note {
-            var __bjs_str_note = __bjs_unwrapped_note
-            __bjs_str_note.withUTF8 { ptr in
-                _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-            }
+            __bjs_unwrapped_note.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_note ? 1 : 0)
     }
@@ -2981,17 +2861,14 @@ public func _bjs_CopyableCart_static_fromJSObject(_ object: Int32) -> Void {
 
 extension CopyableCartItem: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> CopyableCartItem {
-        let quantity = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let sku = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let quantity = Int.bridgeJSLiftParameter()
+        let sku = String.bridgeJSLiftParameter()
         return CopyableCartItem(sku: sku, quantity: quantity)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        var __bjs_sku = self.sku
-        __bjs_sku.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        _swift_js_push_i32(Int32(self.quantity))
+        self.sku.bridgeJSLowerStackReturn()
+        self.quantity.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -3029,14 +2906,14 @@ fileprivate func _bjs_struct_lift_CopyableCartItem() -> Int32 {
 
 extension CopyableNestedCart: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> CopyableNestedCart {
-        let shippingAddress = Optional<Address>.bridgeJSLiftParameter(_swift_js_pop_i32())
+        let shippingAddress = Optional<Address>.bridgeJSLiftParameter()
         let item = CopyableCartItem.bridgeJSLiftParameter()
-        let id = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
+        let id = Int.bridgeJSLiftParameter()
         return CopyableNestedCart(id: id, item: item, shippingAddress: shippingAddress)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        _swift_js_push_i32(Int32(self.id))
+        self.id.bridgeJSLowerStackReturn()
         self.item.bridgeJSLowerReturn()
         let __bjs_isSome_shippingAddress = self.shippingAddress != nil
         if let __bjs_unwrapped_shippingAddress = self.shippingAddress {
@@ -3091,17 +2968,14 @@ public func _bjs_CopyableNestedCart_static_fromJSObject(_ object: Int32) -> Void
 
 extension ConfigStruct: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ConfigStruct {
-        let value = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
-        let name = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())
+        let value = Int.bridgeJSLiftParameter()
+        let name = String.bridgeJSLiftParameter()
         return ConfigStruct(name: name, value: value)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        var __bjs_name = self.name
-        __bjs_name.withUTF8 { ptr in
-            _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-        }
-        _swift_js_push_i32(Int32(self.value))
+        self.name.bridgeJSLowerStackReturn()
+        self.value.bridgeJSLowerStackReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -4566,16 +4440,7 @@ public func _bjs_testEmptyInit(_ object: UnsafeMutableRawPointer) -> UnsafeMutab
 @_cdecl("bjs_arrayWithDefault")
 public func _bjs_arrayWithDefault() -> Int32 {
     #if arch(wasm32)
-    let ret = arrayWithDefault(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
+    let ret = arrayWithDefault(_: [Int].bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -4590,16 +4455,7 @@ public func _bjs_arrayWithOptionalDefault(_ values: Int32) -> Int32 {
         if values == 0 {
             return Optional<[Int]>.none
         } else {
-            return {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                }()
+            return [Int].bridgeJSLiftParameter()
         }
         }())
     return ret.bridgeJSLowerReturn()
@@ -4612,16 +4468,7 @@ public func _bjs_arrayWithOptionalDefault(_ values: Int32) -> Int32 {
 @_cdecl("bjs_arrayMixedDefaults")
 public func _bjs_arrayMixedDefaults(_ prefixBytes: Int32, _ prefixLength: Int32, _ suffixBytes: Int32, _ suffixLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = arrayMixedDefaults(prefix: String.bridgeJSLiftParameter(prefixBytes, prefixLength), values: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }(), suffix: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
+    let ret = arrayMixedDefaults(prefix: String.bridgeJSLiftParameter(prefixBytes, prefixLength), values: [Int].bridgeJSLiftParameter(), suffix: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -4665,19 +4512,8 @@ public func _bjs_makeAdder(_ base: Int32) -> UnsafeMutableRawPointer {
 @_cdecl("bjs_roundTripIntArray")
 public func _bjs_roundTripIntArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripIntArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret))}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripIntArray(_: [Int].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -4687,22 +4523,8 @@ public func _bjs_roundTripIntArray() -> Void {
 @_cdecl("bjs_roundTripStringArray")
 public func _bjs_roundTripStringArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripStringArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [String] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    var __bjs_ret_elem = __bjs_elem_ret
-    __bjs_ret_elem.withUTF8 { ptr in
-        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-    }}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripStringArray(_: [String].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -4712,19 +4534,8 @@ public func _bjs_roundTripStringArray() -> Void {
 @_cdecl("bjs_roundTripDoubleArray")
 public func _bjs_roundTripDoubleArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripDoubleArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Double] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_f64(__bjs_elem_ret)}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripDoubleArray(_: [Double].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -4734,19 +4545,8 @@ public func _bjs_roundTripDoubleArray() -> Void {
 @_cdecl("bjs_roundTripBoolArray")
 public func _bjs_roundTripBoolArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripBoolArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Bool] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(__bjs_elem_ret ? 1 : 0)}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripBoolArray(_: [Bool].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -4756,19 +4556,8 @@ public func _bjs_roundTripBoolArray() -> Void {
 @_cdecl("bjs_roundTripDirectionArray")
 public func _bjs_roundTripDirectionArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripDirectionArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Direction] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Direction.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret.bridgeJSLowerParameter()))}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripDirectionArray(_: [Direction].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -4778,19 +4567,8 @@ public func _bjs_roundTripDirectionArray() -> Void {
 @_cdecl("bjs_roundTripStatusArray")
 public func _bjs_roundTripStatusArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripStatusArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Status] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Status.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret.bridgeJSLowerParameter()))}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripStatusArray(_: [Status].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -4800,22 +4578,8 @@ public func _bjs_roundTripStatusArray() -> Void {
 @_cdecl("bjs_roundTripThemeArray")
 public func _bjs_roundTripThemeArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripThemeArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Theme] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Theme.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    var __bjs_ret_elem = __bjs_elem_ret.rawValue
-    __bjs_ret_elem.withUTF8 { ptr in
-        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-    }}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripThemeArray(_: [Theme].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -4825,19 +4589,8 @@ public func _bjs_roundTripThemeArray() -> Void {
 @_cdecl("bjs_roundTripHttpStatusArray")
 public func _bjs_roundTripHttpStatusArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripHttpStatusArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [HttpStatus] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(HttpStatus.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret.bridgeJSLowerParameter()))}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripHttpStatusArray(_: [HttpStatus].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -4847,19 +4600,8 @@ public func _bjs_roundTripHttpStatusArray() -> Void {
 @_cdecl("bjs_roundTripDataPointArray")
 public func _bjs_roundTripDataPointArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripDataPointArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [DataPoint] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(DataPoint.bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripDataPointArray(_: [DataPoint].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -4869,19 +4611,8 @@ public func _bjs_roundTripDataPointArray() -> Void {
 @_cdecl("bjs_roundTripGreeterArray")
 public func _bjs_roundTripGreeterArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripGreeterArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Greeter] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Greeter.bridgeJSLiftParameter(_swift_js_pop_pointer()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripGreeterArray(_: [Greeter].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -4896,7 +4627,7 @@ public func _bjs_roundTripOptionalIntArray() -> Void {
         var __result: [Optional<Int>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<Int>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            __result.append(Optional<Int>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -4904,7 +4635,7 @@ public func _bjs_roundTripOptionalIntArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    _swift_js_push_i32(Int32(__bjs_unwrapped_ret_elem))}
+    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()}
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)}
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -4921,7 +4652,7 @@ public func _bjs_roundTripOptionalStringArray() -> Void {
         var __result: [Optional<String>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<String>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32(), _swift_js_pop_i32()))
+            __result.append(Optional<String>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -4929,10 +4660,7 @@ public func _bjs_roundTripOptionalStringArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    var __bjs_str_ret_elem = __bjs_unwrapped_ret_elem
-    __bjs_str_ret_elem.withUTF8 { ptr in
-        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-    }}
+    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()}
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)}
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -4949,7 +4677,7 @@ public func _bjs_roundTripOptionalDataPointArray() -> Void {
         var __result: [Optional<DataPoint>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<DataPoint>.bridgeJSLiftParameter(_swift_js_pop_i32()))
+            __result.append(Optional<DataPoint>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -4974,7 +4702,7 @@ public func _bjs_roundTripOptionalDirectionArray() -> Void {
         var __result: [Optional<Direction>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<Direction>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            __result.append(Optional<Direction>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -4982,7 +4710,7 @@ public func _bjs_roundTripOptionalDirectionArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    _swift_js_push_i32(__bjs_unwrapped_ret_elem.bridgeJSLowerParameter())}
+    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()}
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)}
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -4999,7 +4727,7 @@ public func _bjs_roundTripOptionalStatusArray() -> Void {
         var __result: [Optional<Status>] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append(Optional<Status>.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
+            __result.append(Optional<Status>.bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
@@ -5007,7 +4735,7 @@ public func _bjs_roundTripOptionalStatusArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    _swift_js_push_i32(__bjs_unwrapped_ret_elem.bridgeJSLowerParameter())}
+    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()}
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)}
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -5023,23 +4751,12 @@ public func _bjs_roundTripOptionalIntArrayType(_ values: Int32) -> Void {
         if values == 0 {
             return Optional<[Int]>.none
         } else {
-            return {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                }()
+            return [Int].bridgeJSLiftParameter()
         }
         }())
     let __bjs_isSome_ret = ret != nil
     if let __bjs_unwrapped_ret = ret {
-    for __bjs_elem_ret in __bjs_unwrapped_ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret))}
-    _swift_js_push_i32(Int32(__bjs_unwrapped_ret.count))}
+    __bjs_unwrapped_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
     #else
     fatalError("Only available on WebAssembly")
@@ -5054,26 +4771,12 @@ public func _bjs_roundTripOptionalStringArrayType(_ values: Int32) -> Void {
         if values == 0 {
             return Optional<[String]>.none
         } else {
-            return {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [String] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                }()
+            return [String].bridgeJSLiftParameter()
         }
         }())
     let __bjs_isSome_ret = ret != nil
     if let __bjs_unwrapped_ret = ret {
-    for __bjs_elem_ret in __bjs_unwrapped_ret {
-    var __bjs_ret_elem = __bjs_elem_ret
-    __bjs_ret_elem.withUTF8 { ptr in
-        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-    }}
-    _swift_js_push_i32(Int32(__bjs_unwrapped_ret.count))}
+    __bjs_unwrapped_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
     #else
     fatalError("Only available on WebAssembly")
@@ -5088,23 +4791,12 @@ public func _bjs_roundTripOptionalGreeterArrayType(_ greeters: Int32) -> Void {
         if greeters == 0 {
             return Optional<[Greeter]>.none
         } else {
-            return {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Greeter] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Greeter.bridgeJSLiftParameter(_swift_js_pop_pointer()))
-        }
-        __result.reverse()
-        return __result
-                }()
+            return [Greeter].bridgeJSLiftParameter()
         }
         }())
     let __bjs_isSome_ret = ret != nil
     if let __bjs_unwrapped_ret = ret {
-    for __bjs_elem_ret in __bjs_unwrapped_ret {
-    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(__bjs_unwrapped_ret.count))}
+    __bjs_unwrapped_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
     #else
     fatalError("Only available on WebAssembly")
@@ -5120,24 +4812,13 @@ public func _bjs_roundTripNestedIntArray() -> Void {
         var __result: [[Int]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Int] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([Int].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret_elem))}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -5153,27 +4834,13 @@ public func _bjs_roundTripNestedStringArray() -> Void {
         var __result: [[String]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [String] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([String].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    var __bjs_ret_elem_elem = __bjs_elem_ret_elem
-    __bjs_ret_elem_elem.withUTF8 { ptr in
-        _swift_js_push_string(ptr.baseAddress, Int32(ptr.count))
-    }}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -5189,24 +4856,13 @@ public func _bjs_roundTripNestedDoubleArray() -> Void {
         var __result: [[Double]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Double] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Double.bridgeJSLiftParameter(_swift_js_pop_f64()))
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([Double].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    _swift_js_push_f64(__bjs_elem_ret_elem)}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -5222,24 +4878,13 @@ public func _bjs_roundTripNestedBoolArray() -> Void {
         var __result: [[Bool]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Bool] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Bool.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([Bool].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    _swift_js_push_i32(__bjs_elem_ret_elem ? 1 : 0)}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -5255,24 +4900,13 @@ public func _bjs_roundTripNestedDataPointArray() -> Void {
         var __result: [[DataPoint]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [DataPoint] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(DataPoint.bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([DataPoint].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    __bjs_elem_ret_elem.bridgeJSLowerReturn()}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -5288,24 +4922,13 @@ public func _bjs_roundTripNestedDirectionArray() -> Void {
         var __result: [[Direction]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Direction] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Direction.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([Direction].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    _swift_js_push_i32(Int32(__bjs_elem_ret_elem.bridgeJSLowerParameter()))}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -5321,24 +4944,13 @@ public func _bjs_roundTripNestedGreeterArray() -> Void {
         var __result: [[Greeter]] = []
         __result.reserveCapacity(__count)
         for _ in 0 ..< __count {
-            __result.append({
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Greeter] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(Greeter.bridgeJSLiftParameter(_swift_js_pop_pointer()))
-        }
-        __result.reverse()
-        return __result
-                    }())
+            __result.append([Greeter].bridgeJSLiftParameter())
         }
         __result.reverse()
         return __result
         }())
     for __bjs_elem_ret in ret {
-    for __bjs_elem_ret_elem in __bjs_elem_ret {
-    _swift_js_push_pointer(__bjs_elem_ret_elem.bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(__bjs_elem_ret.count))}
+    __bjs_elem_ret.bridgeJSLowerReturn()}
     _swift_js_push_i32(Int32(ret.count))
     #else
     fatalError("Only available on WebAssembly")
@@ -5349,19 +4961,8 @@ public func _bjs_roundTripNestedGreeterArray() -> Void {
 @_cdecl("bjs_roundTripUnsafeRawPointerArray")
 public func _bjs_roundTripUnsafeRawPointerArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripUnsafeRawPointerArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [UnsafeRawPointer] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(UnsafeRawPointer.bridgeJSLiftParameter(_swift_js_pop_pointer()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripUnsafeRawPointerArray(_: [UnsafeRawPointer].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5371,19 +4972,8 @@ public func _bjs_roundTripUnsafeRawPointerArray() -> Void {
 @_cdecl("bjs_roundTripUnsafeMutableRawPointerArray")
 public func _bjs_roundTripUnsafeMutableRawPointerArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripUnsafeMutableRawPointerArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [UnsafeMutableRawPointer] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(UnsafeMutableRawPointer.bridgeJSLiftParameter(_swift_js_pop_pointer()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripUnsafeMutableRawPointerArray(_: [UnsafeMutableRawPointer].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5393,19 +4983,30 @@ public func _bjs_roundTripUnsafeMutableRawPointerArray() -> Void {
 @_cdecl("bjs_roundTripOpaquePointerArray")
 public func _bjs_roundTripOpaquePointerArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripOpaquePointerArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [OpaquePointer] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(OpaquePointer.bridgeJSLiftParameter(_swift_js_pop_pointer()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_pointer(__bjs_elem_ret.bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripOpaquePointerArray(_: [OpaquePointer].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripUnsafePointerArray")
+@_cdecl("bjs_roundTripUnsafePointerArray")
+public func _bjs_roundTripUnsafePointerArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripUnsafePointerArray(_: [UnsafePointer<UInt8>].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripUnsafeMutablePointerArray")
+@_cdecl("bjs_roundTripUnsafeMutablePointerArray")
+public func _bjs_roundTripUnsafeMutablePointerArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripUnsafeMutablePointerArray(_: [UnsafeMutablePointer<UInt8>].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5415,16 +5016,7 @@ public func _bjs_roundTripOpaquePointerArray() -> Void {
 @_cdecl("bjs_consumeDataProcessorArrayType")
 public func _bjs_consumeDataProcessorArrayType() -> Int32 {
     #if arch(wasm32)
-    let ret = consumeDataProcessorArrayType(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [AnyDataProcessor] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(AnyDataProcessor.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
+    let ret = consumeDataProcessorArrayType(_: [AnyDataProcessor].bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -5435,19 +5027,10 @@ public func _bjs_consumeDataProcessorArrayType() -> Int32 {
 @_cdecl("bjs_roundTripDataProcessorArrayType")
 public func _bjs_roundTripDataProcessorArrayType() -> Void {
     #if arch(wasm32)
-    let ret = roundTripDataProcessorArrayType(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [AnyDataProcessor] = []
-        __result.reserveCapacity(__count)
-        for _ in 0 ..< __count {
-            __result.append(AnyDataProcessor.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        }
-        __result.reverse()
-        return __result
-        }())
-    for __bjs_elem_ret in ret {
-    _swift_js_push_i32((__bjs_elem_ret as! AnyDataProcessor).bridgeJSLowerReturn())}
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripDataProcessorArrayType(_: [AnyDataProcessor].bridgeJSLiftParameter())
+    ret.map {
+        $0 as! AnyDataProcessor
+    } .bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -9138,6 +9138,84 @@
         }
       },
       {
+        "abiName" : "bjs_roundTripUnsafePointerArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripUnsafePointerArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "unsafePointer" : {
+                    "_0" : {
+                      "kind" : "unsafePointer",
+                      "pointee" : "UInt8"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "unsafePointer" : {
+                "_0" : {
+                  "kind" : "unsafePointer",
+                  "pointee" : "UInt8"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripUnsafeMutablePointerArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripUnsafeMutablePointerArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "unsafePointer" : {
+                    "_0" : {
+                      "kind" : "unsafeMutablePointer",
+                      "pointee" : "UInt8"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "unsafePointer" : {
+                "_0" : {
+                  "kind" : "unsafeMutablePointer",
+                  "pointee" : "UInt8"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
         "abiName" : "bjs_consumeDataProcessorArrayType",
         "effects" : {
           "isAsync" : false,

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -1385,6 +1385,8 @@ function testArraySupport(exports) {
     assert.deepEqual(exports.roundTripUnsafeRawPointerArray(pointerValues), pointerValues);
     assert.deepEqual(exports.roundTripUnsafeMutableRawPointerArray(pointerValues), pointerValues);
     assert.deepEqual(exports.roundTripOpaquePointerArray(pointerValues), pointerValues);
+    assert.deepEqual(exports.roundTripUnsafePointerArray(pointerValues), pointerValues);
+    assert.deepEqual(exports.roundTripUnsafeMutablePointerArray(pointerValues), pointerValues);
     assert.deepEqual(exports.roundTripUnsafeRawPointerArray([]), []);
 
     // Default values


### PR DESCRIPTION
## Overview

This PR simplifies generated BridgeJS code by abstracting repeatable lifting/lowering logic for stack-based types into dedicated protocol extensions in `BridgeJSIntrinsics.swift`.

## Changes

1. New `_BridgedSwiftStackType` protocol and centralized intrinsic extensions for Array

Introduced a protocol for types that can be lifted from and lowered to the JavaScript stack:
```
  public protocol _BridgedSwiftStackType {
      associatedtype StackLiftResult = Self
      static func bridgeJSLiftParameter() -> StackLiftResult
      consuming func bridgeJSLowerStackReturn()
  }
```

2. Updated code generation for some stack based types

Before: Code generator emitted explicit `pop/push` calls for each type:

```swift
  let x = Int.bridgeJSLiftParameter(_swift_js_pop_i32())
  let y = Double.bridgeJSLiftParameter(_swift_js_pop_f64())
  let name = String.bridgeJSLiftParameter(_swift_js_pop_i32(), _swift_js_pop_i32())

  // Arrays required inline loops
  let ret = processIntArray(_: {
      let __count = Int(_swift_js_pop_i32())
      var __result: [Int] = []
      __result.reserveCapacity(__count)
      for _ in 0 ..< __count {
          __result.append(Int.bridgeJSLiftParameter(_swift_js_pop_i32()))
      }
      __result.reverse()
      return __result
  }())
  for __bjs_elem_ret in ret {
      _swift_js_push_i32(Int32(__bjs_elem_ret))
  }
  _swift_js_push_i32(Int32(ret.count))
```

Now: Types handle their own stack operations within instrinsics:

```swift
  let x = Int.bridgeJSLiftParameter()
  let y = Double.bridgeJSLiftParameter()
  let name = String.bridgeJSLiftParameter()

  let ret = processIntArray(_: [Int].bridgeJSLiftParameter())
  ret.bridgeJSLowerReturn()
```

3. Fixed support for `UnsafePointer<T>` and `UnsafeMutablePointer<T>`

Added `_BridgedSwiftStackType` conformance to `UnsafePointer<T>` and `UnsafeMutablePointer<T>` and missing e2e tests.

## Notes
I was running into issues that were showing up only when building PlayBridgeJS example:
```
wasm-ld: error: import module mismatch for symbol: $s13JavaScriptKit21_swift_js_pop_pointerSvyF
>>> defined as bjs in /Users/krzysztofrodak/git/JavaScriptKit/Examples/PlayBridgeJS/.build/wasm32-unknown-wasip1-threads/release/JavaScriptKit.build/BridgeJSIntrinsics.swift.o
>>> defined as env in /Users/krzysztofrodak/git/JavaScriptKit/Examples/PlayBridgeJS/.build/wasm32-unknown-wasip1-threads/release/PlayBridgeJS.build/main.swift.o
```
Fixed it by adding `@inline(never)` to functions that call `_swift_js_pop_pointer()` to prevent WebAssembly module mismatch errors when generic specialization inlines extern declarations across module boundaries, but I'm not sure whether this is proper solution 