### PR TITLE
fix: Functions with @JS were being generated with `@_expose(wasm "bjs_someFunctionName")` rather than `@_expose(wasm, "bjs_someFunctionName")`

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -760,10 +760,10 @@ enum SwiftCodePattern {
         return AttributeListSyntax {
             #if canImport(SwiftSyntax602)
             let exposeAttrArgs = AttributeSyntax.Arguments.argumentList(
-                [
-                    LabeledExprSyntax(label: nil, expression: DeclReferenceExprSyntax(baseName: "wasm")),
-                    LabeledExprSyntax(label: nil, expression: StringLiteralExprSyntax(content: abiName)),
-                ]
+                LabeledExprListSyntax {
+                    LabeledExprSyntax(expression: DeclReferenceExprSyntax(baseName: "wasm"))
+                    LabeledExprSyntax(expression: StringLiteralExprSyntax(content: abiName))
+                }
             )
             let cdeclAttrArgs = AttributeSyntax.Arguments.argumentList(
                 [


### PR DESCRIPTION
## Problem summary

A recent BridgeJS change caused generated swift interfacing code to use `@_expose(wasm "bjs_someFunctionName")`, rather than `@_expose(wasm, "bjs_someFunctionName")`.

This change adds back the command, which is required to compile.

## Details
For the following code:

```
@JS public func load() {}
```

A recent change caused the following swift code to be generated:

```swift
@_spi(BridgeJS) import JavaScriptKit

@_expose(wasm "bjs_load")
@_cdecl("bjs_load")
public func _bjs_load() -> Void {}
```

This fails to compile with an error like the following:

```<omitted>/.build/plugins/outputs/<omitted>/destination/BridgeJS/BridgeJS.swift:10:2: error: expected ')' in '_expose' attribute
 8 | @_spi(BridgeJS) import JavaScriptKit
 9 | 
10 | @_expose(wasm "bjs_load")
   |  `- error: expected ')' in '_expose' attribute
11 | @_cdecl("bjs_load")
12 | public func _bjs_load() -> Void {
```

Instead, the generated code needs to add a comma separator:

```swift
@_spi(BridgeJS) import JavaScriptKit

@_expose(wasm, "bjs_load")
@_cdecl("bjs_load")
public func _bjs_load() -> Void {}
```