### PR TITLE
Examples: Build SwiftSyntax in debug mode for macro plugins

### DIFF
--- a/Examples/ActorOnWebWorker/build.sh
+++ b/Examples/ActorOnWebWorker/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" -c release \
+swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
     plugin --allow-writing-to-package-directory \
-    js --use-cdn --output ./Bundle
+    js --use-cdn --output ./Bundle -c release

--- a/Examples/Basic/build.sh
+++ b/Examples/Basic/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}" -c "${1:-debug}" js --use-cdn
+swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}" js --use-cdn -c "${1:-debug}"

--- a/Examples/Multithreading/build.sh
+++ b/Examples/Multithreading/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" -c release \
+swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
     plugin --allow-writing-to-package-directory \
-    js --use-cdn --output ./Bundle
+    js --use-cdn --output ./Bundle -c release

--- a/Examples/OffscrenCanvas/build.sh
+++ b/Examples/OffscrenCanvas/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" -c release \
+swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
     plugin --allow-writing-to-package-directory \
-    js --use-cdn --output ./Bundle
+    js --use-cdn --output ./Bundle -c release

--- a/Examples/PlayBridgeJS/build.sh
+++ b/Examples/PlayBridgeJS/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
-env JAVASCRIPTKIT_EXPERIMENTAL_BRIDGEJS=1 swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}" -c "${1:-debug}" \
+env JAVASCRIPTKIT_EXPERIMENTAL_BRIDGEJS=1 swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}" \
     plugin --allow-writing-to-package-directory \
-    js --use-cdn --output ./Bundle
+    js --use-cdn --output ./Bundle -c "${1:-debug}"


### PR DESCRIPTION
It reduces the CI time from [43mins](https://github.com/swiftwasm/JavaScriptKit/actions/runs/21611526833/job/62281146750) to [18mins](https://github.com/swiftwasm/JavaScriptKit/actions/runs/21612643089/job/62284644161?pr=558)