### PR TITLE
BridgeJS: Fix namespace enum with `@JS(namespace:)` attribute

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -533,14 +533,9 @@ public class ExportSwift {
         if function.effects.isStatic, let staticContext = function.staticContext {
             let callName: String
             switch staticContext {
-            case .className(let baseName), .enumName(let baseName), .structName(let baseName):
+            case .className(let baseName), .enumName(let baseName), .structName(let baseName),
+                .namespaceEnum(let baseName):
                 callName = "\(baseName).\(function.name)"
-            case .namespaceEnum:
-                if let namespace = function.namespace, !namespace.isEmpty {
-                    callName = "\(namespace.joined(separator: ".")).\(function.name)"
-                } else {
-                    callName = function.name
-                }
             }
             builder.call(name: callName, returnType: function.returnType)
         } else {

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -990,7 +990,8 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             }
 
             let isNamespaceEnum = exportedEnumByName[enumKey]?.cases.isEmpty ?? true
-            staticContext = isNamespaceEnum ? .namespaceEnum : .enumName(enumName)
+            let swiftCallName = exportedEnumByName[enumKey]?.swiftCallName ?? enumName
+            staticContext = isNamespaceEnum ? .namespaceEnum(swiftCallName) : .enumName(enumName)
         case .protocolBody(_, _):
             return nil
         case .structBody(let structName, _):
@@ -1187,7 +1188,10 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
                 return .skipChildren
             }
             let isNamespaceEnum = exportedEnumByName[enumKey]?.cases.isEmpty ?? true
-            staticContext = isStatic ? (isNamespaceEnum ? .namespaceEnum : .enumName(enumName)) : nil
+            // Use swiftCallName for the full Swift call path (handles nested enums correctly)
+            let swiftCallName = exportedEnumByName[enumKey]?.swiftCallName ?? enumName
+            staticContext =
+                isStatic ? (isNamespaceEnum ? .namespaceEnum(swiftCallName) : .enumName(swiftCallName)) : nil
         case .topLevel:
             diagnose(node: node, message: "@JS var must be inside a @JS class or enum")
             return .skipChildren

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -242,7 +242,7 @@ public enum StaticContext: Codable, Equatable, Sendable {
     case className(String)
     case structName(String)
     case enumName(String)
-    case namespaceEnum
+    case namespaceEnum(String)
 }
 
 // MARK: - Struct Skeleton
@@ -533,13 +533,9 @@ public struct ExportedProperty: Codable, Equatable, Sendable {
     public func callName(prefix: String? = nil) -> String {
         if let staticContext = staticContext {
             switch staticContext {
-            case .className(let baseName), .enumName(let baseName), .structName(let baseName):
+            case .className(let baseName), .enumName(let baseName), .structName(let baseName),
+                .namespaceEnum(let baseName):
                 return "\(baseName).\(name)"
-            case .namespaceEnum:
-                if let namespace = namespace, !namespace.isEmpty {
-                    let namespacePath = namespace.joined(separator: ".")
-                    return "\(namespacePath).\(name)"
-                }
             }
         }
         if let prefix = prefix {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/EnumNamespace.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/EnumNamespace.swift
@@ -53,4 +53,17 @@ enum Internal {
     }
 }
 
-// TODO: Add namespace enum with static functions when supported
+@JS(namespace: "Services.Graph")
+enum GraphOperations {
+    @JS static func createGraph(rootId: Int) -> Int {
+        return rootId * 10
+    }
+
+    @JS static func nodeCount(graphId: Int) -> Int {
+        return graphId
+    }
+
+    @JS static func validate(graphId: Int) throws(JSException) -> Bool {
+        return graphId > 0
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.d.ts
@@ -84,6 +84,15 @@ export type Exports = {
             },
         },
     },
+    Services: {
+        Graph: {
+            GraphOperations: {
+                createGraph(rootId: number): number;
+                nodeCount(graphId: number): number;
+                validate(graphId: number): boolean;
+            },
+        },
+    },
     Utils: {
         Converter: {
             new(): Converter;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Export.js
@@ -332,6 +332,30 @@ export async function createInstantiator(options, swift) {
                         },
                     },
                 },
+                Services: {
+                    Graph: {
+                        GraphOperations: {
+                            createGraph: function bjs_Services_Graph_GraphOperations_static_createGraph(rootId) {
+                                const ret = instance.exports.bjs_Services_Graph_GraphOperations_static_createGraph(rootId);
+                                return ret;
+                            },
+                            nodeCount: function bjs_Services_Graph_GraphOperations_static_nodeCount(graphId) {
+                                const ret = instance.exports.bjs_Services_Graph_GraphOperations_static_nodeCount(graphId);
+                                return ret;
+                            },
+                            validate: function bjs_Services_Graph_GraphOperations_static_validate(graphId) {
+                                const ret = instance.exports.bjs_Services_Graph_GraphOperations_static_validate(graphId);
+                                if (tmpRetException) {
+                                    const error = swift.memory.getObject(tmpRetException);
+                                    swift.memory.release(tmpRetException);
+                                    tmpRetException = undefined;
+                                    throw error;
+                                }
+                                return ret !== 0;
+                            },
+                        },
+                    },
+                },
                 Utils: {
                     Converter,
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.Export.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.Export.d.ts
@@ -58,6 +58,15 @@ declare global {
             }
         }
     }
+    namespace Services {
+        namespace Graph {
+            namespace GraphOperations {
+                createGraph(rootId: number): number;
+                nodeCount(graphId: number): number;
+                validate(graphId: number): boolean;
+            }
+        }
+    }
     namespace Utils {
         class Converter {
             constructor();
@@ -100,6 +109,15 @@ export type Exports = {
                     new(): TestServer;
                 }
                 SupportedMethod: SupportedMethodObject
+            },
+        },
+    },
+    Services: {
+        Graph: {
+            GraphOperations: {
+                createGraph(rootId: number): number;
+                nodeCount(graphId: number): number;
+                validate(graphId: number): boolean;
             },
         },
     },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.Export.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.Export.js
@@ -349,6 +349,15 @@ export async function createInstantiator(options, swift) {
             if (typeof globalThis.Networking.APIV2.Internal === 'undefined') {
                 globalThis.Networking.APIV2.Internal = {};
             }
+            if (typeof globalThis.Services === 'undefined') {
+                globalThis.Services = {};
+            }
+            if (typeof globalThis.Services.Graph === 'undefined') {
+                globalThis.Services.Graph = {};
+            }
+            if (typeof globalThis.Services.Graph.GraphOperations === 'undefined') {
+                globalThis.Services.Graph.GraphOperations = {};
+            }
             if (typeof globalThis.Utils === 'undefined') {
                 globalThis.Utils = {};
             }
@@ -369,6 +378,30 @@ export async function createInstantiator(options, swift) {
                         },
                     },
                 },
+                Services: {
+                    Graph: {
+                        GraphOperations: {
+                            createGraph: function bjs_Services_Graph_GraphOperations_static_createGraph(rootId) {
+                                const ret = instance.exports.bjs_Services_Graph_GraphOperations_static_createGraph(rootId);
+                                return ret;
+                            },
+                            nodeCount: function bjs_Services_Graph_GraphOperations_static_nodeCount(graphId) {
+                                const ret = instance.exports.bjs_Services_Graph_GraphOperations_static_nodeCount(graphId);
+                                return ret;
+                            },
+                            validate: function bjs_Services_Graph_GraphOperations_static_validate(graphId) {
+                                const ret = instance.exports.bjs_Services_Graph_GraphOperations_static_validate(graphId);
+                                if (tmpRetException) {
+                                    const error = swift.memory.getObject(tmpRetException);
+                                    swift.memory.release(tmpRetException);
+                                    tmpRetException = undefined;
+                                    throw error;
+                                }
+                                return ret !== 0;
+                            },
+                        },
+                    },
+                },
                 Utils: {
                     Converter,
                 },
@@ -377,6 +410,9 @@ export async function createInstantiator(options, swift) {
             globalThis.Utils.Converter = exports.Utils.Converter;
             globalThis.Networking.API.HTTPServer = exports.Networking.API.HTTPServer;
             globalThis.Networking.APIV2.Internal.TestServer = exports.Networking.APIV2.Internal.TestServer;
+            globalThis.Services.Graph.GraphOperations.createGraph = exports.Services.Graph.GraphOperations.createGraph;
+            globalThis.Services.Graph.GraphOperations.nodeCount = exports.Services.Graph.GraphOperations.nodeCount;
+            globalThis.Services.Graph.GraphOperations.validate = exports.Services.Graph.GraphOperations.validate;
             return exports;
         },
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.Global.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.Global.json
@@ -400,6 +400,129 @@
       ],
       "swiftCallName" : "Internal.SupportedMethod",
       "tsFullPath" : "Networking.APIV2.Internal.SupportedMethod"
+    },
+    {
+      "cases" : [
+
+      ],
+      "emitStyle" : "const",
+      "name" : "GraphOperations",
+      "namespace" : [
+        "Services",
+        "Graph"
+      ],
+      "staticMethods" : [
+        {
+          "abiName" : "bjs_Services_Graph_GraphOperations_static_createGraph",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : true,
+            "isThrows" : false
+          },
+          "name" : "createGraph",
+          "namespace" : [
+            "Services",
+            "Graph",
+            "GraphOperations"
+          ],
+          "parameters" : [
+            {
+              "label" : "rootId",
+              "name" : "rootId",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "int" : {
+
+            }
+          },
+          "staticContext" : {
+            "namespaceEnum" : {
+              "_0" : "GraphOperations"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_Services_Graph_GraphOperations_static_nodeCount",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : true,
+            "isThrows" : false
+          },
+          "name" : "nodeCount",
+          "namespace" : [
+            "Services",
+            "Graph",
+            "GraphOperations"
+          ],
+          "parameters" : [
+            {
+              "label" : "graphId",
+              "name" : "graphId",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "int" : {
+
+            }
+          },
+          "staticContext" : {
+            "namespaceEnum" : {
+              "_0" : "GraphOperations"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_Services_Graph_GraphOperations_static_validate",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : true,
+            "isThrows" : true
+          },
+          "name" : "validate",
+          "namespace" : [
+            "Services",
+            "Graph",
+            "GraphOperations"
+          ],
+          "parameters" : [
+            {
+              "label" : "graphId",
+              "name" : "graphId",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "bool" : {
+
+            }
+          },
+          "staticContext" : {
+            "namespaceEnum" : {
+              "_0" : "GraphOperations"
+            }
+          }
+        }
+      ],
+      "staticProperties" : [
+
+      ],
+      "swiftCallName" : "GraphOperations",
+      "tsFullPath" : "Services.Graph.GraphOperations"
     }
   ],
   "exposeToGlobal" : true,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.Global.swift
@@ -82,6 +82,53 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
     }
 }
 
+@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_createGraph")
+@_cdecl("bjs_Services_Graph_GraphOperations_static_createGraph")
+public func _bjs_Services_Graph_GraphOperations_static_createGraph(_ rootId: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = GraphOperations.createGraph(rootId: Int.bridgeJSLiftParameter(rootId))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_nodeCount")
+@_cdecl("bjs_Services_Graph_GraphOperations_static_nodeCount")
+public func _bjs_Services_Graph_GraphOperations_static_nodeCount(_ graphId: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = GraphOperations.nodeCount(graphId: Int.bridgeJSLiftParameter(graphId))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_validate")
+@_cdecl("bjs_Services_Graph_GraphOperations_static_validate")
+public func _bjs_Services_Graph_GraphOperations_static_validate(_ graphId: Int32) -> Int32 {
+    #if arch(wasm32)
+    do {
+        let ret = try GraphOperations.validate(graphId: Int.bridgeJSLiftParameter(graphId))
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_Converter_init")
 @_cdecl("bjs_Converter_init")
 public func _bjs_Converter_init() -> UnsafeMutableRawPointer {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.json
@@ -400,6 +400,129 @@
       ],
       "swiftCallName" : "Internal.SupportedMethod",
       "tsFullPath" : "Networking.APIV2.Internal.SupportedMethod"
+    },
+    {
+      "cases" : [
+
+      ],
+      "emitStyle" : "const",
+      "name" : "GraphOperations",
+      "namespace" : [
+        "Services",
+        "Graph"
+      ],
+      "staticMethods" : [
+        {
+          "abiName" : "bjs_Services_Graph_GraphOperations_static_createGraph",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : true,
+            "isThrows" : false
+          },
+          "name" : "createGraph",
+          "namespace" : [
+            "Services",
+            "Graph",
+            "GraphOperations"
+          ],
+          "parameters" : [
+            {
+              "label" : "rootId",
+              "name" : "rootId",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "int" : {
+
+            }
+          },
+          "staticContext" : {
+            "namespaceEnum" : {
+              "_0" : "GraphOperations"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_Services_Graph_GraphOperations_static_nodeCount",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : true,
+            "isThrows" : false
+          },
+          "name" : "nodeCount",
+          "namespace" : [
+            "Services",
+            "Graph",
+            "GraphOperations"
+          ],
+          "parameters" : [
+            {
+              "label" : "graphId",
+              "name" : "graphId",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "int" : {
+
+            }
+          },
+          "staticContext" : {
+            "namespaceEnum" : {
+              "_0" : "GraphOperations"
+            }
+          }
+        },
+        {
+          "abiName" : "bjs_Services_Graph_GraphOperations_static_validate",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : true,
+            "isThrows" : true
+          },
+          "name" : "validate",
+          "namespace" : [
+            "Services",
+            "Graph",
+            "GraphOperations"
+          ],
+          "parameters" : [
+            {
+              "label" : "graphId",
+              "name" : "graphId",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            }
+          ],
+          "returnType" : {
+            "bool" : {
+
+            }
+          },
+          "staticContext" : {
+            "namespaceEnum" : {
+              "_0" : "GraphOperations"
+            }
+          }
+        }
+      ],
+      "staticProperties" : [
+
+      ],
+      "swiftCallName" : "GraphOperations",
+      "tsFullPath" : "Services.Graph.GraphOperations"
     }
   ],
   "exposeToGlobal" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/EnumNamespace.swift
@@ -82,6 +82,53 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
     }
 }
 
+@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_createGraph")
+@_cdecl("bjs_Services_Graph_GraphOperations_static_createGraph")
+public func _bjs_Services_Graph_GraphOperations_static_createGraph(_ rootId: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = GraphOperations.createGraph(rootId: Int.bridgeJSLiftParameter(rootId))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_nodeCount")
+@_cdecl("bjs_Services_Graph_GraphOperations_static_nodeCount")
+public func _bjs_Services_Graph_GraphOperations_static_nodeCount(_ graphId: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = GraphOperations.nodeCount(graphId: Int.bridgeJSLiftParameter(graphId))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_validate")
+@_cdecl("bjs_Services_Graph_GraphOperations_static_validate")
+public func _bjs_Services_Graph_GraphOperations_static_validate(_ graphId: Int32) -> Int32 {
+    #if arch(wasm32)
+    do {
+        let ret = try GraphOperations.validate(graphId: Int.bridgeJSLiftParameter(graphId))
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_Converter_init")
 @_cdecl("bjs_Converter_init")
 public func _bjs_Converter_init() -> UnsafeMutableRawPointer {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticFunctions.Global.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticFunctions.Global.json
@@ -311,7 +311,7 @@
           },
           "staticContext" : {
             "namespaceEnum" : {
-
+              "_0" : "Utils.String"
             }
           }
         }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticFunctions.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticFunctions.json
@@ -311,7 +311,7 @@
           },
           "staticContext" : {
             "namespaceEnum" : {
-
+              "_0" : "Utils.String"
             }
           }
         }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticProperties.Global.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticProperties.Global.json
@@ -220,7 +220,7 @@
           ],
           "staticContext" : {
             "namespaceEnum" : {
-
+              "_0" : "PropertyNamespace"
             }
           },
           "type" : {
@@ -238,7 +238,7 @@
           ],
           "staticContext" : {
             "namespaceEnum" : {
-
+              "_0" : "PropertyNamespace"
             }
           },
           "type" : {
@@ -274,7 +274,7 @@
           ],
           "staticContext" : {
             "namespaceEnum" : {
-
+              "_0" : "PropertyNamespace.Nested"
             }
           },
           "type" : {
@@ -293,7 +293,7 @@
           ],
           "staticContext" : {
             "namespaceEnum" : {
-
+              "_0" : "PropertyNamespace.Nested"
             }
           },
           "type" : {
@@ -312,7 +312,7 @@
           ],
           "staticContext" : {
             "namespaceEnum" : {
-
+              "_0" : "PropertyNamespace.Nested"
             }
           },
           "type" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticProperties.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/ExportSwiftTests/StaticProperties.json
@@ -220,7 +220,7 @@
           ],
           "staticContext" : {
             "namespaceEnum" : {
-
+              "_0" : "PropertyNamespace"
             }
           },
           "type" : {
@@ -238,7 +238,7 @@
           ],
           "staticContext" : {
             "namespaceEnum" : {
-
+              "_0" : "PropertyNamespace"
             }
           },
           "type" : {
@@ -274,7 +274,7 @@
           ],
           "staticContext" : {
             "namespaceEnum" : {
-
+              "_0" : "PropertyNamespace.Nested"
             }
           },
           "type" : {
@@ -293,7 +293,7 @@
           ],
           "staticContext" : {
             "namespaceEnum" : {
-
+              "_0" : "PropertyNamespace.Nested"
             }
           },
           "type" : {
@@ -312,7 +312,7 @@
           ],
           "staticContext" : {
             "namespaceEnum" : {
-
+              "_0" : "PropertyNamespace.Nested"
             }
           },
           "type" : {

--- a/Tests/BridgeJSGlobalTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSGlobalTests/Generated/JavaScript/BridgeJS.json
@@ -406,7 +406,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-
+                "_0" : "GlobalStaticPropertyNamespace"
               }
             },
             "type" : {
@@ -424,7 +424,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-
+                "_0" : "GlobalStaticPropertyNamespace"
               }
             },
             "type" : {
@@ -460,7 +460,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-
+                "_0" : "GlobalStaticPropertyNamespace.NestedProperties"
               }
             },
             "type" : {
@@ -479,7 +479,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-
+                "_0" : "GlobalStaticPropertyNamespace.NestedProperties"
               }
             },
             "type" : {
@@ -498,7 +498,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-
+                "_0" : "GlobalStaticPropertyNamespace.NestedProperties"
               }
             },
             "type" : {

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -295,6 +295,16 @@ struct TestError: Error {
             return String(value)
         }
     }
+
+    @JS enum StringUtils {
+        @JS static func uppercase(_ text: String) -> String {
+            return text.uppercased()
+        }
+
+        @JS static func lowercase(_ text: String) -> String {
+            return text.lowercased()
+        }
+    }
 }
 
 @JS enum Networking {
@@ -785,6 +795,17 @@ enum APIOptionalResult {
         @JS static func roundtrip(_ value: String) -> String {
             return value
         }
+    }
+}
+
+@JS(namespace: "Services.Graph")
+enum GraphOperations {
+    @JS static func createGraph(rootId: Int) -> Int {
+        return rootId * 10
+    }
+
+    @JS static func nodeCount(graphId: Int) -> Int {
+        return graphId
     }
 }
 

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -1350,6 +1350,28 @@ extension TSDirection: _BridgedSwiftCaseEnum {
 extension TSTheme: _BridgedSwiftEnumNoPayload {
 }
 
+@_expose(wasm, "bjs_Utils_StringUtils_static_uppercase")
+@_cdecl("bjs_Utils_StringUtils_static_uppercase")
+public func _bjs_Utils_StringUtils_static_uppercase(_ textBytes: Int32, _ textLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = Utils.StringUtils.uppercase(_: String.bridgeJSLiftParameter(textBytes, textLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_Utils_StringUtils_static_lowercase")
+@_cdecl("bjs_Utils_StringUtils_static_lowercase")
+public func _bjs_Utils_StringUtils_static_lowercase(_ textBytes: Int32, _ textLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = Utils.StringUtils.lowercase(_: String.bridgeJSLiftParameter(textBytes, textLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 extension Networking.API.Method: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
@@ -1986,6 +2008,28 @@ public func _bjs_StaticCalculator_static_roundtrip(_ value: Int32) -> Int32 {
 public func _bjs_StaticUtils_Nested_static_roundtrip(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = StaticUtils.Nested.roundtrip(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_createGraph")
+@_cdecl("bjs_Services_Graph_GraphOperations_static_createGraph")
+public func _bjs_Services_Graph_GraphOperations_static_createGraph(_ rootId: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = GraphOperations.createGraph(rootId: Int.bridgeJSLiftParameter(rootId))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_nodeCount")
+@_cdecl("bjs_Services_Graph_GraphOperations_static_nodeCount")
+public func _bjs_Services_Graph_GraphOperations_static_nodeCount(_ graphId: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = GraphOperations.nodeCount(graphId: Int.bridgeJSLiftParameter(graphId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -3502,6 +3502,91 @@
 
         ],
         "emitStyle" : "const",
+        "name" : "StringUtils",
+        "namespace" : [
+          "Utils"
+        ],
+        "staticMethods" : [
+          {
+            "abiName" : "bjs_Utils_StringUtils_static_uppercase",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "uppercase",
+            "namespace" : [
+              "Utils",
+              "StringUtils"
+            ],
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "text",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            },
+            "staticContext" : {
+              "namespaceEnum" : {
+                "_0" : "Utils.StringUtils"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_Utils_StringUtils_static_lowercase",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "lowercase",
+            "namespace" : [
+              "Utils",
+              "StringUtils"
+            ],
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "text",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            },
+            "staticContext" : {
+              "namespaceEnum" : {
+                "_0" : "Utils.StringUtils"
+              }
+            }
+          }
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "Utils.StringUtils",
+        "tsFullPath" : "Utils.StringUtils"
+      },
+      {
+        "cases" : [
+
+        ],
+        "emitStyle" : "const",
         "name" : "Networking",
         "staticMethods" : [
 
@@ -4356,7 +4441,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-
+                "_0" : "StaticUtils.Nested"
               }
             }
           }
@@ -4366,6 +4451,94 @@
         ],
         "swiftCallName" : "StaticUtils.Nested",
         "tsFullPath" : "StaticUtils.Nested"
+      },
+      {
+        "cases" : [
+
+        ],
+        "emitStyle" : "const",
+        "name" : "GraphOperations",
+        "namespace" : [
+          "Services",
+          "Graph"
+        ],
+        "staticMethods" : [
+          {
+            "abiName" : "bjs_Services_Graph_GraphOperations_static_createGraph",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "createGraph",
+            "namespace" : [
+              "Services",
+              "Graph",
+              "GraphOperations"
+            ],
+            "parameters" : [
+              {
+                "label" : "rootId",
+                "name" : "rootId",
+                "type" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "int" : {
+
+              }
+            },
+            "staticContext" : {
+              "namespaceEnum" : {
+                "_0" : "GraphOperations"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_Services_Graph_GraphOperations_static_nodeCount",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "nodeCount",
+            "namespace" : [
+              "Services",
+              "Graph",
+              "GraphOperations"
+            ],
+            "parameters" : [
+              {
+                "label" : "graphId",
+                "name" : "graphId",
+                "type" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "int" : {
+
+              }
+            },
+            "staticContext" : {
+              "namespaceEnum" : {
+                "_0" : "GraphOperations"
+              }
+            }
+          }
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "GraphOperations",
+        "tsFullPath" : "Services.Graph.GraphOperations"
       },
       {
         "cases" : [
@@ -4501,7 +4674,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-
+                "_0" : "StaticPropertyNamespace"
               }
             },
             "type" : {
@@ -4519,7 +4692,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-
+                "_0" : "StaticPropertyNamespace"
               }
             },
             "type" : {
@@ -4555,7 +4728,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-
+                "_0" : "StaticPropertyNamespace.NestedProperties"
               }
             },
             "type" : {
@@ -4574,7 +4747,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-
+                "_0" : "StaticPropertyNamespace.NestedProperties"
               }
             },
             "type" : {
@@ -4593,7 +4766,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-
+                "_0" : "StaticPropertyNamespace.NestedProperties"
               }
             },
             "type" : {

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -527,6 +527,11 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     assert.equal(converter.toString(123), "123");
     converter.release();
 
+    assert.equal(exports.Utils.StringUtils.uppercase("hello"), "HELLO");
+    assert.equal(exports.Utils.StringUtils.uppercase(""), "");
+    assert.equal(exports.Utils.StringUtils.lowercase("WORLD"), "world");
+    assert.equal(exports.Utils.StringUtils.lowercase("HeLLo"), "hello");
+
     const httpServer = new exports.Networking.API.HTTPServer();
     httpServer.call(exports.Networking.API.Method.Get);
     httpServer.call(exports.Networking.API.Method.Post);
@@ -716,6 +721,11 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     assert.equal(StaticCalculatorValues.Basic, exports.StaticCalculator.Basic);
     assert.equal(exports.StaticUtils.Nested.roundtrip("hello world"), "hello world");
     assert.equal(exports.StaticUtils.Nested.roundtrip("test"), "test");
+
+    assert.equal(exports.Services.Graph.GraphOperations.createGraph(5), 50);
+    assert.equal(exports.Services.Graph.GraphOperations.createGraph(0), 0);
+    assert.equal(exports.Services.Graph.GraphOperations.nodeCount(42), 42);
+    assert.equal(exports.Services.Graph.GraphOperations.nodeCount(0), 0);
 
     // Test default parameters
     assert.equal(exports.testStringDefault(), "Hello World");


### PR DESCRIPTION
## Overview
Fixes a bug where namespace enums with explicit `@JS(namespace:)` attribute generated incorrect Swift code that failed to compile.

## Issue

When using `@JS(namespace: "Services.Graph")` on a namespace enum:

```swift
@JS(namespace: "Services.Graph")
enum GraphOperations {
    @JS static func createGraph(rootId: Int) -> Int {
        return rootId * 10
    }
}
```

The generated Swift code incorrectly used the JavaScript namespace path as the Swift call path:

```swift
let ret = Services.Graph.GraphOperations.createGraph(rootId: ...)
//        ^^^^^^^^^^^^^^ - doesn't exist in Swift!
```

## Fix

Changed `StaticContext.namespaceEnum` to carry the actual Swift type name (`swiftCallName`) instead of relying on the JavaScript namespace path.

Now generates correct Swift code:
```swift
let ret = GraphOperations.createGraph(rootId: ...)
```

The JavaScript namespace organization is preserved separately and doesn't affect the Swift call site.

## Testing
- Added snapshot tests for namespace enum with `@JS(namespace:)` attribute
- Added E2E tests for `Services.Graph.GraphOperations` namespace
- Added tests for nested namespace enums (`Utils.StringUtils`) which was missing