### PR TITLE
BridgeJS: Enforce throws(JSException) on @JS protocol methods

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -1346,7 +1346,7 @@ struct ProtocolCodegen {
             let builder = ImportTS.CallJSEmission(
                 moduleName: moduleName,
                 abiName: "_extern_\(method.name)",
-                context: .exportSwift
+                context: .exportSwiftProtocol
             )
             try builder.lowerParameter(param: Parameter(label: nil, name: "jsObject", type: .jsObject(nil)))
             for param in method.parameters {
@@ -1359,7 +1359,7 @@ struct ProtocolCodegen {
             let signature = SwiftSignatureBuilder.buildFunctionSignature(
                 parameters: method.parameters,
                 returnType: method.returnType,
-                effects: nil
+                effects: method.effects
             )
 
             // Build extern declaration using helper function

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -187,8 +187,8 @@ public struct ImportTS {
                 body.append("let ret = \(raw: callExpr)")
             }
 
-            // Add exception check for ImportTS context
-            if context == .importTS {
+            // Add exception check for contexts that call INTO JavaScript
+            if context == .importTS || context == .exportSwiftProtocol {
                 body.append("if let error = _swift_js_take_exception() { throw error }")
             }
         }
@@ -887,7 +887,7 @@ extension BridgeType {
                     Swift classes can only be used in @JS protocols where Swift owns the instance.
                     """
                 )
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return LoweringParameterInfo(loweredParameters: [("pointer", .pointer)])
             }
         case .swiftProtocol:
@@ -896,14 +896,14 @@ extension BridgeType {
             switch context {
             case .importTS:
                 throw BridgeJSCoreError("Enum types are not yet supported in TypeScript imports")
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return LoweringParameterInfo(loweredParameters: [("value", .i32)])
             }
         case .rawValueEnum(_, let rawType):
             switch context {
             case .importTS:
                 return LoweringParameterInfo(loweredParameters: [("value", rawType.wasmCoreType ?? .i32)])
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 // For protocol export we return .i32 for String raw value type instead of nil
                 return LoweringParameterInfo(loweredParameters: [("value", rawType.wasmCoreType ?? .i32)])
             }
@@ -911,7 +911,7 @@ extension BridgeType {
             switch context {
             case .importTS:
                 throw BridgeJSCoreError("Enum types are not yet supported in TypeScript imports")
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return LoweringParameterInfo(loweredParameters: [("caseId", .i32)])
             }
         case .swiftStruct:
@@ -919,7 +919,7 @@ extension BridgeType {
             case .importTS:
                 // Swift structs are bridged as JS objects (object IDs) in imported signatures.
                 return LoweringParameterInfo(loweredParameters: [("objectId", .i32)])
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return LoweringParameterInfo(loweredParameters: [])
             }
         case .namespaceEnum:
@@ -928,7 +928,7 @@ extension BridgeType {
             switch context {
             case .importTS:
                 throw BridgeJSCoreError("Optional types are not yet supported in TypeScript imports")
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 let wrappedInfo = try wrappedType.loweringParameterInfo(context: context)
                 var params = [("isSome", WasmCoreType.i32)]
                 params.append(contentsOf: wrappedInfo.loweredParameters)
@@ -938,7 +938,7 @@ extension BridgeType {
             switch context {
             case .importTS:
                 throw BridgeJSCoreError("Array types are not yet supported in TypeScript imports")
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return LoweringParameterInfo(loweredParameters: [])
             }
         }
@@ -981,7 +981,7 @@ extension BridgeType {
                     JavaScript cannot create Swift heap objects.
                     """
                 )
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return LiftingReturnInfo(valueToLift: .pointer)
             }
         case .swiftProtocol:
@@ -990,14 +990,14 @@ extension BridgeType {
             switch context {
             case .importTS:
                 throw BridgeJSCoreError("Enum types are not yet supported in TypeScript imports")
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return LiftingReturnInfo(valueToLift: .i32)
             }
         case .rawValueEnum(_, let rawType):
             switch context {
             case .importTS:
                 return LiftingReturnInfo(valueToLift: rawType.wasmCoreType ?? .i32)
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 // For protocol export we return .i32 for String raw value type instead of nil
                 return LiftingReturnInfo(valueToLift: rawType.wasmCoreType ?? .i32)
             }
@@ -1005,7 +1005,7 @@ extension BridgeType {
             switch context {
             case .importTS:
                 throw BridgeJSCoreError("Enum types are not yet supported in TypeScript imports")
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return LiftingReturnInfo(valueToLift: .i32)
             }
         case .swiftStruct:
@@ -1013,7 +1013,7 @@ extension BridgeType {
             case .importTS:
                 // Swift structs are bridged as JS objects (object IDs) in imported signatures.
                 return LiftingReturnInfo(valueToLift: .i32)
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return LiftingReturnInfo(valueToLift: nil)
             }
         case .namespaceEnum:
@@ -1022,7 +1022,7 @@ extension BridgeType {
             switch context {
             case .importTS:
                 throw BridgeJSCoreError("Optional types are not yet supported in TypeScript imports")
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 let wrappedInfo = try wrappedType.liftingReturnInfo(context: context)
                 return LiftingReturnInfo(valueToLift: wrappedInfo.valueToLift)
             }
@@ -1030,7 +1030,7 @@ extension BridgeType {
             switch context {
             case .importTS:
                 throw BridgeJSCoreError("Array types are not yet supported in TypeScript imports")
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return LiftingReturnInfo(valueToLift: nil)
             }
         }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -1608,6 +1608,15 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             return nil
         }
 
+        guard effects.isThrows else {
+            diagnose(
+                node: node,
+                message: "@JS protocol methods must be throws.",
+                hint: "Declare the method as 'throws(JSException)'."
+            )
+            return nil
+        }
+
         return ExportedFunction(
             name: name,
             abiName: abiName,

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -1477,7 +1477,7 @@ struct IntrinsicJSFragment: Sendable {
                 throw BridgeJSLinkError(
                     message: "swiftHeapObject '\(name)' can only be used in protocol exports, not in \(context)"
                 )
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return .swiftHeapObjectLiftParameter(name)
             }
         case .swiftProtocol: return .jsObjectLiftParameter
@@ -1491,7 +1491,7 @@ struct IntrinsicJSFragment: Sendable {
                 throw BridgeJSLinkError(
                     message: "Optional types are not supported for imported JS functions: \(wrappedType)"
                 )
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return try .optionalLiftParameter(wrappedType: wrappedType)
             }
         case .caseEnum: return .identity
@@ -1508,7 +1508,7 @@ struct IntrinsicJSFragment: Sendable {
                     message:
                         "Associated value enums are not supported to be passed as parameters to imported JS functions: \(fullName)"
                 )
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 let base = fullName.components(separatedBy: ".").last ?? fullName
                 return IntrinsicJSFragment(
                     parameters: ["caseId"],
@@ -1526,7 +1526,7 @@ struct IntrinsicJSFragment: Sendable {
             switch context {
             case .importTS:
                 return .jsObjectLiftRetainedObjectId
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 let base = fullName.components(separatedBy: ".").last ?? fullName
                 return IntrinsicJSFragment(
                     parameters: [],
@@ -1558,7 +1558,7 @@ struct IntrinsicJSFragment: Sendable {
                 throw BridgeJSLinkError(
                     message: "Arrays are not yet supported to be passed as parameters to imported JS functions"
                 )
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return try arrayLift(elementType: elementType)
             }
         }
@@ -1578,7 +1578,7 @@ struct IntrinsicJSFragment: Sendable {
                 throw BridgeJSLinkError(
                     message: "swiftHeapObject '\(name)' can only be used in protocol exports, not in \(context)"
                 )
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return .swiftHeapObjectLowerReturn
             }
         case .swiftProtocol: return .jsObjectLowerReturn
@@ -1589,7 +1589,7 @@ struct IntrinsicJSFragment: Sendable {
                 throw BridgeJSLinkError(
                     message: "Optional types are not supported for imported JS functions: \(wrappedType)"
                 )
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return try .optionalLowerReturn(wrappedType: wrappedType)
             }
         case .caseEnum: return .identity
@@ -1606,7 +1606,7 @@ struct IntrinsicJSFragment: Sendable {
                     message:
                         "Associated value enums are not supported to be returned from imported JS functions: \(fullName)"
                 )
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return associatedValueLowerReturn(fullName: fullName)
             }
         case .swiftStruct(let fullName):
@@ -1614,7 +1614,7 @@ struct IntrinsicJSFragment: Sendable {
             case .importTS:
                 // ImportTS expects Swift structs to come back as a retained JS object ID.
                 return .jsObjectLowerReturn
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return swiftStructLowerReturn(fullName: fullName)
             }
         case .closure:
@@ -1640,7 +1640,7 @@ struct IntrinsicJSFragment: Sendable {
                 throw BridgeJSLinkError(
                     message: "Arrays are not yet supported to be returned from imported JS functions"
                 )
-            case .exportSwift:
+            case .exportSwift, .exportSwiftProtocol:
                 return try arrayLower(elementType: elementType)
             }
         }

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -71,6 +71,7 @@ public struct ABINameGenerator {
 public enum BridgeContext: Sendable {
     case importTS
     case exportSwift
+    case exportSwiftProtocol
 }
 
 public struct ClosureSignature: Codable, Equatable, Hashable, Sendable {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Protocol.swift
@@ -47,18 +47,18 @@ import JavaScriptKit
     var directionOptional: Direction? { get set }
     var priority: Priority { get set }
     var priorityOptional: Priority? { get set }
-    func onSomethingHappened()
-    func onValueChanged(_ value: String)
-    func onCountUpdated(count: Int) -> Bool
-    func onLabelUpdated(_ prefix: String, _ suffix: String)
-    func isCountEven() -> Bool
-    func onHelperUpdated(_ helper: Helper)
-    func createHelper() -> Helper
-    func onOptionalHelperUpdated(_ helper: Helper?)
-    func createOptionalHelper() -> Helper?
-    func createEnum() -> ExampleEnum
-    func handleResult(_ result: Result)
-    func getResult() -> Result
+    func onSomethingHappened() throws(JSException)
+    func onValueChanged(_ value: String) throws(JSException)
+    func onCountUpdated(count: Int) throws(JSException) -> Bool
+    func onLabelUpdated(_ prefix: String, _ suffix: String) throws(JSException)
+    func isCountEven() throws(JSException) -> Bool
+    func onHelperUpdated(_ helper: Helper) throws(JSException)
+    func createHelper() throws(JSException) -> Helper
+    func onOptionalHelperUpdated(_ helper: Helper?) throws(JSException)
+    func createOptionalHelper() throws(JSException) -> Helper?
+    func createEnum() throws(JSException) -> ExampleEnum
+    func handleResult(_ result: Result) throws(JSException)
+    func getResult() throws(JSException) -> Result
 }
 
 @JS class MyViewController {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.json
@@ -499,7 +499,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "onSomethingHappened",
             "parameters" : [
@@ -516,7 +516,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "onValueChanged",
             "parameters" : [
@@ -541,7 +541,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "onCountUpdated",
             "parameters" : [
@@ -566,7 +566,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "onLabelUpdated",
             "parameters" : [
@@ -600,7 +600,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "isCountEven",
             "parameters" : [
@@ -617,7 +617,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "onHelperUpdated",
             "parameters" : [
@@ -642,7 +642,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "createHelper",
             "parameters" : [
@@ -659,7 +659,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "onOptionalHelperUpdated",
             "parameters" : [
@@ -688,7 +688,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "createOptionalHelper",
             "parameters" : [
@@ -709,7 +709,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "createEnum",
             "parameters" : [
@@ -727,7 +727,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "handleResult",
             "parameters" : [
@@ -752,7 +752,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getResult",
             "parameters" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
@@ -1,76 +1,112 @@
 struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProtocolWrapper {
     let jsObject: JSObject
 
-    func onSomethingHappened() -> Void {
+    func onSomethingHappened() throws(JSException) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         _extern_onSomethingHappened(jsObjectValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
     }
 
-    func onValueChanged(_ value: String) -> Void {
+    func onValueChanged(_ value: String) throws(JSException) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let valueValue = value.bridgeJSLowerParameter()
         _extern_onValueChanged(jsObjectValue, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
     }
 
-    func onCountUpdated(count: Int) -> Bool {
+    func onCountUpdated(count: Int) throws(JSException) -> Bool {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let countValue = count.bridgeJSLowerParameter()
         let ret = _extern_onCountUpdated(jsObjectValue, countValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return Bool.bridgeJSLiftReturn(ret)
     }
 
-    func onLabelUpdated(_ prefix: String, _ suffix: String) -> Void {
+    func onLabelUpdated(_ prefix: String, _ suffix: String) throws(JSException) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let prefixValue = prefix.bridgeJSLowerParameter()
         let suffixValue = suffix.bridgeJSLowerParameter()
         _extern_onLabelUpdated(jsObjectValue, prefixValue, suffixValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
     }
 
-    func isCountEven() -> Bool {
+    func isCountEven() throws(JSException) -> Bool {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_isCountEven(jsObjectValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return Bool.bridgeJSLiftReturn(ret)
     }
 
-    func onHelperUpdated(_ helper: Helper) -> Void {
+    func onHelperUpdated(_ helper: Helper) throws(JSException) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let helperPointer = helper.bridgeJSLowerParameter()
         _extern_onHelperUpdated(jsObjectValue, helperPointer)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
     }
 
-    func createHelper() -> Helper {
+    func createHelper() throws(JSException) -> Helper {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_createHelper(jsObjectValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return Helper.bridgeJSLiftReturn(ret)
     }
 
-    func onOptionalHelperUpdated(_ helper: Optional<Helper>) -> Void {
+    func onOptionalHelperUpdated(_ helper: Optional<Helper>) throws(JSException) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let (helperIsSome, helperPointer) = helper.bridgeJSLowerParameter()
         _extern_onOptionalHelperUpdated(jsObjectValue, helperIsSome, helperPointer)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
     }
 
-    func createOptionalHelper() -> Optional<Helper> {
+    func createOptionalHelper() throws(JSException) -> Optional<Helper> {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_createOptionalHelper(jsObjectValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return Optional<Helper>.bridgeJSLiftReturn(ret)
     }
 
-    func createEnum() -> ExampleEnum {
+    func createEnum() throws(JSException) -> ExampleEnum {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_createEnum(jsObjectValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return ExampleEnum.bridgeJSLiftReturn(ret)
     }
 
-    func handleResult(_ result: Result) -> Void {
+    func handleResult(_ result: Result) throws(JSException) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let resultCaseId = result.bridgeJSLowerParameter()
         _extern_handleResult(jsObjectValue, resultCaseId)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
     }
 
-    func getResult() -> Result {
+    func getResult() throws(JSException) -> Result {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_getResult(jsObjectValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return Result.bridgeJSLiftReturn(ret)
     }
 

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Protocols.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Protocols.md
@@ -15,7 +15,7 @@ When you mark a protocol with `@JS`, BridgeJS generates:
 
 ## Example: Counter Protocol
 
-Mark a Swift protocol with `@JS` to expose it:
+Mark a Swift protocol with `@JS` to expose it. Protocol methods must declare `throws(JSException)` to align with the import side error handling:
 
 ```swift
 import JavaScriptKit
@@ -24,9 +24,9 @@ import JavaScriptKit
     var count: Int { get set }
     var name: String { get }
     var label: String? { get set }
-    func increment(by amount: Int)
-    func reset()
-    func getValue() -> Int
+    func increment(by amount: Int) throws(JSException)
+    func reset() throws(JSException)
+    func getValue() throws(JSException) -> Int
 }
 
 @JS class CounterManager {
@@ -122,24 +122,24 @@ You can also implement protocols in Swift and use them from JavaScript:
 @JS protocol Counter {
     var count: Int { get set }
     var name: String { get }
-    func increment(by amount: Int)
-    func reset()
-    func getValue() -> Int
+    func increment(by amount: Int) throws(JSException)
+    func reset() throws(JSException)
+    func getValue() throws(JSException) -> Int
 }
 
 final class SwiftCounter: Counter {
     var count = 0
     let name = "SwiftCounter"
-    
-    func increment(by amount: Int) {
+
+    func increment(by amount: Int) throws(JSException) {
         count += amount
     }
-    
-    func reset() {
+
+    func reset() throws(JSException) {
         count = 0
     }
-    
-    func getValue() -> Int {
+
+    func getValue() throws(JSException) -> Int {
         return count
     }
 }
@@ -195,7 +195,7 @@ struct AnyCounter: Counter, _BridgedSwiftProtocolWrapper {
         }
     }
 
-    func increment(by amount: Int) {
+    func increment(by amount: Int) throws(JSException) {
         @_extern(wasm, module: "TestModule", name: "bjs_Counter_increment")
         func _extern_increment(this: Int32, amount: Int32)
         _extern_increment(
@@ -212,7 +212,7 @@ struct AnyCounter: Counter, _BridgedSwiftProtocolWrapper {
 
 | Swift Feature | Status |
 |:--------------|:-------|
-| Method requirements: `func foo(_ param: String?) -> FooClass?` | ✅ |
+| Method requirements: `func foo(_ param: String?) throws(JSException) -> FooClass?` | ✅ |
 | Property requirements: `var property: Type { get }` / `var property: Type { get set }` | ✅ |
 | Optional parameters / return values in methods | ✅ |
 | Optional properties | ✅ |

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -988,17 +988,17 @@ enum GraphOperations {
     var apiResult: APIResult? { get set }
     var helper: Greeter { get set }
     var optionalHelper: Greeter? { get set }
-    func increment(by amount: Int)
-    func getValue() -> Int
-    func setLabelElements(_ labelPrefix: String, _ labelSuffix: String)
-    func getLabel() -> String
-    func isEven() -> Bool
-    func processGreeter(_ greeter: Greeter) -> String
-    func createGreeter() -> Greeter
-    func processOptionalGreeter(_ greeter: Greeter?) -> String
-    func createOptionalGreeter() -> Greeter?
-    func handleAPIResult(_ result: APIResult?)
-    func getAPIResult() -> APIResult?
+    func increment(by amount: Int) throws(JSException)
+    func getValue() throws(JSException) -> Int
+    func setLabelElements(_ labelPrefix: String, _ labelSuffix: String) throws(JSException)
+    func getLabel() throws(JSException) -> String
+    func isEven() throws(JSException) -> Bool
+    func processGreeter(_ greeter: Greeter) throws(JSException) -> String
+    func createGreeter() throws(JSException) -> Greeter
+    func processOptionalGreeter(_ greeter: Greeter?) throws(JSException) -> String
+    func createOptionalGreeter() throws(JSException) -> Greeter?
+    func handleAPIResult(_ result: APIResult?) throws(JSException)
+    func getAPIResult() throws(JSException) -> APIResult?
 }
 
 @JS class DataProcessorManager {
@@ -1011,33 +1011,33 @@ enum GraphOperations {
         self.backupProcessor = nil
     }
 
-    @JS func incrementByAmount(_ amount: Int) {
-        processor.increment(by: amount)
+    @JS func incrementByAmount(_ amount: Int) throws(JSException) {
+        try processor.increment(by: amount)
     }
 
-    @JS func setProcessorLabel(_ prefix: String, _ suffix: String) {
-        processor.setLabelElements(prefix, suffix)
+    @JS func setProcessorLabel(_ prefix: String, _ suffix: String) throws(JSException) {
+        try processor.setLabelElements(prefix, suffix)
     }
 
-    @JS func isProcessorEven() -> Bool {
-        return processor.isEven()
+    @JS func isProcessorEven() throws(JSException) -> Bool {
+        return try processor.isEven()
     }
 
-    @JS func getProcessorLabel() -> String {
-        return processor.getLabel()
+    @JS func getProcessorLabel() throws(JSException) -> String {
+        return try processor.getLabel()
     }
 
-    @JS func getCurrentValue() -> Int {
-        return processor.getValue()
+    @JS func getCurrentValue() throws(JSException) -> Int {
+        return try processor.getValue()
     }
 
-    @JS func incrementBoth() {
-        processor.increment(by: 1)
-        backupProcessor?.increment(by: 1)
+    @JS func incrementBoth() throws(JSException) {
+        try processor.increment(by: 1)
+        try backupProcessor?.increment(by: 1)
     }
 
-    @JS func getBackupValue() -> Int? {
-        return backupProcessor?.getValue()
+    @JS func getBackupValue() throws(JSException) -> Int? {
+        return try backupProcessor?.getValue()
     }
 
     @JS func hasBackup() -> Bool {
@@ -1084,12 +1084,12 @@ enum GraphOperations {
         processor.httpStatus = status
     }
 
-    @JS func getProcessorAPIResult() -> APIResult? {
-        return processor.getAPIResult()
+    @JS func getProcessorAPIResult() throws(JSException) -> APIResult? {
+        return try processor.getAPIResult()
     }
 
-    @JS func setProcessorAPIResult(_ apiResult: APIResult?) {
-        processor.handleAPIResult(apiResult)
+    @JS func setProcessorAPIResult(_ apiResult: APIResult?) throws(JSException) {
+        try processor.handleAPIResult(apiResult)
     }
 }
 

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -921,72 +921,105 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_S
 struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
     let jsObject: JSObject
 
-    func increment(by amount: Int) -> Void {
+    func increment(by amount: Int) throws(JSException) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let amountValue = amount.bridgeJSLowerParameter()
         _extern_increment(jsObjectValue, amountValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
     }
 
-    func getValue() -> Int {
+    func getValue() throws(JSException) -> Int {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_getValue(jsObjectValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return Int.bridgeJSLiftReturn(ret)
     }
 
-    func setLabelElements(_ labelPrefix: String, _ labelSuffix: String) -> Void {
+    func setLabelElements(_ labelPrefix: String, _ labelSuffix: String) throws(JSException) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let labelPrefixValue = labelPrefix.bridgeJSLowerParameter()
         let labelSuffixValue = labelSuffix.bridgeJSLowerParameter()
         _extern_setLabelElements(jsObjectValue, labelPrefixValue, labelSuffixValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
     }
 
-    func getLabel() -> String {
+    func getLabel() throws(JSException) -> String {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_getLabel(jsObjectValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return String.bridgeJSLiftReturn(ret)
     }
 
-    func isEven() -> Bool {
+    func isEven() throws(JSException) -> Bool {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_isEven(jsObjectValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return Bool.bridgeJSLiftReturn(ret)
     }
 
-    func processGreeter(_ greeter: Greeter) -> String {
+    func processGreeter(_ greeter: Greeter) throws(JSException) -> String {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let greeterPointer = greeter.bridgeJSLowerParameter()
         let ret = _extern_processGreeter(jsObjectValue, greeterPointer)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return String.bridgeJSLiftReturn(ret)
     }
 
-    func createGreeter() -> Greeter {
+    func createGreeter() throws(JSException) -> Greeter {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_createGreeter(jsObjectValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return Greeter.bridgeJSLiftReturn(ret)
     }
 
-    func processOptionalGreeter(_ greeter: Optional<Greeter>) -> String {
+    func processOptionalGreeter(_ greeter: Optional<Greeter>) throws(JSException) -> String {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let (greeterIsSome, greeterPointer) = greeter.bridgeJSLowerParameter()
         let ret = _extern_processOptionalGreeter(jsObjectValue, greeterIsSome, greeterPointer)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return String.bridgeJSLiftReturn(ret)
     }
 
-    func createOptionalGreeter() -> Optional<Greeter> {
+    func createOptionalGreeter() throws(JSException) -> Optional<Greeter> {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_createOptionalGreeter(jsObjectValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return Optional<Greeter>.bridgeJSLiftReturn(ret)
     }
 
-    func handleAPIResult(_ result: Optional<APIResult>) -> Void {
+    func handleAPIResult(_ result: Optional<APIResult>) throws(JSException) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let (resultIsSome, resultCaseId) = result.bridgeJSLowerParameter()
         _extern_handleAPIResult(jsObjectValue, resultIsSome, resultCaseId)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
     }
 
-    func getAPIResult() -> Optional<APIResult> {
+    func getAPIResult() throws(JSException) -> Optional<APIResult> {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_getAPIResult(jsObjectValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
         return Optional<APIResult>.bridgeJSLiftReturn(ret)
     }
 
@@ -6559,7 +6592,21 @@ public func _bjs_DataProcessorManager_init(_ processor: Int32) -> UnsafeMutableR
 @_cdecl("bjs_DataProcessorManager_incrementByAmount")
 public func _bjs_DataProcessorManager_incrementByAmount(_ _self: UnsafeMutableRawPointer, _ amount: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).incrementByAmount(_: Int.bridgeJSLiftParameter(amount))
+    do {
+        try DataProcessorManager.bridgeJSLiftParameter(_self).incrementByAmount(_: Int.bridgeJSLiftParameter(amount))
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6569,7 +6616,21 @@ public func _bjs_DataProcessorManager_incrementByAmount(_ _self: UnsafeMutableRa
 @_cdecl("bjs_DataProcessorManager_setProcessorLabel")
 public func _bjs_DataProcessorManager_setProcessorLabel(_ _self: UnsafeMutableRawPointer, _ prefixBytes: Int32, _ prefixLength: Int32, _ suffixBytes: Int32, _ suffixLength: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorLabel(_: String.bridgeJSLiftParameter(prefixBytes, prefixLength), _: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
+    do {
+        try DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorLabel(_: String.bridgeJSLiftParameter(prefixBytes, prefixLength), _: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6579,8 +6640,22 @@ public func _bjs_DataProcessorManager_setProcessorLabel(_ _self: UnsafeMutableRa
 @_cdecl("bjs_DataProcessorManager_isProcessorEven")
 public func _bjs_DataProcessorManager_isProcessorEven(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).isProcessorEven()
-    return ret.bridgeJSLowerReturn()
+    do {
+        let ret = try DataProcessorManager.bridgeJSLiftParameter(_self).isProcessorEven()
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6590,8 +6665,22 @@ public func _bjs_DataProcessorManager_isProcessorEven(_ _self: UnsafeMutableRawP
 @_cdecl("bjs_DataProcessorManager_getProcessorLabel")
 public func _bjs_DataProcessorManager_getProcessorLabel(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorLabel()
-    return ret.bridgeJSLowerReturn()
+    do {
+        let ret = try DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorLabel()
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6601,8 +6690,22 @@ public func _bjs_DataProcessorManager_getProcessorLabel(_ _self: UnsafeMutableRa
 @_cdecl("bjs_DataProcessorManager_getCurrentValue")
 public func _bjs_DataProcessorManager_getCurrentValue(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getCurrentValue()
-    return ret.bridgeJSLowerReturn()
+    do {
+        let ret = try DataProcessorManager.bridgeJSLiftParameter(_self).getCurrentValue()
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6612,7 +6715,21 @@ public func _bjs_DataProcessorManager_getCurrentValue(_ _self: UnsafeMutableRawP
 @_cdecl("bjs_DataProcessorManager_incrementBoth")
 public func _bjs_DataProcessorManager_incrementBoth(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).incrementBoth()
+    do {
+        try DataProcessorManager.bridgeJSLiftParameter(_self).incrementBoth()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6622,8 +6739,22 @@ public func _bjs_DataProcessorManager_incrementBoth(_ _self: UnsafeMutableRawPoi
 @_cdecl("bjs_DataProcessorManager_getBackupValue")
 public func _bjs_DataProcessorManager_getBackupValue(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getBackupValue()
-    return ret.bridgeJSLowerReturn()
+    do {
+        let ret = try DataProcessorManager.bridgeJSLiftParameter(_self).getBackupValue()
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6749,8 +6880,22 @@ public func _bjs_DataProcessorManager_setProcessorHttpStatus(_ _self: UnsafeMuta
 @_cdecl("bjs_DataProcessorManager_getProcessorAPIResult")
 public func _bjs_DataProcessorManager_getProcessorAPIResult(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorAPIResult()
-    return ret.bridgeJSLowerReturn()
+    do {
+        let ret = try DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorAPIResult()
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6760,7 +6905,21 @@ public func _bjs_DataProcessorManager_getProcessorAPIResult(_ _self: UnsafeMutab
 @_cdecl("bjs_DataProcessorManager_setProcessorAPIResult")
 public func _bjs_DataProcessorManager_setProcessorAPIResult(_ _self: UnsafeMutableRawPointer, _ apiResultIsSome: Int32, _ apiResultCaseId: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorAPIResult(_: Optional<APIResult>.bridgeJSLiftParameter(apiResultIsSome, apiResultCaseId))
+    do {
+        try DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorAPIResult(_: Optional<APIResult>.bridgeJSLiftParameter(apiResultIsSome, apiResultCaseId))
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -1365,7 +1365,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "incrementByAmount",
             "parameters" : [
@@ -1390,7 +1390,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "setProcessorLabel",
             "parameters" : [
@@ -1424,7 +1424,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "isProcessorEven",
             "parameters" : [
@@ -1441,7 +1441,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getProcessorLabel",
             "parameters" : [
@@ -1458,7 +1458,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getCurrentValue",
             "parameters" : [
@@ -1475,7 +1475,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "incrementBoth",
             "parameters" : [
@@ -1492,7 +1492,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getBackupValue",
             "parameters" : [
@@ -1784,7 +1784,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getProcessorAPIResult",
             "parameters" : [
@@ -1805,7 +1805,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "setProcessorAPIResult",
             "parameters" : [
@@ -9844,7 +9844,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "increment",
             "parameters" : [
@@ -9869,7 +9869,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getValue",
             "parameters" : [
@@ -9886,7 +9886,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "setLabelElements",
             "parameters" : [
@@ -9920,7 +9920,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getLabel",
             "parameters" : [
@@ -9937,7 +9937,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "isEven",
             "parameters" : [
@@ -9954,7 +9954,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "processGreeter",
             "parameters" : [
@@ -9979,7 +9979,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "createGreeter",
             "parameters" : [
@@ -9996,7 +9996,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "processOptionalGreeter",
             "parameters" : [
@@ -10025,7 +10025,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "createOptionalGreeter",
             "parameters" : [
@@ -10046,7 +10046,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "handleAPIResult",
             "parameters" : [
@@ -10075,7 +10075,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getAPIResult",
             "parameters" : [


### PR DESCRIPTION
## Overview
- Require `throws(JSException)` on `@JS protocol` methods, matching the import side (`@JSFunction`) behavior
- Fix generated protocol wrapper code to propagate throws effect
- Updated tests and documentation

### Test updates

- `Protocol.swift` test input: Added `throws(JSException)` to all protocol methods
- `ExportAPITests.swift`: Updated `DataProcessor` protocol methods with throws
- Regenerated snapshots

### Documentation

- Updated `Exporting-Swift-Protocols.md` with throws requirement and examples

## Motivation
This partially addresses [the inconsistency](https://github.com/swiftwasm/JavaScriptKit/pull/560#issuecomment-3840061515) where `@JSFunction` (import side) requires `throws(JSException)` but `@JS protocol` methods (export side) didn't. 

Properties will be covered in separate PR 🙏🏻 