### PR TITLE
BridgeJS:  Enforce throws(JSException) for @JS protocol properties

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ClosureCodegen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ClosureCodegen.swift
@@ -61,6 +61,11 @@ public struct ClosureCodegen {
 
         // Generate the call and return value lifting
         try builder.call(returnType: signature.returnType)
+
+        if signature.isThrows {
+            builder.body.append("if let error = _swift_js_take_exception() { throw error }")
+        }
+
         try builder.liftReturnValue(returnType: signature.returnType)
 
         // Get the body code

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -406,15 +406,18 @@ public struct ExportedProtocolProperty: Codable, Equatable, Sendable {
     public let name: String
     public let type: BridgeType
     public let isReadonly: Bool
+    public let effects: Effects
 
     public init(
         name: String,
         type: BridgeType,
-        isReadonly: Bool
+        isReadonly: Bool,
+        effects: Effects
     ) {
         self.name = name
         self.type = type
         self.isReadonly = isReadonly
+        self.effects = effects
     }
 }
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Protocol.swift
@@ -36,17 +36,27 @@ import JavaScriptKit
 }
 
 @JS protocol MyViewControllerDelegate {
-    var eventCount: Int { get set }
-    var delegateName: String { get }
-    var optionalName: String? { get set }
-    var optionalRawEnum: ExampleEnum? { get set }
-    var rawStringEnum: ExampleEnum { get set }
-    var result: Result { get set }
-    var optionalResult: Result? { get set }
-    var direction: Direction { get set }
-    var directionOptional: Direction? { get set }
-    var priority: Priority { get set }
-    var priorityOptional: Priority? { get set }
+    var eventCount: Int { get throws(JSException) }
+    var delegateName: String { get throws(JSException) }
+    var optionalName: String? { get throws(JSException) }
+    var optionalRawEnum: ExampleEnum? { get throws(JSException) }
+    var rawStringEnum: ExampleEnum { get throws(JSException) }
+    var result: Result { get throws(JSException) }
+    var optionalResult: Result? { get throws(JSException) }
+    var direction: Direction { get throws(JSException) }
+    var directionOptional: Direction? { get throws(JSException) }
+    var priority: Priority { get throws(JSException) }
+    var priorityOptional: Priority? { get throws(JSException) }
+    func setEventCount(_ value: Int) throws(JSException)
+    func setOptionalName(_ value: String?) throws(JSException)
+    func setOptionalRawEnum(_ value: ExampleEnum?) throws(JSException)
+    func setRawStringEnum(_ value: ExampleEnum) throws(JSException)
+    func setResult(_ value: Result) throws(JSException)
+    func setOptionalResult(_ value: Result?) throws(JSException)
+    func setDirection(_ value: Direction) throws(JSException)
+    func setDirectionOptional(_ value: Direction?) throws(JSException)
+    func setPriority(_ value: Priority) throws(JSException)
+    func setPriorityOptional(_ value: Priority?) throws(JSException)
     func onSomethingHappened() throws(JSException)
     func onValueChanged(_ value: String) throws(JSException)
     func onCountUpdated(count: Int) throws(JSException) -> Bool

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.json
@@ -495,6 +495,280 @@
       {
         "methods" : [
           {
+            "abiName" : "bjs_MyViewControllerDelegate_setEventCount",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setEventCount",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_MyViewControllerDelegate_setOptionalName",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setOptionalName",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_MyViewControllerDelegate_setOptionalRawEnum",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setOptionalRawEnum",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "rawValueEnum" : {
+                        "_0" : "ExampleEnum",
+                        "_1" : "String"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_MyViewControllerDelegate_setRawStringEnum",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setRawStringEnum",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "rawValueEnum" : {
+                    "_0" : "ExampleEnum",
+                    "_1" : "String"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_MyViewControllerDelegate_setResult",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setResult",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "associatedValueEnum" : {
+                    "_0" : "Result"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_MyViewControllerDelegate_setOptionalResult",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setOptionalResult",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "associatedValueEnum" : {
+                        "_0" : "Result"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_MyViewControllerDelegate_setDirection",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setDirection",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "caseEnum" : {
+                    "_0" : "Direction"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_MyViewControllerDelegate_setDirectionOptional",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setDirectionOptional",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "caseEnum" : {
+                        "_0" : "Direction"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_MyViewControllerDelegate_setPriority",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setPriority",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "rawValueEnum" : {
+                    "_0" : "Priority",
+                    "_1" : "Int"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_MyViewControllerDelegate_setPriorityOptional",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setPriorityOptional",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "rawValueEnum" : {
+                        "_0" : "Priority",
+                        "_1" : "Int"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
             "abiName" : "bjs_MyViewControllerDelegate_onSomethingHappened",
             "effects" : {
               "isAsync" : false,
@@ -768,7 +1042,12 @@
         "name" : "MyViewControllerDelegate",
         "properties" : [
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "eventCount",
             "type" : {
               "int" : {
@@ -777,6 +1056,11 @@
             }
           },
           {
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
             "isReadonly" : true,
             "name" : "delegateName",
             "type" : {
@@ -786,7 +1070,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "optionalName",
             "type" : {
               "optional" : {
@@ -799,7 +1088,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "optionalRawEnum",
             "type" : {
               "optional" : {
@@ -813,7 +1107,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "rawStringEnum",
             "type" : {
               "rawValueEnum" : {
@@ -823,7 +1122,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
@@ -832,7 +1136,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "optionalResult",
             "type" : {
               "optional" : {
@@ -845,7 +1154,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "direction",
             "type" : {
               "caseEnum" : {
@@ -854,7 +1168,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "directionOptional",
             "type" : {
               "optional" : {
@@ -867,7 +1186,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "priority",
             "type" : {
               "rawValueEnum" : {
@@ -877,7 +1201,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "priorityOptional",
             "type" : {
               "optional" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
@@ -1,6 +1,96 @@
 struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProtocolWrapper {
     let jsObject: JSObject
 
+    func setEventCount(_ value: Int) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let valueValue = value.bridgeJSLowerParameter()
+        _extern_setEventCount(jsObjectValue, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setOptionalName(_ value: Optional<String>) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+        _extern_setOptionalName(jsObjectValue, valueIsSome, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setOptionalRawEnum(_ value: Optional<ExampleEnum>) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+        _extern_setOptionalRawEnum(jsObjectValue, valueIsSome, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setRawStringEnum(_ value: ExampleEnum) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let valueValue = value.bridgeJSLowerParameter()
+        _extern_setRawStringEnum(jsObjectValue, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setResult(_ value: Result) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let valueCaseId = value.bridgeJSLowerParameter()
+        _extern_setResult(jsObjectValue, valueCaseId)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setOptionalResult(_ value: Optional<Result>) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let (valueIsSome, valueCaseId) = value.bridgeJSLowerParameter()
+        _extern_setOptionalResult(jsObjectValue, valueIsSome, valueCaseId)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setDirection(_ value: Direction) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let valueValue = value.bridgeJSLowerParameter()
+        _extern_setDirection(jsObjectValue, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setDirectionOptional(_ value: Optional<Direction>) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+        _extern_setDirectionOptional(jsObjectValue, valueIsSome, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setPriority(_ value: Priority) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let valueValue = value.bridgeJSLowerParameter()
+        _extern_setPriority(jsObjectValue, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setPriorityOptional(_ value: Optional<Priority>) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+        _extern_setPriorityOptional(jsObjectValue, valueIsSome, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
     func onSomethingHappened() throws(JSException) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         _extern_onSomethingHappened(jsObjectValue)
@@ -111,140 +201,123 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
     }
 
     var eventCount: Int {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_eventCount_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Int.bridgeJSLiftReturn(ret)
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let newValueValue = newValue.bridgeJSLowerParameter()
-            bjs_MyViewControllerDelegate_eventCount_set(jsObjectValue, newValueValue)
         }
     }
 
     var delegateName: String {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_delegateName_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return String.bridgeJSLiftReturn(ret)
         }
     }
 
     var optionalName: Optional<String> {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_MyViewControllerDelegate_optionalName_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Optional<String>.bridgeJSLiftReturnFromSideChannel()
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
-            bjs_MyViewControllerDelegate_optionalName_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
 
     var optionalRawEnum: Optional<ExampleEnum> {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_MyViewControllerDelegate_optionalRawEnum_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Optional<ExampleEnum>.bridgeJSLiftReturnFromSideChannel()
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
-            bjs_MyViewControllerDelegate_optionalRawEnum_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
 
     var rawStringEnum: ExampleEnum {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_rawStringEnum_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return ExampleEnum.bridgeJSLiftReturn(ret)
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let newValueValue = newValue.bridgeJSLowerParameter()
-            bjs_MyViewControllerDelegate_rawStringEnum_set(jsObjectValue, newValueValue)
         }
     }
 
     var result: Result {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_result_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Result.bridgeJSLiftReturn(ret)
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let newValueCaseId = newValue.bridgeJSLowerParameter()
-            bjs_MyViewControllerDelegate_result_set(jsObjectValue, newValueCaseId)
         }
     }
 
     var optionalResult: Optional<Result> {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_optionalResult_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Optional<Result>.bridgeJSLiftReturn(ret)
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let (newValueIsSome, newValueCaseId) = newValue.bridgeJSLowerParameter()
-            bjs_MyViewControllerDelegate_optionalResult_set(jsObjectValue, newValueIsSome, newValueCaseId)
         }
     }
 
     var direction: Direction {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_direction_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Direction.bridgeJSLiftReturn(ret)
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let newValueValue = newValue.bridgeJSLowerParameter()
-            bjs_MyViewControllerDelegate_direction_set(jsObjectValue, newValueValue)
         }
     }
 
     var directionOptional: Optional<Direction> {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_directionOptional_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Optional<Direction>.bridgeJSLiftReturn(ret)
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
-            bjs_MyViewControllerDelegate_directionOptional_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
 
     var priority: Priority {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_priority_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Priority.bridgeJSLiftReturn(ret)
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let newValueValue = newValue.bridgeJSLowerParameter()
-            bjs_MyViewControllerDelegate_priority_set(jsObjectValue, newValueValue)
         }
     }
 
     var priorityOptional: Optional<Priority> {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_MyViewControllerDelegate_priorityOptional_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Optional<Priority>.bridgeJSLiftReturnFromSideChannel()
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
-            bjs_MyViewControllerDelegate_priorityOptional_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
 
@@ -252,6 +325,36 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
         return AnyMyViewControllerDelegate(jsObject: JSObject(id: UInt32(bitPattern: value)))
     }
 }
+
+@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_setEventCount")
+fileprivate func _extern_setEventCount(_ jsObject: Int32, _ value: Int32) -> Void
+
+@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_setOptionalName")
+fileprivate func _extern_setOptionalName(_ jsObject: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+
+@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_setOptionalRawEnum")
+fileprivate func _extern_setOptionalRawEnum(_ jsObject: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+
+@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_setRawStringEnum")
+fileprivate func _extern_setRawStringEnum(_ jsObject: Int32, _ value: Int32) -> Void
+
+@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_setResult")
+fileprivate func _extern_setResult(_ jsObject: Int32, _ value: Int32) -> Void
+
+@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_setOptionalResult")
+fileprivate func _extern_setOptionalResult(_ jsObject: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void
+
+@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_setDirection")
+fileprivate func _extern_setDirection(_ jsObject: Int32, _ value: Int32) -> Void
+
+@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_setDirectionOptional")
+fileprivate func _extern_setDirectionOptional(_ jsObject: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+
+@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_setPriority")
+fileprivate func _extern_setPriority(_ jsObject: Int32, _ value: Int32) -> Void
+
+@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_setPriorityOptional")
+fileprivate func _extern_setPriorityOptional(_ jsObject: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
 
 @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_onSomethingHappened")
 fileprivate func _extern_onSomethingHappened(_ jsObject: Int32) -> Void
@@ -292,65 +395,35 @@ fileprivate func _extern_getResult(_ jsObject: Int32) -> Int32
 @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_eventCount_get")
 fileprivate func bjs_MyViewControllerDelegate_eventCount_get(_ jsObject: Int32) -> Int32
 
-@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_eventCount_set")
-fileprivate func bjs_MyViewControllerDelegate_eventCount_set(_ jsObject: Int32, _ newValue: Int32) -> Void
-
 @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_delegateName_get")
 fileprivate func bjs_MyViewControllerDelegate_delegateName_get(_ jsObject: Int32) -> Int32
 
 @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_optionalName_get")
 fileprivate func bjs_MyViewControllerDelegate_optionalName_get(_ jsObject: Int32) -> Void
 
-@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_optionalName_set")
-fileprivate func bjs_MyViewControllerDelegate_optionalName_set(_ jsObject: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void
-
 @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_optionalRawEnum_get")
 fileprivate func bjs_MyViewControllerDelegate_optionalRawEnum_get(_ jsObject: Int32) -> Void
-
-@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_optionalRawEnum_set")
-fileprivate func bjs_MyViewControllerDelegate_optionalRawEnum_set(_ jsObject: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void
 
 @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_rawStringEnum_get")
 fileprivate func bjs_MyViewControllerDelegate_rawStringEnum_get(_ jsObject: Int32) -> Int32
 
-@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_rawStringEnum_set")
-fileprivate func bjs_MyViewControllerDelegate_rawStringEnum_set(_ jsObject: Int32, _ newValue: Int32) -> Void
-
 @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_result_get")
 fileprivate func bjs_MyViewControllerDelegate_result_get(_ jsObject: Int32) -> Int32
-
-@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_result_set")
-fileprivate func bjs_MyViewControllerDelegate_result_set(_ jsObject: Int32, _ newValue: Int32) -> Void
 
 @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_optionalResult_get")
 fileprivate func bjs_MyViewControllerDelegate_optionalResult_get(_ jsObject: Int32) -> Int32
 
-@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_optionalResult_set")
-fileprivate func bjs_MyViewControllerDelegate_optionalResult_set(_ jsObject: Int32, _ newValueIsSome: Int32, _ newValueCaseId: Int32) -> Void
-
 @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_direction_get")
 fileprivate func bjs_MyViewControllerDelegate_direction_get(_ jsObject: Int32) -> Int32
-
-@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_direction_set")
-fileprivate func bjs_MyViewControllerDelegate_direction_set(_ jsObject: Int32, _ newValue: Int32) -> Void
 
 @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_directionOptional_get")
 fileprivate func bjs_MyViewControllerDelegate_directionOptional_get(_ jsObject: Int32) -> Int32
 
-@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_directionOptional_set")
-fileprivate func bjs_MyViewControllerDelegate_directionOptional_set(_ jsObject: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void
-
 @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_priority_get")
 fileprivate func bjs_MyViewControllerDelegate_priority_get(_ jsObject: Int32) -> Int32
 
-@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_priority_set")
-fileprivate func bjs_MyViewControllerDelegate_priority_set(_ jsObject: Int32, _ newValue: Int32) -> Void
-
 @_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_priorityOptional_get")
 fileprivate func bjs_MyViewControllerDelegate_priorityOptional_get(_ jsObject: Int32) -> Void
-
-@_extern(wasm, module: "TestModule", name: "bjs_MyViewControllerDelegate_priorityOptional_set")
-fileprivate func bjs_MyViewControllerDelegate_priorityOptional_set(_ jsObject: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void
 
 extension Direction: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.d.ts
@@ -5,6 +5,16 @@
 // `swift package bridge-js`.
 
 export interface MyViewControllerDelegate {
+    setEventCount(value: number): void;
+    setOptionalName(value: string | null): void;
+    setOptionalRawEnum(value: ExampleEnumTag | null): void;
+    setRawStringEnum(value: ExampleEnumTag): void;
+    setResult(value: ResultTag): void;
+    setOptionalResult(value: ResultTag | null): void;
+    setDirection(value: DirectionTag): void;
+    setDirectionOptional(value: DirectionTag | null): void;
+    setPriority(value: PriorityTag): void;
+    setPriorityOptional(value: PriorityTag | null): void;
     onSomethingHappened(): void;
     onValueChanged(value: string): void;
     onCountUpdated(count: number): boolean;
@@ -17,17 +27,17 @@ export interface MyViewControllerDelegate {
     createEnum(): ExampleEnumTag;
     handleResult(result: ResultTag): void;
     getResult(): ResultTag;
-    eventCount: number;
+    readonly eventCount: number;
     readonly delegateName: string;
-    optionalName: string | null;
-    optionalRawEnum: ExampleEnumTag | null;
-    rawStringEnum: ExampleEnumTag;
-    result: ResultTag;
-    optionalResult: ResultTag | null;
-    direction: DirectionTag;
-    directionOptional: DirectionTag | null;
-    priority: PriorityTag;
-    priorityOptional: PriorityTag | null;
+    readonly optionalName: string | null;
+    readonly optionalRawEnum: ExampleEnumTag | null;
+    readonly rawStringEnum: ExampleEnumTag;
+    readonly result: ResultTag;
+    readonly optionalResult: ResultTag | null;
+    readonly direction: DirectionTag;
+    readonly directionOptional: DirectionTag | null;
+    readonly priority: PriorityTag;
+    readonly priorityOptional: PriorityTag | null;
 }
 
 export const DirectionValues: {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
@@ -291,13 +291,6 @@ export async function createInstantiator(options, swift) {
                     return 0
                 }
             }
-            TestModule["bjs_MyViewControllerDelegate_eventCount_set"] = function bjs_MyViewControllerDelegate_eventCount_set(self, value) {
-                try {
-                    swift.memory.getObject(self).eventCount = value;
-                } catch (error) {
-                    setException(error);
-                }
-            }
             TestModule["bjs_MyViewControllerDelegate_delegateName_get"] = function bjs_MyViewControllerDelegate_delegateName_get(self) {
                 try {
                     let ret = swift.memory.getObject(self).delegateName;
@@ -315,34 +308,10 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            TestModule["bjs_MyViewControllerDelegate_optionalName_set"] = function bjs_MyViewControllerDelegate_optionalName_set(self, valueIsSome, valueWrappedValue) {
-                try {
-                    let obj;
-                    if (valueIsSome) {
-                        obj = swift.memory.getObject(valueWrappedValue);
-                        swift.memory.release(valueWrappedValue);
-                    }
-                    swift.memory.getObject(self).optionalName = valueIsSome ? obj : null;
-                } catch (error) {
-                    setException(error);
-                }
-            }
             TestModule["bjs_MyViewControllerDelegate_optionalRawEnum_get"] = function bjs_MyViewControllerDelegate_optionalRawEnum_get(self) {
                 try {
                     let ret = swift.memory.getObject(self).optionalRawEnum;
                     tmpRetString = ret;
-                } catch (error) {
-                    setException(error);
-                }
-            }
-            TestModule["bjs_MyViewControllerDelegate_optionalRawEnum_set"] = function bjs_MyViewControllerDelegate_optionalRawEnum_set(self, valueIsSome, valueWrappedValue) {
-                try {
-                    let obj;
-                    if (valueIsSome) {
-                        obj = swift.memory.getObject(valueWrappedValue);
-                        swift.memory.release(valueWrappedValue);
-                    }
-                    swift.memory.getObject(self).optionalRawEnum = valueIsSome ? obj : null;
                 } catch (error) {
                     setException(error);
                 }
@@ -356,28 +325,11 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            TestModule["bjs_MyViewControllerDelegate_rawStringEnum_set"] = function bjs_MyViewControllerDelegate_rawStringEnum_set(self, value) {
-                try {
-                    const valueObject = swift.memory.getObject(value);
-                    swift.memory.release(value);
-                    swift.memory.getObject(self).rawStringEnum = valueObject;
-                } catch (error) {
-                    setException(error);
-                }
-            }
             TestModule["bjs_MyViewControllerDelegate_result_get"] = function bjs_MyViewControllerDelegate_result_get(self) {
                 try {
                     let ret = swift.memory.getObject(self).result;
                     const { caseId: caseId, cleanup: cleanup } = enumHelpers.Result.lower(ret);
                     return caseId;
-                } catch (error) {
-                    setException(error);
-                }
-            }
-            TestModule["bjs_MyViewControllerDelegate_result_set"] = function bjs_MyViewControllerDelegate_result_set(self, value) {
-                try {
-                    const enumValue = enumHelpers.Result.lift(value, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
-                    swift.memory.getObject(self).result = enumValue;
                 } catch (error) {
                     setException(error);
                 }
@@ -396,17 +348,6 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            TestModule["bjs_MyViewControllerDelegate_optionalResult_set"] = function bjs_MyViewControllerDelegate_optionalResult_set(self, valueIsSome, valueWrappedValue) {
-                try {
-                    let enumValue;
-                    if (valueIsSome) {
-                        enumValue = enumHelpers.Result.lift(valueWrappedValue, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
-                    }
-                    swift.memory.getObject(self).optionalResult = valueIsSome ? enumValue : null;
-                } catch (error) {
-                    setException(error);
-                }
-            }
             TestModule["bjs_MyViewControllerDelegate_direction_get"] = function bjs_MyViewControllerDelegate_direction_get(self) {
                 try {
                     let ret = swift.memory.getObject(self).direction;
@@ -416,25 +357,11 @@ export async function createInstantiator(options, swift) {
                     return 0
                 }
             }
-            TestModule["bjs_MyViewControllerDelegate_direction_set"] = function bjs_MyViewControllerDelegate_direction_set(self, value) {
-                try {
-                    swift.memory.getObject(self).direction = value;
-                } catch (error) {
-                    setException(error);
-                }
-            }
             TestModule["bjs_MyViewControllerDelegate_directionOptional_get"] = function bjs_MyViewControllerDelegate_directionOptional_get(self) {
                 try {
                     let ret = swift.memory.getObject(self).directionOptional;
                     const isSome = ret != null;
                     return isSome ? (ret | 0) : -1;
-                } catch (error) {
-                    setException(error);
-                }
-            }
-            TestModule["bjs_MyViewControllerDelegate_directionOptional_set"] = function bjs_MyViewControllerDelegate_directionOptional_set(self, valueIsSome, valueWrappedValue) {
-                try {
-                    swift.memory.getObject(self).directionOptional = valueIsSome ? valueWrappedValue : null;
                 } catch (error) {
                     setException(error);
                 }
@@ -448,13 +375,6 @@ export async function createInstantiator(options, swift) {
                     return 0
                 }
             }
-            TestModule["bjs_MyViewControllerDelegate_priority_set"] = function bjs_MyViewControllerDelegate_priority_set(self, value) {
-                try {
-                    swift.memory.getObject(self).priority = value;
-                } catch (error) {
-                    setException(error);
-                }
-            }
             TestModule["bjs_MyViewControllerDelegate_priorityOptional_get"] = function bjs_MyViewControllerDelegate_priorityOptional_get(self) {
                 try {
                     let ret = swift.memory.getObject(self).priorityOptional;
@@ -463,7 +383,87 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            TestModule["bjs_MyViewControllerDelegate_priorityOptional_set"] = function bjs_MyViewControllerDelegate_priorityOptional_set(self, valueIsSome, valueWrappedValue) {
+            TestModule["bjs_MyViewControllerDelegate_setEventCount"] = function bjs_MyViewControllerDelegate_setEventCount(self, value) {
+                try {
+                    swift.memory.getObject(self).eventCount = value;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_setOptionalName"] = function bjs_MyViewControllerDelegate_setOptionalName(self, valueIsSome, valueWrappedValue) {
+                try {
+                    let obj;
+                    if (valueIsSome) {
+                        obj = swift.memory.getObject(valueWrappedValue);
+                        swift.memory.release(valueWrappedValue);
+                    }
+                    swift.memory.getObject(self).optionalName = valueIsSome ? obj : null;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_setOptionalRawEnum"] = function bjs_MyViewControllerDelegate_setOptionalRawEnum(self, valueIsSome, valueWrappedValue) {
+                try {
+                    let obj;
+                    if (valueIsSome) {
+                        obj = swift.memory.getObject(valueWrappedValue);
+                        swift.memory.release(valueWrappedValue);
+                    }
+                    swift.memory.getObject(self).optionalRawEnum = valueIsSome ? obj : null;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_setRawStringEnum"] = function bjs_MyViewControllerDelegate_setRawStringEnum(self, value) {
+                try {
+                    const valueObject = swift.memory.getObject(value);
+                    swift.memory.release(value);
+                    swift.memory.getObject(self).rawStringEnum = valueObject;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_setResult"] = function bjs_MyViewControllerDelegate_setResult(self, value) {
+                try {
+                    const enumValue = enumHelpers.Result.lift(value, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                    swift.memory.getObject(self).result = enumValue;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_setOptionalResult"] = function bjs_MyViewControllerDelegate_setOptionalResult(self, valueIsSome, valueWrappedValue) {
+                try {
+                    let enumValue;
+                    if (valueIsSome) {
+                        enumValue = enumHelpers.Result.lift(valueWrappedValue, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s);
+                    }
+                    swift.memory.getObject(self).optionalResult = valueIsSome ? enumValue : null;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_setDirection"] = function bjs_MyViewControllerDelegate_setDirection(self, value) {
+                try {
+                    swift.memory.getObject(self).direction = value;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_setDirectionOptional"] = function bjs_MyViewControllerDelegate_setDirectionOptional(self, valueIsSome, valueWrappedValue) {
+                try {
+                    swift.memory.getObject(self).directionOptional = valueIsSome ? valueWrappedValue : null;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_setPriority"] = function bjs_MyViewControllerDelegate_setPriority(self, value) {
+                try {
+                    swift.memory.getObject(self).priority = value;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_MyViewControllerDelegate_setPriorityOptional"] = function bjs_MyViewControllerDelegate_setPriorityOptional(self, valueIsSome, valueWrappedValue) {
                 try {
                     swift.memory.getObject(self).priorityOptional = valueIsSome ? valueWrappedValue : null;
                 } catch (error) {

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -978,16 +978,25 @@ enum GraphOperations {
 // MARK: - Protocol Tests
 
 @JS protocol DataProcessor {
-    var count: Int { get set }
-    var name: String { get }
-    var optionalTag: String? { get set }
-    var optionalCount: Int? { get set }
-    var direction: Direction? { get set }
-    var optionalTheme: Theme? { get set }
-    var httpStatus: HttpStatus? { get set }
-    var apiResult: APIResult? { get set }
-    var helper: Greeter { get set }
-    var optionalHelper: Greeter? { get set }
+    var count: Int { get throws(JSException) }
+    var name: String { get throws(JSException) }
+    var optionalTag: String? { get throws(JSException) }
+    var optionalCount: Int? { get throws(JSException) }
+    var direction: Direction? { get throws(JSException) }
+    var optionalTheme: Theme? { get throws(JSException) }
+    var httpStatus: HttpStatus? { get throws(JSException) }
+    var apiResult: APIResult? { get throws(JSException) }
+    var helper: Greeter { get throws(JSException) }
+    var optionalHelper: Greeter? { get throws(JSException) }
+    func setCount(_ value: Int) throws(JSException)
+    func setOptionalTag(_ value: String?) throws(JSException)
+    func setOptionalCount(_ value: Int?) throws(JSException)
+    func setDirection(_ value: Direction?) throws(JSException)
+    func setOptionalTheme(_ value: Theme?) throws(JSException)
+    func setHttpStatus(_ value: HttpStatus?) throws(JSException)
+    func setApiResult(_ value: APIResult?) throws(JSException)
+    func setHelper(_ value: Greeter) throws(JSException)
+    func setOptionalHelper(_ value: Greeter?) throws(JSException)
     func increment(by amount: Int) throws(JSException)
     func getValue() throws(JSException) -> Int
     func setLabelElements(_ labelPrefix: String, _ labelSuffix: String) throws(JSException)
@@ -1044,44 +1053,44 @@ enum GraphOperations {
         return backupProcessor != nil
     }
 
-    @JS func getProcessorOptionalTag() -> String? {
-        return processor.optionalTag
+    @JS func getProcessorOptionalTag() throws(JSException) -> String? {
+        return try processor.optionalTag
     }
 
-    @JS func setProcessorOptionalTag(_ tag: String?) {
-        processor.optionalTag = tag
+    @JS func setProcessorOptionalTag(_ tag: String?) throws(JSException) {
+        try processor.setOptionalTag(tag)
     }
 
-    @JS func getProcessorOptionalCount() -> Int? {
-        return processor.optionalCount
+    @JS func getProcessorOptionalCount() throws(JSException) -> Int? {
+        return try processor.optionalCount
     }
 
-    @JS func setProcessorOptionalCount(_ count: Int?) {
-        processor.optionalCount = count
+    @JS func setProcessorOptionalCount(_ count: Int?) throws(JSException) {
+        try processor.setOptionalCount(count)
     }
 
-    @JS func getProcessorDirection() -> Direction? {
-        return processor.direction
+    @JS func getProcessorDirection() throws(JSException) -> Direction? {
+        return try processor.direction
     }
 
-    @JS func setProcessorDirection(_ direction: Direction?) {
-        processor.direction = direction
+    @JS func setProcessorDirection(_ direction: Direction?) throws(JSException) {
+        try processor.setDirection(direction)
     }
 
-    @JS func getProcessorTheme() -> Theme? {
-        return processor.optionalTheme
+    @JS func getProcessorTheme() throws(JSException) -> Theme? {
+        return try processor.optionalTheme
     }
 
-    @JS func setProcessorTheme(_ theme: Theme?) {
-        processor.optionalTheme = theme
+    @JS func setProcessorTheme(_ theme: Theme?) throws(JSException) {
+        try processor.setOptionalTheme(theme)
     }
 
-    @JS func getProcessorHttpStatus() -> HttpStatus? {
-        return processor.httpStatus
+    @JS func getProcessorHttpStatus() throws(JSException) -> HttpStatus? {
+        return try processor.httpStatus
     }
 
-    @JS func setProcessorHttpStatus(_ status: HttpStatus?) {
-        processor.httpStatus = status
+    @JS func setProcessorHttpStatus(_ status: HttpStatus?) throws(JSException) {
+        try processor.setHttpStatus(status)
     }
 
     @JS func getProcessorAPIResult() throws(JSException) -> APIResult? {
@@ -1107,6 +1116,42 @@ enum GraphOperations {
     private var label: String = ""
 
     @JS init() {}
+
+    @JS func setCount(_ value: Int) {
+        count = value
+    }
+
+    @JS func setOptionalTag(_ value: String?) {
+        optionalTag = value
+    }
+
+    @JS func setOptionalCount(_ value: Int?) {
+        optionalCount = value
+    }
+
+    @JS func setDirection(_ value: Direction?) {
+        direction = value
+    }
+
+    @JS func setOptionalTheme(_ value: Theme?) {
+        optionalTheme = value
+    }
+
+    @JS func setHttpStatus(_ value: HttpStatus?) {
+        httpStatus = value
+    }
+
+    @JS func setApiResult(_ value: APIResult?) {
+        apiResult = value
+    }
+
+    @JS func setHelper(_ value: Greeter) {
+        helper = value
+    }
+
+    @JS func setOptionalHelper(_ value: Greeter?) {
+        optionalHelper = value
+    }
 
     @JS func increment(by amount: Int) {
         count += amount

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -921,6 +921,87 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_S
 struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
     let jsObject: JSObject
 
+    func setCount(_ value: Int) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let valueValue = value.bridgeJSLowerParameter()
+        _extern_setCount(jsObjectValue, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setOptionalTag(_ value: Optional<String>) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+        _extern_setOptionalTag(jsObjectValue, valueIsSome, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setOptionalCount(_ value: Optional<Int>) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+        _extern_setOptionalCount(jsObjectValue, valueIsSome, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setDirection(_ value: Optional<Direction>) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+        _extern_setDirection(jsObjectValue, valueIsSome, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setOptionalTheme(_ value: Optional<Theme>) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+        _extern_setOptionalTheme(jsObjectValue, valueIsSome, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setHttpStatus(_ value: Optional<HttpStatus>) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+        _extern_setHttpStatus(jsObjectValue, valueIsSome, valueValue)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setApiResult(_ value: Optional<APIResult>) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let (valueIsSome, valueCaseId) = value.bridgeJSLowerParameter()
+        _extern_setApiResult(jsObjectValue, valueIsSome, valueCaseId)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setHelper(_ value: Greeter) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let valuePointer = value.bridgeJSLowerParameter()
+        _extern_setHelper(jsObjectValue, valuePointer)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
+    func setOptionalHelper(_ value: Optional<Greeter>) throws(JSException) -> Void {
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
+        let (valueIsSome, valuePointer) = value.bridgeJSLowerParameter()
+        _extern_setOptionalHelper(jsObjectValue, valueIsSome, valuePointer)
+        if let error = _swift_js_take_exception() {
+            throw error
+        }
+    }
+
     func increment(by amount: Int) throws(JSException) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let amountValue = amount.bridgeJSLowerParameter()
@@ -1024,127 +1105,112 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
     }
 
     var count: Int {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_DataProcessor_count_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Int.bridgeJSLiftReturn(ret)
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let newValueValue = newValue.bridgeJSLowerParameter()
-            bjs_DataProcessor_count_set(jsObjectValue, newValueValue)
         }
     }
 
     var name: String {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_DataProcessor_name_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return String.bridgeJSLiftReturn(ret)
         }
     }
 
     var optionalTag: Optional<String> {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_optionalTag_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Optional<String>.bridgeJSLiftReturnFromSideChannel()
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
-            bjs_DataProcessor_optionalTag_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
 
     var optionalCount: Optional<Int> {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_optionalCount_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Optional<Int>.bridgeJSLiftReturnFromSideChannel()
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
-            bjs_DataProcessor_optionalCount_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
 
     var direction: Optional<Direction> {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_DataProcessor_direction_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Optional<Direction>.bridgeJSLiftReturn(ret)
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
-            bjs_DataProcessor_direction_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
 
     var optionalTheme: Optional<Theme> {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_optionalTheme_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Optional<Theme>.bridgeJSLiftReturnFromSideChannel()
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
-            bjs_DataProcessor_optionalTheme_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
 
     var httpStatus: Optional<HttpStatus> {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_httpStatus_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Optional<HttpStatus>.bridgeJSLiftReturnFromSideChannel()
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
-            bjs_DataProcessor_httpStatus_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
 
     var apiResult: Optional<APIResult> {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_DataProcessor_apiResult_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Optional<APIResult>.bridgeJSLiftReturn(ret)
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let (newValueIsSome, newValueCaseId) = newValue.bridgeJSLowerParameter()
-            bjs_DataProcessor_apiResult_set(jsObjectValue, newValueIsSome, newValueCaseId)
         }
     }
 
     var helper: Greeter {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_DataProcessor_helper_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Greeter.bridgeJSLiftReturn(ret)
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let newValuePointer = newValue.bridgeJSLowerParameter()
-            bjs_DataProcessor_helper_set(jsObjectValue, newValuePointer)
         }
     }
 
     var optionalHelper: Optional<Greeter> {
-        get {
+        get throws(JSException) {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_DataProcessor_optionalHelper_get(jsObjectValue)
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
             return Optional<Greeter>.bridgeJSLiftReturn(ret)
-        }
-        set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
-            let (newValueIsSome, newValuePointer) = newValue.bridgeJSLowerParameter()
-            bjs_DataProcessor_optionalHelper_set(jsObjectValue, newValueIsSome, newValuePointer)
         }
     }
 
@@ -1152,6 +1218,33 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
         return AnyDataProcessor(jsObject: JSObject(id: UInt32(bitPattern: value)))
     }
 }
+
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_setCount")
+fileprivate func _extern_setCount(_ jsObject: Int32, _ value: Int32) -> Void
+
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_setOptionalTag")
+fileprivate func _extern_setOptionalTag(_ jsObject: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_setOptionalCount")
+fileprivate func _extern_setOptionalCount(_ jsObject: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_setDirection")
+fileprivate func _extern_setDirection(_ jsObject: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_setOptionalTheme")
+fileprivate func _extern_setOptionalTheme(_ jsObject: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_setHttpStatus")
+fileprivate func _extern_setHttpStatus(_ jsObject: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_setApiResult")
+fileprivate func _extern_setApiResult(_ jsObject: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void
+
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_setHelper")
+fileprivate func _extern_setHelper(_ jsObject: Int32, _ value: UnsafeMutableRawPointer) -> Void
+
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_setOptionalHelper")
+fileprivate func _extern_setOptionalHelper(_ jsObject: Int32, _ valueIsSome: Int32, _ valuePointer: UnsafeMutableRawPointer) -> Void
 
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_increment")
 fileprivate func _extern_increment(_ jsObject: Int32, _ amount: Int32) -> Void
@@ -1189,59 +1282,32 @@ fileprivate func _extern_getAPIResult(_ jsObject: Int32) -> Int32
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_count_get")
 fileprivate func bjs_DataProcessor_count_get(_ jsObject: Int32) -> Int32
 
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_count_set")
-fileprivate func bjs_DataProcessor_count_set(_ jsObject: Int32, _ newValue: Int32) -> Void
-
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_name_get")
 fileprivate func bjs_DataProcessor_name_get(_ jsObject: Int32) -> Int32
 
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_optionalTag_get")
 fileprivate func bjs_DataProcessor_optionalTag_get(_ jsObject: Int32) -> Void
 
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_optionalTag_set")
-fileprivate func bjs_DataProcessor_optionalTag_set(_ jsObject: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void
-
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_optionalCount_get")
 fileprivate func bjs_DataProcessor_optionalCount_get(_ jsObject: Int32) -> Void
-
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_optionalCount_set")
-fileprivate func bjs_DataProcessor_optionalCount_set(_ jsObject: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void
 
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_direction_get")
 fileprivate func bjs_DataProcessor_direction_get(_ jsObject: Int32) -> Int32
 
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_direction_set")
-fileprivate func bjs_DataProcessor_direction_set(_ jsObject: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void
-
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_optionalTheme_get")
 fileprivate func bjs_DataProcessor_optionalTheme_get(_ jsObject: Int32) -> Void
-
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_optionalTheme_set")
-fileprivate func bjs_DataProcessor_optionalTheme_set(_ jsObject: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void
 
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_httpStatus_get")
 fileprivate func bjs_DataProcessor_httpStatus_get(_ jsObject: Int32) -> Void
 
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_httpStatus_set")
-fileprivate func bjs_DataProcessor_httpStatus_set(_ jsObject: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void
-
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_apiResult_get")
 fileprivate func bjs_DataProcessor_apiResult_get(_ jsObject: Int32) -> Int32
-
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_apiResult_set")
-fileprivate func bjs_DataProcessor_apiResult_set(_ jsObject: Int32, _ newValueIsSome: Int32, _ newValueCaseId: Int32) -> Void
 
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_helper_get")
 fileprivate func bjs_DataProcessor_helper_get(_ jsObject: Int32) -> UnsafeMutableRawPointer
 
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_helper_set")
-fileprivate func bjs_DataProcessor_helper_set(_ jsObject: Int32, _ newValue: UnsafeMutableRawPointer) -> Void
-
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_optionalHelper_get")
 fileprivate func bjs_DataProcessor_optionalHelper_get(_ jsObject: Int32) -> UnsafeMutableRawPointer
-
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessor_optionalHelper_set")
-fileprivate func bjs_DataProcessor_optionalHelper_set(_ jsObject: Int32, _ newValueIsSome: Int32, _ newValuePointer: UnsafeMutableRawPointer) -> Void
 
 extension Direction: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
@@ -6775,8 +6841,22 @@ public func _bjs_DataProcessorManager_hasBackup(_ _self: UnsafeMutableRawPointer
 @_cdecl("bjs_DataProcessorManager_getProcessorOptionalTag")
 public func _bjs_DataProcessorManager_getProcessorOptionalTag(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorOptionalTag()
-    return ret.bridgeJSLowerReturn()
+    do {
+        let ret = try DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorOptionalTag()
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6786,7 +6866,21 @@ public func _bjs_DataProcessorManager_getProcessorOptionalTag(_ _self: UnsafeMut
 @_cdecl("bjs_DataProcessorManager_setProcessorOptionalTag")
 public func _bjs_DataProcessorManager_setProcessorOptionalTag(_ _self: UnsafeMutableRawPointer, _ tagIsSome: Int32, _ tagBytes: Int32, _ tagLength: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorOptionalTag(_: Optional<String>.bridgeJSLiftParameter(tagIsSome, tagBytes, tagLength))
+    do {
+        try DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorOptionalTag(_: Optional<String>.bridgeJSLiftParameter(tagIsSome, tagBytes, tagLength))
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6796,8 +6890,22 @@ public func _bjs_DataProcessorManager_setProcessorOptionalTag(_ _self: UnsafeMut
 @_cdecl("bjs_DataProcessorManager_getProcessorOptionalCount")
 public func _bjs_DataProcessorManager_getProcessorOptionalCount(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorOptionalCount()
-    return ret.bridgeJSLowerReturn()
+    do {
+        let ret = try DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorOptionalCount()
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6807,7 +6915,21 @@ public func _bjs_DataProcessorManager_getProcessorOptionalCount(_ _self: UnsafeM
 @_cdecl("bjs_DataProcessorManager_setProcessorOptionalCount")
 public func _bjs_DataProcessorManager_setProcessorOptionalCount(_ _self: UnsafeMutableRawPointer, _ countIsSome: Int32, _ countValue: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorOptionalCount(_: Optional<Int>.bridgeJSLiftParameter(countIsSome, countValue))
+    do {
+        try DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorOptionalCount(_: Optional<Int>.bridgeJSLiftParameter(countIsSome, countValue))
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6817,8 +6939,22 @@ public func _bjs_DataProcessorManager_setProcessorOptionalCount(_ _self: UnsafeM
 @_cdecl("bjs_DataProcessorManager_getProcessorDirection")
 public func _bjs_DataProcessorManager_getProcessorDirection(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorDirection()
-    return ret.bridgeJSLowerReturn()
+    do {
+        let ret = try DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorDirection()
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6828,7 +6964,21 @@ public func _bjs_DataProcessorManager_getProcessorDirection(_ _self: UnsafeMutab
 @_cdecl("bjs_DataProcessorManager_setProcessorDirection")
 public func _bjs_DataProcessorManager_setProcessorDirection(_ _self: UnsafeMutableRawPointer, _ directionIsSome: Int32, _ directionValue: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorDirection(_: Optional<Direction>.bridgeJSLiftParameter(directionIsSome, directionValue))
+    do {
+        try DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorDirection(_: Optional<Direction>.bridgeJSLiftParameter(directionIsSome, directionValue))
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6838,8 +6988,22 @@ public func _bjs_DataProcessorManager_setProcessorDirection(_ _self: UnsafeMutab
 @_cdecl("bjs_DataProcessorManager_getProcessorTheme")
 public func _bjs_DataProcessorManager_getProcessorTheme(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorTheme()
-    return ret.bridgeJSLowerReturn()
+    do {
+        let ret = try DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorTheme()
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6849,7 +7013,21 @@ public func _bjs_DataProcessorManager_getProcessorTheme(_ _self: UnsafeMutableRa
 @_cdecl("bjs_DataProcessorManager_setProcessorTheme")
 public func _bjs_DataProcessorManager_setProcessorTheme(_ _self: UnsafeMutableRawPointer, _ themeIsSome: Int32, _ themeBytes: Int32, _ themeLength: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorTheme(_: Optional<Theme>.bridgeJSLiftParameter(themeIsSome, themeBytes, themeLength))
+    do {
+        try DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorTheme(_: Optional<Theme>.bridgeJSLiftParameter(themeIsSome, themeBytes, themeLength))
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6859,8 +7037,22 @@ public func _bjs_DataProcessorManager_setProcessorTheme(_ _self: UnsafeMutableRa
 @_cdecl("bjs_DataProcessorManager_getProcessorHttpStatus")
 public func _bjs_DataProcessorManager_getProcessorHttpStatus(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorHttpStatus()
-    return ret.bridgeJSLowerReturn()
+    do {
+        let ret = try DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorHttpStatus()
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6870,7 +7062,21 @@ public func _bjs_DataProcessorManager_getProcessorHttpStatus(_ _self: UnsafeMuta
 @_cdecl("bjs_DataProcessorManager_setProcessorHttpStatus")
 public func _bjs_DataProcessorManager_setProcessorHttpStatus(_ _self: UnsafeMutableRawPointer, _ statusIsSome: Int32, _ statusValue: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorHttpStatus(_: Optional<HttpStatus>.bridgeJSLiftParameter(statusIsSome, statusValue))
+    do {
+        try DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorHttpStatus(_: Optional<HttpStatus>.bridgeJSLiftParameter(statusIsSome, statusValue))
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7000,6 +7206,96 @@ public func _bjs_SwiftDataProcessor_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = SwiftDataProcessor()
     return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftDataProcessor_setCount")
+@_cdecl("bjs_SwiftDataProcessor_setCount")
+public func _bjs_SwiftDataProcessor_setCount(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+    #if arch(wasm32)
+    SwiftDataProcessor.bridgeJSLiftParameter(_self).setCount(_: Int.bridgeJSLiftParameter(value))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftDataProcessor_setOptionalTag")
+@_cdecl("bjs_SwiftDataProcessor_setOptionalTag")
+public func _bjs_SwiftDataProcessor_setOptionalTag(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    #if arch(wasm32)
+    SwiftDataProcessor.bridgeJSLiftParameter(_self).setOptionalTag(_: Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftDataProcessor_setOptionalCount")
+@_cdecl("bjs_SwiftDataProcessor_setOptionalCount")
+public func _bjs_SwiftDataProcessor_setOptionalCount(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    #if arch(wasm32)
+    SwiftDataProcessor.bridgeJSLiftParameter(_self).setOptionalCount(_: Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftDataProcessor_setDirection")
+@_cdecl("bjs_SwiftDataProcessor_setDirection")
+public func _bjs_SwiftDataProcessor_setDirection(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    #if arch(wasm32)
+    SwiftDataProcessor.bridgeJSLiftParameter(_self).setDirection(_: Optional<Direction>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftDataProcessor_setOptionalTheme")
+@_cdecl("bjs_SwiftDataProcessor_setOptionalTheme")
+public func _bjs_SwiftDataProcessor_setOptionalTheme(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    #if arch(wasm32)
+    SwiftDataProcessor.bridgeJSLiftParameter(_self).setOptionalTheme(_: Optional<Theme>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftDataProcessor_setHttpStatus")
+@_cdecl("bjs_SwiftDataProcessor_setHttpStatus")
+public func _bjs_SwiftDataProcessor_setHttpStatus(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    #if arch(wasm32)
+    SwiftDataProcessor.bridgeJSLiftParameter(_self).setHttpStatus(_: Optional<HttpStatus>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftDataProcessor_setApiResult")
+@_cdecl("bjs_SwiftDataProcessor_setApiResult")
+public func _bjs_SwiftDataProcessor_setApiResult(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
+    #if arch(wasm32)
+    SwiftDataProcessor.bridgeJSLiftParameter(_self).setApiResult(_: Optional<APIResult>.bridgeJSLiftParameter(valueIsSome, valueCaseId))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftDataProcessor_setHelper")
+@_cdecl("bjs_SwiftDataProcessor_setHelper")
+public func _bjs_SwiftDataProcessor_setHelper(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    SwiftDataProcessor.bridgeJSLiftParameter(_self).setHelper(_: Greeter.bridgeJSLiftParameter(value))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_SwiftDataProcessor_setOptionalHelper")
+@_cdecl("bjs_SwiftDataProcessor_setOptionalHelper")
+public func _bjs_SwiftDataProcessor_setOptionalHelper(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    SwiftDataProcessor.bridgeJSLiftParameter(_self).setOptionalHelper(_: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue))
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -1530,7 +1530,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getProcessorOptionalTag",
             "parameters" : [
@@ -1551,7 +1551,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "setProcessorOptionalTag",
             "parameters" : [
@@ -1580,7 +1580,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getProcessorOptionalCount",
             "parameters" : [
@@ -1601,7 +1601,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "setProcessorOptionalCount",
             "parameters" : [
@@ -1630,7 +1630,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getProcessorDirection",
             "parameters" : [
@@ -1651,7 +1651,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "setProcessorDirection",
             "parameters" : [
@@ -1680,7 +1680,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getProcessorTheme",
             "parameters" : [
@@ -1702,7 +1702,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "setProcessorTheme",
             "parameters" : [
@@ -1732,7 +1732,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "getProcessorHttpStatus",
             "parameters" : [
@@ -1754,7 +1754,7 @@
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
-              "isThrows" : false
+              "isThrows" : true
             },
             "name" : "setProcessorHttpStatus",
             "parameters" : [
@@ -1872,6 +1872,261 @@
           ]
         },
         "methods" : [
+          {
+            "abiName" : "bjs_SwiftDataProcessor_setCount",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "setCount",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_SwiftDataProcessor_setOptionalTag",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "setOptionalTag",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_SwiftDataProcessor_setOptionalCount",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "setOptionalCount",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_SwiftDataProcessor_setDirection",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "setDirection",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "caseEnum" : {
+                        "_0" : "Direction"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_SwiftDataProcessor_setOptionalTheme",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "setOptionalTheme",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "rawValueEnum" : {
+                        "_0" : "Theme",
+                        "_1" : "String"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_SwiftDataProcessor_setHttpStatus",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "setHttpStatus",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "rawValueEnum" : {
+                        "_0" : "HttpStatus",
+                        "_1" : "Int"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_SwiftDataProcessor_setApiResult",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "setApiResult",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "associatedValueEnum" : {
+                        "_0" : "APIResult"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_SwiftDataProcessor_setHelper",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "setHelper",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "swiftHeapObject" : {
+                    "_0" : "Greeter"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_SwiftDataProcessor_setOptionalHelper",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "setOptionalHelper",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "swiftHeapObject" : {
+                        "_0" : "Greeter"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
           {
             "abiName" : "bjs_SwiftDataProcessor_increment",
             "effects" : {
@@ -9840,6 +10095,261 @@
       {
         "methods" : [
           {
+            "abiName" : "bjs_DataProcessor_setCount",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setCount",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_DataProcessor_setOptionalTag",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setOptionalTag",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_DataProcessor_setOptionalCount",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setOptionalCount",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_DataProcessor_setDirection",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setDirection",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "caseEnum" : {
+                        "_0" : "Direction"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_DataProcessor_setOptionalTheme",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setOptionalTheme",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "rawValueEnum" : {
+                        "_0" : "Theme",
+                        "_1" : "String"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_DataProcessor_setHttpStatus",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setHttpStatus",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "rawValueEnum" : {
+                        "_0" : "HttpStatus",
+                        "_1" : "Int"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_DataProcessor_setApiResult",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setApiResult",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "associatedValueEnum" : {
+                        "_0" : "APIResult"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_DataProcessor_setHelper",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setHelper",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "swiftHeapObject" : {
+                    "_0" : "Greeter"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_DataProcessor_setOptionalHelper",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "setOptionalHelper",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "optional" : {
+                    "_0" : {
+                      "swiftHeapObject" : {
+                        "_0" : "Greeter"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
             "abiName" : "bjs_DataProcessor_increment",
             "effects" : {
               "isAsync" : false,
@@ -10095,7 +10605,12 @@
         "name" : "DataProcessor",
         "properties" : [
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "count",
             "type" : {
               "int" : {
@@ -10104,6 +10619,11 @@
             }
           },
           {
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
             "isReadonly" : true,
             "name" : "name",
             "type" : {
@@ -10113,7 +10633,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "optionalTag",
             "type" : {
               "optional" : {
@@ -10126,7 +10651,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "optionalCount",
             "type" : {
               "optional" : {
@@ -10139,7 +10669,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "direction",
             "type" : {
               "optional" : {
@@ -10152,7 +10687,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "optionalTheme",
             "type" : {
               "optional" : {
@@ -10166,7 +10706,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "httpStatus",
             "type" : {
               "optional" : {
@@ -10180,7 +10725,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "apiResult",
             "type" : {
               "optional" : {
@@ -10193,7 +10743,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "helper",
             "type" : {
               "swiftHeapObject" : {
@@ -10202,7 +10757,12 @@
             }
           },
           {
-            "isReadonly" : false,
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "isReadonly" : true,
             "name" : "optionalHelper",
             "type" : {
               "optional" : {


### PR DESCRIPTION
## Overview
- Require `throws(JSException)` on `@JS protocol` property getters, matching the import side (`@JSGetter`) behavior
- `{ get set }` properties no longer supported - use readonly getter + setter method pattern
- Fix generated protocol wrapper code to include exception checking for property access
- Updated tests and documentation

### Test updates

- `Protocol.swift` test input: Updated properties to `{ get throws(JSException) }` pattern with setter methods
- `ExportAPITests.swift`: Updated `DataProcessor` protocol with new property pattern

### Documentation

- Updated `Exporting-Swift-Protocols.md` with new property pattern and examples

### Motivation

This completes the work started in #563 which enforced `throws(JSException)` on protocol methods. Properties now follow the same pattern, fully addressing [the inconsistency](https://github.com/swiftwasm/JavaScriptKit/pull/560#issuecomment-3840061515) between import and export sides.

### Notes

While working on this, I realized that removing the exception check condition in `ImportTS.swift` would break the current closure implementation - non-throwing closures would fail to compile. 
Should we consider enforcing `throws(JSException)` on all closures as well? It makes sense given they're calling into JavaScript which can always throw. I'd prefer to tackle that in a separate follow-up PR.