### PR TITLE
TS2Swift: Skip type checks when translating TS -> Swift

### DIFF
--- a/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/src/processor.js
+++ b/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/src/processor.js
@@ -27,7 +27,11 @@ export class TypeProcessor {
     static createProgram(filePaths, options) {
         const host = ts.createCompilerHost(options);
         const roots = Array.isArray(filePaths) ? filePaths : [filePaths];
-        return ts.createProgram(roots, options, host);
+        return ts.createProgram(roots, {
+            ...options,
+            noCheck: true,
+            skipLibCheck: true,
+        }, host);
     }
 
     /**


### PR DESCRIPTION
Close https://github.com/swiftwasm/JavaScriptKit/issues/512