### PR TITLE
Add import-side array handling and JSClass array tests

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -2147,12 +2147,10 @@ extension BridgeJSLink {
 
         func liftParameter(param: Parameter) throws {
             let liftingFragment = try IntrinsicJSFragment.liftParameter(type: param.type, context: context)
-            assert(
-                liftingFragment.parameters.count >= 1,
-                "Lifting fragment should have at least one parameter to lift"
-            )
             let valuesToLift: [String]
-            if liftingFragment.parameters.count == 1 {
+            if liftingFragment.parameters.isEmpty {
+                valuesToLift = []
+            } else if liftingFragment.parameters.count == 1 {
                 parameterNames.append(param.name)
                 valuesToLift = [scope.variable(param.name)]
             } else {

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -1565,14 +1565,7 @@ struct IntrinsicJSFragment: Sendable {
                     "Namespace enums are not supported to be passed as parameters to imported JS functions: \(string)"
             )
         case .array(let elementType):
-            switch context {
-            case .importTS:
-                throw BridgeJSLinkError(
-                    message: "Arrays are not yet supported to be passed as parameters to imported JS functions"
-                )
-            case .exportSwift:
-                return try arrayLift(elementType: elementType)
-            }
+            return try arrayLift(elementType: elementType)
         }
     }
 
@@ -1640,14 +1633,7 @@ struct IntrinsicJSFragment: Sendable {
                 message: "Namespace enums are not supported to be returned from imported JS functions: \(string)"
             )
         case .array(let elementType):
-            switch context {
-            case .importTS:
-                throw BridgeJSLinkError(
-                    message: "Arrays are not yet supported to be returned from imported JS functions"
-                )
-            case .exportSwift:
-                return try arrayLower(elementType: elementType)
-            }
+            return try arrayLower(elementType: elementType)
         }
     }
 
@@ -2756,11 +2742,10 @@ struct IntrinsicJSFragment: Sendable {
                     // Lift return value if needed
                     if method.returnType != .void {
                         let liftFragment = try! IntrinsicJSFragment.liftReturn(type: method.returnType)
-                        if !liftFragment.parameters.isEmpty {
-                            let lifted = liftFragment.printCode(["ret"], methodScope, printer, methodCleanup)
-                            if let liftedValue = lifted.first {
-                                printer.write("return \(liftedValue);")
-                            }
+                        let liftArgs = liftFragment.parameters.isEmpty ? [] : ["ret"]
+                        let lifted = liftFragment.printCode(liftArgs, methodScope, printer, methodCleanup)
+                        if let liftedValue = lifted.first {
+                            printer.write("return \(liftedValue);")
                         }
                     }
                 }
@@ -3090,7 +3075,7 @@ struct IntrinsicJSFragment: Sendable {
                             printer.write("\(JSGlueVariableScope.reservedTmpParamInts).push(\(isSomeVar) ? 1 : 0);")
                             cleanup.write("if (\(enumCleanupVar)) { \(enumCleanupVar)(); }")
                         default:
-                            // For other types (nested structs, etc.), original logic applies
+                            // For other types (including arrays), generate lowering under the isSome guard
                             let wrappedFragment = structFieldLowerFragment(
                                 field: ExportedProperty(
                                     name: field.name,
@@ -3100,9 +3085,37 @@ struct IntrinsicJSFragment: Sendable {
                                 ),
                                 allStructs: allStructs
                             )
+                            let guardedPrinter = CodeFragmentPrinter()
+                            let guardedCleanup = CodeFragmentPrinter()
+                            _ = wrappedFragment.printCode([value], scope, guardedPrinter, guardedCleanup)
+                            var loweredLines = guardedPrinter.lines
+                            var hoistedCleanupVar: String?
+                            if let first = loweredLines.first {
+                                let trimmed = first.trimmingCharacters(in: .whitespaces)
+                                if trimmed.hasPrefix("const "),
+                                    let namePart = trimmed.split(separator: " ").dropFirst().first,
+                                    trimmed.contains("= []")
+                                {
+                                    hoistedCleanupVar = String(namePart)
+                                    loweredLines[0] = "\(hoistedCleanupVar!) = [];"
+                                }
+                            }
+                            if let hoistedName = hoistedCleanupVar {
+                                printer.write("let \(hoistedName);")
+                            }
                             printer.write("if (\(isSomeVar)) {")
                             printer.indent {
-                                _ = wrappedFragment.printCode([value], scope, printer, cleanup)
+                                for line in loweredLines {
+                                    printer.write(line)
+                                }
+                                // Cleanup is conditional on isSome as well
+                                if !guardedCleanup.lines.isEmpty {
+                                    cleanup.write("if (\(isSomeVar)) {")
+                                    cleanup.indent {
+                                        cleanup.write(contentsOf: guardedCleanup)
+                                    }
+                                    cleanup.write("}")
+                                }
                             }
                             printer.write("}")
                             printer.write("\(JSGlueVariableScope.reservedTmpParamInts).push(\(isSomeVar) ? 1 : 0);")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/ImportArray.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/ImportArray.swift
@@ -1,0 +1,2 @@
+@JSFunction func roundtrip(_ items: [Int]) throws(JSException) -> [Int]
+@JSFunction func logStrings(_ items: [String]) throws(JSException)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.json
@@ -1,0 +1,80 @@
+{
+  "exported" : {
+    "classes" : [
+
+    ],
+    "enums" : [
+
+    ],
+    "exposeToGlobal" : false,
+    "functions" : [
+
+    ],
+    "protocols" : [
+
+    ],
+    "structs" : [
+
+    ]
+  },
+  "imported" : {
+    "children" : [
+      {
+        "functions" : [
+          {
+            "name" : "roundtrip",
+            "parameters" : [
+              {
+                "name" : "items",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name" : "logStrings",
+            "parameters" : [
+              {
+                "name" : "items",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          }
+        ],
+        "types" : [
+
+        ]
+      }
+    ]
+  },
+  "moduleName" : "TestModule"
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.swift
@@ -1,0 +1,34 @@
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_roundtrip")
+fileprivate func bjs_roundtrip() -> Void
+#else
+fileprivate func bjs_roundtrip() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$roundtrip(_ items: [Int]) throws(JSException) -> [Int] {
+    let _ = items.bridgeJSLowerParameter()
+    bjs_roundtrip()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Int].bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_logStrings")
+fileprivate func bjs_logStrings() -> Void
+#else
+fileprivate func bjs_logStrings() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$logStrings(_ items: [String]) throws(JSException) -> Void {
+    let _ = items.bridgeJSLowerParameter()
+    bjs_logStrings()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.d.ts
@@ -1,0 +1,19 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export type Exports = {
+}
+export type Imports = {
+    roundtrip(items: number[]): number[];
+    logStrings(items: string[]): void;
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
@@ -1,0 +1,257 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let tmpRetTag;
+    let tmpRetStrings = [];
+    let tmpRetInts = [];
+    let tmpRetF32s = [];
+    let tmpRetF64s = [];
+    let tmpParamInts = [];
+    let tmpParamF32s = [];
+    let tmpParamF64s = [];
+    let tmpRetPointers = [];
+    let tmpParamPointers = [];
+    let tmpStructCleanups = [];
+    const enumHelpers = {};
+    const structHelpers = {};
+    
+    let _exports = null;
+    let bjs = null;
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            bjs = {};
+            importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                tmpRetString = textDecoder.decode(bytes);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                return swift.memory.retain(textDecoder.decode(bytes));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr, len);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_tag"] = function(tag) {
+                tmpRetTag = tag;
+            }
+            bjs["swift_js_push_i32"] = function(v) {
+                tmpRetInts.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                tmpRetF32s.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                tmpRetF64s.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                const value = textDecoder.decode(bytes);
+                tmpRetStrings.push(value);
+            }
+            bjs["swift_js_pop_i32"] = function() {
+                return tmpParamInts.pop();
+            }
+            bjs["swift_js_pop_f32"] = function() {
+                return tmpParamF32s.pop();
+            }
+            bjs["swift_js_pop_f64"] = function() {
+                return tmpParamF64s.pop();
+            }
+            bjs["swift_js_push_pointer"] = function(pointer) {
+                tmpRetPointers.push(pointer);
+            }
+            bjs["swift_js_pop_pointer"] = function() {
+                return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    const bytes = new Uint8Array(memory.buffer, ptr, len);
+                    tmpRetString = textDecoder.decode(bytes);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            bjs["swift_js_get_optional_int_presence"] = function() {
+                return tmpRetOptionalInt != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_int_value"] = function() {
+                const value = tmpRetOptionalInt;
+                tmpRetOptionalInt = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_string"] = function() {
+                const str = tmpRetString;
+                tmpRetString = undefined;
+                if (str == null) {
+                    return -1;
+                } else {
+                    const bytes = textEncoder.encode(str);
+                    tmpRetBytes = bytes;
+                    return bytes.length;
+                }
+            }
+            bjs["swift_js_get_optional_float_presence"] = function() {
+                return tmpRetOptionalFloat != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_float_value"] = function() {
+                const value = tmpRetOptionalFloat;
+                tmpRetOptionalFloat = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_double_presence"] = function() {
+                return tmpRetOptionalDouble != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_double_value"] = function() {
+                const value = tmpRetOptionalDouble;
+                tmpRetOptionalDouble = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_heap_object_pointer"] = function() {
+                const pointer = tmpRetOptionalHeapObject;
+                tmpRetOptionalHeapObject = undefined;
+                return pointer || 0;
+            }
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
+            TestModule["bjs_roundtrip"] = function bjs_roundtrip() {
+                try {
+                    const arrayLen = tmpRetInts.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const int = tmpRetInts.pop();
+                        arrayResult.push(int);
+                    }
+                    arrayResult.reverse();
+                    let ret = imports.roundtrip(arrayResult);
+                    const arrayCleanups = [];
+                    for (const elem of ret) {
+                        tmpParamInts.push((elem | 0));
+                    }
+                    tmpParamInts.push(ret.length);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_logStrings"] = function bjs_logStrings() {
+                try {
+                    const arrayLen = tmpRetInts.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const string = tmpRetStrings.pop();
+                        arrayResult.push(string);
+                    }
+                    arrayResult.reverse();
+                    imports.logStrings(arrayResult);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            const exports = {
+            };
+            _exports = exports;
+            return exports;
+        },
+    }
+}

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -2156,7 +2156,9 @@ extension _BridgedAsOptional where Wrapped: _BridgedSwiftStruct {
 
 // MARK: - Array Support
 
-extension Array where Element: _BridgedSwiftStackType, Element.StackLiftResult == Element {
+extension Array: _BridgedSwiftStackType where Element: _BridgedSwiftStackType, Element.StackLiftResult == Element {
+    public typealias StackLiftResult = [Element]
+
     @_spi(BridgeJS) public static func bridgeJSLiftParameter() -> [Element] {
         let count = Int(_swift_js_pop_i32())
         var result: [Element] = []
@@ -2168,10 +2170,23 @@ extension Array where Element: _BridgedSwiftStackType, Element.StackLiftResult =
         return result
     }
 
-    @_spi(BridgeJS) public func bridgeJSLowerReturn() {
-        for elem in self {
+    @_spi(BridgeJS) public static func bridgeJSLiftReturn() -> [Element] {
+        bridgeJSLiftParameter()
+    }
+
+    @_spi(BridgeJS) public consuming func bridgeJSLowerStackReturn() {
+        bridgeJSLowerReturn()
+    }
+
+    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() {
+        let array = self
+        for elem in array {
             elem.bridgeJSLowerStackReturn()
         }
-        _swift_js_push_i32(Int32(self.count))
+        _swift_js_push_i32(Int32(array.count))
+    }
+
+    @_spi(BridgeJS) public consuming func bridgeJSLowerParameter() {
+        bridgeJSLowerReturn()
     }
 }

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -3267,6 +3267,84 @@ fileprivate func _bjs_struct_lift_FooContainer() -> Int32 {
 }
 #endif
 
+extension ArrayMembers: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ArrayMembers {
+        let optStrings = {
+    let __isSome = _swift_js_pop_i32()
+    if __isSome == 0 {
+        return Optional<[String]>.none
+    } else {
+        return [String].bridgeJSLiftParameter()
+    }
+        }()
+        let ints = [Int].bridgeJSLiftParameter()
+        return ArrayMembers(ints: ints, optStrings: optStrings)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        self.ints.bridgeJSLowerReturn()
+        let __bjs_isSome_optStrings = self.optStrings != nil
+        if let __bjs_unwrapped_optStrings = self.optStrings {
+            __bjs_unwrapped_optStrings.bridgeJSLowerReturn()
+        }
+        _swift_js_push_i32(__bjs_isSome_optStrings ? 1 : 0)
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _bjs_struct_lower_ArrayMembers(jsObject.bridgeJSLowerParameter())
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ArrayMembers()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ArrayMembers")
+fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ArrayMembers")
+fileprivate func _bjs_struct_lift_ArrayMembers() -> Int32
+#else
+fileprivate func _bjs_struct_lift_ArrayMembers() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_ArrayMembers_sumValues")
+@_cdecl("bjs_ArrayMembers_sumValues")
+public func _bjs_ArrayMembers_sumValues() -> Int32 {
+    #if arch(wasm32)
+    let ret = ArrayMembers.bridgeJSLiftParameter().sumValues(_: [Int].bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayMembers_firstString")
+@_cdecl("bjs_ArrayMembers_firstString")
+public func _bjs_ArrayMembers_firstString() -> Void {
+    #if arch(wasm32)
+    let ret = ArrayMembers.bridgeJSLiftParameter().firstString(_: [String].bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_roundTripVoid")
 @_cdecl("bjs_roundTripVoid")
 public func _bjs_roundTripVoid() -> Void {
@@ -5507,6 +5585,43 @@ public func _bjs_roundTripJSObjectContainer() -> Void {
 public func _bjs_roundTripFooContainer() -> Void {
     #if arch(wasm32)
     let ret = roundTripFooContainer(_: FooContainer.bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripArrayMembers")
+@_cdecl("bjs_roundTripArrayMembers")
+public func _bjs_roundTripArrayMembers() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripArrayMembers(_: ArrayMembers.bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_arrayMembersSum")
+@_cdecl("bjs_arrayMembersSum")
+public func _bjs_arrayMembersSum() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_values = [Int].bridgeJSLiftParameter()
+    let _tmp_value = ArrayMembers.bridgeJSLiftParameter()
+    let ret = arrayMembersSum(_: _tmp_value, _: _tmp_values)
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_arrayMembersFirst")
+@_cdecl("bjs_arrayMembersFirst")
+public func _bjs_arrayMembersFirst() -> Void {
+    #if arch(wasm32)
+    let _tmp_values = [String].bridgeJSLiftParameter()
+    let _tmp_value = ArrayMembers.bridgeJSLiftParameter()
+    let ret = arrayMembersFirst(_: _tmp_value, _: _tmp_values)
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -8602,6 +8717,227 @@ func _$Animal_getIsCat(_ self: JSObject) throws(JSException) -> Bool {
         throw error
     }
     return Bool.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripIntArray")
+fileprivate func bjs_jsRoundTripIntArray() -> Void
+#else
+fileprivate func bjs_jsRoundTripIntArray() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsRoundTripIntArray(_ items: [Int]) throws(JSException) -> [Int] {
+    let _ = items.bridgeJSLowerParameter()
+    bjs_jsRoundTripIntArray()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Int].bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripStringArray")
+fileprivate func bjs_jsRoundTripStringArray() -> Void
+#else
+fileprivate func bjs_jsRoundTripStringArray() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsRoundTripStringArray(_ items: [String]) throws(JSException) -> [String] {
+    let _ = items.bridgeJSLowerParameter()
+    bjs_jsRoundTripStringArray()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [String].bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsArrayLength")
+fileprivate func bjs_jsArrayLength() -> Int32
+#else
+fileprivate func bjs_jsArrayLength() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsArrayLength(_ items: [Int]) throws(JSException) -> Int {
+    let _ = items.bridgeJSLowerParameter()
+    let ret = bjs_jsArrayLength()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Int.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_makeArrayHost")
+fileprivate func bjs_makeArrayHost() -> Int32
+#else
+fileprivate func bjs_makeArrayHost() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$makeArrayHost(_ numbers: [Int], _ labels: [String]) throws(JSException) -> ArrayHost {
+    let _ = labels.bridgeJSLowerParameter()
+    let _ = numbers.bridgeJSLowerParameter()
+    let ret = bjs_makeArrayHost()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return ArrayHost.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_init")
+fileprivate func bjs_ArrayHost_init() -> Int32
+#else
+fileprivate func bjs_ArrayHost_init() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_numbers_get")
+fileprivate func bjs_ArrayHost_numbers_get(_ self: Int32) -> Void
+#else
+fileprivate func bjs_ArrayHost_numbers_get(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_labels_get")
+fileprivate func bjs_ArrayHost_labels_get(_ self: Int32) -> Void
+#else
+fileprivate func bjs_ArrayHost_labels_get(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_numbers_set")
+fileprivate func bjs_ArrayHost_numbers_set(_ self: Int32) -> Void
+#else
+fileprivate func bjs_ArrayHost_numbers_set(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_labels_set")
+fileprivate func bjs_ArrayHost_labels_set(_ self: Int32) -> Void
+#else
+fileprivate func bjs_ArrayHost_labels_set(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_concatNumbers")
+fileprivate func bjs_ArrayHost_concatNumbers(_ self: Int32) -> Void
+#else
+fileprivate func bjs_ArrayHost_concatNumbers(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_concatLabels")
+fileprivate func bjs_ArrayHost_concatLabels(_ self: Int32) -> Void
+#else
+fileprivate func bjs_ArrayHost_concatLabels(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_firstLabel")
+fileprivate func bjs_ArrayHost_firstLabel(_ self: Int32) -> Int32
+#else
+fileprivate func bjs_ArrayHost_firstLabel(_ self: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$ArrayHost_init(_ numbers: [Int], _ labels: [String]) throws(JSException) -> JSObject {
+    let _ = labels.bridgeJSLowerParameter()
+    let _ = numbers.bridgeJSLowerParameter()
+    let ret = bjs_ArrayHost_init()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSObject.bridgeJSLiftReturn(ret)
+}
+
+func _$ArrayHost_numbers_get(_ self: JSObject) throws(JSException) -> [Int] {
+    let selfValue = self.bridgeJSLowerParameter()
+    bjs_ArrayHost_numbers_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Int].bridgeJSLiftReturn()
+}
+
+func _$ArrayHost_labels_get(_ self: JSObject) throws(JSException) -> [String] {
+    let selfValue = self.bridgeJSLowerParameter()
+    bjs_ArrayHost_labels_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [String].bridgeJSLiftReturn()
+}
+
+func _$ArrayHost_numbers_set(_ self: JSObject, _ newValue: [Int]) throws(JSException) -> Void {
+    let selfValue = self.bridgeJSLowerParameter()
+    let _ = newValue.bridgeJSLowerParameter()
+    bjs_ArrayHost_numbers_set(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+func _$ArrayHost_labels_set(_ self: JSObject, _ newValue: [String]) throws(JSException) -> Void {
+    let selfValue = self.bridgeJSLowerParameter()
+    let _ = newValue.bridgeJSLowerParameter()
+    bjs_ArrayHost_labels_set(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+func _$ArrayHost_concatNumbers(_ self: JSObject, _ values: [Int]) throws(JSException) -> [Int] {
+    let selfValue = self.bridgeJSLowerParameter()
+    let _ = values.bridgeJSLowerParameter()
+    bjs_ArrayHost_concatNumbers(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Int].bridgeJSLiftReturn()
+}
+
+func _$ArrayHost_concatLabels(_ self: JSObject, _ values: [String]) throws(JSException) -> [String] {
+    let selfValue = self.bridgeJSLowerParameter()
+    let _ = values.bridgeJSLowerParameter()
+    bjs_ArrayHost_concatLabels(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [String].bridgeJSLiftReturn()
+}
+
+func _$ArrayHost_firstLabel(_ self: JSObject, _ values: [String]) throws(JSException) -> String {
+    let selfValue = self.bridgeJSLowerParameter()
+    let _ = values.bridgeJSLowerParameter()
+    let ret = bjs_ArrayHost_firstLabel(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return String.bridgeJSLiftReturn(ret)
 }
 
 #if arch(wasm32)

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -10375,6 +10375,112 @@
             "_0" : "FooContainer"
           }
         }
+      },
+      {
+        "abiName" : "bjs_roundTripArrayMembers",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripArrayMembers",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "ArrayMembers"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "ArrayMembers"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_arrayMembersSum",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "arrayMembersSum",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "ArrayMembers"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "int" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_arrayMembersFirst",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "arrayMembersFirst",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "ArrayMembers"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "string" : {
+
+              }
+            },
+            "_1" : "null"
+          }
+        }
       }
     ],
     "protocols" : [
@@ -12005,6 +12111,110 @@
           }
         ],
         "swiftCallName" : "FooContainer"
+      },
+      {
+        "methods" : [
+          {
+            "abiName" : "bjs_ArrayMembers_sumValues",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "sumValues",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "int" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayMembers_firstString",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "firstString",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "name" : "ArrayMembers",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "ints",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "optStrings",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "ArrayMembers"
       }
     ]
   },
@@ -12657,6 +12867,284 @@
         ],
         "types" : [
 
+        ]
+      },
+      {
+        "functions" : [
+          {
+            "name" : "jsRoundTripIntArray",
+            "parameters" : [
+              {
+                "name" : "items",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name" : "jsRoundTripStringArray",
+            "parameters" : [
+              {
+                "name" : "items",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name" : "jsArrayLength",
+            "parameters" : [
+              {
+                "name" : "items",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "int" : {
+
+              }
+            }
+          },
+          {
+            "name" : "makeArrayHost",
+            "parameters" : [
+              {
+                "name" : "numbers",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "name" : "labels",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "jsObject" : {
+                "_0" : "ArrayHost"
+              }
+            }
+          }
+        ],
+        "types" : [
+          {
+            "constructor" : {
+              "parameters" : [
+                {
+                  "name" : "numbers",
+                  "type" : {
+                    "array" : {
+                      "_0" : {
+                        "int" : {
+
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name" : "labels",
+                  "type" : {
+                    "array" : {
+                      "_0" : {
+                        "string" : {
+
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "getters" : [
+              {
+                "name" : "numbers",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "name" : "labels",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "methods" : [
+              {
+                "name" : "concatNumbers",
+                "parameters" : [
+                  {
+                    "name" : "values",
+                    "type" : {
+                      "array" : {
+                        "_0" : {
+                          "int" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "name" : "concatLabels",
+                "parameters" : [
+                  {
+                    "name" : "values",
+                    "type" : {
+                      "array" : {
+                        "_0" : {
+                          "string" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "name" : "firstLabel",
+                "parameters" : [
+                  {
+                    "name" : "values",
+                    "type" : {
+                      "array" : {
+                        "_0" : {
+                          "string" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "name" : "ArrayHost",
+            "setters" : [
+              {
+                "functionName" : "numbers_set",
+                "name" : "numbers",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "functionName" : "labels_set",
+                "name" : "labels",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "staticMethods" : [
+
+            ]
+          }
         ]
       },
       {

--- a/Tests/BridgeJSRuntimeTests/ImportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ImportAPITests.swift
@@ -134,6 +134,40 @@ class ImportAPITests: XCTestCase {
         XCTAssertEqual(prefixer("world!"), "Hello, world!")
     }
 
+    func testRoundTripIntArray() throws {
+        let values = [1, 2, 3, 4, 5]
+        let result = try jsRoundTripIntArray(values)
+        XCTAssertEqual(result, values)
+        XCTAssertEqual(try jsArrayLength(values), values.count)
+        XCTAssertEqual(try jsRoundTripIntArray([]), [])
+    }
+
+    func testRoundTripStringArray() throws {
+        let values = ["", "Hello", "こんにちは", "emoji 👋"]
+        let result = try jsRoundTripStringArray(values)
+        XCTAssertEqual(result, values)
+        XCTAssertEqual(try jsRoundTripStringArray([]), [])
+    }
+
+    func testJSClassArrayMembers() throws {
+        let numbers = [1, 2, 3]
+        let labels = ["alpha", "beta"]
+        let host = try makeArrayHost(numbers, labels)
+
+        XCTAssertEqual(try host.numbers, numbers)
+        XCTAssertEqual(try host.labels, labels)
+
+        try host.setNumbers([10, 20])
+        try host.setLabels(["gamma"])
+        XCTAssertEqual(try host.numbers, [10, 20])
+        XCTAssertEqual(try host.labels, ["gamma"])
+
+        XCTAssertEqual(try host.concatNumbers([30, 40]), [10, 20, 30, 40])
+        XCTAssertEqual(try host.concatLabels(["delta", "epsilon"]), ["gamma", "delta", "epsilon"])
+        XCTAssertEqual(try host.firstLabel([]), "gamma")
+        XCTAssertEqual(try host.firstLabel(["zeta"]), "zeta")
+    }
+
     func testClosureParameterIntToVoid() throws {
         var total = 0
         let ret = try jsCallTwice(5) { total += $0 }

--- a/Tests/BridgeJSRuntimeTests/ImportArrayAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/ImportArrayAPIs.swift
@@ -1,0 +1,18 @@
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
+
+@JSFunction func jsRoundTripIntArray(_ items: [Int]) throws(JSException) -> [Int]
+@JSFunction func jsRoundTripStringArray(_ items: [String]) throws(JSException) -> [String]
+@JSFunction func jsArrayLength(_ items: [Int]) throws(JSException) -> Int
+
+@JSClass struct ArrayHost {
+    @JSGetter var numbers: [Int]
+    @JSGetter var labels: [String]
+    @JSSetter func setNumbers(_ value: [Int]) throws(JSException)
+    @JSSetter func setLabels(_ value: [String]) throws(JSException)
+    @JSFunction init(_ numbers: [Int], _ labels: [String]) throws(JSException)
+    @JSFunction func concatNumbers(_ values: [Int]) throws(JSException) -> [Int]
+    @JSFunction func concatLabels(_ values: [String]) throws(JSException) -> [String]
+    @JSFunction func firstLabel(_ values: [String]) throws(JSException) -> String
+}
+
+@JSFunction func makeArrayHost(_ numbers: [Int], _ labels: [String]) throws(JSException) -> ArrayHost

--- a/Tests/BridgeJSRuntimeTests/StructAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/StructAPIs.swift
@@ -234,3 +234,28 @@
 @JS func roundTripFooContainer(_ container: FooContainer) -> FooContainer {
     return container
 }
+
+@JS struct ArrayMembers {
+    var ints: [Int]
+    var optStrings: [String]?
+
+    @JS func sumValues(_ values: [Int]) -> Int {
+        values.reduce(0, +)
+    }
+
+    @JS func firstString(_ values: [String]) -> String? {
+        values.first
+    }
+}
+
+@JS func roundTripArrayMembers(_ value: ArrayMembers) -> ArrayMembers {
+    value
+}
+
+@JS func arrayMembersSum(_ value: ArrayMembers, _ values: [Int]) -> Int {
+    value.sumValues(values)
+}
+
+@JS func arrayMembersFirst(_ value: ArrayMembers, _ values: [String]) -> String? {
+    value.firstString(values)
+}

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -33,6 +33,22 @@ export async function setupOptions(options, context) {
     return {
         ...options,
         getImports: (importsContext) => {
+            const ArrayHost = class {
+                constructor(numbers, labels) {
+                    this.numbers = numbers;
+                    this.labels = labels;
+                }
+                concatNumbers(values) {
+                    return [...this.numbers, ...values];
+                }
+                concatLabels(values) {
+                    return [...this.labels, ...values];
+                }
+                firstLabel(values) {
+                    const merged = [...values, ...this.labels];
+                    return merged.length > 0 ? merged[0] : "";
+                }
+            };
             return {
                 "jsRoundTripVoid": () => {
                     return;
@@ -51,6 +67,15 @@ export async function setupOptions(options, context) {
                 },
                 "jsRoundTripOptionalNumberUndefined": (v) => {
                     return v === undefined ? undefined : v;
+                },
+                "jsRoundTripIntArray": (items) => {
+                    return items;
+                },
+                "jsRoundTripStringArray": (items) => {
+                    return items;
+                },
+                "jsArrayLength": (items) => {
+                    return items.length;
                 },
                 "jsThrowOrVoid": (shouldThrow) => {
                     if (shouldThrow) {
@@ -80,6 +105,10 @@ export async function setupOptions(options, context) {
                 },
                 "$jsWeirdFunction": () => {
                     return 42;
+                },
+                ArrayHost,
+                makeArrayHost: (numbers, labels) => {
+                    return new ArrayHost(numbers, labels);
                 },
                 JsGreeter: class {
                     /**
@@ -134,6 +163,9 @@ export async function setupOptions(options, context) {
                 },
                 jsTranslatePoint: (point, dx, dy) => {
                     return { x: (point.x | 0) + (dx | 0), y: (point.y | 0) + (dy | 0) };
+                },
+                roundTripArrayMembers: (value) => {
+                    return value;
                 }
             };
         },
@@ -217,6 +249,12 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     ]) {
         assert.equal(exports.roundTripString(v), v);
     }
+    const arrayStruct = { ints: [1, 2, 3], optStrings: ["a", "b"] };
+    const arrayStructRoundTrip = exports.roundTripArrayMembers(arrayStruct);
+    assert.deepEqual(arrayStructRoundTrip.ints, [1, 2, 3]);
+    assert.deepEqual(arrayStructRoundTrip.optStrings, ["a", "b"]);
+    assert.equal(exports.arrayMembersSum(arrayStruct, [10, 20]), 30);
+    assert.equal(exports.arrayMembersFirst(arrayStruct, ["x", "y"]), "x");
 
     for (const p of [1, 4, 1024, 65536, 2147483647]) {
         assert.equal(exports.roundTripUnsafeRawPointer(p), p);


### PR DESCRIPTION
Motivation:
- Import-side arrays lacked ordering guarantees when multiple stack-based parameters were present and we were missing coverage for arrays in imported JS class members.

Overview:
- Reverse stack-based parameter lowering in ImportTS, deduplicate raw-value enum handling, and ensure lift fragments without parameters run so array returns are emitted.
- Add ArrayHost fixtures and runtime checks for JSClass array properties/methods, wire them into the JS prelude, and regenerate BridgeJS outputs.
