### PR TITLE
BridgeJS: Import-side Array Support 

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -2212,12 +2212,10 @@ extension BridgeJSLink {
 
         func liftParameter(param: Parameter) throws {
             let liftingFragment = try IntrinsicJSFragment.liftParameter(type: param.type, context: context)
-            assert(
-                liftingFragment.parameters.count >= 1,
-                "Lifting fragment should have at least one parameter to lift"
-            )
             let valuesToLift: [String]
-            if liftingFragment.parameters.count == 1 {
+            if liftingFragment.parameters.count == 0 {
+                valuesToLift = []
+            } else if liftingFragment.parameters.count == 1 {
                 parameterNames.append(param.name)
                 valuesToLift = [scope.variable(param.name)]
             } else {

--- a/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/src/processor.js
+++ b/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/src/processor.js
@@ -663,6 +663,15 @@ export class TypeProcessor {
      * @private
      */
     visitType(type, node) {
+        if (this.checker.isArrayType(type)) {
+            const typeArgs = this.checker.getTypeArguments(type);
+            if (typeArgs && typeArgs.length > 0) {
+                const elementType = this.visitType(typeArgs[0], node);
+                return `[${elementType}]`;
+            }
+            return "[JSObject]";
+        }
+
         // Treat A<B> and A<C> as the same type
         if (isTypeReference(type)) {
             type = type.target;
@@ -727,7 +736,7 @@ export class TypeProcessor {
                 return this.renderTypeIdentifier(typeName);
             }
 
-            if (this.checker.isArrayType(type) || this.checker.isTupleType(type) || type.getCallSignatures().length > 0) {
+            if (this.checker.isTupleType(type) || type.getCallSignatures().length > 0) {
                 return "JSObject";
             }
             // "a" | "b" -> string

--- a/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/__snapshots__/ts2swift.test.js.snap
+++ b/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/__snapshots__/ts2swift.test.js.snap
@@ -9,11 +9,17 @@ exports[`ts2swift > snapshots Swift output for ArrayParameter.d.ts > ArrayParame
 
 @_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
 
-@JSFunction func checkArray(_ a: JSObject) throws(JSException) -> Void
+@JSFunction func processNumbers(_ values: [Double]) throws(JSException) -> Void
 
-@JSFunction func checkArrayWithLength(_ a: JSObject, _ b: Double) throws(JSException) -> Void
+@JSFunction func getNumbers() throws(JSException) -> [Double]
 
-@JSFunction func checkArray(_ a: JSObject) throws(JSException) -> Void
+@JSFunction func transformNumbers(_ values: [Double]) throws(JSException) -> [Double]
+
+@JSFunction func processStrings(_ values: [String]) throws(JSException) -> [String]
+
+@JSFunction func processBooleans(_ values: [Bool]) throws(JSException) -> [Bool]
+
+@JSFunction func processArraySyntax(_ values: [Double]) throws(JSException) -> [Double]
 "
 `;
 

--- a/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/fixtures/ArrayParameter.d.ts
+++ b/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/fixtures/ArrayParameter.d.ts
@@ -1,3 +1,17 @@
-export function checkArray(a: number[]): void;
-export function checkArrayWithLength(a: number[], b: number): void;
-export function checkArray(a: Array<number>): void;
+// Array as parameter
+export function processNumbers(values: number[]): void;
+
+// Array as return value
+export function getNumbers(): number[];
+
+// Array as both parameter and return value
+export function transformNumbers(values: number[]): number[];
+
+// String arrays
+export function processStrings(values: string[]): string[];
+
+// Boolean arrays
+export function processBooleans(values: boolean[]): boolean[];
+
+// Using Array<T> syntax
+export function processArraySyntax(values: Array<number>): Array<number>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/ArrayTypes.swift
@@ -61,3 +61,9 @@
 
 @JSFunction func checkArray(_ a: JSObject) throws(JSException) -> Void
 @JSFunction func checkArrayWithLength(_ a: JSObject, _ b: Double) throws(JSException) -> Void
+
+@JSFunction func importProcessNumbers(_ values: [Double]) throws(JSException) -> Void
+@JSFunction func importGetNumbers() throws(JSException) -> [Double]
+@JSFunction func importTransformNumbers(_ values: [Double]) throws(JSException) -> [Double]
+@JSFunction func importProcessStrings(_ values: [String]) throws(JSException) -> [String]
+@JSFunction func importProcessBooleans(_ values: [Bool]) throws(JSException) -> [Bool]

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/ImportArray.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/ImportArray.swift
@@ -1,0 +1,2 @@
+@JSFunction func roundtrip(_ items: [Int]) throws(JSException) -> [Int]
+@JSFunction func logStrings(_ items: [String]) throws(JSException)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.json
@@ -1158,6 +1158,121 @@
 
               }
             }
+          },
+          {
+            "name" : "importProcessNumbers",
+            "parameters" : [
+              {
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "double" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "name" : "importGetNumbers",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "double" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name" : "importTransformNumbers",
+            "parameters" : [
+              {
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "double" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "double" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name" : "importProcessStrings",
+            "parameters" : [
+              {
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name" : "importProcessBooleans",
+            "parameters" : [
+              {
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "bool" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "bool" : {
+
+                  }
+                }
+              }
+            }
           }
         ],
         "types" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
@@ -582,3 +582,91 @@ func _$checkArrayWithLength(_ a: JSObject, _ b: Double) throws(JSException) -> V
         throw error
     }
 }
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_importProcessNumbers")
+fileprivate func bjs_importProcessNumbers() -> Void
+#else
+fileprivate func bjs_importProcessNumbers() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$importProcessNumbers(_ values: [Double]) throws(JSException) -> Void {
+    let _ = values.bridgeJSLowerParameter()
+    bjs_importProcessNumbers()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_importGetNumbers")
+fileprivate func bjs_importGetNumbers() -> Void
+#else
+fileprivate func bjs_importGetNumbers() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$importGetNumbers() throws(JSException) -> [Double] {
+    bjs_importGetNumbers()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Double].bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_importTransformNumbers")
+fileprivate func bjs_importTransformNumbers() -> Void
+#else
+fileprivate func bjs_importTransformNumbers() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$importTransformNumbers(_ values: [Double]) throws(JSException) -> [Double] {
+    let _ = values.bridgeJSLowerParameter()
+    bjs_importTransformNumbers()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Double].bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_importProcessStrings")
+fileprivate func bjs_importProcessStrings() -> Void
+#else
+fileprivate func bjs_importProcessStrings() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$importProcessStrings(_ values: [String]) throws(JSException) -> [String] {
+    let _ = values.bridgeJSLowerParameter()
+    bjs_importProcessStrings()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [String].bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_importProcessBooleans")
+fileprivate func bjs_importProcessBooleans() -> Void
+#else
+fileprivate func bjs_importProcessBooleans() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$importProcessBooleans(_ values: [Bool]) throws(JSException) -> [Bool] {
+    let _ = values.bridgeJSLowerParameter()
+    bjs_importProcessBooleans()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Bool].bridgeJSLiftReturn()
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.json
@@ -1,0 +1,62 @@
+{
+  "imported" : {
+    "children" : [
+      {
+        "functions" : [
+          {
+            "name" : "roundtrip",
+            "parameters" : [
+              {
+                "name" : "items",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name" : "logStrings",
+            "parameters" : [
+              {
+                "name" : "items",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          }
+        ],
+        "types" : [
+
+        ]
+      }
+    ]
+  },
+  "moduleName" : "TestModule"
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.swift
@@ -1,0 +1,34 @@
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_roundtrip")
+fileprivate func bjs_roundtrip() -> Void
+#else
+fileprivate func bjs_roundtrip() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$roundtrip(_ items: [Int]) throws(JSException) -> [Int] {
+    let _ = items.bridgeJSLowerParameter()
+    bjs_roundtrip()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Int].bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_logStrings")
+fileprivate func bjs_logStrings() -> Void
+#else
+fileprivate func bjs_logStrings() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$logStrings(_ items: [String]) throws(JSException) -> Void {
+    let _ = items.bridgeJSLowerParameter()
+    bjs_logStrings()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.d.ts
@@ -71,6 +71,11 @@ export type Exports = {
 export type Imports = {
     checkArray(a: any): void;
     checkArrayWithLength(a: any, b: number): void;
+    importProcessNumbers(values: number[]): void;
+    importGetNumbers(): number[];
+    importTransformNumbers(values: number[]): number[];
+    importProcessStrings(values: string[]): string[];
+    importProcessBooleans(values: boolean[]): boolean[];
 }
 export function createInstantiator(options: {
     imports: Imports;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
@@ -263,6 +263,95 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
+            TestModule["bjs_importProcessNumbers"] = function bjs_importProcessNumbers() {
+                try {
+                    const arrayLen = tmpRetInts.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const f64 = tmpRetF64s.pop();
+                        arrayResult.push(f64);
+                    }
+                    arrayResult.reverse();
+                    imports.importProcessNumbers(arrayResult);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_importGetNumbers"] = function bjs_importGetNumbers() {
+                try {
+                    let ret = imports.importGetNumbers();
+                    const arrayCleanups = [];
+                    for (const elem of ret) {
+                        tmpParamF64s.push(elem);
+                    }
+                    tmpParamInts.push(ret.length);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_importTransformNumbers"] = function bjs_importTransformNumbers() {
+                try {
+                    const arrayLen = tmpRetInts.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const f64 = tmpRetF64s.pop();
+                        arrayResult.push(f64);
+                    }
+                    arrayResult.reverse();
+                    let ret = imports.importTransformNumbers(arrayResult);
+                    const arrayCleanups = [];
+                    for (const elem of ret) {
+                        tmpParamF64s.push(elem);
+                    }
+                    tmpParamInts.push(ret.length);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_importProcessStrings"] = function bjs_importProcessStrings() {
+                try {
+                    const arrayLen = tmpRetInts.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const string = tmpRetStrings.pop();
+                        arrayResult.push(string);
+                    }
+                    arrayResult.reverse();
+                    let ret = imports.importProcessStrings(arrayResult);
+                    const arrayCleanups = [];
+                    for (const elem of ret) {
+                        const bytes = textEncoder.encode(elem);
+                        const id = swift.memory.retain(bytes);
+                        tmpParamInts.push(bytes.length);
+                        tmpParamInts.push(id);
+                        arrayCleanups.push(() => {
+                            swift.memory.release(id);
+                        });
+                    }
+                    tmpParamInts.push(ret.length);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_importProcessBooleans"] = function bjs_importProcessBooleans() {
+                try {
+                    const arrayLen = tmpRetInts.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const bool = tmpRetInts.pop() !== 0;
+                        arrayResult.push(bool);
+                    }
+                    arrayResult.reverse();
+                    let ret = imports.importProcessBooleans(arrayResult);
+                    const arrayCleanups = [];
+                    for (const elem of ret) {
+                        tmpParamInts.push(elem ? 1 : 0);
+                    }
+                    tmpParamInts.push(ret.length);
+                } catch (error) {
+                    setException(error);
+                }
+            }
         },
         setInstance: (i) => {
             instance = i;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.d.ts
@@ -1,0 +1,19 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export type Exports = {
+}
+export type Imports = {
+    roundtrip(items: number[]): number[];
+    logStrings(items: string[]): void;
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
@@ -1,0 +1,257 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let tmpRetTag = [];
+    let tmpRetStrings = [];
+    let tmpRetInts = [];
+    let tmpRetF32s = [];
+    let tmpRetF64s = [];
+    let tmpParamInts = [];
+    let tmpParamF32s = [];
+    let tmpParamF64s = [];
+    let tmpRetPointers = [];
+    let tmpParamPointers = [];
+    let tmpStructCleanups = [];
+    const enumHelpers = {};
+    const structHelpers = {};
+
+    let _exports = null;
+    let bjs = null;
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            bjs = {};
+            importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                tmpRetString = textDecoder.decode(bytes);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                return swift.memory.retain(textDecoder.decode(bytes));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr, len);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_tag"] = function(tag) {
+                tmpRetTag.push(tag);
+            }
+            bjs["swift_js_push_i32"] = function(v) {
+                tmpRetInts.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                tmpRetF32s.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                tmpRetF64s.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const bytes = new Uint8Array(memory.buffer, ptr, len);
+                const value = textDecoder.decode(bytes);
+                tmpRetStrings.push(value);
+            }
+            bjs["swift_js_pop_i32"] = function() {
+                return tmpParamInts.pop();
+            }
+            bjs["swift_js_pop_f32"] = function() {
+                return tmpParamF32s.pop();
+            }
+            bjs["swift_js_pop_f64"] = function() {
+                return tmpParamF64s.pop();
+            }
+            bjs["swift_js_push_pointer"] = function(pointer) {
+                tmpRetPointers.push(pointer);
+            }
+            bjs["swift_js_pop_pointer"] = function() {
+                return tmpParamPointers.pop();
+            }
+            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
+                if (cleanupId === 0) { return; }
+                const index = (cleanupId | 0) - 1;
+                const cleanup = tmpStructCleanups[index];
+                tmpStructCleanups[index] = null;
+                if (cleanup) { cleanup(); }
+                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
+                    tmpStructCleanups.pop();
+                }
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    const bytes = new Uint8Array(memory.buffer, ptr, len);
+                    tmpRetString = textDecoder.decode(bytes);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            bjs["swift_js_get_optional_int_presence"] = function() {
+                return tmpRetOptionalInt != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_int_value"] = function() {
+                const value = tmpRetOptionalInt;
+                tmpRetOptionalInt = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_string"] = function() {
+                const str = tmpRetString;
+                tmpRetString = undefined;
+                if (str == null) {
+                    return -1;
+                } else {
+                    const bytes = textEncoder.encode(str);
+                    tmpRetBytes = bytes;
+                    return bytes.length;
+                }
+            }
+            bjs["swift_js_get_optional_float_presence"] = function() {
+                return tmpRetOptionalFloat != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_float_value"] = function() {
+                const value = tmpRetOptionalFloat;
+                tmpRetOptionalFloat = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_double_presence"] = function() {
+                return tmpRetOptionalDouble != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_double_value"] = function() {
+                const value = tmpRetOptionalDouble;
+                tmpRetOptionalDouble = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_heap_object_pointer"] = function() {
+                const pointer = tmpRetOptionalHeapObject;
+                tmpRetOptionalHeapObject = undefined;
+                return pointer || 0;
+            }
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
+            TestModule["bjs_roundtrip"] = function bjs_roundtrip() {
+                try {
+                    const arrayLen = tmpRetInts.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const int = tmpRetInts.pop();
+                        arrayResult.push(int);
+                    }
+                    arrayResult.reverse();
+                    let ret = imports.roundtrip(arrayResult);
+                    const arrayCleanups = [];
+                    for (const elem of ret) {
+                        tmpParamInts.push((elem | 0));
+                    }
+                    tmpParamInts.push(ret.length);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_logStrings"] = function bjs_logStrings() {
+                try {
+                    const arrayLen = tmpRetInts.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const string = tmpRetStrings.pop();
+                        arrayResult.push(string);
+                    }
+                    arrayResult.reverse();
+                    imports.logStrings(arrayResult);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            const exports = {
+            };
+            _exports = exports;
+            return exports;
+        },
+    }
+}

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -2297,7 +2297,9 @@ extension _BridgedAsOptional where Wrapped: _BridgedSwiftStruct {
 
 // MARK: - Array Support
 
-extension Array where Element: _BridgedSwiftStackType, Element.StackLiftResult == Element {
+extension Array: _BridgedSwiftStackType where Element: _BridgedSwiftStackType, Element.StackLiftResult == Element {
+    public typealias StackLiftResult = [Element]
+
     @_spi(BridgeJS) public static func bridgeJSLiftParameter() -> [Element] {
         let count = Int(_swift_js_pop_i32())
         var result: [Element] = []
@@ -2309,10 +2311,23 @@ extension Array where Element: _BridgedSwiftStackType, Element.StackLiftResult =
         return result
     }
 
-    @_spi(BridgeJS) public func bridgeJSLowerReturn() {
-        for elem in self {
+    @_spi(BridgeJS) public static func bridgeJSLiftReturn() -> [Element] {
+        bridgeJSLiftParameter()
+    }
+
+    @_spi(BridgeJS) public consuming func bridgeJSLowerStackReturn() {
+        bridgeJSLowerReturn()
+    }
+
+    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() {
+        let array = self
+        for elem in array {
             elem.bridgeJSLowerStackReturn()
         }
-        _swift_js_push_i32(Int32(self.count))
+        _swift_js_push_i32(Int32(array.count))
+    }
+
+    @_spi(BridgeJS) public consuming func bridgeJSLowerParameter() {
+        bridgeJSLowerReturn()
     }
 }

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Supported-Types.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Supported-Types.md
@@ -9,7 +9,7 @@ Use this page as a quick reference for how common TypeScript types appear in Swi
 | `number` | `Double` |
 | `string` | `String` |
 | `boolean` | `Bool` |
-| TODO | `Array<T>` |
+| `T[]` | `[T]` |
 | TODO | `Dictionary<K, V>` |
 | `T \| undefined` | TODO |
 | `T \| null` | `Optional<T>` |

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.Macros.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.Macros.swift
@@ -63,6 +63,16 @@ extension FeatureFlag: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {}
     @JSFunction(jsName: "with-dashes") static func with_dashes() throws(JSException) -> StaticBox
 }
 
+@JSFunction func jsRoundTripNumberArray(_ values: [Double]) throws(JSException) -> [Double]
+
+@JSFunction func jsRoundTripStringArray(_ values: [String]) throws(JSException) -> [String]
+
+@JSFunction func jsRoundTripBoolArray(_ values: [Bool]) throws(JSException) -> [Bool]
+
+@JSFunction func jsSumNumberArray(_ values: [Double]) throws(JSException) -> Double
+
+@JSFunction func jsCreateNumberArray() throws(JSException) -> [Double]
+
 @JSFunction(from: .global) func parseInt(_ string: String) throws(JSException) -> Double
 
 @JSClass(from: .global) struct Animal {

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -3579,6 +3579,84 @@ fileprivate func _bjs_struct_lift_FooContainer() -> Int32 {
 }
 #endif
 
+extension ArrayMembers: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ArrayMembers {
+        let optStrings = {
+    let __isSome = _swift_js_pop_i32()
+    if __isSome == 0 {
+        return Optional<[String]>.none
+    } else {
+        return [String].bridgeJSLiftParameter()
+    }
+        }()
+        let ints = [Int].bridgeJSLiftParameter()
+        return ArrayMembers(ints: ints, optStrings: optStrings)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        self.ints.bridgeJSLowerReturn()
+        let __bjs_isSome_optStrings = self.optStrings != nil
+        if let __bjs_unwrapped_optStrings = self.optStrings {
+            __bjs_unwrapped_optStrings.bridgeJSLowerReturn()
+        }
+        _swift_js_push_i32(__bjs_isSome_optStrings ? 1 : 0)
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _bjs_struct_lower_ArrayMembers(jsObject.bridgeJSLowerParameter())
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ArrayMembers()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ArrayMembers")
+fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ArrayMembers")
+fileprivate func _bjs_struct_lift_ArrayMembers() -> Int32
+#else
+fileprivate func _bjs_struct_lift_ArrayMembers() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_ArrayMembers_sumValues")
+@_cdecl("bjs_ArrayMembers_sumValues")
+public func _bjs_ArrayMembers_sumValues() -> Int32 {
+    #if arch(wasm32)
+    let ret = ArrayMembers.bridgeJSLiftParameter().sumValues(_: [Int].bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ArrayMembers_firstString")
+@_cdecl("bjs_ArrayMembers_firstString")
+public func _bjs_ArrayMembers_firstString() -> Void {
+    #if arch(wasm32)
+    let ret = ArrayMembers.bridgeJSLiftParameter().firstString(_: [String].bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_roundTripVoid")
 @_cdecl("bjs_roundTripVoid")
 public func _bjs_roundTripVoid() -> Void {
@@ -5907,6 +5985,43 @@ public func _bjs_roundTripJSObjectContainer() -> Void {
 public func _bjs_roundTripFooContainer() -> Void {
     #if arch(wasm32)
     let ret = roundTripFooContainer(_: FooContainer.bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripArrayMembers")
+@_cdecl("bjs_roundTripArrayMembers")
+public func _bjs_roundTripArrayMembers() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripArrayMembers(_: ArrayMembers.bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_arrayMembersSum")
+@_cdecl("bjs_arrayMembersSum")
+public func _bjs_arrayMembersSum() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_values = [Int].bridgeJSLiftParameter()
+    let _tmp_value = ArrayMembers.bridgeJSLiftParameter()
+    let ret = arrayMembersSum(_: _tmp_value, _: _tmp_values)
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_arrayMembersFirst")
+@_cdecl("bjs_arrayMembersFirst")
+public func _bjs_arrayMembersFirst() -> Void {
+    #if arch(wasm32)
+    let _tmp_values = [String].bridgeJSLiftParameter()
+    let _tmp_value = ArrayMembers.bridgeJSLiftParameter()
+    let ret = arrayMembersFirst(_: _tmp_value, _: _tmp_values)
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -8592,6 +8707,95 @@ func _$_jsWeirdFunction() throws(JSException) -> Double {
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripNumberArray")
+fileprivate func bjs_jsRoundTripNumberArray() -> Void
+#else
+fileprivate func bjs_jsRoundTripNumberArray() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsRoundTripNumberArray(_ values: [Double]) throws(JSException) -> [Double] {
+    let _ = values.bridgeJSLowerParameter()
+    bjs_jsRoundTripNumberArray()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Double].bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripStringArray")
+fileprivate func bjs_jsRoundTripStringArray() -> Void
+#else
+fileprivate func bjs_jsRoundTripStringArray() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsRoundTripStringArray(_ values: [String]) throws(JSException) -> [String] {
+    let _ = values.bridgeJSLowerParameter()
+    bjs_jsRoundTripStringArray()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [String].bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripBoolArray")
+fileprivate func bjs_jsRoundTripBoolArray() -> Void
+#else
+fileprivate func bjs_jsRoundTripBoolArray() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsRoundTripBoolArray(_ values: [Bool]) throws(JSException) -> [Bool] {
+    let _ = values.bridgeJSLowerParameter()
+    bjs_jsRoundTripBoolArray()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Bool].bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsSumNumberArray")
+fileprivate func bjs_jsSumNumberArray() -> Float64
+#else
+fileprivate func bjs_jsSumNumberArray() -> Float64 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsSumNumberArray(_ values: [Double]) throws(JSException) -> Double {
+    let _ = values.bridgeJSLowerParameter()
+    let ret = bjs_jsSumNumberArray()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Double.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsCreateNumberArray")
+fileprivate func bjs_jsCreateNumberArray() -> Void
+#else
+fileprivate func bjs_jsCreateNumberArray() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsCreateNumberArray() throws(JSException) -> [Double] {
+    bjs_jsCreateNumberArray()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Double].bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_parseInt")
 fileprivate func bjs_parseInt(_ string: Int32) -> Float64
 #else
@@ -9020,6 +9224,209 @@ func _$Animal_getIsCat(_ self: JSObject) throws(JSException) -> Bool {
         throw error
     }
     return Bool.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripIntArray")
+fileprivate func bjs_jsRoundTripIntArray() -> Void
+#else
+fileprivate func bjs_jsRoundTripIntArray() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsRoundTripIntArray(_ items: [Int]) throws(JSException) -> [Int] {
+    let _ = items.bridgeJSLowerParameter()
+    bjs_jsRoundTripIntArray()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Int].bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsArrayLength")
+fileprivate func bjs_jsArrayLength() -> Int32
+#else
+fileprivate func bjs_jsArrayLength() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsArrayLength(_ items: [Int]) throws(JSException) -> Int {
+    let _ = items.bridgeJSLowerParameter()
+    let ret = bjs_jsArrayLength()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Int.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_makeArrayHost")
+fileprivate func bjs_makeArrayHost() -> Int32
+#else
+fileprivate func bjs_makeArrayHost() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$makeArrayHost(_ numbers: [Int], _ labels: [String]) throws(JSException) -> ArrayHost {
+    let _ = labels.bridgeJSLowerParameter()
+    let _ = numbers.bridgeJSLowerParameter()
+    let ret = bjs_makeArrayHost()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return ArrayHost.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_init")
+fileprivate func bjs_ArrayHost_init() -> Int32
+#else
+fileprivate func bjs_ArrayHost_init() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_numbers_get")
+fileprivate func bjs_ArrayHost_numbers_get(_ self: Int32) -> Void
+#else
+fileprivate func bjs_ArrayHost_numbers_get(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_labels_get")
+fileprivate func bjs_ArrayHost_labels_get(_ self: Int32) -> Void
+#else
+fileprivate func bjs_ArrayHost_labels_get(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_numbers_set")
+fileprivate func bjs_ArrayHost_numbers_set(_ self: Int32) -> Void
+#else
+fileprivate func bjs_ArrayHost_numbers_set(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_labels_set")
+fileprivate func bjs_ArrayHost_labels_set(_ self: Int32) -> Void
+#else
+fileprivate func bjs_ArrayHost_labels_set(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_concatNumbers")
+fileprivate func bjs_ArrayHost_concatNumbers(_ self: Int32) -> Void
+#else
+fileprivate func bjs_ArrayHost_concatNumbers(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_concatLabels")
+fileprivate func bjs_ArrayHost_concatLabels(_ self: Int32) -> Void
+#else
+fileprivate func bjs_ArrayHost_concatLabels(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayHost_firstLabel")
+fileprivate func bjs_ArrayHost_firstLabel(_ self: Int32) -> Int32
+#else
+fileprivate func bjs_ArrayHost_firstLabel(_ self: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$ArrayHost_init(_ numbers: [Int], _ labels: [String]) throws(JSException) -> JSObject {
+    let _ = labels.bridgeJSLowerParameter()
+    let _ = numbers.bridgeJSLowerParameter()
+    let ret = bjs_ArrayHost_init()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSObject.bridgeJSLiftReturn(ret)
+}
+
+func _$ArrayHost_numbers_get(_ self: JSObject) throws(JSException) -> [Int] {
+    let selfValue = self.bridgeJSLowerParameter()
+    bjs_ArrayHost_numbers_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Int].bridgeJSLiftReturn()
+}
+
+func _$ArrayHost_labels_get(_ self: JSObject) throws(JSException) -> [String] {
+    let selfValue = self.bridgeJSLowerParameter()
+    bjs_ArrayHost_labels_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [String].bridgeJSLiftReturn()
+}
+
+func _$ArrayHost_numbers_set(_ self: JSObject, _ newValue: [Int]) throws(JSException) -> Void {
+    let selfValue = self.bridgeJSLowerParameter()
+    let _ = newValue.bridgeJSLowerParameter()
+    bjs_ArrayHost_numbers_set(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+func _$ArrayHost_labels_set(_ self: JSObject, _ newValue: [String]) throws(JSException) -> Void {
+    let selfValue = self.bridgeJSLowerParameter()
+    let _ = newValue.bridgeJSLowerParameter()
+    bjs_ArrayHost_labels_set(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+func _$ArrayHost_concatNumbers(_ self: JSObject, _ values: [Int]) throws(JSException) -> [Int] {
+    let selfValue = self.bridgeJSLowerParameter()
+    let _ = values.bridgeJSLowerParameter()
+    bjs_ArrayHost_concatNumbers(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Int].bridgeJSLiftReturn()
+}
+
+func _$ArrayHost_concatLabels(_ self: JSObject, _ values: [String]) throws(JSException) -> [String] {
+    let selfValue = self.bridgeJSLowerParameter()
+    let _ = values.bridgeJSLowerParameter()
+    bjs_ArrayHost_concatLabels(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [String].bridgeJSLiftReturn()
+}
+
+func _$ArrayHost_firstLabel(_ self: JSObject, _ values: [String]) throws(JSException) -> String {
+    let selfValue = self.bridgeJSLowerParameter()
+    let _ = values.bridgeJSLowerParameter()
+    let ret = bjs_ArrayHost_firstLabel(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return String.bridgeJSLiftReturn(ret)
 }
 
 #if arch(wasm32)

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -10917,6 +10917,112 @@
             "_0" : "FooContainer"
           }
         }
+      },
+      {
+        "abiName" : "bjs_roundTripArrayMembers",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripArrayMembers",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "ArrayMembers"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "ArrayMembers"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_arrayMembersSum",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "arrayMembersSum",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "ArrayMembers"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "int" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_arrayMembersFirst",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "arrayMembersFirst",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "ArrayMembers"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "string" : {
+
+              }
+            },
+            "_1" : "null"
+          }
+        }
       }
     ],
     "protocols" : [
@@ -12547,6 +12653,110 @@
           }
         ],
         "swiftCallName" : "FooContainer"
+      },
+      {
+        "methods" : [
+          {
+            "abiName" : "bjs_ArrayMembers_sumValues",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "sumValues",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "int" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ArrayMembers_firstString",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "firstString",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "name" : "ArrayMembers",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "ints",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "optStrings",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "ArrayMembers"
       }
     ]
   },
@@ -12846,6 +13056,121 @@
             "returnType" : {
               "double" : {
 
+              }
+            }
+          },
+          {
+            "name" : "jsRoundTripNumberArray",
+            "parameters" : [
+              {
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "double" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "double" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name" : "jsRoundTripStringArray",
+            "parameters" : [
+              {
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name" : "jsRoundTripBoolArray",
+            "parameters" : [
+              {
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "bool" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "bool" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name" : "jsSumNumberArray",
+            "parameters" : [
+              {
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "double" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "double" : {
+
+              }
+            }
+          },
+          {
+            "name" : "jsCreateNumberArray",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "double" : {
+
+                  }
+                }
               }
             }
           },
@@ -13193,6 +13518,258 @@
                 "type" : {
                   "bool" : {
 
+                  }
+                }
+              }
+            ],
+            "staticMethods" : [
+
+            ]
+          }
+        ]
+      },
+      {
+        "functions" : [
+          {
+            "name" : "jsRoundTripIntArray",
+            "parameters" : [
+              {
+                "name" : "items",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name" : "jsArrayLength",
+            "parameters" : [
+              {
+                "name" : "items",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "int" : {
+
+              }
+            }
+          },
+          {
+            "name" : "makeArrayHost",
+            "parameters" : [
+              {
+                "name" : "numbers",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "name" : "labels",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "jsObject" : {
+                "_0" : "ArrayHost"
+              }
+            }
+          }
+        ],
+        "types" : [
+          {
+            "constructor" : {
+              "parameters" : [
+                {
+                  "name" : "numbers",
+                  "type" : {
+                    "array" : {
+                      "_0" : {
+                        "int" : {
+
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name" : "labels",
+                  "type" : {
+                    "array" : {
+                      "_0" : {
+                        "string" : {
+
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "getters" : [
+              {
+                "name" : "numbers",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "name" : "labels",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "methods" : [
+              {
+                "name" : "concatNumbers",
+                "parameters" : [
+                  {
+                    "name" : "values",
+                    "type" : {
+                      "array" : {
+                        "_0" : {
+                          "int" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "name" : "concatLabels",
+                "parameters" : [
+                  {
+                    "name" : "values",
+                    "type" : {
+                      "array" : {
+                        "_0" : {
+                          "string" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "name" : "firstLabel",
+                "parameters" : [
+                  {
+                    "name" : "values",
+                    "type" : {
+                      "array" : {
+                        "_0" : {
+                          "string" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "name" : "ArrayHost",
+            "setters" : [
+              {
+                "functionName" : "numbers_set",
+                "name" : "numbers",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "functionName" : "labels_set",
+                "name" : "labels",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    }
                   }
                 }
               }

--- a/Tests/BridgeJSRuntimeTests/ImportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ImportAPITests.swift
@@ -152,6 +152,33 @@ class ImportAPITests: XCTestCase {
         XCTAssertEqual(prefixer("world!"), "Hello, world!")
     }
 
+    func testRoundTripIntArray() throws {
+        let values = [1, 2, 3, 4, 5]
+        let result = try jsRoundTripIntArray(values)
+        XCTAssertEqual(result, values)
+        XCTAssertEqual(try jsArrayLength(values), values.count)
+        XCTAssertEqual(try jsRoundTripIntArray([]), [])
+    }
+
+    func testJSClassArrayMembers() throws {
+        let numbers = [1, 2, 3]
+        let labels = ["alpha", "beta"]
+        let host = try makeArrayHost(numbers, labels)
+
+        XCTAssertEqual(try host.numbers, numbers)
+        XCTAssertEqual(try host.labels, labels)
+
+        try host.setNumbers([10, 20])
+        try host.setLabels(["gamma"])
+        XCTAssertEqual(try host.numbers, [10, 20])
+        XCTAssertEqual(try host.labels, ["gamma"])
+
+        XCTAssertEqual(try host.concatNumbers([30, 40]), [10, 20, 30, 40])
+        XCTAssertEqual(try host.concatLabels(["delta", "epsilon"]), ["gamma", "delta", "epsilon"])
+        XCTAssertEqual(try host.firstLabel([]), "gamma")
+        XCTAssertEqual(try host.firstLabel(["zeta"]), "zeta")
+    }
+
     func testClosureParameterIntToVoid() throws {
         var total = 0
         let ret = try jsCallTwice(5) { total += $0 }
@@ -177,5 +204,39 @@ class ImportAPITests: XCTestCase {
 
         let dashed = try StaticBox.with_dashes()
         XCTAssertEqual(try dashed.value(), 7)
+    }
+
+    func testRoundTripNumberArray() throws {
+        let input: [Double] = [1.0, 2.5, 3.0, -4.5]
+        let result = try jsRoundTripNumberArray(input)
+        XCTAssertEqual(result, input)
+        XCTAssertEqual(try jsRoundTripNumberArray([]), [])
+        XCTAssertEqual(try jsRoundTripNumberArray([42.0]), [42.0])
+    }
+
+    func testRoundTripStringArray() throws {
+        let input = ["Hello", "World", "🎉"]
+        let result = try jsRoundTripStringArray(input)
+        XCTAssertEqual(result, input)
+        XCTAssertEqual(try jsRoundTripStringArray([]), [])
+        XCTAssertEqual(try jsRoundTripStringArray(["", "a", ""]), ["", "a", ""])
+    }
+
+    func testRoundTripBoolArray() throws {
+        let input = [true, false, true, false]
+        let result = try jsRoundTripBoolArray(input)
+        XCTAssertEqual(result, input)
+        XCTAssertEqual(try jsRoundTripBoolArray([]), [])
+    }
+
+    func testSumNumberArray() throws {
+        XCTAssertEqual(try jsSumNumberArray([1.0, 2.0, 3.0, 4.0]), 10.0)
+        XCTAssertEqual(try jsSumNumberArray([]), 0.0)
+        XCTAssertEqual(try jsSumNumberArray([42.0]), 42.0)
+    }
+
+    func testCreateNumberArray() throws {
+        let result = try jsCreateNumberArray()
+        XCTAssertEqual(result, [1.0, 2.0, 3.0, 4.0, 5.0])
     }
 }

--- a/Tests/BridgeJSRuntimeTests/ImportArrayAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/ImportArrayAPIs.swift
@@ -1,0 +1,17 @@
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
+
+@JSFunction func jsRoundTripIntArray(_ items: [Int]) throws(JSException) -> [Int]
+@JSFunction func jsArrayLength(_ items: [Int]) throws(JSException) -> Int
+
+@JSClass struct ArrayHost {
+    @JSGetter var numbers: [Int]
+    @JSGetter var labels: [String]
+    @JSSetter func setNumbers(_ value: [Int]) throws(JSException)
+    @JSSetter func setLabels(_ value: [String]) throws(JSException)
+    @JSFunction init(_ numbers: [Int], _ labels: [String]) throws(JSException)
+    @JSFunction func concatNumbers(_ values: [Int]) throws(JSException) -> [Int]
+    @JSFunction func concatLabels(_ values: [String]) throws(JSException) -> [String]
+    @JSFunction func firstLabel(_ values: [String]) throws(JSException) -> String
+}
+
+@JSFunction func makeArrayHost(_ numbers: [Int], _ labels: [String]) throws(JSException) -> ArrayHost

--- a/Tests/BridgeJSRuntimeTests/StructAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/StructAPIs.swift
@@ -234,3 +234,28 @@
 @JS func roundTripFooContainer(_ container: FooContainer) -> FooContainer {
     return container
 }
+
+@JS struct ArrayMembers {
+    var ints: [Int]
+    var optStrings: [String]?
+
+    @JS func sumValues(_ values: [Int]) -> Int {
+        values.reduce(0, +)
+    }
+
+    @JS func firstString(_ values: [String]) -> String? {
+        values.first
+    }
+}
+
+@JS func roundTripArrayMembers(_ value: ArrayMembers) -> ArrayMembers {
+    value
+}
+
+@JS func arrayMembersSum(_ value: ArrayMembers, _ values: [Int]) -> Int {
+    value.sumValues(values)
+}
+
+@JS func arrayMembersFirst(_ value: ArrayMembers, _ values: [String]) -> String? {
+    value.firstString(values)
+}

--- a/Tests/BridgeJSRuntimeTests/bridge-js.d.ts
+++ b/Tests/BridgeJSRuntimeTests/bridge-js.d.ts
@@ -44,3 +44,9 @@ export class StaticBox {
     static makeDefault(): StaticBox;
     static "with-dashes"(): StaticBox;
 }
+
+export function jsRoundTripNumberArray(values: number[]): number[];
+export function jsRoundTripStringArray(values: string[]): string[];
+export function jsRoundTripBoolArray(values: boolean[]): boolean[];
+export function jsSumNumberArray(values: number[]): number;
+export function jsCreateNumberArray(): number[];


### PR DESCRIPTION
## Overview

Hey @kateinoigakukun, this is a PR where I tried implementing import-side array support for BridgeJS. I noticed your PR #572 covers the same area, so I integrated some of the fixes from there (like `stackLoweringStmts`, `Array: _BridgedSwiftStackType` conformance, the `let _ =` pattern, and the liftReturn fix for 0-param fragments).

Hopefully some parts of this can help you finalise your PR. Feel free to close if not needed.

## Additional bits not in #572
- **processor.js**: TypeScript array type detection using `checker.isArrayType()` so `number[]` generates `[Double]` instead of `JSObject`
- **E2E import tests**: Added `bridge-js.d.ts` declarations, Swift test cases, and JS implementations for:
  - `jsRoundTripNumberArray` / `jsRoundTripStringArray` / `jsRoundTripBoolArray`
  - `jsSumNumberArray` / `jsCreateNumberArray`
