### PR TITLE
Add ts2swift Record to Dictionary mapping

### DIFF
--- a/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/__snapshots__/ts2swift.test.js.snap
+++ b/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/__snapshots__/ts2swift.test.js.snap
@@ -251,6 +251,36 @@ exports[`ts2swift > snapshots Swift output for ReExportFrom.d.ts > ReExportFrom 
 "
 `;
 
+exports[`ts2swift > snapshots Swift output for RecordDictionary.d.ts > RecordDictionary 1`] = `
+"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// \`swift package bridge-js\`.
+
+@_spi(Experimental) @_spi(BridgeJS) import JavaScriptKit
+
+@JSFunction func takeRecord(_ value: [String: Double]) throws(JSException) -> Void
+
+@JSFunction func returnRecord() throws(JSException) -> [String: String]
+
+@JSFunction func optionalRecord(_ value: Optional<[String: Bool]>) throws(JSException) -> Optional<[String: Bool]>
+
+@JSFunction func nestedRecord(_ value: [String: [String: Double]]) throws(JSException) -> [String: [String: Double]]
+
+@JSFunction func recordWithArrayValues(_ values: [String: [Double]]) throws(JSException) -> [String: [Double]]
+
+@JSFunction func recordWithObjects(_ values: [String: Optional<Box>]) throws(JSException) -> [String: Optional<Box>]
+
+@JSClass struct Box {
+    @JSGetter var value: Double
+    @JSSetter func setValue(_ value: Double) throws(JSException)
+}
+
+@JSFunction func unsupportedKeyRecord(_ values: JSObject) throws(JSException) -> Void
+"
+`;
+
 exports[`ts2swift > snapshots Swift output for StringEnum.d.ts > StringEnum 1`] = `
 "// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.

--- a/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/fixtures/RecordDictionary.d.ts
+++ b/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/fixtures/RecordDictionary.d.ts
@@ -1,0 +1,17 @@
+export interface Box {
+    value: number;
+}
+
+export function takeRecord(value: Record<string, number>): void;
+
+export function returnRecord(): Record<string, string>;
+
+export function optionalRecord(value: Record<string, boolean> | null): Record<string, boolean> | null;
+
+export function nestedRecord(value: Record<string, Record<string, number>>): Record<string, Record<string, number>>;
+
+export function recordWithArrayValues(values: Record<string, number[]>): Record<string, number[]>;
+
+export function recordWithObjects(values: Record<string, Box | null>): Record<string, Box | null>;
+
+export function unsupportedKeyRecord(values: Record<number, string>): void;


### PR DESCRIPTION
Motivation:
- Support ts2swift translation for `Record<string, T>` outputs.

Changes:
- Map `Record<string, T>` (including alias instantiations) to `[String: T]` with a warning fallback for non-string keys.
- Add Record fixture and refresh Vitest snapshot covering nested, optional, array, and object values plus unsupported key coverage.
