### PR TITLE
[NFC] BridgeJS: Split out OptionalSupportTests.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -183,6 +183,7 @@ let package = Package(
                 "bridge-js.d.ts",
                 "bridge-js.global.d.ts",
                 "Generated/JavaScript",
+                "JavaScript",
             ],
             swiftSettings: [
                 .enableExperimentalFeature("Extern")

--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -194,6 +194,7 @@ let package = Package(
                 "bridge-js.d.ts",
                 "bridge-js.global.d.ts",
                 "Generated/JavaScript",
+                "JavaScript",
             ],
             swiftSettings: [
                 .enableExperimentalFeature("Extern")

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -515,123 +515,6 @@ enum ComplexResult {
     return result
 }
 
-// MARK: - Optionals
-
-@JS func roundTripOptionalString(name: String?) -> String? {
-    return name
-}
-
-@JS func roundTripOptionalInt(value: Int?) -> Int? {
-    return value
-}
-
-@JS func roundTripOptionalBool(flag: Bool?) -> Bool? {
-    return flag
-}
-
-@JS func roundTripOptionalFloat(number: Float?) -> Float? {
-    return number
-}
-
-@JS func roundTripOptionalDouble(precision: Double?) -> Double? {
-    return precision
-}
-
-@JS func roundTripOptionalSyntax(name: Optional<String>) -> Optional<String> {
-    return name
-}
-
-@JS func roundTripOptionalMixSyntax(name: String?) -> Optional<String> {
-    return name
-}
-
-@JS func roundTripOptionalSwiftSyntax(name: Swift.Optional<String>) -> Swift.Optional<String> {
-    return name
-}
-
-@JS func roundTripOptionalWithSpaces(value: Optional<Double>) -> Optional<Double> {
-    return value
-}
-
-typealias OptionalAge = Int?
-@JS func roundTripOptionalTypeAlias(age: OptionalAge) -> OptionalAge {
-    return age
-}
-
-@JS func roundTripOptionalStatus(value: Status?) -> Status? {
-    return value
-}
-
-@JS func roundTripOptionalTheme(value: Theme?) -> Theme? {
-    return value
-}
-
-@JS func roundTripOptionalHttpStatus(value: HttpStatus?) -> HttpStatus? {
-    return value
-}
-
-@JS func roundTripOptionalTSDirection(value: TSDirection?) -> TSDirection? {
-    return value
-}
-
-@JS func roundTripOptionalTSTheme(value: TSTheme?) -> TSTheme? {
-    return value
-}
-
-@JS func roundTripOptionalNetworkingAPIMethod(_ method: Networking.API.Method?) -> Networking.API.Method? {
-    return method
-}
-
-@JS func roundTripOptionalAPIResult(value: APIResult?) -> APIResult? {
-    return value
-}
-
-@JS enum TypedPayloadResult {
-    case precision(Precision)
-    case direction(Direction)
-    case optPrecision(Precision?)
-    case optDirection(Direction?)
-    case empty
-}
-
-@JS func roundTripTypedPayloadResult(_ result: TypedPayloadResult) -> TypedPayloadResult {
-    return result
-}
-
-@JS func roundTripOptionalTypedPayloadResult(_ result: TypedPayloadResult?) -> TypedPayloadResult? {
-    return result
-}
-
-@JS func compareAPIResults(_ r1: APIResult?, _ r2: APIResult?) -> String {
-    let r1Str: String
-    switch r1 {
-    case .none: r1Str = "nil"
-    case .some(.success(let msg)): r1Str = "success:\(msg)"
-    case .some(.failure(let code)): r1Str = "failure:\(code)"
-    case .some(.info): r1Str = "info"
-    case .some(.flag(let b)): r1Str = "flag:\(b)"
-    case .some(.rate(let r)): r1Str = "rate:\(r)"
-    case .some(.precise(let p)): r1Str = "precise:\(p)"
-    }
-
-    let r2Str: String
-    switch r2 {
-    case .none: r2Str = "nil"
-    case .some(.success(let msg)): r2Str = "success:\(msg)"
-    case .some(.failure(let code)): r2Str = "failure:\(code)"
-    case .some(.info): r2Str = "info"
-    case .some(.flag(let b)): r2Str = "flag:\(b)"
-    case .some(.rate(let r)): r2Str = "rate:\(r)"
-    case .some(.precise(let p)): r2Str = "precise:\(p)"
-    }
-
-    return "r1:\(r1Str),r2:\(r2Str)"
-}
-
-@JS func roundTripOptionalComplexResult(_ result: ComplexResult?) -> ComplexResult? {
-    return result
-}
-
 @JS
 enum AllTypesResult {
     case structPayload(Address)
@@ -644,76 +527,19 @@ enum AllTypesResult {
 }
 
 @JS func roundTripAllTypesResult(_ result: AllTypesResult) -> AllTypesResult {
-    return result
+    result
 }
 
-@JS func roundTripOptionalAllTypesResult(_ result: AllTypesResult?) -> AllTypesResult? {
-    return result
-}
-
-@JS
-enum OptionalAllTypesResult {
-    case optStruct(Address?)
-    case optClass(Greeter?)
-    case optJSObject(JSObject?)
-    case optNestedEnum(APIResult?)
-    case optArray([Int]?)
-    case optJsClass(Foo?)
+@JS enum TypedPayloadResult {
+    case precision(Precision)
+    case direction(Direction)
+    case optPrecision(Precision?)
+    case optDirection(Direction?)
     case empty
 }
 
-@JS func roundTripOptionalPayloadResult(_ result: OptionalAllTypesResult) -> OptionalAllTypesResult {
-    return result
-}
-
-@JS func roundTripOptionalPayloadResultOpt(_ result: OptionalAllTypesResult?) -> OptionalAllTypesResult? {
-    return result
-}
-
-@JS func roundTripOptionalClass(value: Greeter?) -> Greeter? {
-    return value
-}
-
-@JS func roundTripOptionalGreeter(_ value: Greeter?) -> Greeter? {
-    value
-}
-
-@JS func applyOptionalGreeter(_ value: Greeter?, _ transform: (Greeter?) -> Greeter?) -> Greeter? {
-    transform(value)
-}
-
-@JS class OptionalHolder {
-    @JS var nullableGreeter: Greeter?
-    @JS var undefinedNumber: JSUndefinedOr<Double>
-
-    @JS init(nullableGreeter: Greeter?, undefinedNumber: JSUndefinedOr<Double>) {
-        self.nullableGreeter = nullableGreeter
-        self.undefinedNumber = undefinedNumber
-    }
-}
-
-@JS func makeOptionalHolder(nullableGreeter: Greeter?, undefinedNumber: JSUndefinedOr<Double>) -> OptionalHolder {
-    OptionalHolder(nullableGreeter: nullableGreeter, undefinedNumber: undefinedNumber)
-}
-
-@JS class OptionalPropertyHolder {
-    @JS var optionalName: String?
-    @JS var optionalAge: Int? = nil
-    @JS var optionalGreeter: Greeter? = nil
-
-    @JS init(optionalName: String?) {
-        self.optionalName = optionalName
-    }
-}
-
-@JS
-enum APIOptionalResult {
-    case success(String?)
-    case failure(Int?, Bool?)
-    case status(Bool?, Int?, String?)
-}
-@JS func roundTripOptionalAPIOptionalResult(result: APIOptionalResult?) -> APIOptionalResult? {
-    return result
+@JS func roundTripTypedPayloadResult(_ result: TypedPayloadResult) -> TypedPayloadResult {
+    result
 }
 
 // MARK: - Property Tests

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.Macros.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.Macros.swift
@@ -14,10 +14,6 @@
 
 @JSFunction func jsRoundTripString(_ v: String) throws(JSException) -> String
 
-@JSFunction func jsRoundTripOptionalNumberNull(_ v: Optional<Double>) throws(JSException) -> Optional<Double>
-
-@JSFunction func jsRoundTripOptionalNumberUndefined(_ v: JSUndefinedOr<Double>) throws(JSException) -> JSUndefinedOr<Double>
-
 @JSFunction func jsRoundTripJSValue(_ v: JSValue) throws(JSException) -> JSValue
 
 @JSFunction func jsThrowOrVoid(_ shouldThrow: Bool) throws(JSException) -> Void

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -1806,91 +1806,6 @@ extension API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
-    private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> TypedPayloadResult {
-        switch caseId {
-        case 0:
-            return .precision(Precision.bridgeJSLiftParameter(_swift_js_pop_f32()))
-        case 1:
-            return .direction(Direction.bridgeJSLiftParameter(_swift_js_pop_i32()))
-        case 2:
-            return .optPrecision(Optional<Precision>.bridgeJSLiftParameter())
-        case 3:
-            return .optDirection(Optional<Direction>.bridgeJSLiftParameter())
-        case 4:
-            return .empty
-        default:
-            fatalError("Unknown TypedPayloadResult case ID: \(caseId)")
-        }
-    }
-
-    // MARK: Protocol Export
-
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
-        switch self {
-        case .precision(let param0):
-            param0.bridgeJSLowerStackReturn()
-            return Int32(0)
-        case .direction(let param0):
-            param0.bridgeJSLowerStackReturn()
-            return Int32(1)
-        case .optPrecision(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            return Int32(2)
-        case .optDirection(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            return Int32(3)
-        case .empty:
-            return Int32(4)
-        }
-    }
-
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ caseId: Int32) -> TypedPayloadResult {
-        return _bridgeJSLiftFromCaseId(caseId)
-    }
-
-    // MARK: ExportSwift
-
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ caseId: Int32) -> TypedPayloadResult {
-        return _bridgeJSLiftFromCaseId(caseId)
-    }
-
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        switch self {
-        case .precision(let param0):
-            param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
-        case .direction(let param0):
-            param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
-        case .optPrecision(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(2))
-        case .optDirection(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(3))
-        case .empty:
-            _swift_js_push_tag(Int32(4))
-        }
-    }
-}
-
 extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
     private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> AllTypesResult {
         switch caseId {
@@ -1976,34 +1891,21 @@ extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
-    private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> OptionalAllTypesResult {
+extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
+    private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> TypedPayloadResult {
         switch caseId {
         case 0:
-            return .optStruct(Optional<Address>.bridgeJSLiftParameter())
+            return .precision(Precision.bridgeJSLiftParameter(_swift_js_pop_f32()))
         case 1:
-            return .optClass(Optional<Greeter>.bridgeJSLiftParameter())
+            return .direction(Direction.bridgeJSLiftParameter(_swift_js_pop_i32()))
         case 2:
-            return .optJSObject(Optional<JSObject>.bridgeJSLiftParameter())
+            return .optPrecision(Optional<Precision>.bridgeJSLiftParameter())
         case 3:
-            return .optNestedEnum(Optional<APIResult>.bridgeJSLiftParameter())
+            return .optDirection(Optional<Direction>.bridgeJSLiftParameter())
         case 4:
-            return .optArray({
-                let __isSome = _swift_js_pop_i32()
-                if __isSome == 0 {
-                    return Optional<[Int]>.none
-                } else {
-                    return [Int].bridgeJSLiftParameter()
-                }
-                }())
-        case 5:
-            return .optJsClass(Optional<JSObject>.bridgeJSLiftParameter().map {
-                    Foo(unsafelyWrapping: $0)
-                })
-        case 6:
             return .empty
         default:
-            fatalError("Unknown OptionalAllTypesResult case ID: \(caseId)")
+            fatalError("Unknown TypedPayloadResult case ID: \(caseId)")
         }
     }
 
@@ -2011,218 +1913,65 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
-        case .optStruct(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+        case .precision(let param0):
+            param0.bridgeJSLowerStackReturn()
             return Int32(0)
-        case .optClass(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+        case .direction(let param0):
+            param0.bridgeJSLowerStackReturn()
             return Int32(1)
-        case .optJSObject(let param0):
+        case .optPrecision(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
                 __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(2)
-        case .optNestedEnum(let param0):
+        case .optDirection(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                _swift_js_push_i32(__bjs_unwrapped_param0.bridgeJSLowerParameter())
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(3)
-        case .optArray(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            return Int32(4)
-        case .optJsClass(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.jsObject.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            return Int32(5)
         case .empty:
-            return Int32(6)
+            return Int32(4)
         }
     }
 
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ caseId: Int32) -> OptionalAllTypesResult {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ caseId: Int32) -> TypedPayloadResult {
         return _bridgeJSLiftFromCaseId(caseId)
     }
 
     // MARK: ExportSwift
 
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ caseId: Int32) -> OptionalAllTypesResult {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ caseId: Int32) -> TypedPayloadResult {
         return _bridgeJSLiftFromCaseId(caseId)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
         switch self {
-        case .optStruct(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+        case .precision(let param0):
+            param0.bridgeJSLowerStackReturn()
             _swift_js_push_tag(Int32(0))
-        case .optClass(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+        case .direction(let param0):
+            param0.bridgeJSLowerStackReturn()
             _swift_js_push_tag(Int32(1))
-        case .optJSObject(let param0):
+        case .optPrecision(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
                 __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             _swift_js_push_tag(Int32(2))
-        case .optNestedEnum(let param0):
+        case .optDirection(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-                _swift_js_push_i32(__bjs_unwrapped_param0.bridgeJSLowerParameter())
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             _swift_js_push_tag(Int32(3))
-        case .optArray(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(4))
-        case .optJsClass(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.jsObject.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(5))
         case .empty:
-            _swift_js_push_tag(Int32(6))
-        }
-    }
-}
-
-extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
-    private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> APIOptionalResult {
-        switch caseId {
-        case 0:
-            return .success(Optional<String>.bridgeJSLiftParameter())
-        case 1:
-            return .failure(Optional<Int>.bridgeJSLiftParameter(), Optional<Bool>.bridgeJSLiftParameter())
-        case 2:
-            return .status(Optional<Bool>.bridgeJSLiftParameter(), Optional<Int>.bridgeJSLiftParameter(), Optional<String>.bridgeJSLiftParameter())
-        default:
-            fatalError("Unknown APIOptionalResult case ID: \(caseId)")
-        }
-    }
-
-    // MARK: Protocol Export
-
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
-        switch self {
-        case .success(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            return Int32(0)
-        case .failure(let param0, let param1):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            let __bjs_isSome_param1 = param1 != nil
-            if let __bjs_unwrapped_param1 = param1 {
-                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
-            return Int32(1)
-        case .status(let param0, let param1, let param2):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            let __bjs_isSome_param1 = param1 != nil
-            if let __bjs_unwrapped_param1 = param1 {
-                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
-            let __bjs_isSome_param2 = param2 != nil
-            if let __bjs_unwrapped_param2 = param2 {
-                __bjs_unwrapped_param2.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param2 ? 1 : 0)
-            return Int32(2)
-        }
-    }
-
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ caseId: Int32) -> APIOptionalResult {
-        return _bridgeJSLiftFromCaseId(caseId)
-    }
-
-    // MARK: ExportSwift
-
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ caseId: Int32) -> APIOptionalResult {
-        return _bridgeJSLiftFromCaseId(caseId)
-    }
-
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        switch self {
-        case .success(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(0))
-        case .failure(let param0, let param1):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            let __bjs_isSome_param1 = param1 != nil
-            if let __bjs_unwrapped_param1 = param1 {
-                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
-            _swift_js_push_tag(Int32(1))
-        case .status(let param0, let param1, let param2):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            let __bjs_isSome_param1 = param1 != nil
-            if let __bjs_unwrapped_param1 = param1 {
-                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
-            let __bjs_isSome_param2 = param2 != nil
-            if let __bjs_unwrapped_param2 = param2 {
-                __bjs_unwrapped_param2.bridgeJSLowerStackReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param2 ? 1 : 0)
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_tag(Int32(4))
         }
     }
 }
@@ -2530,6 +2279,257 @@ public func _bjs_StaticPropertyNamespace_NestedProperties_static_nestedDouble_se
     #else
     fatalError("Only available on WebAssembly")
     #endif
+}
+
+extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
+    private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> OptionalAllTypesResult {
+        switch caseId {
+        case 0:
+            return .optStruct(Optional<Address>.bridgeJSLiftParameter())
+        case 1:
+            return .optClass(Optional<Greeter>.bridgeJSLiftParameter())
+        case 2:
+            return .optJSObject(Optional<JSObject>.bridgeJSLiftParameter())
+        case 3:
+            return .optNestedEnum(Optional<APIResult>.bridgeJSLiftParameter())
+        case 4:
+            return .optArray({
+                let __isSome = _swift_js_pop_i32()
+                if __isSome == 0 {
+                    return Optional<[Int]>.none
+                } else {
+                    return [Int].bridgeJSLiftParameter()
+                }
+                }())
+        case 5:
+            return .optJsClass(Optional<JSObject>.bridgeJSLiftParameter().map {
+                    Foo(unsafelyWrapping: $0)
+                })
+        case 6:
+            return .empty
+        default:
+            fatalError("Unknown OptionalAllTypesResult case ID: \(caseId)")
+        }
+    }
+
+    // MARK: Protocol Export
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
+        switch self {
+        case .optStruct(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            return Int32(0)
+        case .optClass(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            return Int32(1)
+        case .optJSObject(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            return Int32(2)
+        case .optNestedEnum(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                _swift_js_push_i32(__bjs_unwrapped_param0.bridgeJSLowerParameter())
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            return Int32(3)
+        case .optArray(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            return Int32(4)
+        case .optJsClass(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.jsObject.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            return Int32(5)
+        case .empty:
+            return Int32(6)
+        }
+    }
+
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ caseId: Int32) -> OptionalAllTypesResult {
+        return _bridgeJSLiftFromCaseId(caseId)
+    }
+
+    // MARK: ExportSwift
+
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ caseId: Int32) -> OptionalAllTypesResult {
+        return _bridgeJSLiftFromCaseId(caseId)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        switch self {
+        case .optStruct(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            _swift_js_push_tag(Int32(0))
+        case .optClass(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            _swift_js_push_tag(Int32(1))
+        case .optJSObject(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            _swift_js_push_tag(Int32(2))
+        case .optNestedEnum(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                _swift_js_push_i32(__bjs_unwrapped_param0.bridgeJSLowerParameter())
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            _swift_js_push_tag(Int32(3))
+        case .optArray(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            _swift_js_push_tag(Int32(4))
+        case .optJsClass(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.jsObject.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            _swift_js_push_tag(Int32(5))
+        case .empty:
+            _swift_js_push_tag(Int32(6))
+        }
+    }
+}
+
+extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
+    private static func _bridgeJSLiftFromCaseId(_ caseId: Int32) -> APIOptionalResult {
+        switch caseId {
+        case 0:
+            return .success(Optional<String>.bridgeJSLiftParameter())
+        case 1:
+            return .failure(Optional<Int>.bridgeJSLiftParameter(), Optional<Bool>.bridgeJSLiftParameter())
+        case 2:
+            return .status(Optional<Bool>.bridgeJSLiftParameter(), Optional<Int>.bridgeJSLiftParameter(), Optional<String>.bridgeJSLiftParameter())
+        default:
+            fatalError("Unknown APIOptionalResult case ID: \(caseId)")
+        }
+    }
+
+    // MARK: Protocol Export
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
+        switch self {
+        case .success(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            return Int32(0)
+        case .failure(let param0, let param1):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            let __bjs_isSome_param1 = param1 != nil
+            if let __bjs_unwrapped_param1 = param1 {
+                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
+            return Int32(1)
+        case .status(let param0, let param1, let param2):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            let __bjs_isSome_param1 = param1 != nil
+            if let __bjs_unwrapped_param1 = param1 {
+                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
+            let __bjs_isSome_param2 = param2 != nil
+            if let __bjs_unwrapped_param2 = param2 {
+                __bjs_unwrapped_param2.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param2 ? 1 : 0)
+            return Int32(2)
+        }
+    }
+
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ caseId: Int32) -> APIOptionalResult {
+        return _bridgeJSLiftFromCaseId(caseId)
+    }
+
+    // MARK: ExportSwift
+
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ caseId: Int32) -> APIOptionalResult {
+        return _bridgeJSLiftFromCaseId(caseId)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        switch self {
+        case .success(let param0):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            _swift_js_push_tag(Int32(0))
+        case .failure(let param0, let param1):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            let __bjs_isSome_param1 = param1 != nil
+            if let __bjs_unwrapped_param1 = param1 {
+                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
+            _swift_js_push_tag(Int32(1))
+        case .status(let param0, let param1, let param2):
+            let __bjs_isSome_param0 = param0 != nil
+            if let __bjs_unwrapped_param0 = param0 {
+                __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            let __bjs_isSome_param1 = param1 != nil
+            if let __bjs_unwrapped_param1 = param1 {
+                __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
+            let __bjs_isSome_param2 = param2 != nil
+            if let __bjs_unwrapped_param2 = param2 {
+                __bjs_unwrapped_param2.bridgeJSLowerStackReturn()
+            }
+            _swift_js_push_i32(__bjs_isSome_param2 ? 1 : 0)
+            _swift_js_push_tag(Int32(2))
+        }
+    }
 }
 
 extension Point: _BridgedSwiftStruct {
@@ -4654,239 +4654,6 @@ public func _bjs_roundtripAPINetworkingResult(_ result: Int32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalString")
-@_cdecl("bjs_roundTripOptionalString")
-public func _bjs_roundTripOptionalString(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalString(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalInt")
-@_cdecl("bjs_roundTripOptionalInt")
-public func _bjs_roundTripOptionalInt(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalInt(value: Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalBool")
-@_cdecl("bjs_roundTripOptionalBool")
-public func _bjs_roundTripOptionalBool(_ flagIsSome: Int32, _ flagValue: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalBool(flag: Optional<Bool>.bridgeJSLiftParameter(flagIsSome, flagValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalFloat")
-@_cdecl("bjs_roundTripOptionalFloat")
-public func _bjs_roundTripOptionalFloat(_ numberIsSome: Int32, _ numberValue: Float32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalFloat(number: Optional<Float>.bridgeJSLiftParameter(numberIsSome, numberValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalDouble")
-@_cdecl("bjs_roundTripOptionalDouble")
-public func _bjs_roundTripOptionalDouble(_ precisionIsSome: Int32, _ precisionValue: Float64) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalDouble(precision: Optional<Double>.bridgeJSLiftParameter(precisionIsSome, precisionValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalSyntax")
-@_cdecl("bjs_roundTripOptionalSyntax")
-public func _bjs_roundTripOptionalSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalSyntax(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalMixSyntax")
-@_cdecl("bjs_roundTripOptionalMixSyntax")
-public func _bjs_roundTripOptionalMixSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalMixSyntax(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalSwiftSyntax")
-@_cdecl("bjs_roundTripOptionalSwiftSyntax")
-public func _bjs_roundTripOptionalSwiftSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalSwiftSyntax(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalWithSpaces")
-@_cdecl("bjs_roundTripOptionalWithSpaces")
-public func _bjs_roundTripOptionalWithSpaces(_ valueIsSome: Int32, _ valueValue: Float64) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalWithSpaces(value: Optional<Double>.bridgeJSLiftParameter(valueIsSome, valueValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalTypeAlias")
-@_cdecl("bjs_roundTripOptionalTypeAlias")
-public func _bjs_roundTripOptionalTypeAlias(_ ageIsSome: Int32, _ ageValue: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalTypeAlias(age: Optional<Int>.bridgeJSLiftParameter(ageIsSome, ageValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalStatus")
-@_cdecl("bjs_roundTripOptionalStatus")
-public func _bjs_roundTripOptionalStatus(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalStatus(value: Optional<Status>.bridgeJSLiftParameter(valueIsSome, valueValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalTheme")
-@_cdecl("bjs_roundTripOptionalTheme")
-public func _bjs_roundTripOptionalTheme(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalTheme(value: Optional<Theme>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalHttpStatus")
-@_cdecl("bjs_roundTripOptionalHttpStatus")
-public func _bjs_roundTripOptionalHttpStatus(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalHttpStatus(value: Optional<HttpStatus>.bridgeJSLiftParameter(valueIsSome, valueValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalTSDirection")
-@_cdecl("bjs_roundTripOptionalTSDirection")
-public func _bjs_roundTripOptionalTSDirection(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalTSDirection(value: Optional<TSDirection>.bridgeJSLiftParameter(valueIsSome, valueValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalTSTheme")
-@_cdecl("bjs_roundTripOptionalTSTheme")
-public func _bjs_roundTripOptionalTSTheme(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalTSTheme(value: Optional<TSTheme>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalNetworkingAPIMethod")
-@_cdecl("bjs_roundTripOptionalNetworkingAPIMethod")
-public func _bjs_roundTripOptionalNetworkingAPIMethod(_ methodIsSome: Int32, _ methodValue: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalNetworkingAPIMethod(_: Optional<Networking.API.Method>.bridgeJSLiftParameter(methodIsSome, methodValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalAPIResult")
-@_cdecl("bjs_roundTripOptionalAPIResult")
-public func _bjs_roundTripOptionalAPIResult(_ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalAPIResult(value: Optional<APIResult>.bridgeJSLiftParameter(valueIsSome, valueCaseId))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripTypedPayloadResult")
-@_cdecl("bjs_roundTripTypedPayloadResult")
-public func _bjs_roundTripTypedPayloadResult(_ result: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripTypedPayloadResult(_: TypedPayloadResult.bridgeJSLiftParameter(result))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalTypedPayloadResult")
-@_cdecl("bjs_roundTripOptionalTypedPayloadResult")
-public func _bjs_roundTripOptionalTypedPayloadResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalTypedPayloadResult(_: Optional<TypedPayloadResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_compareAPIResults")
-@_cdecl("bjs_compareAPIResults")
-public func _bjs_compareAPIResults(_ r1IsSome: Int32, _ r1CaseId: Int32, _ r2IsSome: Int32, _ r2CaseId: Int32) -> Void {
-    #if arch(wasm32)
-    let _tmp_r2 = Optional<APIResult>.bridgeJSLiftParameter(r2IsSome, r2CaseId)
-    let _tmp_r1 = Optional<APIResult>.bridgeJSLiftParameter(r1IsSome, r1CaseId)
-    let ret = compareAPIResults(_: _tmp_r1, _: _tmp_r2)
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalComplexResult")
-@_cdecl("bjs_roundTripOptionalComplexResult")
-public func _bjs_roundTripOptionalComplexResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalComplexResult(_: Optional<ComplexResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
 @_expose(wasm, "bjs_roundTripAllTypesResult")
 @_cdecl("bjs_roundTripAllTypesResult")
 public func _bjs_roundTripAllTypesResult(_ result: Int32) -> Void {
@@ -4898,88 +4665,11 @@ public func _bjs_roundTripAllTypesResult(_ result: Int32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalAllTypesResult")
-@_cdecl("bjs_roundTripOptionalAllTypesResult")
-public func _bjs_roundTripOptionalAllTypesResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_roundTripTypedPayloadResult")
+@_cdecl("bjs_roundTripTypedPayloadResult")
+public func _bjs_roundTripTypedPayloadResult(_ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalAllTypesResult(_: Optional<AllTypesResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalPayloadResult")
-@_cdecl("bjs_roundTripOptionalPayloadResult")
-public func _bjs_roundTripOptionalPayloadResult(_ result: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalPayloadResult(_: OptionalAllTypesResult.bridgeJSLiftParameter(result))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalPayloadResultOpt")
-@_cdecl("bjs_roundTripOptionalPayloadResultOpt")
-public func _bjs_roundTripOptionalPayloadResultOpt(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalPayloadResultOpt(_: Optional<OptionalAllTypesResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalClass")
-@_cdecl("bjs_roundTripOptionalClass")
-public func _bjs_roundTripOptionalClass(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalClass(value: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalGreeter")
-@_cdecl("bjs_roundTripOptionalGreeter")
-public func _bjs_roundTripOptionalGreeter(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalGreeter(_: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_applyOptionalGreeter")
-@_cdecl("bjs_applyOptionalGreeter")
-public func _bjs_applyOptionalGreeter(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer, _ transform: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = applyOptionalGreeter(_: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue), _: _BJS_Closure_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC.bridgeJSLift(transform))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_makeOptionalHolder")
-@_cdecl("bjs_makeOptionalHolder")
-public func _bjs_makeOptionalHolder(_ nullableGreeterIsSome: Int32, _ nullableGreeterValue: UnsafeMutableRawPointer, _ undefinedNumberIsSome: Int32, _ undefinedNumberValue: Float64) -> UnsafeMutableRawPointer {
-    #if arch(wasm32)
-    let ret = makeOptionalHolder(nullableGreeter: Optional<Greeter>.bridgeJSLiftParameter(nullableGreeterIsSome, nullableGreeterValue), undefinedNumber: JSUndefinedOr<Double>.bridgeJSLiftParameter(undefinedNumberIsSome, undefinedNumberValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalAPIOptionalResult")
-@_cdecl("bjs_roundTripOptionalAPIOptionalResult")
-public func _bjs_roundTripOptionalAPIOptionalResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalAPIOptionalResult(result: Optional<APIOptionalResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    let ret = roundTripTypedPayloadResult(_: TypedPayloadResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -5824,6 +5514,316 @@ public func _bjs_roundTripOptionalFooArray() -> Void {
     #endif
 }
 
+@_expose(wasm, "bjs_roundTripOptionalString")
+@_cdecl("bjs_roundTripOptionalString")
+public func _bjs_roundTripOptionalString(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalString(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalInt")
+@_cdecl("bjs_roundTripOptionalInt")
+public func _bjs_roundTripOptionalInt(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalInt(value: Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalBool")
+@_cdecl("bjs_roundTripOptionalBool")
+public func _bjs_roundTripOptionalBool(_ flagIsSome: Int32, _ flagValue: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalBool(flag: Optional<Bool>.bridgeJSLiftParameter(flagIsSome, flagValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalFloat")
+@_cdecl("bjs_roundTripOptionalFloat")
+public func _bjs_roundTripOptionalFloat(_ numberIsSome: Int32, _ numberValue: Float32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalFloat(number: Optional<Float>.bridgeJSLiftParameter(numberIsSome, numberValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalDouble")
+@_cdecl("bjs_roundTripOptionalDouble")
+public func _bjs_roundTripOptionalDouble(_ precisionIsSome: Int32, _ precisionValue: Float64) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalDouble(precision: Optional<Double>.bridgeJSLiftParameter(precisionIsSome, precisionValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalSyntax")
+@_cdecl("bjs_roundTripOptionalSyntax")
+public func _bjs_roundTripOptionalSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalSyntax(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalMixSyntax")
+@_cdecl("bjs_roundTripOptionalMixSyntax")
+public func _bjs_roundTripOptionalMixSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalMixSyntax(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalSwiftSyntax")
+@_cdecl("bjs_roundTripOptionalSwiftSyntax")
+public func _bjs_roundTripOptionalSwiftSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalSwiftSyntax(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalWithSpaces")
+@_cdecl("bjs_roundTripOptionalWithSpaces")
+public func _bjs_roundTripOptionalWithSpaces(_ valueIsSome: Int32, _ valueValue: Float64) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalWithSpaces(value: Optional<Double>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalTypeAlias")
+@_cdecl("bjs_roundTripOptionalTypeAlias")
+public func _bjs_roundTripOptionalTypeAlias(_ ageIsSome: Int32, _ ageValue: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalTypeAlias(age: Optional<Int>.bridgeJSLiftParameter(ageIsSome, ageValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalStatus")
+@_cdecl("bjs_roundTripOptionalStatus")
+public func _bjs_roundTripOptionalStatus(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalStatus(value: Optional<Status>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalTheme")
+@_cdecl("bjs_roundTripOptionalTheme")
+public func _bjs_roundTripOptionalTheme(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalTheme(value: Optional<Theme>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalHttpStatus")
+@_cdecl("bjs_roundTripOptionalHttpStatus")
+public func _bjs_roundTripOptionalHttpStatus(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalHttpStatus(value: Optional<HttpStatus>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalTSDirection")
+@_cdecl("bjs_roundTripOptionalTSDirection")
+public func _bjs_roundTripOptionalTSDirection(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalTSDirection(value: Optional<TSDirection>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalTSTheme")
+@_cdecl("bjs_roundTripOptionalTSTheme")
+public func _bjs_roundTripOptionalTSTheme(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalTSTheme(value: Optional<TSTheme>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalNetworkingAPIMethod")
+@_cdecl("bjs_roundTripOptionalNetworkingAPIMethod")
+public func _bjs_roundTripOptionalNetworkingAPIMethod(_ methodIsSome: Int32, _ methodValue: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalNetworkingAPIMethod(_: Optional<Networking.API.Method>.bridgeJSLiftParameter(methodIsSome, methodValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalAPIResult")
+@_cdecl("bjs_roundTripOptionalAPIResult")
+public func _bjs_roundTripOptionalAPIResult(_ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalAPIResult(value: Optional<APIResult>.bridgeJSLiftParameter(valueIsSome, valueCaseId))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalTypedPayloadResult")
+@_cdecl("bjs_roundTripOptionalTypedPayloadResult")
+public func _bjs_roundTripOptionalTypedPayloadResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalTypedPayloadResult(_: Optional<TypedPayloadResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_compareAPIResults")
+@_cdecl("bjs_compareAPIResults")
+public func _bjs_compareAPIResults(_ r1IsSome: Int32, _ r1CaseId: Int32, _ r2IsSome: Int32, _ r2CaseId: Int32) -> Void {
+    #if arch(wasm32)
+    let _tmp_r2 = Optional<APIResult>.bridgeJSLiftParameter(r2IsSome, r2CaseId)
+    let _tmp_r1 = Optional<APIResult>.bridgeJSLiftParameter(r1IsSome, r1CaseId)
+    let ret = compareAPIResults(_: _tmp_r1, _: _tmp_r2)
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalComplexResult")
+@_cdecl("bjs_roundTripOptionalComplexResult")
+public func _bjs_roundTripOptionalComplexResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalComplexResult(_: Optional<ComplexResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalAllTypesResult")
+@_cdecl("bjs_roundTripOptionalAllTypesResult")
+public func _bjs_roundTripOptionalAllTypesResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalAllTypesResult(_: Optional<AllTypesResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalPayloadResult")
+@_cdecl("bjs_roundTripOptionalPayloadResult")
+public func _bjs_roundTripOptionalPayloadResult(_ result: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalPayloadResult(_: OptionalAllTypesResult.bridgeJSLiftParameter(result))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalPayloadResultOpt")
+@_cdecl("bjs_roundTripOptionalPayloadResultOpt")
+public func _bjs_roundTripOptionalPayloadResultOpt(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalPayloadResultOpt(_: Optional<OptionalAllTypesResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalClass")
+@_cdecl("bjs_roundTripOptionalClass")
+public func _bjs_roundTripOptionalClass(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalClass(value: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalGreeter")
+@_cdecl("bjs_roundTripOptionalGreeter")
+public func _bjs_roundTripOptionalGreeter(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalGreeter(_: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_applyOptionalGreeter")
+@_cdecl("bjs_applyOptionalGreeter")
+public func _bjs_applyOptionalGreeter(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer, _ transform: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = applyOptionalGreeter(_: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue), _: _BJS_Closure_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC.bridgeJSLift(transform))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeOptionalHolder")
+@_cdecl("bjs_makeOptionalHolder")
+public func _bjs_makeOptionalHolder(_ nullableGreeterIsSome: Int32, _ nullableGreeterValue: UnsafeMutableRawPointer, _ undefinedNumberIsSome: Int32, _ undefinedNumberValue: Float64) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = makeOptionalHolder(nullableGreeter: Optional<Greeter>.bridgeJSLiftParameter(nullableGreeterIsSome, nullableGreeterValue), undefinedNumber: JSUndefinedOr<Double>.bridgeJSLiftParameter(undefinedNumberIsSome, undefinedNumberValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalAPIOptionalResult")
+@_cdecl("bjs_roundTripOptionalAPIOptionalResult")
+public func _bjs_roundTripOptionalAPIOptionalResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalAPIOptionalResult(result: Optional<APIOptionalResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_roundTripPointerFields")
 @_cdecl("bjs_roundTripPointerFields")
 public func _bjs_roundTripPointerFields() -> Void {
@@ -6418,183 +6418,6 @@ extension Internal.TestServer: ConvertibleToJSValue, _BridgedSwiftHeapObject {
 fileprivate func _bjs_TestServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
 fileprivate func _bjs_TestServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-
-@_expose(wasm, "bjs_OptionalHolder_init")
-@_cdecl("bjs_OptionalHolder_init")
-public func _bjs_OptionalHolder_init(_ nullableGreeterIsSome: Int32, _ nullableGreeterValue: UnsafeMutableRawPointer, _ undefinedNumberIsSome: Int32, _ undefinedNumberValue: Float64) -> UnsafeMutableRawPointer {
-    #if arch(wasm32)
-    let ret = OptionalHolder(nullableGreeter: Optional<Greeter>.bridgeJSLiftParameter(nullableGreeterIsSome, nullableGreeterValue), undefinedNumber: JSUndefinedOr<Double>.bridgeJSLiftParameter(undefinedNumberIsSome, undefinedNumberValue))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_OptionalHolder_nullableGreeter_get")
-@_cdecl("bjs_OptionalHolder_nullableGreeter_get")
-public func _bjs_OptionalHolder_nullableGreeter_get(_ _self: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    let ret = OptionalHolder.bridgeJSLiftParameter(_self).nullableGreeter
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_OptionalHolder_nullableGreeter_set")
-@_cdecl("bjs_OptionalHolder_nullableGreeter_set")
-public func _bjs_OptionalHolder_nullableGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    OptionalHolder.bridgeJSLiftParameter(_self).nullableGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_OptionalHolder_undefinedNumber_get")
-@_cdecl("bjs_OptionalHolder_undefinedNumber_get")
-public func _bjs_OptionalHolder_undefinedNumber_get(_ _self: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    let ret = OptionalHolder.bridgeJSLiftParameter(_self).undefinedNumber
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_OptionalHolder_undefinedNumber_set")
-@_cdecl("bjs_OptionalHolder_undefinedNumber_set")
-public func _bjs_OptionalHolder_undefinedNumber_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Float64) -> Void {
-    #if arch(wasm32)
-    OptionalHolder.bridgeJSLiftParameter(_self).undefinedNumber = JSUndefinedOr<Double>.bridgeJSLiftParameter(valueIsSome, valueValue)
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_OptionalHolder_deinit")
-@_cdecl("bjs_OptionalHolder_deinit")
-public func _bjs_OptionalHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    Unmanaged<OptionalHolder>.fromOpaque(pointer).release()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-extension OptionalHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject {
-    var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_OptionalHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
-    }
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalHolder_wrap")
-fileprivate func _bjs_OptionalHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32
-#else
-fileprivate func _bjs_OptionalHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-
-@_expose(wasm, "bjs_OptionalPropertyHolder_init")
-@_cdecl("bjs_OptionalPropertyHolder_init")
-public func _bjs_OptionalPropertyHolder_init(_ optionalNameIsSome: Int32, _ optionalNameBytes: Int32, _ optionalNameLength: Int32) -> UnsafeMutableRawPointer {
-    #if arch(wasm32)
-    let ret = OptionalPropertyHolder(optionalName: Optional<String>.bridgeJSLiftParameter(optionalNameIsSome, optionalNameBytes, optionalNameLength))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalName_get")
-@_cdecl("bjs_OptionalPropertyHolder_optionalName_get")
-public func _bjs_OptionalPropertyHolder_optionalName_get(_ _self: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    let ret = OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalName
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalName_set")
-@_cdecl("bjs_OptionalPropertyHolder_optionalName_set")
-public func _bjs_OptionalPropertyHolder_optionalName_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    #if arch(wasm32)
-    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalName = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalAge_get")
-@_cdecl("bjs_OptionalPropertyHolder_optionalAge_get")
-public func _bjs_OptionalPropertyHolder_optionalAge_get(_ _self: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    let ret = OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalAge
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalAge_set")
-@_cdecl("bjs_OptionalPropertyHolder_optionalAge_set")
-public func _bjs_OptionalPropertyHolder_optionalAge_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
-    #if arch(wasm32)
-    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalAge = Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue)
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalGreeter_get")
-@_cdecl("bjs_OptionalPropertyHolder_optionalGreeter_get")
-public func _bjs_OptionalPropertyHolder_optionalGreeter_get(_ _self: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    let ret = OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalGreeter_set")
-@_cdecl("bjs_OptionalPropertyHolder_optionalGreeter_set")
-public func _bjs_OptionalPropertyHolder_optionalGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_OptionalPropertyHolder_deinit")
-@_cdecl("bjs_OptionalPropertyHolder_deinit")
-public func _bjs_OptionalPropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    Unmanaged<OptionalPropertyHolder>.fromOpaque(pointer).release()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-extension OptionalPropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject {
-    var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_OptionalPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
-    }
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalPropertyHolder_wrap")
-fileprivate func _bjs_OptionalPropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32
-#else
-fileprivate func _bjs_OptionalPropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -8326,6 +8149,183 @@ fileprivate func _bjs_TextProcessor_wrap(_ pointer: UnsafeMutableRawPointer) -> 
 }
 #endif
 
+@_expose(wasm, "bjs_OptionalHolder_init")
+@_cdecl("bjs_OptionalHolder_init")
+public func _bjs_OptionalHolder_init(_ nullableGreeterIsSome: Int32, _ nullableGreeterValue: UnsafeMutableRawPointer, _ undefinedNumberIsSome: Int32, _ undefinedNumberValue: Float64) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = OptionalHolder(nullableGreeter: Optional<Greeter>.bridgeJSLiftParameter(nullableGreeterIsSome, nullableGreeterValue), undefinedNumber: JSUndefinedOr<Double>.bridgeJSLiftParameter(undefinedNumberIsSome, undefinedNumberValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_OptionalHolder_nullableGreeter_get")
+@_cdecl("bjs_OptionalHolder_nullableGreeter_get")
+public func _bjs_OptionalHolder_nullableGreeter_get(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = OptionalHolder.bridgeJSLiftParameter(_self).nullableGreeter
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_OptionalHolder_nullableGreeter_set")
+@_cdecl("bjs_OptionalHolder_nullableGreeter_set")
+public func _bjs_OptionalHolder_nullableGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    OptionalHolder.bridgeJSLiftParameter(_self).nullableGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_OptionalHolder_undefinedNumber_get")
+@_cdecl("bjs_OptionalHolder_undefinedNumber_get")
+public func _bjs_OptionalHolder_undefinedNumber_get(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = OptionalHolder.bridgeJSLiftParameter(_self).undefinedNumber
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_OptionalHolder_undefinedNumber_set")
+@_cdecl("bjs_OptionalHolder_undefinedNumber_set")
+public func _bjs_OptionalHolder_undefinedNumber_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Float64) -> Void {
+    #if arch(wasm32)
+    OptionalHolder.bridgeJSLiftParameter(_self).undefinedNumber = JSUndefinedOr<Double>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_OptionalHolder_deinit")
+@_cdecl("bjs_OptionalHolder_deinit")
+public func _bjs_OptionalHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<OptionalHolder>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension OptionalHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_OptionalHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalHolder_wrap")
+fileprivate func _bjs_OptionalHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_OptionalHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_OptionalPropertyHolder_init")
+@_cdecl("bjs_OptionalPropertyHolder_init")
+public func _bjs_OptionalPropertyHolder_init(_ optionalNameIsSome: Int32, _ optionalNameBytes: Int32, _ optionalNameLength: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = OptionalPropertyHolder(optionalName: Optional<String>.bridgeJSLiftParameter(optionalNameIsSome, optionalNameBytes, optionalNameLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_OptionalPropertyHolder_optionalName_get")
+@_cdecl("bjs_OptionalPropertyHolder_optionalName_get")
+public func _bjs_OptionalPropertyHolder_optionalName_get(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalName
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_OptionalPropertyHolder_optionalName_set")
+@_cdecl("bjs_OptionalPropertyHolder_optionalName_set")
+public func _bjs_OptionalPropertyHolder_optionalName_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    #if arch(wasm32)
+    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalName = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_OptionalPropertyHolder_optionalAge_get")
+@_cdecl("bjs_OptionalPropertyHolder_optionalAge_get")
+public func _bjs_OptionalPropertyHolder_optionalAge_get(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalAge
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_OptionalPropertyHolder_optionalAge_set")
+@_cdecl("bjs_OptionalPropertyHolder_optionalAge_set")
+public func _bjs_OptionalPropertyHolder_optionalAge_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    #if arch(wasm32)
+    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalAge = Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_OptionalPropertyHolder_optionalGreeter_get")
+@_cdecl("bjs_OptionalPropertyHolder_optionalGreeter_get")
+public func _bjs_OptionalPropertyHolder_optionalGreeter_get(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_OptionalPropertyHolder_optionalGreeter_set")
+@_cdecl("bjs_OptionalPropertyHolder_optionalGreeter_set")
+public func _bjs_OptionalPropertyHolder_optionalGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_OptionalPropertyHolder_deinit")
+@_cdecl("bjs_OptionalPropertyHolder_deinit")
+public func _bjs_OptionalPropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<OptionalPropertyHolder>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension OptionalPropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_OptionalPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalPropertyHolder_wrap")
+fileprivate func _bjs_OptionalPropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_OptionalPropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
 @_expose(wasm, "bjs_Container_init")
 @_cdecl("bjs_Container_init")
 public func _bjs_Container_init(_ config: Int32) -> UnsafeMutableRawPointer {
@@ -8527,42 +8527,6 @@ func _$jsRoundTripString(_ v: String) throws(JSException) -> String {
         throw error
     }
     return String.bridgeJSLiftReturn(ret)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripOptionalNumberNull")
-fileprivate func bjs_jsRoundTripOptionalNumberNull(_ vIsSome: Int32, _ vValue: Float64) -> Void
-#else
-fileprivate func bjs_jsRoundTripOptionalNumberNull(_ vIsSome: Int32, _ vValue: Float64) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-
-func _$jsRoundTripOptionalNumberNull(_ v: Optional<Double>) throws(JSException) -> Optional<Double> {
-    let (vIsSome, vValue) = v.bridgeJSLowerParameter()
-    bjs_jsRoundTripOptionalNumberNull(vIsSome, vValue)
-    if let error = _swift_js_take_exception() {
-        throw error
-    }
-    return Optional<Double>.bridgeJSLiftReturnFromSideChannel()
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripOptionalNumberUndefined")
-fileprivate func bjs_jsRoundTripOptionalNumberUndefined(_ vIsSome: Int32, _ vValue: Float64) -> Void
-#else
-fileprivate func bjs_jsRoundTripOptionalNumberUndefined(_ vIsSome: Int32, _ vValue: Float64) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-
-func _$jsRoundTripOptionalNumberUndefined(_ v: JSUndefinedOr<Double>) throws(JSException) -> JSUndefinedOr<Double> {
-    let (vIsSome, vValue) = v.bridgeJSLowerParameter()
-    bjs_jsRoundTripOptionalNumberUndefined(vIsSome, vValue)
-    if let error = _swift_js_take_exception() {
-        throw error
-    }
-    return JSUndefinedOr<Double>.bridgeJSLiftReturnFromSideChannel()
 }
 
 #if arch(wasm32)
@@ -9540,4 +9504,92 @@ func _$jsTranslatePoint(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException
         throw error
     }
     return Point.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_runJsOptionalSupportTests")
+fileprivate func bjs_runJsOptionalSupportTests() -> Void
+#else
+fileprivate func bjs_runJsOptionalSupportTests() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$runJsOptionalSupportTests() throws(JSException) -> Void {
+    bjs_runJsOptionalSupportTests()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripOptionalNumberNull")
+fileprivate func bjs_jsRoundTripOptionalNumberNull(_ valueIsSome: Int32, _ valueValue: Int32) -> Void
+#else
+fileprivate func bjs_jsRoundTripOptionalNumberNull(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsRoundTripOptionalNumberNull(_ value: Optional<Int>) throws(JSException) -> Optional<Int> {
+    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    bjs_jsRoundTripOptionalNumberNull(valueIsSome, valueValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<Int>.bridgeJSLiftReturnFromSideChannel()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripOptionalNumberUndefined")
+fileprivate func bjs_jsRoundTripOptionalNumberUndefined(_ valueIsSome: Int32, _ valueValue: Int32) -> Void
+#else
+fileprivate func bjs_jsRoundTripOptionalNumberUndefined(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsRoundTripOptionalNumberUndefined(_ value: JSUndefinedOr<Int>) throws(JSException) -> JSUndefinedOr<Int> {
+    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    bjs_jsRoundTripOptionalNumberUndefined(valueIsSome, valueValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSUndefinedOr<Int>.bridgeJSLiftReturnFromSideChannel()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripOptionalStringNull")
+fileprivate func bjs_jsRoundTripOptionalStringNull(_ nameIsSome: Int32, _ nameValue: Int32) -> Void
+#else
+fileprivate func bjs_jsRoundTripOptionalStringNull(_ nameIsSome: Int32, _ nameValue: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsRoundTripOptionalStringNull(_ name: Optional<String>) throws(JSException) -> Optional<String> {
+    let (nameIsSome, nameValue) = name.bridgeJSLowerParameter()
+    bjs_jsRoundTripOptionalStringNull(nameIsSome, nameValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<String>.bridgeJSLiftReturnFromSideChannel()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripOptionalStringUndefined")
+fileprivate func bjs_jsRoundTripOptionalStringUndefined(_ nameIsSome: Int32, _ nameValue: Int32) -> Void
+#else
+fileprivate func bjs_jsRoundTripOptionalStringUndefined(_ nameIsSome: Int32, _ nameValue: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsRoundTripOptionalStringUndefined(_ name: JSUndefinedOr<String>) throws(JSException) -> JSUndefinedOr<String> {
+    let (nameIsSome, nameValue) = name.bridgeJSLowerParameter()
+    bjs_jsRoundTripOptionalStringUndefined(nameIsSome, nameValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSUndefinedOr<String>.bridgeJSLiftReturnFromSideChannel()
 }

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -527,161 +527,6 @@
       },
       {
         "constructor" : {
-          "abiName" : "bjs_OptionalHolder_init",
-          "effects" : {
-            "isAsync" : false,
-            "isStatic" : false,
-            "isThrows" : false
-          },
-          "parameters" : [
-            {
-              "label" : "nullableGreeter",
-              "name" : "nullableGreeter",
-              "type" : {
-                "nullable" : {
-                  "_0" : {
-                    "swiftHeapObject" : {
-                      "_0" : "Greeter"
-                    }
-                  },
-                  "_1" : "null"
-                }
-              }
-            },
-            {
-              "label" : "undefinedNumber",
-              "name" : "undefinedNumber",
-              "type" : {
-                "nullable" : {
-                  "_0" : {
-                    "double" : {
-
-                    }
-                  },
-                  "_1" : "undefined"
-                }
-              }
-            }
-          ]
-        },
-        "methods" : [
-
-        ],
-        "name" : "OptionalHolder",
-        "properties" : [
-          {
-            "isReadonly" : false,
-            "isStatic" : false,
-            "name" : "nullableGreeter",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "swiftHeapObject" : {
-                    "_0" : "Greeter"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          },
-          {
-            "isReadonly" : false,
-            "isStatic" : false,
-            "name" : "undefinedNumber",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "double" : {
-
-                  }
-                },
-                "_1" : "undefined"
-              }
-            }
-          }
-        ],
-        "swiftCallName" : "OptionalHolder"
-      },
-      {
-        "constructor" : {
-          "abiName" : "bjs_OptionalPropertyHolder_init",
-          "effects" : {
-            "isAsync" : false,
-            "isStatic" : false,
-            "isThrows" : false
-          },
-          "parameters" : [
-            {
-              "label" : "optionalName",
-              "name" : "optionalName",
-              "type" : {
-                "nullable" : {
-                  "_0" : {
-                    "string" : {
-
-                    }
-                  },
-                  "_1" : "null"
-                }
-              }
-            }
-          ]
-        },
-        "methods" : [
-
-        ],
-        "name" : "OptionalPropertyHolder",
-        "properties" : [
-          {
-            "isReadonly" : false,
-            "isStatic" : false,
-            "name" : "optionalName",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "string" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          },
-          {
-            "isReadonly" : false,
-            "isStatic" : false,
-            "name" : "optionalAge",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "int" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          },
-          {
-            "isReadonly" : false,
-            "isStatic" : false,
-            "name" : "optionalGreeter",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "swiftHeapObject" : {
-                    "_0" : "Greeter"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "swiftCallName" : "OptionalPropertyHolder"
-      },
-      {
-        "constructor" : {
           "abiName" : "bjs_SimplePropertyHolder_init",
           "effects" : {
             "isAsync" : false,
@@ -3241,6 +3086,161 @@
       },
       {
         "constructor" : {
+          "abiName" : "bjs_OptionalHolder_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "nullableGreeter",
+              "name" : "nullableGreeter",
+              "type" : {
+                "nullable" : {
+                  "_0" : {
+                    "swiftHeapObject" : {
+                      "_0" : "Greeter"
+                    }
+                  },
+                  "_1" : "null"
+                }
+              }
+            },
+            {
+              "label" : "undefinedNumber",
+              "name" : "undefinedNumber",
+              "type" : {
+                "nullable" : {
+                  "_0" : {
+                    "double" : {
+
+                    }
+                  },
+                  "_1" : "undefined"
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+
+        ],
+        "name" : "OptionalHolder",
+        "properties" : [
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "name" : "nullableGreeter",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "swiftHeapObject" : {
+                    "_0" : "Greeter"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          },
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "name" : "undefinedNumber",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "double" : {
+
+                  }
+                },
+                "_1" : "undefined"
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "OptionalHolder"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_OptionalPropertyHolder_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "optionalName",
+              "name" : "optionalName",
+              "type" : {
+                "nullable" : {
+                  "_0" : {
+                    "string" : {
+
+                    }
+                  },
+                  "_1" : "null"
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+
+        ],
+        "name" : "OptionalPropertyHolder",
+        "properties" : [
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "name" : "optionalName",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          },
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "name" : "optionalAge",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          },
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "name" : "optionalGreeter",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "swiftHeapObject" : {
+                    "_0" : "Greeter"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "OptionalPropertyHolder"
+      },
+      {
+        "constructor" : {
           "abiName" : "bjs_Container_init",
           "effects" : {
             "isAsync" : false,
@@ -4363,86 +4363,6 @@
             "associatedValues" : [
               {
                 "type" : {
-                  "rawValueEnum" : {
-                    "_0" : "Precision",
-                    "_1" : "Float"
-                  }
-                }
-              }
-            ],
-            "name" : "precision"
-          },
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "caseEnum" : {
-                    "_0" : "Direction"
-                  }
-                }
-              }
-            ],
-            "name" : "direction"
-          },
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "rawValueEnum" : {
-                        "_0" : "Precision",
-                        "_1" : "Float"
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              }
-            ],
-            "name" : "optPrecision"
-          },
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "caseEnum" : {
-                        "_0" : "Direction"
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              }
-            ],
-            "name" : "optDirection"
-          },
-          {
-            "associatedValues" : [
-
-            ],
-            "name" : "empty"
-          }
-        ],
-        "emitStyle" : "const",
-        "name" : "TypedPayloadResult",
-        "staticMethods" : [
-
-        ],
-        "staticProperties" : [
-
-        ],
-        "swiftCallName" : "TypedPayloadResult",
-        "tsFullPath" : "TypedPayloadResult"
-      },
-      {
-        "cases" : [
-          {
-            "associatedValues" : [
-              {
-                "type" : {
                   "swiftStruct" : {
                     "_0" : "Address"
                   }
@@ -4539,18 +4459,26 @@
             "associatedValues" : [
               {
                 "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "swiftStruct" : {
-                        "_0" : "Address"
-                      }
-                    },
-                    "_1" : "null"
+                  "rawValueEnum" : {
+                    "_0" : "Precision",
+                    "_1" : "Float"
                   }
                 }
               }
             ],
-            "name" : "optStruct"
+            "name" : "precision"
+          },
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "caseEnum" : {
+                    "_0" : "Direction"
+                  }
+                }
+              }
+            ],
+            "name" : "direction"
           },
           {
             "associatedValues" : [
@@ -4558,8 +4486,9 @@
                 "type" : {
                   "nullable" : {
                     "_0" : {
-                      "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                      "rawValueEnum" : {
+                        "_0" : "Precision",
+                        "_1" : "Float"
                       }
                     },
                     "_1" : "null"
@@ -4567,7 +4496,7 @@
                 }
               }
             ],
-            "name" : "optClass"
+            "name" : "optPrecision"
           },
           {
             "associatedValues" : [
@@ -4575,8 +4504,8 @@
                 "type" : {
                   "nullable" : {
                     "_0" : {
-                      "jsObject" : {
-
+                      "caseEnum" : {
+                        "_0" : "Direction"
                       }
                     },
                     "_1" : "null"
@@ -4584,62 +4513,7 @@
                 }
               }
             ],
-            "name" : "optJSObject"
-          },
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "associatedValueEnum" : {
-                        "_0" : "APIResult"
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              }
-            ],
-            "name" : "optNestedEnum"
-          },
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "array" : {
-                        "_0" : {
-                          "int" : {
-
-                          }
-                        }
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              }
-            ],
-            "name" : "optArray"
-          },
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "jsObject" : {
-                        "_0" : "Foo"
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              }
-            ],
-            "name" : "optJsClass"
+            "name" : "optDirection"
           },
           {
             "associatedValues" : [
@@ -4649,116 +4523,15 @@
           }
         ],
         "emitStyle" : "const",
-        "name" : "OptionalAllTypesResult",
+        "name" : "TypedPayloadResult",
         "staticMethods" : [
 
         ],
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "OptionalAllTypesResult",
-        "tsFullPath" : "OptionalAllTypesResult"
-      },
-      {
-        "cases" : [
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "string" : {
-
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              }
-            ],
-            "name" : "success"
-          },
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "int" : {
-
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              },
-              {
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "bool" : {
-
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              }
-            ],
-            "name" : "failure"
-          },
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "bool" : {
-
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              },
-              {
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "int" : {
-
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              },
-              {
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "string" : {
-
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              }
-            ],
-            "name" : "status"
-          }
-        ],
-        "emitStyle" : "const",
-        "name" : "APIOptionalResult",
-        "staticMethods" : [
-
-        ],
-        "staticProperties" : [
-
-        ],
-        "swiftCallName" : "APIOptionalResult",
-        "tsFullPath" : "APIOptionalResult"
+        "swiftCallName" : "TypedPayloadResult",
+        "tsFullPath" : "TypedPayloadResult"
       },
       {
         "cases" : [
@@ -5207,6 +4980,233 @@
         ],
         "swiftCallName" : "StaticPropertyNamespace.NestedProperties",
         "tsFullPath" : "StaticPropertyNamespace.NestedProperties"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "Address"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "name" : "optStruct"
+          },
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "swiftHeapObject" : {
+                        "_0" : "Greeter"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "name" : "optClass"
+          },
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "jsObject" : {
+
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "name" : "optJSObject"
+          },
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "associatedValueEnum" : {
+                        "_0" : "APIResult"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "name" : "optNestedEnum"
+          },
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "array" : {
+                        "_0" : {
+                          "int" : {
+
+                          }
+                        }
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "name" : "optArray"
+          },
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "jsObject" : {
+                        "_0" : "Foo"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "name" : "optJsClass"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "empty"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "OptionalAllTypesResult",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "OptionalAllTypesResult",
+        "tsFullPath" : "OptionalAllTypesResult"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "name" : "success"
+          },
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              },
+              {
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "bool" : {
+
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "name" : "failure"
+          },
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "bool" : {
+
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              },
+              {
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              },
+              {
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "name" : "status"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "APIOptionalResult",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "APIOptionalResult",
+        "tsFullPath" : "APIOptionalResult"
       }
     ],
     "exposeToGlobal" : false,
@@ -7259,746 +7259,6 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalString",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalString",
-        "parameters" : [
-          {
-            "label" : "name",
-            "name" : "name",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "string" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "string" : {
-
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalInt",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalInt",
-        "parameters" : [
-          {
-            "label" : "value",
-            "name" : "value",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "int" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "int" : {
-
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalBool",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalBool",
-        "parameters" : [
-          {
-            "label" : "flag",
-            "name" : "flag",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "bool" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "bool" : {
-
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalFloat",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalFloat",
-        "parameters" : [
-          {
-            "label" : "number",
-            "name" : "number",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "float" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "float" : {
-
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalDouble",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalDouble",
-        "parameters" : [
-          {
-            "label" : "precision",
-            "name" : "precision",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "double" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "double" : {
-
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalSyntax",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalSyntax",
-        "parameters" : [
-          {
-            "label" : "name",
-            "name" : "name",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "string" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "string" : {
-
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalMixSyntax",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalMixSyntax",
-        "parameters" : [
-          {
-            "label" : "name",
-            "name" : "name",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "string" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "string" : {
-
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalSwiftSyntax",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalSwiftSyntax",
-        "parameters" : [
-          {
-            "label" : "name",
-            "name" : "name",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "string" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "string" : {
-
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalWithSpaces",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalWithSpaces",
-        "parameters" : [
-          {
-            "label" : "value",
-            "name" : "value",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "double" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "double" : {
-
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalTypeAlias",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalTypeAlias",
-        "parameters" : [
-          {
-            "label" : "age",
-            "name" : "age",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "int" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "int" : {
-
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalStatus",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalStatus",
-        "parameters" : [
-          {
-            "label" : "value",
-            "name" : "value",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "caseEnum" : {
-                    "_0" : "Status"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "caseEnum" : {
-                "_0" : "Status"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalTheme",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalTheme",
-        "parameters" : [
-          {
-            "label" : "value",
-            "name" : "value",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "rawValueEnum" : {
-                    "_0" : "Theme",
-                    "_1" : "String"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "rawValueEnum" : {
-                "_0" : "Theme",
-                "_1" : "String"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalHttpStatus",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalHttpStatus",
-        "parameters" : [
-          {
-            "label" : "value",
-            "name" : "value",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "rawValueEnum" : {
-                    "_0" : "HttpStatus",
-                    "_1" : "Int"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "rawValueEnum" : {
-                "_0" : "HttpStatus",
-                "_1" : "Int"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalTSDirection",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalTSDirection",
-        "parameters" : [
-          {
-            "label" : "value",
-            "name" : "value",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "caseEnum" : {
-                    "_0" : "TSDirection"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "caseEnum" : {
-                "_0" : "TSDirection"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalTSTheme",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalTSTheme",
-        "parameters" : [
-          {
-            "label" : "value",
-            "name" : "value",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "rawValueEnum" : {
-                    "_0" : "TSTheme",
-                    "_1" : "String"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "rawValueEnum" : {
-                "_0" : "TSTheme",
-                "_1" : "String"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalNetworkingAPIMethod",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalNetworkingAPIMethod",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "method",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "caseEnum" : {
-                    "_0" : "Networking.API.Method"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "caseEnum" : {
-                "_0" : "Networking.API.Method"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalAPIResult",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalAPIResult",
-        "parameters" : [
-          {
-            "label" : "value",
-            "name" : "value",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "associatedValueEnum" : {
-                    "_0" : "APIResult"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "associatedValueEnum" : {
-                "_0" : "APIResult"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripTypedPayloadResult",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripTypedPayloadResult",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "result",
-            "type" : {
-              "associatedValueEnum" : {
-                "_0" : "TypedPayloadResult"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "associatedValueEnum" : {
-            "_0" : "TypedPayloadResult"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalTypedPayloadResult",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalTypedPayloadResult",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "result",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "associatedValueEnum" : {
-                    "_0" : "TypedPayloadResult"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "associatedValueEnum" : {
-                "_0" : "TypedPayloadResult"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_compareAPIResults",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "compareAPIResults",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "r1",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "associatedValueEnum" : {
-                    "_0" : "APIResult"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          },
-          {
-            "label" : "_",
-            "name" : "r2",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "associatedValueEnum" : {
-                    "_0" : "APIResult"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "string" : {
-
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalComplexResult",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalComplexResult",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "result",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "associatedValueEnum" : {
-                    "_0" : "ComplexResult"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "associatedValueEnum" : {
-                "_0" : "ComplexResult"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
         "abiName" : "bjs_roundTripAllTypesResult",
         "effects" : {
           "isAsync" : false,
@@ -8024,317 +7284,27 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalAllTypesResult",
+        "abiName" : "bjs_roundTripTypedPayloadResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
           "isThrows" : false
         },
-        "name" : "roundTripOptionalAllTypesResult",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "result",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "associatedValueEnum" : {
-                    "_0" : "AllTypesResult"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "associatedValueEnum" : {
-                "_0" : "AllTypesResult"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalPayloadResult",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalPayloadResult",
+        "name" : "roundTripTypedPayloadResult",
         "parameters" : [
           {
             "label" : "_",
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "OptionalAllTypesResult"
+                "_0" : "TypedPayloadResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "OptionalAllTypesResult"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalPayloadResultOpt",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalPayloadResultOpt",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "result",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "associatedValueEnum" : {
-                    "_0" : "OptionalAllTypesResult"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "associatedValueEnum" : {
-                "_0" : "OptionalAllTypesResult"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalClass",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalClass",
-        "parameters" : [
-          {
-            "label" : "value",
-            "name" : "value",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "swiftHeapObject" : {
-                    "_0" : "Greeter"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "swiftHeapObject" : {
-                "_0" : "Greeter"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalGreeter",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalGreeter",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "value",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "swiftHeapObject" : {
-                    "_0" : "Greeter"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "swiftHeapObject" : {
-                "_0" : "Greeter"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_applyOptionalGreeter",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "applyOptionalGreeter",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "value",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "swiftHeapObject" : {
-                    "_0" : "Greeter"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          },
-          {
-            "label" : "_",
-            "name" : "transform",
-            "type" : {
-              "closure" : {
-                "_0" : {
-                  "isAsync" : false,
-                  "isThrows" : false,
-                  "mangleName" : "20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC",
-                  "moduleName" : "BridgeJSRuntimeTests",
-                  "parameters" : [
-                    {
-                      "nullable" : {
-                        "_0" : {
-                          "swiftHeapObject" : {
-                            "_0" : "Greeter"
-                          }
-                        },
-                        "_1" : "null"
-                      }
-                    }
-                  ],
-                  "returnType" : {
-                    "nullable" : {
-                      "_0" : {
-                        "swiftHeapObject" : {
-                          "_0" : "Greeter"
-                        }
-                      },
-                      "_1" : "null"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "swiftHeapObject" : {
-                "_0" : "Greeter"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_makeOptionalHolder",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "makeOptionalHolder",
-        "parameters" : [
-          {
-            "label" : "nullableGreeter",
-            "name" : "nullableGreeter",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "swiftHeapObject" : {
-                    "_0" : "Greeter"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          },
-          {
-            "label" : "undefinedNumber",
-            "name" : "undefinedNumber",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "double" : {
-
-                  }
-                },
-                "_1" : "undefined"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "swiftHeapObject" : {
-            "_0" : "OptionalHolder"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_roundTripOptionalAPIOptionalResult",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalAPIOptionalResult",
-        "parameters" : [
-          {
-            "label" : "result",
-            "name" : "result",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "associatedValueEnum" : {
-                    "_0" : "APIOptionalResult"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "associatedValueEnum" : {
-                "_0" : "APIOptionalResult"
-              }
-            },
-            "_1" : "null"
+            "_0" : "TypedPayloadResult"
           }
         }
       },
@@ -10479,6 +9449,1036 @@
                 "_1" : "null"
               }
             }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalString",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalString",
+        "parameters" : [
+          {
+            "label" : "name",
+            "name" : "name",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "string" : {
+
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalInt",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalInt",
+        "parameters" : [
+          {
+            "label" : "value",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "int" : {
+
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalBool",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalBool",
+        "parameters" : [
+          {
+            "label" : "flag",
+            "name" : "flag",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "bool" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "bool" : {
+
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalFloat",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalFloat",
+        "parameters" : [
+          {
+            "label" : "number",
+            "name" : "number",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "float" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "float" : {
+
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalDouble",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalDouble",
+        "parameters" : [
+          {
+            "label" : "precision",
+            "name" : "precision",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "double" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "double" : {
+
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalSyntax",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalSyntax",
+        "parameters" : [
+          {
+            "label" : "name",
+            "name" : "name",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "string" : {
+
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalMixSyntax",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalMixSyntax",
+        "parameters" : [
+          {
+            "label" : "name",
+            "name" : "name",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "string" : {
+
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalSwiftSyntax",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalSwiftSyntax",
+        "parameters" : [
+          {
+            "label" : "name",
+            "name" : "name",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "string" : {
+
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalWithSpaces",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalWithSpaces",
+        "parameters" : [
+          {
+            "label" : "value",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "double" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "double" : {
+
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalTypeAlias",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalTypeAlias",
+        "parameters" : [
+          {
+            "label" : "age",
+            "name" : "age",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "int" : {
+
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalStatus",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalStatus",
+        "parameters" : [
+          {
+            "label" : "value",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Status"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "Status"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalTheme",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalTheme",
+        "parameters" : [
+          {
+            "label" : "value",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "Theme",
+                    "_1" : "String"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "Theme",
+                "_1" : "String"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalHttpStatus",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalHttpStatus",
+        "parameters" : [
+          {
+            "label" : "value",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "HttpStatus",
+                    "_1" : "Int"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "HttpStatus",
+                "_1" : "Int"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalTSDirection",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalTSDirection",
+        "parameters" : [
+          {
+            "label" : "value",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "TSDirection"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "TSDirection"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalTSTheme",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalTSTheme",
+        "parameters" : [
+          {
+            "label" : "value",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "TSTheme",
+                    "_1" : "String"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "TSTheme",
+                "_1" : "String"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalNetworkingAPIMethod",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalNetworkingAPIMethod",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "method",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Networking.API.Method"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "Networking.API.Method"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalAPIResult",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalAPIResult",
+        "parameters" : [
+          {
+            "label" : "value",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "associatedValueEnum" : {
+                    "_0" : "APIResult"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "associatedValueEnum" : {
+                "_0" : "APIResult"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalTypedPayloadResult",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalTypedPayloadResult",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "result",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "associatedValueEnum" : {
+                    "_0" : "TypedPayloadResult"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "associatedValueEnum" : {
+                "_0" : "TypedPayloadResult"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_compareAPIResults",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "compareAPIResults",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "r1",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "associatedValueEnum" : {
+                    "_0" : "APIResult"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "r2",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "associatedValueEnum" : {
+                    "_0" : "APIResult"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalComplexResult",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalComplexResult",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "result",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "associatedValueEnum" : {
+                    "_0" : "ComplexResult"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "associatedValueEnum" : {
+                "_0" : "ComplexResult"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalAllTypesResult",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalAllTypesResult",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "result",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "associatedValueEnum" : {
+                    "_0" : "AllTypesResult"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "associatedValueEnum" : {
+                "_0" : "AllTypesResult"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalPayloadResult",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalPayloadResult",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "result",
+            "type" : {
+              "associatedValueEnum" : {
+                "_0" : "OptionalAllTypesResult"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "associatedValueEnum" : {
+            "_0" : "OptionalAllTypesResult"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalPayloadResultOpt",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalPayloadResultOpt",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "result",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "associatedValueEnum" : {
+                    "_0" : "OptionalAllTypesResult"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "associatedValueEnum" : {
+                "_0" : "OptionalAllTypesResult"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalClass",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalClass",
+        "parameters" : [
+          {
+            "label" : "value",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "swiftHeapObject" : {
+                    "_0" : "Greeter"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "swiftHeapObject" : {
+                "_0" : "Greeter"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalGreeter",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalGreeter",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "swiftHeapObject" : {
+                    "_0" : "Greeter"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "swiftHeapObject" : {
+                "_0" : "Greeter"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_applyOptionalGreeter",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "applyOptionalGreeter",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "swiftHeapObject" : {
+                    "_0" : "Greeter"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "transform",
+            "type" : {
+              "closure" : {
+                "_0" : {
+                  "isAsync" : false,
+                  "isThrows" : false,
+                  "mangleName" : "20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC",
+                  "moduleName" : "BridgeJSRuntimeTests",
+                  "parameters" : [
+                    {
+                      "nullable" : {
+                        "_0" : {
+                          "swiftHeapObject" : {
+                            "_0" : "Greeter"
+                          }
+                        },
+                        "_1" : "null"
+                      }
+                    }
+                  ],
+                  "returnType" : {
+                    "nullable" : {
+                      "_0" : {
+                        "swiftHeapObject" : {
+                          "_0" : "Greeter"
+                        }
+                      },
+                      "_1" : "null"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "swiftHeapObject" : {
+                "_0" : "Greeter"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeOptionalHolder",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeOptionalHolder",
+        "parameters" : [
+          {
+            "label" : "nullableGreeter",
+            "name" : "nullableGreeter",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "swiftHeapObject" : {
+                    "_0" : "Greeter"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          },
+          {
+            "label" : "undefinedNumber",
+            "name" : "undefinedNumber",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "double" : {
+
+                  }
+                },
+                "_1" : "undefined"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftHeapObject" : {
+            "_0" : "OptionalHolder"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalAPIOptionalResult",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalAPIOptionalResult",
+        "parameters" : [
+          {
+            "label" : "result",
+            "name" : "result",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "associatedValueEnum" : {
+                    "_0" : "APIOptionalResult"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "associatedValueEnum" : {
+                "_0" : "APIOptionalResult"
+              }
+            },
+            "_1" : "null"
           }
         }
       },
@@ -12871,62 +12871,6 @@
             }
           },
           {
-            "name" : "jsRoundTripOptionalNumberNull",
-            "parameters" : [
-              {
-                "name" : "v",
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "double" : {
-
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              }
-            ],
-            "returnType" : {
-              "nullable" : {
-                "_0" : {
-                  "double" : {
-
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          },
-          {
-            "name" : "jsRoundTripOptionalNumberUndefined",
-            "parameters" : [
-              {
-                "name" : "v",
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "double" : {
-
-                      }
-                    },
-                    "_1" : "undefined"
-                  }
-                }
-              }
-            ],
-            "returnType" : {
-              "nullable" : {
-                "_0" : {
-                  "double" : {
-
-                  }
-                },
-                "_1" : "undefined"
-              }
-            }
-          },
-          {
             "name" : "jsRoundTripJSValue",
             "parameters" : [
               {
@@ -14019,6 +13963,136 @@
             "returnType" : {
               "swiftStruct" : {
                 "_0" : "Point"
+              }
+            }
+          }
+        ],
+        "types" : [
+
+        ]
+      },
+      {
+        "functions" : [
+          {
+            "name" : "runJsOptionalSupportTests",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "name" : "jsRoundTripOptionalNumberNull",
+            "parameters" : [
+              {
+                "name" : "value",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          },
+          {
+            "name" : "jsRoundTripOptionalNumberUndefined",
+            "parameters" : [
+              {
+                "name" : "value",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "int" : {
+
+                      }
+                    },
+                    "_1" : "undefined"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "int" : {
+
+                  }
+                },
+                "_1" : "undefined"
+              }
+            }
+          },
+          {
+            "name" : "jsRoundTripOptionalStringNull",
+            "parameters" : [
+              {
+                "name" : "name",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          },
+          {
+            "name" : "jsRoundTripOptionalStringUndefined",
+            "parameters" : [
+              {
+                "name" : "name",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "string" : {
+
+                      }
+                    },
+                    "_1" : "undefined"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "string" : {
+
+                  }
+                },
+                "_1" : "undefined"
               }
             }
           }

--- a/Tests/BridgeJSRuntimeTests/ImportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ImportAPITests.swift
@@ -35,26 +35,6 @@ class ImportAPITests: XCTestCase {
         }
     }
 
-    func testRoundTripOptionalNumberNull() throws {
-        try XCTAssertEqual(jsRoundTripOptionalNumberNull(42), 42)
-        try XCTAssertNil(jsRoundTripOptionalNumberNull(nil))
-    }
-
-    func testRoundTripOptionalNumberUndefined() throws {
-        let some = try jsRoundTripOptionalNumberUndefined(.value(42))
-        switch some {
-        case .value(let value):
-            XCTAssertEqual(value, 42)
-        case .undefined:
-            XCTFail("Expected defined value")
-        }
-
-        let undefined = try jsRoundTripOptionalNumberUndefined(.undefinedValue)
-        if case .value = undefined {
-            XCTFail("Expected undefined")
-        }
-    }
-
     func testRoundTripJSValue() throws {
         let symbol = JSSymbol("roundTrip")
         let bigInt = JSBigInt(_slowBridge: Int64(123456789))

--- a/Tests/BridgeJSRuntimeTests/JavaScript/OptionalSupportTests.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/OptionalSupportTests.mjs
@@ -1,0 +1,219 @@
+// @ts-check
+
+import assert from 'node:assert';
+import {
+    StatusValues,
+    ThemeValues,
+    HttpStatusValues,
+    TSDirection,
+    TSTheme,
+    APIResultValues,
+    APIOptionalResultValues,
+    AllTypesResultValues,
+    OptionalAllTypesResultValues,
+} from '../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.js';
+
+import { ImportedFoo } from './Types.mjs';
+
+/**
+ * Optional value bridging coverage for BridgeJS runtime tests.
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+export function runJsOptionalSupportTests(exports) {
+    assert.equal(exports.roundTripOptionalString(null), null);
+    assert.equal(exports.roundTripOptionalInt(null), null);
+    assert.equal(exports.roundTripOptionalBool(null), null);
+    assert.equal(exports.roundTripOptionalFloat(null), null);
+    assert.equal(exports.roundTripOptionalDouble(null), null);
+
+    assert.equal(exports.roundTripOptionalString('Hello'), 'Hello');
+    assert.equal(exports.roundTripOptionalInt(42), 42);
+    assert.equal(exports.roundTripOptionalBool(true), true);
+    assert.equal(exports.roundTripOptionalFloat(3.141592502593994), 3.141592502593994); // Float32 precision
+    assert.equal(exports.roundTripOptionalDouble(2.718), 2.718);
+
+    assert.equal(exports.roundTripOptionalSyntax(null), null);
+    assert.equal(exports.roundTripOptionalSyntax('Test'), 'Test');
+    assert.equal(exports.roundTripOptionalMixSyntax(null), null);
+    assert.equal(exports.roundTripOptionalMixSyntax('Mix'), 'Mix');
+    assert.equal(exports.roundTripOptionalSwiftSyntax(null), null);
+    assert.equal(exports.roundTripOptionalSwiftSyntax('Swift'), 'Swift');
+    assert.equal(exports.roundTripOptionalWithSpaces(null), null);
+    assert.equal(exports.roundTripOptionalWithSpaces(1.618), 1.618);
+    assert.equal(exports.roundTripOptionalTypeAlias(null), null);
+    assert.equal(exports.roundTripOptionalTypeAlias(25), 25);
+    assert.equal(exports.roundTripOptionalStatus(exports.Status.Success), StatusValues.Success);
+    assert.equal(exports.roundTripOptionalTheme(exports.Theme.Light), ThemeValues.Light);
+    assert.equal(exports.roundTripOptionalHttpStatus(exports.HttpStatus.Ok), HttpStatusValues.Ok);
+    assert.equal(exports.roundTripOptionalTSDirection(TSDirection.North), TSDirection.North);
+    assert.equal(exports.roundTripOptionalTSTheme(TSTheme.Light), TSTheme.Light);
+    assert.equal(exports.roundTripOptionalNetworkingAPIMethod(exports.Networking.API.Method.Get), exports.Networking.API.Method.Get);
+
+    const pVal = 3.141592653589793;
+    const p1 = { tag: APIResultValues.Tag.Precise, param0: pVal };
+    const cl1 = { tag: exports.ComplexResult.Tag.Location, param0: 37.7749, param1: -122.4194, param2: 'San Francisco' };
+
+    assert.deepEqual(exports.roundTripOptionalAPIResult(p1), p1);
+    assert.deepEqual(exports.roundTripOptionalComplexResult(cl1), cl1);
+
+    const apiSuccess = { tag: exports.APIResult.Tag.Success, param0: 'test success' };
+    const apiFailure = { tag: exports.APIResult.Tag.Failure, param0: 404 };
+    const apiInfo = { tag: exports.APIResult.Tag.Info };
+
+    assert.equal(exports.compareAPIResults(apiSuccess, apiFailure), 'r1:success:test success,r2:failure:404');
+    assert.equal(exports.compareAPIResults(null, apiInfo), 'r1:nil,r2:info');
+    assert.equal(exports.compareAPIResults(apiFailure, null), 'r1:failure:404,r2:nil');
+    assert.equal(exports.compareAPIResults(null, null), 'r1:nil,r2:nil');
+
+    const optionalGreeter = new exports.Greeter('Schrödinger');
+    const optionalGreeter2 = exports.roundTripOptionalClass(optionalGreeter);
+    assert.equal(optionalGreeter2?.greet() ?? '', 'Hello, Schrödinger!');
+    assert.equal(optionalGreeter2?.name ?? '', 'Schrödinger');
+    assert.equal(optionalGreeter2?.prefix ?? '', 'Hello');
+    assert.equal(exports.roundTripOptionalClass(null), null);
+    optionalGreeter.release();
+    optionalGreeter2?.release();
+
+    const optionalsHolder = new exports.OptionalPropertyHolder(null);
+
+    assert.equal(optionalsHolder.optionalName, null);
+    assert.equal(optionalsHolder.optionalAge, null);
+    assert.equal(optionalsHolder.optionalGreeter, null);
+
+    optionalsHolder.optionalName = 'Alice';
+    optionalsHolder.optionalAge = 25;
+    assert.equal(optionalsHolder.optionalName, 'Alice');
+    assert.equal(optionalsHolder.optionalAge, 25);
+
+    const testPropertyGreeter = new exports.Greeter('Bob');
+    optionalsHolder.optionalGreeter = testPropertyGreeter;
+    assert.equal(optionalsHolder.optionalGreeter.greet(), 'Hello, Bob!');
+    assert.equal(optionalsHolder.optionalGreeter.name, 'Bob');
+
+    optionalsHolder.optionalName = null;
+    optionalsHolder.optionalAge = null;
+    optionalsHolder.optionalGreeter = null;
+    assert.equal(optionalsHolder.optionalName, null);
+    assert.equal(optionalsHolder.optionalAge, null);
+    assert.equal(optionalsHolder.optionalGreeter, null);
+    testPropertyGreeter.release();
+    optionalsHolder.release();
+
+    const optGreeter = new exports.Greeter('Optionaly');
+    assert.equal(exports.roundTripOptionalGreeter(null), null);
+    const optGreeterReturned = exports.roundTripOptionalGreeter(optGreeter);
+    assert.equal(optGreeterReturned.name, 'Optionaly');
+    assert.equal(optGreeterReturned.greet(), 'Hello, Optionaly!');
+
+    const appliedOptional = exports.applyOptionalGreeter(null, (g) => g ?? optGreeter);
+    assert.equal(appliedOptional.name, 'Optionaly');
+
+    const holderOpt = exports.makeOptionalHolder(null, undefined);
+    assert.equal(holderOpt.nullableGreeter, null);
+    assert.equal(holderOpt.undefinedNumber, undefined);
+    holderOpt.nullableGreeter = optGreeter;
+    holderOpt.undefinedNumber = 123.5;
+    assert.equal(holderOpt.nullableGreeter.name, 'Optionaly');
+    assert.equal(holderOpt.undefinedNumber, 123.5);
+    holderOpt.release();
+    optGreeterReturned.release();
+    optGreeter.release();
+
+    const aor1 = { tag: APIOptionalResultValues.Tag.Success, param0: 'hello world' };
+    const aor2 = { tag: APIOptionalResultValues.Tag.Success, param0: null };
+    const aor3 = { tag: APIOptionalResultValues.Tag.Failure, param0: 404, param1: true };
+    const aor4 = { tag: APIOptionalResultValues.Tag.Failure, param0: 404, param1: null };
+    const aor5 = { tag: APIOptionalResultValues.Tag.Failure, param0: null, param1: null };
+    const aor6 = { tag: APIOptionalResultValues.Tag.Status, param0: true, param1: 200, param2: 'OK' };
+    const aor7 = { tag: APIOptionalResultValues.Tag.Status, param0: true, param1: null, param2: 'Partial' };
+    const aor8 = { tag: APIOptionalResultValues.Tag.Status, param0: null, param1: null, param2: 'Zero' };
+    const aor9 = { tag: APIOptionalResultValues.Tag.Status, param0: false, param1: 500, param2: null };
+    const aor10 = { tag: APIOptionalResultValues.Tag.Status, param0: null, param1: 0, param2: 'Zero' };
+
+    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor1), aor1);
+    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor2), aor2);
+    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor3), aor3);
+    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor4), aor4);
+    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor5), aor5);
+    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor6), aor6);
+    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor7), aor7);
+    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor8), aor8);
+    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor9), aor9);
+    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor10), aor10);
+    assert.equal(exports.roundTripOptionalAPIOptionalResult(null), null);
+
+    // Optional TypedPayloadResult roundtrip
+    const tpr_precision = { tag: exports.TypedPayloadResult.Tag.Precision, param0: Math.fround(0.1) };
+    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_precision), tpr_precision);
+    const tpr_direction = { tag: exports.TypedPayloadResult.Tag.Direction, param0: exports.Direction.North };
+    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_direction), tpr_direction);
+    const tpr_optPrecisionSome = { tag: exports.TypedPayloadResult.Tag.OptPrecision, param0: Math.fround(0.001) };
+    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_optPrecisionSome), tpr_optPrecisionSome);
+    const tpr_optPrecisionNull = { tag: exports.TypedPayloadResult.Tag.OptPrecision, param0: null };
+    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_optPrecisionNull), tpr_optPrecisionNull);
+    const tpr_empty = { tag: exports.TypedPayloadResult.Tag.Empty };
+    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_empty), tpr_empty);
+    assert.equal(exports.roundTripOptionalTypedPayloadResult(null), null);
+
+    // Optional AllTypesResult roundtrip
+    const atr_struct = { tag: AllTypesResultValues.Tag.StructPayload, param0: { street: "100 Main St", city: "Boston", zipCode: 2101 } };
+    assert.deepEqual(exports.roundTripOptionalAllTypesResult(atr_struct), atr_struct);
+    const atr_array = { tag: AllTypesResultValues.Tag.ArrayPayload, param0: [10, 20, 30] };
+    assert.deepEqual(exports.roundTripOptionalAllTypesResult(atr_array), atr_array);
+    const atr_empty = { tag: AllTypesResultValues.Tag.Empty };
+    assert.deepEqual(exports.roundTripOptionalAllTypesResult(atr_empty), atr_empty);
+    assert.equal(exports.roundTripOptionalAllTypesResult(null), null);
+
+    // OptionalAllTypesResult — optional struct, class, JSObject, nested enum, array as associated value payloads
+    const oatr_structSome = { tag: OptionalAllTypesResultValues.Tag.OptStruct, param0: { street: "200 Oak St", city: "Denver", zipCode: null } };
+    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_structSome), oatr_structSome);
+
+    const oatr_structNone = { tag: OptionalAllTypesResultValues.Tag.OptStruct, param0: null };
+    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_structNone), oatr_structNone);
+
+    const oatr_classSome = { tag: OptionalAllTypesResultValues.Tag.OptClass, param0: new exports.Greeter("OptEnumUser") };
+    const oatr_classSome_result = exports.roundTripOptionalPayloadResult(oatr_classSome);
+    assert.equal(oatr_classSome_result.tag, OptionalAllTypesResultValues.Tag.OptClass);
+    assert.equal(oatr_classSome_result.param0.name, "OptEnumUser");
+
+    const oatr_classNone = { tag: OptionalAllTypesResultValues.Tag.OptClass, param0: null };
+    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_classNone), oatr_classNone);
+
+    const oatr_jsObjectSome = { tag: OptionalAllTypesResultValues.Tag.OptJSObject, param0: { key: "value" } };
+    const oatr_jsObjectSome_result = exports.roundTripOptionalPayloadResult(oatr_jsObjectSome);
+    assert.equal(oatr_jsObjectSome_result.tag, OptionalAllTypesResultValues.Tag.OptJSObject);
+    assert.equal(oatr_jsObjectSome_result.param0.key, "value");
+
+    const oatr_jsObjectNone = { tag: OptionalAllTypesResultValues.Tag.OptJSObject, param0: null };
+    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_jsObjectNone), oatr_jsObjectNone);
+
+    const oatr_nestedEnumSome = { tag: OptionalAllTypesResultValues.Tag.OptNestedEnum, param0: { tag: APIResultValues.Tag.Failure, param0: 404 } };
+    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_nestedEnumSome), oatr_nestedEnumSome);
+
+    const oatr_nestedEnumNone = { tag: OptionalAllTypesResultValues.Tag.OptNestedEnum, param0: null };
+    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_nestedEnumNone), oatr_nestedEnumNone);
+
+    const oatr_arraySome = { tag: OptionalAllTypesResultValues.Tag.OptArray, param0: [1, 2, 3] };
+    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_arraySome), oatr_arraySome);
+
+    const oatr_arrayNone = { tag: OptionalAllTypesResultValues.Tag.OptArray, param0: null };
+    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_arrayNone), oatr_arrayNone);
+
+    const oatr_jsClassSome = { tag: OptionalAllTypesResultValues.Tag.OptJsClass, param0: new ImportedFoo("optEnumFoo") };
+    const oatr_jsClassSome_result = exports.roundTripOptionalPayloadResult(oatr_jsClassSome);
+    assert.equal(oatr_jsClassSome_result.tag, OptionalAllTypesResultValues.Tag.OptJsClass);
+    assert.equal(oatr_jsClassSome_result.param0.value, "optEnumFoo");
+
+    const oatr_jsClassNone = { tag: OptionalAllTypesResultValues.Tag.OptJsClass, param0: null };
+    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_jsClassNone), oatr_jsClassNone);
+
+    const oatr_empty = { tag: OptionalAllTypesResultValues.Tag.Empty };
+    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_empty), oatr_empty);
+
+    // Optional OptionalAllTypesResult roundtrip
+    assert.deepEqual(exports.roundTripOptionalPayloadResultOpt(oatr_structSome), oatr_structSome);
+    assert.deepEqual(exports.roundTripOptionalPayloadResultOpt(oatr_structNone), oatr_structNone);
+    assert.deepEqual(exports.roundTripOptionalPayloadResultOpt(oatr_empty), oatr_empty);
+    assert.equal(exports.roundTripOptionalPayloadResultOpt(null), null);
+
+}

--- a/Tests/BridgeJSRuntimeTests/JavaScript/Types.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/Types.mjs
@@ -1,0 +1,6 @@
+export class ImportedFoo {
+    /** @param {string} value */
+    constructor(value) {
+        this.value = value;
+    }
+}

--- a/Tests/BridgeJSRuntimeTests/OptionalSupportTests.swift
+++ b/Tests/BridgeJSRuntimeTests/OptionalSupportTests.swift
@@ -1,0 +1,232 @@
+import XCTest
+@_spi(Experimental) import JavaScriptKit
+import JavaScriptEventLoop
+
+@JSFunction func runJsOptionalSupportTests() throws
+
+final class OptionalSupportTests: XCTestCase {
+    func testRunJsOptionalSupportTests() throws {
+        try runJsOptionalSupportTests()
+    }
+
+    // FIXME: Optional<String> return type on imported function is broken
+    // func testRoundTripOptionalStringNull() throws {
+    //     try XCTAssertEqual(jsRoundTripOptionalStringNull("hello"), "hello")
+    //     try XCTAssertNil(jsRoundTripOptionalStringNull(nil))
+    // }
+
+    // func testRoundTripOptionalStringUndefined() throws {
+    //     let some = try jsRoundTripOptionalStringUndefined(.value("hi"))
+    //     switch some {
+    //     case .value(let value):
+    //         XCTAssertEqual(value, "hi")
+    //     case .undefined:
+    //         XCTFail("Expected defined value")
+    //     }
+
+    //     let undefined = try jsRoundTripOptionalStringUndefined(.undefinedValue)
+    //     if case .value = undefined {
+    //         XCTFail("Expected undefined")
+    //     }
+    // }
+
+    func testRoundTripOptionalNumberNull() throws {
+        try XCTAssertEqual(jsRoundTripOptionalNumberNull(42), 42)
+        try XCTAssertNil(jsRoundTripOptionalNumberNull(nil))
+    }
+
+    func testRoundTripOptionalNumberUndefined() throws {
+        let some = try jsRoundTripOptionalNumberUndefined(.value(42))
+        switch some {
+        case .value(let value):
+            XCTAssertEqual(value, 42)
+        case .undefined:
+            XCTFail("Expected defined value")
+        }
+
+        let undefined = try jsRoundTripOptionalNumberUndefined(.undefined)
+        if case .value = undefined {
+            XCTFail("Expected undefined")
+        }
+    }
+}
+
+// MARK: - Optional Bridging
+
+@JSFunction func jsRoundTripOptionalNumberNull(_ value: Int?) throws -> Int?
+@JSFunction func jsRoundTripOptionalNumberUndefined(_ value: JSUndefinedOr<Int>) throws -> JSUndefinedOr<Int>
+@JSFunction func jsRoundTripOptionalStringNull(_ name: String?) throws -> String?
+@JSFunction func jsRoundTripOptionalStringUndefined(_ name: JSUndefinedOr<String>) throws -> JSUndefinedOr<String>
+
+@JS func roundTripOptionalString(name: String?) -> String? {
+    name
+}
+
+@JS func roundTripOptionalInt(value: Int?) -> Int? {
+    value
+}
+
+@JS func roundTripOptionalBool(flag: Bool?) -> Bool? {
+    flag
+}
+
+@JS func roundTripOptionalFloat(number: Float?) -> Float? {
+    number
+}
+
+@JS func roundTripOptionalDouble(precision: Double?) -> Double? {
+    precision
+}
+
+@JS func roundTripOptionalSyntax(name: Optional<String>) -> Optional<String> {
+    name
+}
+
+@JS func roundTripOptionalMixSyntax(name: String?) -> Optional<String> {
+    name
+}
+
+@JS func roundTripOptionalSwiftSyntax(name: Swift.Optional<String>) -> Swift.Optional<String> {
+    name
+}
+
+@JS func roundTripOptionalWithSpaces(value: Optional<Double>) -> Optional<Double> {
+    value
+}
+
+typealias OptionalAge = Int?
+@JS func roundTripOptionalTypeAlias(age: OptionalAge) -> OptionalAge {
+    age
+}
+
+@JS func roundTripOptionalStatus(value: Status?) -> Status? {
+    value
+}
+
+@JS func roundTripOptionalTheme(value: Theme?) -> Theme? {
+    value
+}
+
+@JS func roundTripOptionalHttpStatus(value: HttpStatus?) -> HttpStatus? {
+    value
+}
+
+@JS func roundTripOptionalTSDirection(value: TSDirection?) -> TSDirection? {
+    value
+}
+
+@JS func roundTripOptionalTSTheme(value: TSTheme?) -> TSTheme? {
+    value
+}
+
+@JS func roundTripOptionalNetworkingAPIMethod(_ method: Networking.API.Method?) -> Networking.API.Method? {
+    method
+}
+
+@JS func roundTripOptionalAPIResult(value: APIResult?) -> APIResult? {
+    value
+}
+
+@JS func roundTripOptionalTypedPayloadResult(_ result: TypedPayloadResult?) -> TypedPayloadResult? {
+    result
+}
+
+@JS func compareAPIResults(_ r1: APIResult?, _ r2: APIResult?) -> String {
+    let r1Str: String
+    switch r1 {
+    case .none: r1Str = "nil"
+    case .some(.success(let msg)): r1Str = "success:\(msg)"
+    case .some(.failure(let code)): r1Str = "failure:\(code)"
+    case .some(.info): r1Str = "info"
+    case .some(.flag(let b)): r1Str = "flag:\(b)"
+    case .some(.rate(let r)): r1Str = "rate:\(r)"
+    case .some(.precise(let p)): r1Str = "precise:\(p)"
+    }
+
+    let r2Str: String
+    switch r2 {
+    case .none: r2Str = "nil"
+    case .some(.success(let msg)): r2Str = "success:\(msg)"
+    case .some(.failure(let code)): r2Str = "failure:\(code)"
+    case .some(.info): r2Str = "info"
+    case .some(.flag(let b)): r2Str = "flag:\(b)"
+    case .some(.rate(let r)): r2Str = "rate:\(r)"
+    case .some(.precise(let p)): r2Str = "precise:\(p)"
+    }
+
+    return "r1:\(r1Str),r2:\(r2Str)"
+}
+
+@JS func roundTripOptionalComplexResult(_ result: ComplexResult?) -> ComplexResult? {
+    result
+}
+
+@JS func roundTripOptionalAllTypesResult(_ result: AllTypesResult?) -> AllTypesResult? {
+    result
+}
+
+@JS
+enum OptionalAllTypesResult {
+    case optStruct(Address?)
+    case optClass(Greeter?)
+    case optJSObject(JSObject?)
+    case optNestedEnum(APIResult?)
+    case optArray([Int]?)
+    case optJsClass(Foo?)
+    case empty
+}
+
+@JS func roundTripOptionalPayloadResult(_ result: OptionalAllTypesResult) -> OptionalAllTypesResult {
+    result
+}
+
+@JS func roundTripOptionalPayloadResultOpt(_ result: OptionalAllTypesResult?) -> OptionalAllTypesResult? {
+    result
+}
+
+@JS func roundTripOptionalClass(value: Greeter?) -> Greeter? {
+    value
+}
+
+@JS func roundTripOptionalGreeter(_ value: Greeter?) -> Greeter? {
+    value
+}
+
+@JS func applyOptionalGreeter(_ value: Greeter?, _ transform: (Greeter?) -> Greeter?) -> Greeter? {
+    transform(value)
+}
+
+@JS class OptionalHolder {
+    @JS var nullableGreeter: Greeter?
+    @JS var undefinedNumber: JSUndefinedOr<Double>
+
+    @JS init(nullableGreeter: Greeter?, undefinedNumber: JSUndefinedOr<Double>) {
+        self.nullableGreeter = nullableGreeter
+        self.undefinedNumber = undefinedNumber
+    }
+}
+
+@JS func makeOptionalHolder(nullableGreeter: Greeter?, undefinedNumber: JSUndefinedOr<Double>) -> OptionalHolder {
+    OptionalHolder(nullableGreeter: nullableGreeter, undefinedNumber: undefinedNumber)
+}
+
+@JS class OptionalPropertyHolder {
+    @JS var optionalName: String?
+    @JS var optionalAge: Int? = nil
+    @JS var optionalGreeter: Greeter? = nil
+
+    @JS init(optionalName: String?) {
+        self.optionalName = optionalName
+    }
+}
+
+@JS
+enum APIOptionalResult {
+    case success(String?)
+    case failure(Int?, Bool?)
+    case status(Bool?, Int?, String?)
+}
+
+@JS func roundTripOptionalAPIOptionalResult(result: APIOptionalResult?) -> APIOptionalResult? {
+    result
+}

--- a/Tests/BridgeJSRuntimeTests/bridge-js.d.ts
+++ b/Tests/BridgeJSRuntimeTests/bridge-js.d.ts
@@ -2,8 +2,6 @@ export function jsRoundTripVoid(): void
 export function jsRoundTripNumber(v: number): number
 export function jsRoundTripBool(v: boolean): boolean
 export function jsRoundTripString(v: string): string
-export function jsRoundTripOptionalNumberNull(v: number | null): number | null
-export function jsRoundTripOptionalNumberUndefined(v: number | undefined): number | undefined
 export type JSValue = any
 export function jsRoundTripJSValue(v: JSValue): JSValue
 export function jsThrowOrVoid(shouldThrow: boolean): void

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -3,6 +3,8 @@
 import {
     DirectionValues, StatusValues, ThemeValues, HttpStatusValues, TSDirection, TSTheme, APIResultValues, ComplexResultValues, APIOptionalResultValues, StaticCalculatorValues, StaticPropertyEnumValues, PrecisionValues, TypedPayloadResultValues, AllTypesResultValues, OptionalAllTypesResultValues
 } from '../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.js';
+import { ImportedFoo } from './BridgeJSRuntimeTests/JavaScript/Types.mjs';
+import { runJsOptionalSupportTests } from './BridgeJSRuntimeTests/JavaScript/OptionalSupportTests.mjs';
 
 /** @type {import('../.build/plugins/PackageToJS/outputs/PackageTests/test.d.ts').SetupOptionsFn} */
 export async function setupOptions(options, context) {
@@ -66,6 +68,12 @@ export async function setupOptions(options, context) {
                     return v ?? null;
                 },
                 "jsRoundTripOptionalNumberUndefined": (v) => {
+                    return v === undefined ? undefined : v;
+                },
+                "jsRoundTripOptionalStringNull": (v) => {
+                    return v ?? null;
+                },
+                "jsRoundTripOptionalStringUndefined": (v) => {
                     return v === undefined ? undefined : v;
                 },
                 "jsRoundTripJSValue": (v) => {
@@ -184,6 +192,11 @@ export async function setupOptions(options, context) {
                 },
                 roundTripArrayMembers: (value) => {
                     return value;
+                },
+                runJsOptionalSupportTests: () => {
+                    const exports = importsContext.getExports();
+                    if (!exports) { throw new Error("No exports!?"); }
+                    runJsOptionalSupportTests(exports);
                 }
             };
         },
@@ -219,13 +232,6 @@ export async function setupOptions(options, context) {
 }
 
 import assert from "node:assert";
-
-class ImportedFoo {
-    /** @param {string} value */
-    constructor(value) {
-        this.value = value;
-    }
-}
 
 /** @param {import('./../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports */
 function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
@@ -714,123 +720,6 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     assert.deepEqual(exports.makeAPINetworkingResultSuccess("Connected"), { tag: exports.API.NetworkingResult.Tag.Success, param0: "Connected" });
     assert.deepEqual(exports.makeAPINetworkingResultFailure("Timeout", 408), { tag: exports.API.NetworkingResult.Tag.Failure, param0: "Timeout", param1: 408 });
 
-    assert.equal(exports.roundTripOptionalString(null), null);
-    assert.equal(exports.roundTripOptionalInt(null), null);
-    assert.equal(exports.roundTripOptionalBool(null), null);
-    assert.equal(exports.roundTripOptionalFloat(null), null);
-    assert.equal(exports.roundTripOptionalDouble(null), null);
-
-    assert.equal(exports.roundTripOptionalString("Hello"), "Hello");
-    assert.equal(exports.roundTripOptionalInt(42), 42);
-    assert.equal(exports.roundTripOptionalBool(true), true);
-    assert.equal(exports.roundTripOptionalFloat(3.141592502593994), 3.141592502593994); // Float32 precision
-    assert.equal(exports.roundTripOptionalDouble(2.718), 2.718);
-
-    assert.equal(exports.roundTripOptionalSyntax(null), null);
-    assert.equal(exports.roundTripOptionalSyntax("Test"), "Test");
-    assert.equal(exports.roundTripOptionalMixSyntax(null), null);
-    assert.equal(exports.roundTripOptionalMixSyntax("Mix"), "Mix");
-    assert.equal(exports.roundTripOptionalSwiftSyntax(null), null);
-    assert.equal(exports.roundTripOptionalSwiftSyntax("Swift"), "Swift");
-    assert.equal(exports.roundTripOptionalWithSpaces(null), null);
-    assert.equal(exports.roundTripOptionalWithSpaces(1.618), 1.618);
-    assert.equal(exports.roundTripOptionalTypeAlias(null), null);
-    assert.equal(exports.roundTripOptionalTypeAlias(25), 25);
-    assert.equal(exports.roundTripOptionalStatus(exports.Status.Success), StatusValues.Success);
-    assert.equal(exports.roundTripOptionalTheme(exports.Theme.Light), ThemeValues.Light);
-    assert.equal(exports.roundTripOptionalHttpStatus(exports.HttpStatus.Ok), HttpStatusValues.Ok);
-    assert.equal(exports.roundTripOptionalTSDirection(TSDirection.North), TSDirection.North);
-    assert.equal(exports.roundTripOptionalTSTheme(TSTheme.Light), TSTheme.Light);
-    assert.equal(exports.roundTripOptionalNetworkingAPIMethod(exports.Networking.API.Method.Get), exports.Networking.API.Method.Get);
-    assert.deepEqual(exports.roundTripOptionalAPIResult(p1), p1);
-    assert.deepEqual(exports.roundTripOptionalComplexResult(cl1), cl1);
-
-    const apiSuccess = { tag: exports.APIResult.Tag.Success, param0: "test success" };
-    const apiFailure = { tag: exports.APIResult.Tag.Failure, param0: 404 };
-    const apiInfo = { tag: exports.APIResult.Tag.Info };
-
-    assert.equal(exports.compareAPIResults(apiSuccess, apiFailure), "r1:success:test success,r2:failure:404");
-    assert.equal(exports.compareAPIResults(null, apiInfo), "r1:nil,r2:info");
-    assert.equal(exports.compareAPIResults(apiFailure, null), "r1:failure:404,r2:nil");
-    assert.equal(exports.compareAPIResults(null, null), "r1:nil,r2:nil");
-
-    const optionalGreeter = new exports.Greeter("Schrödinger");
-    const optionalGreeter2 = exports.roundTripOptionalClass(optionalGreeter);
-    assert.equal(optionalGreeter2?.greet() ?? "", "Hello, Schrödinger!");
-    assert.equal(optionalGreeter2?.name ?? "", "Schrödinger");
-    assert.equal(optionalGreeter2?.prefix ?? "", "Hello");
-    assert.equal(exports.roundTripOptionalClass(null), null);
-    optionalGreeter.release();
-    optionalGreeter2?.release();
-
-    const optionalsHolder = new exports.OptionalPropertyHolder(null);
-
-    assert.equal(optionalsHolder.optionalName, null);
-    assert.equal(optionalsHolder.optionalAge, null);
-    assert.equal(optionalsHolder.optionalGreeter, null);
-
-    optionalsHolder.optionalName = "Alice";
-    optionalsHolder.optionalAge = 25;
-    assert.equal(optionalsHolder.optionalName, "Alice");
-    assert.equal(optionalsHolder.optionalAge, 25);
-
-    const testPropertyGreeter = new exports.Greeter("Bob");
-    optionalsHolder.optionalGreeter = testPropertyGreeter;
-    assert.equal(optionalsHolder.optionalGreeter.greet(), "Hello, Bob!");
-    assert.equal(optionalsHolder.optionalGreeter.name, "Bob");
-
-    optionalsHolder.optionalName = null;
-    optionalsHolder.optionalAge = null;
-    optionalsHolder.optionalGreeter = null;
-    assert.equal(optionalsHolder.optionalName, null);
-    assert.equal(optionalsHolder.optionalAge, null);
-    assert.equal(optionalsHolder.optionalGreeter, null);
-    testPropertyGreeter.release();
-    optionalsHolder.release();
-
-    const optGreeter = new exports.Greeter("Optionaly");
-    assert.equal(exports.roundTripOptionalGreeter(null), null);
-    const optGreeterReturned = exports.roundTripOptionalGreeter(optGreeter);
-    assert.equal(optGreeterReturned.name, "Optionaly");
-    assert.equal(optGreeterReturned.greet(), "Hello, Optionaly!");
-
-    const appliedOptional = exports.applyOptionalGreeter(null, (g) => g ?? optGreeter);
-    assert.equal(appliedOptional.name, "Optionaly");
-
-    const holderOpt = exports.makeOptionalHolder(null, undefined);
-    assert.equal(holderOpt.nullableGreeter, null);
-    assert.equal(holderOpt.undefinedNumber, undefined);
-    holderOpt.nullableGreeter = optGreeter;
-    holderOpt.undefinedNumber = 123.5;
-    assert.equal(holderOpt.nullableGreeter.name, "Optionaly");
-    assert.equal(holderOpt.undefinedNumber, 123.5);
-    holderOpt.release();
-    optGreeterReturned.release();
-    optGreeter.release();
-
-    const aor1 = { tag: APIOptionalResultValues.Tag.Success, param0: "hello world" };
-    const aor2 = { tag: APIOptionalResultValues.Tag.Success, param0: null };
-    const aor3 = { tag: APIOptionalResultValues.Tag.Failure, param0: 404, param1: true };
-    const aor4 = { tag: APIOptionalResultValues.Tag.Failure, param0: 404, param1: null };
-    const aor5 = { tag: APIOptionalResultValues.Tag.Failure, param0: null, param1: null };
-    const aor6 = { tag: APIOptionalResultValues.Tag.Status, param0: true, param1: 200, param2: "OK" };
-    const aor7 = { tag: APIOptionalResultValues.Tag.Status, param0: true, param1: null, param2: "Partial" };
-    const aor8 = { tag: APIOptionalResultValues.Tag.Status, param0: null, param1: null, param2: "Zero" };
-    const aor9 = { tag: APIOptionalResultValues.Tag.Status, param0: false, param1: 500, param2: null };
-    const aor10 = { tag: APIOptionalResultValues.Tag.Status, param0: null, param1: 0, param2: "Zero" };
-
-    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor1), aor1);
-    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor2), aor2);
-    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor3), aor3);
-    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor4), aor4);
-    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor5), aor5);
-    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor6), aor6);
-    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor7), aor7);
-    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor8), aor8);
-    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor9), aor9);
-    assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor10), aor10);
-    assert.equal(exports.roundTripOptionalAPIOptionalResult(null), null);
-
     // TypedPayloadResult — rawValueEnum and caseEnum as associated value payloads
     assert.equal(exports.Precision.Rough, 0.1);
     assert.equal(exports.Precision.Fine, 0.001);
@@ -858,14 +747,6 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
 
     const tpr_empty = { tag: exports.TypedPayloadResult.Tag.Empty };
     assert.deepEqual(exports.roundTripTypedPayloadResult(tpr_empty), tpr_empty);
-
-    // Optional TypedPayloadResult roundtrip
-    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_precision), tpr_precision);
-    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_direction), tpr_direction);
-    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_optPrecisionSome), tpr_optPrecisionSome);
-    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_optPrecisionNull), tpr_optPrecisionNull);
-    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_empty), tpr_empty);
-    assert.equal(exports.roundTripOptionalTypedPayloadResult(null), null);
 
     // AllTypesResult — struct, class, JSObject, nested enum, array as associated value payloads
     const atr_struct = { tag: AllTypesResultValues.Tag.StructPayload, param0: { street: "100 Main St", city: "Boston", zipCode: 2101 } };
@@ -895,64 +776,6 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
 
     const atr_empty = { tag: AllTypesResultValues.Tag.Empty };
     assert.deepEqual(exports.roundTripAllTypesResult(atr_empty), atr_empty);
-
-    // Optional AllTypesResult roundtrip
-    assert.deepEqual(exports.roundTripOptionalAllTypesResult(atr_struct), atr_struct);
-    assert.deepEqual(exports.roundTripOptionalAllTypesResult(atr_array), atr_array);
-    assert.deepEqual(exports.roundTripOptionalAllTypesResult(atr_empty), atr_empty);
-    assert.equal(exports.roundTripOptionalAllTypesResult(null), null);
-
-    // OptionalAllTypesResult — optional struct, class, JSObject, nested enum, array as associated value payloads
-    const oatr_structSome = { tag: OptionalAllTypesResultValues.Tag.OptStruct, param0: { street: "200 Oak St", city: "Denver", zipCode: null } };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_structSome), oatr_structSome);
-
-    const oatr_structNone = { tag: OptionalAllTypesResultValues.Tag.OptStruct, param0: null };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_structNone), oatr_structNone);
-
-    const oatr_classSome = { tag: OptionalAllTypesResultValues.Tag.OptClass, param0: new exports.Greeter("OptEnumUser") };
-    const oatr_classSome_result = exports.roundTripOptionalPayloadResult(oatr_classSome);
-    assert.equal(oatr_classSome_result.tag, OptionalAllTypesResultValues.Tag.OptClass);
-    assert.equal(oatr_classSome_result.param0.name, "OptEnumUser");
-
-    const oatr_classNone = { tag: OptionalAllTypesResultValues.Tag.OptClass, param0: null };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_classNone), oatr_classNone);
-
-    const oatr_jsObjectSome = { tag: OptionalAllTypesResultValues.Tag.OptJSObject, param0: { key: "value" } };
-    const oatr_jsObjectSome_result = exports.roundTripOptionalPayloadResult(oatr_jsObjectSome);
-    assert.equal(oatr_jsObjectSome_result.tag, OptionalAllTypesResultValues.Tag.OptJSObject);
-    assert.equal(oatr_jsObjectSome_result.param0.key, "value");
-
-    const oatr_jsObjectNone = { tag: OptionalAllTypesResultValues.Tag.OptJSObject, param0: null };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_jsObjectNone), oatr_jsObjectNone);
-
-    const oatr_nestedEnumSome = { tag: OptionalAllTypesResultValues.Tag.OptNestedEnum, param0: { tag: APIResultValues.Tag.Failure, param0: 404 } };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_nestedEnumSome), oatr_nestedEnumSome);
-
-    const oatr_nestedEnumNone = { tag: OptionalAllTypesResultValues.Tag.OptNestedEnum, param0: null };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_nestedEnumNone), oatr_nestedEnumNone);
-
-    const oatr_arraySome = { tag: OptionalAllTypesResultValues.Tag.OptArray, param0: [1, 2, 3] };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_arraySome), oatr_arraySome);
-
-    const oatr_arrayNone = { tag: OptionalAllTypesResultValues.Tag.OptArray, param0: null };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_arrayNone), oatr_arrayNone);
-
-    const oatr_jsClassSome = { tag: OptionalAllTypesResultValues.Tag.OptJsClass, param0: new ImportedFoo("optEnumFoo") };
-    const oatr_jsClassSome_result = exports.roundTripOptionalPayloadResult(oatr_jsClassSome);
-    assert.equal(oatr_jsClassSome_result.tag, OptionalAllTypesResultValues.Tag.OptJsClass);
-    assert.equal(oatr_jsClassSome_result.param0.value, "optEnumFoo");
-
-    const oatr_jsClassNone = { tag: OptionalAllTypesResultValues.Tag.OptJsClass, param0: null };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_jsClassNone), oatr_jsClassNone);
-
-    const oatr_empty = { tag: OptionalAllTypesResultValues.Tag.Empty };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_empty), oatr_empty);
-
-    // Optional OptionalAllTypesResult roundtrip
-    assert.deepEqual(exports.roundTripOptionalPayloadResultOpt(oatr_structSome), oatr_structSome);
-    assert.deepEqual(exports.roundTripOptionalPayloadResultOpt(oatr_structNone), oatr_structNone);
-    assert.deepEqual(exports.roundTripOptionalPayloadResultOpt(oatr_empty), oatr_empty);
-    assert.equal(exports.roundTripOptionalPayloadResultOpt(null), null);
 
     assert.equal(exports.MathUtils.add(2147483647, 0), 2147483647);
     assert.equal(exports.StaticCalculator.roundtrip(42), 42);


### PR DESCRIPTION
I found import-side optional support still has broken cases. To add more test cases, split out the test suite into dedicated files as a preparation.