### PR TITLE
BridgeJS: Fix optional String return handling in generated JS glue code

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -994,19 +994,13 @@ struct IntrinsicJSFragment: Sendable {
                         "bjs[\"swift_js_return_optional_double\"](\(isSomeVar) ? 1 : 0, \(isSomeVar) ? \(value) : 0.0);"
                     )
                 case .string:
-                    let bytesVar = scope.variable("bytes")
                     printer.write("if (\(isSomeVar)) {")
                     printer.indent {
-                        printer.write(
-                            "const \(bytesVar) = \(JSGlueVariableScope.reservedTextEncoder).encode(\(value));"
-                        )
-                        printer.write("bjs[\"swift_js_return_optional_string\"](1, \(bytesVar), \(bytesVar).length);")
-                        printer.write("return \(bytesVar).length;")
+                        printer.write("\(JSGlueVariableScope.reservedStorageToReturnString) = \(value);")
                     }
                     printer.write("} else {")
                     printer.indent {
-                        printer.write("bjs[\"swift_js_return_optional_string\"](0, 0, 0);")
-                        printer.write("return -1;")
+                        printer.write("\(JSGlueVariableScope.reservedStorageToReturnString) = null;")
                     }
                     printer.write("}")
                 case .jsObject, .swiftProtocol:
@@ -1032,19 +1026,13 @@ struct IntrinsicJSFragment: Sendable {
                 case .rawValueEnum(_, let rawType):
                     switch rawType {
                     case .string:
-                        let bytesVar = scope.variable("bytes")
                         printer.write("if (\(isSomeVar)) {")
                         printer.indent {
-                            printer.write(
-                                "const \(bytesVar) = \(JSGlueVariableScope.reservedTextEncoder).encode(\(value));"
-                            )
-                            printer.write(
-                                "bjs[\"swift_js_return_optional_string\"](1, \(bytesVar), \(bytesVar).length);"
-                            )
+                            printer.write("\(JSGlueVariableScope.reservedStorageToReturnString) = \(value);")
                         }
                         printer.write("} else {")
                         printer.indent {
-                            printer.write("bjs[\"swift_js_return_optional_string\"](0, 0, 0);")
+                            printer.write("\(JSGlueVariableScope.reservedStorageToReturnString) = null;")
                         }
                         printer.write("}")
                     default:

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
@@ -238,12 +238,9 @@ export async function createInstantiator(options, swift) {
                     let ret = swift.memory.getObject(self).stringOrNull;
                     const isSome = ret != null;
                     if (isSome) {
-                        const bytes = textEncoder.encode(ret);
-                        bjs["swift_js_return_optional_string"](1, bytes, bytes.length);
-                        return bytes.length;
+                        tmpRetString = ret;
                     } else {
-                        bjs["swift_js_return_optional_string"](0, 0, 0);
-                        return -1;
+                        tmpRetString = null;
                     }
                 } catch (error) {
                     setException(error);
@@ -254,12 +251,9 @@ export async function createInstantiator(options, swift) {
                     let ret = swift.memory.getObject(self).stringOrUndefined;
                     const isSome = ret !== undefined;
                     if (isSome) {
-                        const bytes = textEncoder.encode(ret);
-                        bjs["swift_js_return_optional_string"](1, bytes, bytes.length);
-                        return bytes.length;
+                        tmpRetString = ret;
                     } else {
-                        bjs["swift_js_return_optional_string"](0, 0, 0);
-                        return -1;
+                        tmpRetString = null;
                     }
                 } catch (error) {
                     setException(error);
@@ -395,12 +389,9 @@ export async function createInstantiator(options, swift) {
                     let ret = swift.memory.getObject(self).roundTripStringOrNull(valueIsSome ? obj : null);
                     const isSome = ret != null;
                     if (isSome) {
-                        const bytes = textEncoder.encode(ret);
-                        bjs["swift_js_return_optional_string"](1, bytes, bytes.length);
-                        return bytes.length;
+                        tmpRetString = ret;
                     } else {
-                        bjs["swift_js_return_optional_string"](0, 0, 0);
-                        return -1;
+                        tmpRetString = null;
                     }
                 } catch (error) {
                     setException(error);
@@ -416,12 +407,9 @@ export async function createInstantiator(options, swift) {
                     let ret = swift.memory.getObject(self).roundTripStringOrUndefined(valueIsSome ? obj : undefined);
                     const isSome = ret !== undefined;
                     if (isSome) {
-                        const bytes = textEncoder.encode(ret);
-                        bjs["swift_js_return_optional_string"](1, bytes, bytes.length);
-                        return bytes.length;
+                        tmpRetString = ret;
                     } else {
-                        bjs["swift_js_return_optional_string"](0, 0, 0);
-                        return -1;
+                        tmpRetString = null;
                     }
                 } catch (error) {
                     setException(error);

--- a/Tests/BridgeJSRuntimeTests/OptionalSupportTests.swift
+++ b/Tests/BridgeJSRuntimeTests/OptionalSupportTests.swift
@@ -9,26 +9,25 @@ final class OptionalSupportTests: XCTestCase {
         try runJsOptionalSupportTests()
     }
 
-    // FIXME: Optional<String> return type on imported function is broken
-    // func testRoundTripOptionalStringNull() throws {
-    //     try XCTAssertEqual(jsRoundTripOptionalStringNull("hello"), "hello")
-    //     try XCTAssertNil(jsRoundTripOptionalStringNull(nil))
-    // }
+    func testRoundTripOptionalStringNull() throws {
+        try XCTAssertEqual(jsRoundTripOptionalStringNull("hello"), "hello")
+        try XCTAssertNil(jsRoundTripOptionalStringNull(nil))
+    }
 
-    // func testRoundTripOptionalStringUndefined() throws {
-    //     let some = try jsRoundTripOptionalStringUndefined(.value("hi"))
-    //     switch some {
-    //     case .value(let value):
-    //         XCTAssertEqual(value, "hi")
-    //     case .undefined:
-    //         XCTFail("Expected defined value")
-    //     }
+    func testRoundTripOptionalStringUndefined() throws {
+        let some = try jsRoundTripOptionalStringUndefined(.value("hi"))
+        switch some {
+        case .value(let value):
+            XCTAssertEqual(value, "hi")
+        case .undefined:
+            XCTFail("Expected defined value")
+        }
 
-    //     let undefined = try jsRoundTripOptionalStringUndefined(.undefinedValue)
-    //     if case .value = undefined {
-    //         XCTFail("Expected undefined")
-    //     }
-    // }
+        let undefined = try jsRoundTripOptionalStringUndefined(.undefinedValue)
+        if case .value = undefined {
+            XCTFail("Expected undefined")
+        }
+    }
 
     func testRoundTripOptionalNumberNull() throws {
         try XCTAssertEqual(jsRoundTripOptionalNumberNull(42), 42)


### PR DESCRIPTION
```swift
@JSFunction func makeOptionalString() throws -> String?
@JSFunction func makeUndefinedOrString() throws -> JSUndefinedOr<String>
```

Those imported functions returned corrupted Strings before.