### PR TITLE
[NFC] BridgeJS: Remove explicit stack storage captures from enum/struct helpers

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -618,7 +618,7 @@ struct IntrinsicJSFragment: Sendable {
             printCode: { _, scope, printer, _ in
                 let retName = scope.variable("ret")
                 printer.write(
-                    "const \(retName) = \(JSGlueVariableScope.reservedEnumHelpers).\(enumBase).lift(\(scope.popTagReturn()), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                    "const \(retName) = \(JSGlueVariableScope.reservedEnumHelpers).\(enumBase).lift(\(scope.popTagReturn()));"
                 )
                 return [retName]
             }
@@ -699,7 +699,7 @@ struct IntrinsicJSFragment: Sendable {
                     printer.write("if (\(isSome)) {")
                     printer.indent {
                         printer.write(
-                            "\(enumVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(wrappedValue), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                            "\(enumVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(wrappedValue));"
                         )
                     }
                     printer.write("}")
@@ -711,7 +711,7 @@ struct IntrinsicJSFragment: Sendable {
                     printer.write("if (\(isSome)) {")
                     printer.indent {
                         printer.write(
-                            "\(structVar) = \(JSGlueVariableScope.reservedStructHelpers).\(base).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                            "\(structVar) = \(JSGlueVariableScope.reservedStructHelpers).\(base).lift();"
                         )
                     }
                     printer.write("} else {")
@@ -944,7 +944,7 @@ struct IntrinsicJSFragment: Sendable {
                     printer.write("} else {")
                     printer.indent {
                         printer.write(
-                            "\(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(tagVar), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                            "\(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(tagVar));"
                         )
                     }
                     printer.write("}")
@@ -956,7 +956,7 @@ struct IntrinsicJSFragment: Sendable {
                     printer.write("if (\(isSomeVar)) {")
                     printer.indent {
                         printer.write(
-                            "\(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(base).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                            "\(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(base).lift();"
                         )
                     }
                     printer.write("} else {")
@@ -1283,7 +1283,7 @@ struct IntrinsicJSFragment: Sendable {
                     let targetVar = arguments[1]
                     let base = fullName.components(separatedBy: ".").last ?? fullName
                     printer.write(
-                        "let \(targetVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(caseId), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                        "let \(targetVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(caseId));"
                     )
                     return []
                 }
@@ -1354,7 +1354,7 @@ struct IntrinsicJSFragment: Sendable {
                 case .associatedValueEnum(let fullName):
                     let base = fullName.components(separatedBy: ".").last ?? fullName
                     printer.write(
-                        "\(targetVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(value), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                        "\(targetVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(value));"
                     )
                 default:
                     fatalError("Unsupported optional wrapped type in closure parameter lifting: \(wrappedType)")
@@ -1682,7 +1682,7 @@ struct IntrinsicJSFragment: Sendable {
                     let base = fullName.components(separatedBy: ".").last ?? fullName
                     let resultVar = scope.variable("result")
                     printer.write(
-                        "const \(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(scope.popTagReturn()), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                        "const \(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(scope.popTagReturn()));"
                     )
                     printer.write("return \(resultVar);")
                     return []
@@ -1907,7 +1907,7 @@ struct IntrinsicJSFragment: Sendable {
                         let caseId = arguments[0]
                         let resultVar = scope.variable("enumValue")
                         printer.write(
-                            "const \(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(caseId), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                            "const \(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(caseId));"
                         )
                         return [resultVar]
                     }
@@ -1924,7 +1924,7 @@ struct IntrinsicJSFragment: Sendable {
                     printCode: { arguments, scope, printer, cleanupCode in
                         let resultVar = scope.variable("structValue")
                         printer.write(
-                            "const \(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(base).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                            "const \(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(base).lift();"
                         )
                         return [resultVar]
                     }
@@ -2107,7 +2107,7 @@ struct IntrinsicJSFragment: Sendable {
 
                 // Generate lift function
                 printer.write(
-                    "lift: (tag, \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers)) => {"
+                    "lift: (tag) => {"
                 )
                 printer.indent {
                     printer.write("tag = tag | 0;")
@@ -2505,7 +2505,7 @@ struct IntrinsicJSFragment: Sendable {
                         let caseIdVar = scope.variable("caseId")
                         printer.write("const \(caseIdVar) = \(scope.popI32Return());")
                         printer.write(
-                            "\(optVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(caseIdVar), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                            "\(optVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(caseIdVar));"
                         )
                     } else {
                         let wrappedFragment = associatedValuePopPayload(type: wrappedType)
@@ -2565,7 +2565,7 @@ struct IntrinsicJSFragment: Sendable {
             printCode: { arguments, scope, printer, cleanupCode in
                 let resultVar = scope.variable("structValue")
                 printer.write(
-                    "const \(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(structBase).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                    "const \(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(structBase).lift();"
                 )
                 return [resultVar]
             }
@@ -2705,7 +2705,7 @@ struct IntrinsicJSFragment: Sendable {
                 printCode: { arguments, scope, printer, cleanup in
                     let resultVar = scope.variable("struct")
                     printer.write(
-                        "const \(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(structBase).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                        "const \(resultVar) = \(JSGlueVariableScope.reservedStructHelpers).\(structBase).lift();"
                     )
                     return [resultVar]
                 }
@@ -2765,7 +2765,7 @@ struct IntrinsicJSFragment: Sendable {
                 printCode: { arguments, scope, printer, cleanup in
                     let resultVar = scope.variable("enumValue")
                     printer.write(
-                        "const \(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(scope.popTagReturn()), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                        "const \(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(scope.popTagReturn()), );"
                     )
                     return [resultVar]
                 }
@@ -3125,7 +3125,7 @@ struct IntrinsicJSFragment: Sendable {
                 printer.write("},")
 
                 printer.write(
-                    "lift: (\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers)) => {"
+                    "lift: () => {"
                 )
                 printer.indent {
                     generateStructLiftCode(
@@ -3678,7 +3678,7 @@ struct IntrinsicJSFragment: Sendable {
                             let caseIdVar = scope.variable("enumCaseId")
                             printer.write("const \(caseIdVar) = \(scope.popI32Return());")
                             printer.write(
-                                "\(optVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(caseIdVar), \(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                                "\(optVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(caseIdVar), );"
                             )
                         } else {
                             let wrappedFragment = structFieldLiftFragment(
@@ -3712,7 +3712,7 @@ struct IntrinsicJSFragment: Sendable {
                 printCode: { arguments, scope, printer, cleanup in
                     let structVar = scope.variable("struct")
                     printer.write(
-                        "const \(structVar) = \(JSGlueVariableScope.reservedStructHelpers).\(nestedName).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                        "const \(structVar) = \(JSGlueVariableScope.reservedStructHelpers).\(nestedName).lift();"
                     )
                     return [structVar]
                 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
@@ -54,7 +54,7 @@ export async function createInstantiator(options, swift) {
                 tmpParamF64s.push(value.y);
                 return { cleanup: undefined };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const f64 = tmpRetF64s.pop();
                 const f641 = tmpRetF64s.pop();
                 return { x: f641, y: f64 };
@@ -481,7 +481,7 @@ export async function createInstantiator(options, swift) {
                     const arrayLen = tmpRetInts.pop();
                     const arrayResult = [];
                     for (let i = 0; i < arrayLen; i++) {
-                        const struct = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        const struct = structHelpers.Point.lift();
                         arrayResult.push(struct);
                     }
                     arrayResult.reverse();
@@ -544,7 +544,7 @@ export async function createInstantiator(options, swift) {
                     const matchingBytes = textEncoder.encode(matching);
                     const matchingId = swift.memory.retain(matchingBytes);
                     instance.exports.bjs_findFirstPoint(matchingId, matchingBytes.length);
-                    const structValue = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const structValue = structHelpers.Point.lift();
                     for (const cleanup of arrayCleanups) { cleanup(); }
                     swift.memory.release(matchingId);
                     return structValue;
@@ -715,7 +715,7 @@ export async function createInstantiator(options, swift) {
                         if (isSome1 === 0) {
                             optValue = null;
                         } else {
-                            const struct = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                            const struct = structHelpers.Point.lift();
                             optValue = struct;
                         }
                         arrayResult.push(optValue);
@@ -873,7 +873,7 @@ export async function createInstantiator(options, swift) {
                         const arrayLen1 = tmpRetInts.pop();
                         const arrayResult1 = [];
                         for (let i1 = 0; i1 < arrayLen1; i1++) {
-                            const struct = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                            const struct = structHelpers.Point.lift();
                             arrayResult1.push(struct);
                         }
                         arrayResult1.reverse();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
@@ -54,7 +54,7 @@ export async function createInstantiator(options, swift) {
                 };
                 return { cleanup };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const bool = tmpRetInts.pop() !== 0;
                 const int = tmpRetInts.pop();
                 const string = tmpRetStrings.pop();
@@ -68,7 +68,7 @@ export async function createInstantiator(options, swift) {
                 tmpParamF64s.push(value.baseValue);
                 return { cleanup: undefined };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const f64 = tmpRetF64s.pop();
                 const instance1 = { baseValue: f64 };
                 instance1.add = function(a, b = 10.0) {
@@ -528,7 +528,7 @@ export async function createInstantiator(options, swift) {
                     const isSome1 = tmpRetInts.pop();
                     let optResult;
                     if (isSome1) {
-                        optResult = structHelpers.Config.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = structHelpers.Config.lift();
                     } else {
                         optResult = null;
                     }
@@ -546,7 +546,7 @@ export async function createInstantiator(options, swift) {
                     const isSome1 = tmpRetInts.pop();
                     let optResult;
                     if (isSome1) {
-                        optResult = structHelpers.Config.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = structHelpers.Config.lift();
                     } else {
                         optResult = null;
                     }
@@ -663,7 +663,7 @@ export async function createInstantiator(options, swift) {
                 MathOperations: {
                     init: function(baseValue = 0.0) {
                         instance.exports.bjs_MathOperations_init(baseValue);
-                        const structValue = structHelpers.MathOperations.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        const structValue = structHelpers.MathOperations.lift();
                         return structValue;
                     },
                     subtract: function(a, b) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
@@ -122,7 +122,7 @@ export async function createInstantiator(options, swift) {
                 tmpParamF64s.push(value.y);
                 return { cleanup: undefined };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const f64 = tmpRetF64s.pop();
                 const f641 = tmpRetF64s.pop();
                 return { x: f641, y: f64 };
@@ -171,7 +171,7 @@ export async function createInstantiator(options, swift) {
                     default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
                 }
             },
-            lift: (tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tag) => {
                 tag = tag | 0;
                 switch (tag) {
                     case APIResultValues.Tag.Success: {
@@ -278,7 +278,7 @@ export async function createInstantiator(options, swift) {
                     default: throw new Error("Unknown ComplexResultValues tag: " + String(enumTag));
                 }
             },
-            lift: (tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tag) => {
                 tag = tag | 0;
                 switch (tag) {
                     case ComplexResultValues.Tag.Success: {
@@ -361,7 +361,7 @@ export async function createInstantiator(options, swift) {
                     default: throw new Error("Unknown ResultValues tag: " + String(enumTag));
                 }
             },
-            lift: (tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tag) => {
                 tag = tag | 0;
                 switch (tag) {
                     case ResultValues.Tag.Success: {
@@ -413,7 +413,7 @@ export async function createInstantiator(options, swift) {
                     default: throw new Error("Unknown NetworkingResultValues tag: " + String(enumTag));
                 }
             },
-            lift: (tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tag) => {
                 tag = tag | 0;
                 switch (tag) {
                     case NetworkingResultValues.Tag.Success: {
@@ -494,7 +494,7 @@ export async function createInstantiator(options, swift) {
                     default: throw new Error("Unknown APIOptionalResultValues tag: " + String(enumTag));
                 }
             },
-            lift: (tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tag) => {
                 tag = tag | 0;
                 switch (tag) {
                     case APIOptionalResultValues.Tag.Success: {
@@ -595,7 +595,7 @@ export async function createInstantiator(options, swift) {
                     default: throw new Error("Unknown TypedPayloadResultValues tag: " + String(enumTag));
                 }
             },
-            lift: (tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tag) => {
                 tag = tag | 0;
                 switch (tag) {
                     case TypedPayloadResultValues.Tag.Precision: {
@@ -683,11 +683,11 @@ export async function createInstantiator(options, swift) {
                     default: throw new Error("Unknown AllTypesResultValues tag: " + String(enumTag));
                 }
             },
-            lift: (tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tag) => {
                 tag = tag | 0;
                 switch (tag) {
                     case AllTypesResultValues.Tag.StructPayload: {
-                        const struct = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        const struct = structHelpers.Point.lift();
                         return { tag: AllTypesResultValues.Tag.StructPayload, param0: struct };
                     }
                     case AllTypesResultValues.Tag.ClassPayload: {
@@ -702,7 +702,7 @@ export async function createInstantiator(options, swift) {
                         return { tag: AllTypesResultValues.Tag.JsObjectPayload, param0: obj };
                     }
                     case AllTypesResultValues.Tag.NestedEnum: {
-                        const enumValue = enumHelpers.APIResult.lift(tmpRetTag.pop(), tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        const enumValue = enumHelpers.APIResult.lift(tmpRetTag.pop(), );
                         return { tag: AllTypesResultValues.Tag.NestedEnum, param0: enumValue };
                     }
                     case AllTypesResultValues.Tag.ArrayPayload: {
@@ -807,14 +807,14 @@ export async function createInstantiator(options, swift) {
                     default: throw new Error("Unknown OptionalAllTypesResultValues tag: " + String(enumTag));
                 }
             },
-            lift: (tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tag) => {
                 tag = tag | 0;
                 switch (tag) {
                     case OptionalAllTypesResultValues.Tag.OptStruct: {
                         const isSome = tmpRetInts.pop();
                         let optional;
                         if (isSome) {
-                            const struct = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                            const struct = structHelpers.Point.lift();
                             optional = struct;
                         } else {
                             optional = null;
@@ -851,7 +851,7 @@ export async function createInstantiator(options, swift) {
                         let optional;
                         if (isSome) {
                             const caseId = tmpRetInts.pop();
-                            optional = enumHelpers.APIResult.lift(caseId, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                            optional = enumHelpers.APIResult.lift(caseId);
                         } else {
                             optional = null;
                         }
@@ -1139,13 +1139,13 @@ export async function createInstantiator(options, swift) {
                 },
                 getResult: function bjs_getResult() {
                     instance.exports.bjs_getResult();
-                    const ret = enumHelpers.APIResult.lift(tmpRetTag.pop(), tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const ret = enumHelpers.APIResult.lift(tmpRetTag.pop());
                     return ret;
                 },
                 roundtripAPIResult: function bjs_roundtripAPIResult(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.APIResult.lower(result);
                     instance.exports.bjs_roundtripAPIResult(resultCaseId);
-                    const ret = enumHelpers.APIResult.lift(tmpRetTag.pop(), tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const ret = enumHelpers.APIResult.lift(tmpRetTag.pop());
                     if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
@@ -1164,7 +1164,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.APIResult.lift(tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = enumHelpers.APIResult.lift(tag);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;
@@ -1176,13 +1176,13 @@ export async function createInstantiator(options, swift) {
                 },
                 getComplexResult: function bjs_getComplexResult() {
                     instance.exports.bjs_getComplexResult();
-                    const ret = enumHelpers.ComplexResult.lift(tmpRetTag.pop(), tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const ret = enumHelpers.ComplexResult.lift(tmpRetTag.pop());
                     return ret;
                 },
                 roundtripComplexResult: function bjs_roundtripComplexResult(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.ComplexResult.lower(result);
                     instance.exports.bjs_roundtripComplexResult(resultCaseId);
-                    const ret = enumHelpers.ComplexResult.lift(tmpRetTag.pop(), tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const ret = enumHelpers.ComplexResult.lift(tmpRetTag.pop());
                     if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
@@ -1201,7 +1201,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.ComplexResult.lift(tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = enumHelpers.ComplexResult.lift(tag);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;
@@ -1221,7 +1221,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.Result.lift(tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = enumHelpers.Result.lift(tag);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;
@@ -1241,7 +1241,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.NetworkingResult.lift(tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = enumHelpers.NetworkingResult.lift(tag);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;
@@ -1261,7 +1261,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.APIOptionalResult.lift(tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = enumHelpers.APIOptionalResult.lift(tag);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;
@@ -1288,7 +1288,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.APIOptionalResult.lift(tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = enumHelpers.APIOptionalResult.lift(tag);
                     }
                     if (result1Cleanup) { result1Cleanup(); }
                     if (result2Cleanup) { result2Cleanup(); }
@@ -1297,7 +1297,7 @@ export async function createInstantiator(options, swift) {
                 roundTripTypedPayloadResult: function bjs_roundTripTypedPayloadResult(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.TypedPayloadResult.lower(result);
                     instance.exports.bjs_roundTripTypedPayloadResult(resultCaseId);
-                    const ret = enumHelpers.TypedPayloadResult.lift(tmpRetTag.pop(), tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const ret = enumHelpers.TypedPayloadResult.lift(tmpRetTag.pop());
                     if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
@@ -1316,7 +1316,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.TypedPayloadResult.lift(tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = enumHelpers.TypedPayloadResult.lift(tag);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;
@@ -1324,7 +1324,7 @@ export async function createInstantiator(options, swift) {
                 roundTripAllTypesResult: function bjs_roundTripAllTypesResult(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.AllTypesResult.lower(result);
                     instance.exports.bjs_roundTripAllTypesResult(resultCaseId);
-                    const ret = enumHelpers.AllTypesResult.lift(tmpRetTag.pop(), tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const ret = enumHelpers.AllTypesResult.lift(tmpRetTag.pop());
                     if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
@@ -1343,7 +1343,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.AllTypesResult.lift(tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = enumHelpers.AllTypesResult.lift(tag);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;
@@ -1351,7 +1351,7 @@ export async function createInstantiator(options, swift) {
                 roundTripOptionalPayloadResult: function bjs_roundTripOptionalPayloadResult(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.OptionalAllTypesResult.lower(result);
                     instance.exports.bjs_roundTripOptionalPayloadResult(resultCaseId);
-                    const ret = enumHelpers.OptionalAllTypesResult.lift(tmpRetTag.pop(), tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const ret = enumHelpers.OptionalAllTypesResult.lift(tmpRetTag.pop());
                     if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
@@ -1370,7 +1370,7 @@ export async function createInstantiator(options, swift) {
                     if (isNull) {
                         optResult = null;
                     } else {
-                        optResult = enumHelpers.OptionalAllTypesResult.lift(tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        optResult = enumHelpers.OptionalAllTypesResult.lift(tag);
                     }
                     if (resultCleanup) { resultCleanup(); }
                     return optResult;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
@@ -70,7 +70,7 @@ export async function createInstantiator(options, swift) {
                 };
                 return { cleanup };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const isSome = tmpRetInts.pop();
                 let optional;
                 if (isSome) {
@@ -370,7 +370,7 @@ export async function createInstantiator(options, swift) {
                 roundtripFooContainer: function bjs_roundtripFooContainer(container) {
                     const { cleanup: cleanup } = structHelpers.FooContainer.lower(container);
                     instance.exports.bjs_roundtripFooContainer();
-                    const structValue = structHelpers.FooContainer.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const structValue = structHelpers.FooContainer.lift();
                     if (cleanup) { cleanup(); }
                     return structValue;
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
@@ -81,7 +81,7 @@ export async function createInstantiator(options, swift) {
                     default: throw new Error("Unknown ResultValues tag: " + String(enumTag));
                 }
             },
-            lift: (tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tag) => {
                 tag = tag | 0;
                 switch (tag) {
                     case ResultValues.Tag.Success: {
@@ -375,7 +375,7 @@ export async function createInstantiator(options, swift) {
             }
             TestModule["bjs_MyViewControllerDelegate_result_set"] = function bjs_MyViewControllerDelegate_result_set(self, value) {
                 try {
-                    const enumValue = enumHelpers.Result.lift(value, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const enumValue = enumHelpers.Result.lift(value);
                     swift.memory.getObject(self).result = enumValue;
                 } catch (error) {
                     setException(error);
@@ -399,7 +399,7 @@ export async function createInstantiator(options, swift) {
                 try {
                     let enumValue;
                     if (valueIsSome) {
-                        enumValue = enumHelpers.Result.lift(valueWrappedValue, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        enumValue = enumHelpers.Result.lift(valueWrappedValue);
                     }
                     swift.memory.getObject(self).optionalResult = valueIsSome ? enumValue : null;
                 } catch (error) {
@@ -556,7 +556,7 @@ export async function createInstantiator(options, swift) {
             }
             TestModule["bjs_MyViewControllerDelegate_handleResult"] = function bjs_MyViewControllerDelegate_handleResult(self, result) {
                 try {
-                    const enumValue = enumHelpers.Result.lift(result, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const enumValue = enumHelpers.Result.lift(result);
                     swift.memory.getObject(self).handleResult(enumValue);
                 } catch (error) {
                     setException(error);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
@@ -68,7 +68,7 @@ export async function createInstantiator(options, swift) {
                     default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
                 }
             },
-            lift: (tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tag) => {
                 tag = tag | 0;
                 switch (tag) {
                     case APIResultValues.Tag.Success: {
@@ -335,7 +335,7 @@ export async function createInstantiator(options, swift) {
                     roundtrip: function(value) {
                         const { caseId: valueCaseId, cleanup: valueCleanup } = enumHelpers.APIResult.lower(value);
                         instance.exports.bjs_APIResult_static_roundtrip(valueCaseId);
-                        const ret = enumHelpers.APIResult.lift(tmpRetTag.pop(), tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        const ret = enumHelpers.APIResult.lift(tmpRetTag.pop());
                         if (valueCleanup) { valueCleanup(); }
                         return ret;
                     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
@@ -68,7 +68,7 @@ export async function createInstantiator(options, swift) {
                     default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
                 }
             },
-            lift: (tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tag) => {
                 tag = tag | 0;
                 switch (tag) {
                     case APIResultValues.Tag.Success: {
@@ -329,7 +329,7 @@ export async function createInstantiator(options, swift) {
                     roundtrip: function(value) {
                         const { caseId: valueCaseId, cleanup: valueCleanup } = enumHelpers.APIResult.lower(value);
                         instance.exports.bjs_APIResult_static_roundtrip(valueCaseId);
-                        const ret = enumHelpers.APIResult.lift(tmpRetTag.pop(), tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        const ret = enumHelpers.APIResult.lift(tmpRetTag.pop());
                         if (valueCleanup) { valueCleanup(); }
                         return ret;
                     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -106,7 +106,7 @@ export async function createInstantiator(options, swift) {
                     default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
                 }
             },
-            lift: (tag, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: (tag) => {
                 tag = tag | 0;
                 switch (tag) {
                     case APIResultValues.Tag.Success: {
@@ -422,7 +422,7 @@ export async function createInstantiator(options, swift) {
             bjs["invoke_js_callback_TestModule_10TestModule9APIResultO_SS"] = function(callbackId, param0Id) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
-                    let param0 = enumHelpers.APIResult.lift(param0Id, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    let param0 = enumHelpers.APIResult.lift(param0Id);
                     const result = callback(param0);
                     if (typeof result !== "string") {
                         throw new TypeError("Callback must return a string");
@@ -684,7 +684,7 @@ export async function createInstantiator(options, swift) {
                     const callback = swift.memory.getObject(callbackId);
                     let param0;
                     if (param0IsSome) {
-                        param0 = enumHelpers.APIResult.lift(param0Value, tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        param0 = enumHelpers.APIResult.lift(param0Value);
                     } else {
                         param0 = null;
                     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
@@ -67,7 +67,7 @@ export async function createInstantiator(options, swift) {
                 };
                 return { cleanup };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const isSome = tmpRetInts.pop();
                 let optional;
                 if (isSome) {
@@ -115,7 +115,7 @@ export async function createInstantiator(options, swift) {
                 };
                 return { cleanup };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const isSome = tmpRetInts.pop();
                 let optional;
                 if (isSome) {
@@ -158,7 +158,7 @@ export async function createInstantiator(options, swift) {
                 };
                 return { cleanup };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const isSome = tmpRetInts.pop();
                 let optional;
                 if (isSome) {
@@ -167,7 +167,7 @@ export async function createInstantiator(options, swift) {
                 } else {
                     optional = null;
                 }
-                const struct = structHelpers.Address.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const struct = structHelpers.Address.lift();
                 const int = tmpRetInts.pop();
                 const string1 = tmpRetStrings.pop();
                 return { name: string1, age: int, address: struct, email: optional };
@@ -181,7 +181,7 @@ export async function createInstantiator(options, swift) {
                 tmpParamPointers.push(value.owner.pointer);
                 return { cleanup: undefined };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const ptr = tmpRetPointers.pop();
                 const obj = _exports['Greeter'].__construct(ptr);
                 const int = tmpRetInts.pop();
@@ -203,7 +203,7 @@ export async function createInstantiator(options, swift) {
                 tmpParamInts.push(isSome ? 1 : 0);
                 return { cleanup: undefined };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const isSome = tmpRetInts.pop();
                 let optional;
                 if (isSome) {
@@ -223,7 +223,7 @@ export async function createInstantiator(options, swift) {
             lower: (value) => {
                 return { cleanup: undefined };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 return {  };
             }
         });
@@ -264,7 +264,7 @@ export async function createInstantiator(options, swift) {
                 };
                 return { cleanup };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const isSome = tmpRetInts.pop();
                 let optional;
                 if (isSome) {
@@ -632,14 +632,14 @@ export async function createInstantiator(options, swift) {
                 roundtrip: function bjs_roundtrip(session) {
                     const { cleanup: cleanup } = structHelpers.Person.lower(session);
                     instance.exports.bjs_roundtrip();
-                    const structValue = structHelpers.Person.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const structValue = structHelpers.Person.lift();
                     if (cleanup) { cleanup(); }
                     return structValue;
                 },
                 roundtripContainer: function bjs_roundtripContainer(container) {
                     const { cleanup: cleanup } = structHelpers.Container.lower(container);
                     instance.exports.bjs_roundtripContainer();
-                    const structValue = structHelpers.Container.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const structValue = structHelpers.Container.lift();
                     if (cleanup) { cleanup(); }
                     return structValue;
                 },
@@ -651,7 +651,7 @@ export async function createInstantiator(options, swift) {
                         const isSome = optCount != null;
                         const isSome1 = optFlag != null;
                         instance.exports.bjs_DataPoint_init(x, y, labelId, labelBytes.length, +isSome, isSome ? optCount : 0, +isSome1, isSome1 ? optFlag : 0);
-                        const structValue = structHelpers.DataPoint.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        const structValue = structHelpers.DataPoint.lift();
                         swift.memory.release(labelId);
                         return structValue;
                     },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
@@ -41,7 +41,7 @@ export async function createInstantiator(options, swift) {
                 tmpParamInts.push((value.y | 0));
                 return { cleanup: undefined };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const int = tmpRetInts.pop();
                 const int1 = tmpRetInts.pop();
                 return { x: int1, y: int };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
@@ -44,7 +44,7 @@ export async function createInstantiator(options, swift) {
                 tmpParamPointers.push((value.mutPtr | 0));
                 return { cleanup: undefined };
             },
-            lift: (tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers) => {
+            lift: () => {
                 const pointer = tmpRetPointers.pop();
                 const pointer1 = tmpRetPointers.pop();
                 const pointer2 = tmpRetPointers.pop();
@@ -286,14 +286,14 @@ export async function createInstantiator(options, swift) {
                 roundTripPointerFields: function bjs_roundTripPointerFields(value) {
                     const { cleanup: cleanup } = structHelpers.PointerFields.lower(value);
                     instance.exports.bjs_roundTripPointerFields();
-                    const structValue = structHelpers.PointerFields.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                    const structValue = structHelpers.PointerFields.lift();
                     if (cleanup) { cleanup(); }
                     return structValue;
                 },
                 PointerFields: {
                     init: function(raw, mutRaw, opaque, ptr, mutPtr) {
                         instance.exports.bjs_PointerFields_init(raw, mutRaw, opaque, ptr, mutPtr);
-                        const structValue = structHelpers.PointerFields.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                        const structValue = structHelpers.PointerFields.lift();
                         return structValue;
                     },
                 },


### PR DESCRIPTION
After https://github.com/swiftwasm/JavaScriptKit/pull/579, they naturally have access to those storages