### PR TITLE
[NFC] BridgeJS: Remove remaining explicit captures from enum/struct helpers

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -478,7 +478,7 @@ public struct BridgeJSLink {
                         printer.write("bjs[\"swift_js_struct_lift_\(structDef.name)\"] = function() {")
                         printer.indent {
                             printer.write(
-                                "const value = \(JSGlueVariableScope.reservedStructHelpers).\(structDef.name).lift(\(JSGlueVariableScope.reservedTmpRetStrings), \(JSGlueVariableScope.reservedTmpRetInts), \(JSGlueVariableScope.reservedTmpRetF32s), \(JSGlueVariableScope.reservedTmpRetF64s), \(JSGlueVariableScope.reservedTmpRetPointers));"
+                                "const value = \(JSGlueVariableScope.reservedStructHelpers).\(structDef.name).lift();"
                             )
                             printer.write("return \(JSGlueVariableScope.reservedSwift).memory.retain(value);")
                         }
@@ -1162,7 +1162,7 @@ public struct BridgeJSLink {
         for skeleton in skeletons.compactMap(\.exported) {
             for enumDef in skeleton.enums where enumDef.enumType == .associatedValue {
                 printer.write(
-                    "const \(enumDef.name)Helpers = __bjs_create\(enumDef.valuesName)Helpers()(\(JSGlueVariableScope.reservedTmpParamInts), \(JSGlueVariableScope.reservedTmpParamF32s), \(JSGlueVariableScope.reservedTmpParamF64s), \(JSGlueVariableScope.reservedTmpParamPointers), \(JSGlueVariableScope.reservedTmpRetPointers), \(JSGlueVariableScope.reservedTextEncoder), \(JSGlueVariableScope.reservedSwift), \(JSGlueVariableScope.reservedStructHelpers), \(JSGlueVariableScope.reservedEnumHelpers));"
+                    "const \(enumDef.name)Helpers = __bjs_create\(enumDef.valuesName)Helpers()();"
                 )
                 printer.write("\(JSGlueVariableScope.reservedEnumHelpers).\(enumDef.name) = \(enumDef.name)Helpers;")
                 printer.nextLine()
@@ -1178,7 +1178,7 @@ public struct BridgeJSLink {
         for skeleton in skeletons.compactMap(\.exported) {
             for structDef in skeleton.structs {
                 printer.write(
-                    "const \(structDef.name)Helpers = __bjs_create\(structDef.name)Helpers()(\(JSGlueVariableScope.reservedTmpParamInts), \(JSGlueVariableScope.reservedTmpParamF32s), \(JSGlueVariableScope.reservedTmpParamF64s), \(JSGlueVariableScope.reservedTmpParamPointers), \(JSGlueVariableScope.reservedTmpRetPointers), \(JSGlueVariableScope.reservedTextEncoder), \(JSGlueVariableScope.reservedSwift), \(JSGlueVariableScope.reservedEnumHelpers));"
+                    "const \(structDef.name)Helpers = __bjs_create\(structDef.name)Helpers()();"
                 )
                 printer.write(
                     "\(JSGlueVariableScope.reservedStructHelpers).\(structDef.name) = \(structDef.name)Helpers;"

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -2075,7 +2075,7 @@ struct IntrinsicJSFragment: Sendable {
                 printer.write("const __bjs_create\(enumName)Helpers = () => {")
                 printer.indent()
                 printer.write(
-                    "return (\(JSGlueVariableScope.reservedTmpParamInts), \(JSGlueVariableScope.reservedTmpParamF32s), \(JSGlueVariableScope.reservedTmpParamF64s), \(JSGlueVariableScope.reservedTmpParamPointers), \(JSGlueVariableScope.reservedTmpRetPointers), textEncoder, \(JSGlueVariableScope.reservedSwift), \(JSGlueVariableScope.reservedStructHelpers), \(JSGlueVariableScope.reservedEnumHelpers)) => ({"
+                    "return () => ({"
                 )
                 printer.indent()
 
@@ -3109,7 +3109,7 @@ struct IntrinsicJSFragment: Sendable {
                 printer.write("const __bjs_create\(structName)Helpers = () => {")
                 printer.indent()
                 printer.write(
-                    "return (\(JSGlueVariableScope.reservedTmpParamInts), \(JSGlueVariableScope.reservedTmpParamF32s), \(JSGlueVariableScope.reservedTmpParamF64s), \(JSGlueVariableScope.reservedTmpParamPointers), \(JSGlueVariableScope.reservedTmpRetPointers), textEncoder, \(JSGlueVariableScope.reservedSwift), \(JSGlueVariableScope.reservedEnumHelpers)) => ({"
+                    "return () => ({"
                 )
                 printer.indent()
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
@@ -48,7 +48,7 @@ export async function createInstantiator(options, swift) {
     let _exports = null;
     let bjs = null;
     const __bjs_createPointHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 tmpParamF64s.push(value.x);
                 tmpParamF64s.push(value.y);
@@ -147,7 +147,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_Point"] = function() {
-                const value = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.Point.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
@@ -389,7 +389,7 @@ export async function createInstantiator(options, swift) {
                 }
 
             }
-            const PointHelpers = __bjs_createPointHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const PointHelpers = __bjs_createPointHelpers()();
             structHelpers.Point = PointHelpers;
 
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
@@ -41,7 +41,7 @@ export async function createInstantiator(options, swift) {
     let _exports = null;
     let bjs = null;
     const __bjs_createConfigHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const bytes = textEncoder.encode(value.name);
                 const id = swift.memory.retain(bytes);
@@ -63,7 +63,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createMathOperationsHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 tmpParamF64s.push(value.baseValue);
                 return { cleanup: undefined };
@@ -172,7 +172,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_Config"] = function() {
-                const value = structHelpers.Config.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.Config.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_MathOperations"] = function(objectId) {
@@ -183,7 +183,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_MathOperations"] = function() {
-                const value = structHelpers.MathOperations.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.MathOperations.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
@@ -431,10 +431,10 @@ export async function createInstantiator(options, swift) {
                     }
                 }
             }
-            const ConfigHelpers = __bjs_createConfigHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const ConfigHelpers = __bjs_createConfigHelpers()();
             structHelpers.Config = ConfigHelpers;
 
-            const MathOperationsHelpers = __bjs_createMathOperationsHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const MathOperationsHelpers = __bjs_createMathOperationsHelpers()();
             structHelpers.MathOperations = MathOperationsHelpers;
 
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
@@ -116,7 +116,7 @@ export async function createInstantiator(options, swift) {
     let _exports = null;
     let bjs = null;
     const __bjs_createPointHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 tmpParamF64s.push(value.x);
                 tmpParamF64s.push(value.y);
@@ -130,7 +130,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createAPIResultValuesHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const enumTag = value.tag;
                 switch (enumTag) {
@@ -201,7 +201,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createComplexResultValuesHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const enumTag = value.tag;
                 switch (enumTag) {
@@ -321,7 +321,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createResultValuesHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const enumTag = value.tag;
                 switch (enumTag) {
@@ -385,7 +385,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createNetworkingResultValuesHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const enumTag = value.tag;
                 switch (enumTag) {
@@ -431,7 +431,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createAPIOptionalResultValuesHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const enumTag = value.tag;
                 switch (enumTag) {
@@ -560,7 +560,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createTypedPayloadResultValuesHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const enumTag = value.tag;
                 switch (enumTag) {
@@ -635,7 +635,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createAllTypesResultValuesHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const enumTag = value.tag;
                 switch (enumTag) {
@@ -722,7 +722,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createOptionalAllTypesResultValuesHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const enumTag = value.tag;
                 switch (enumTag) {
@@ -965,7 +965,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_Point"] = function() {
-                const value = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.Point.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
@@ -1103,31 +1103,31 @@ export async function createInstantiator(options, swift) {
                 }
 
             }
-            const PointHelpers = __bjs_createPointHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const PointHelpers = __bjs_createPointHelpers()();
             structHelpers.Point = PointHelpers;
 
-            const APIResultHelpers = __bjs_createAPIResultValuesHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers);
+            const APIResultHelpers = __bjs_createAPIResultValuesHelpers()();
             enumHelpers.APIResult = APIResultHelpers;
 
-            const ComplexResultHelpers = __bjs_createComplexResultValuesHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers);
+            const ComplexResultHelpers = __bjs_createComplexResultValuesHelpers()();
             enumHelpers.ComplexResult = ComplexResultHelpers;
 
-            const ResultHelpers = __bjs_createResultValuesHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers);
+            const ResultHelpers = __bjs_createResultValuesHelpers()();
             enumHelpers.Result = ResultHelpers;
 
-            const NetworkingResultHelpers = __bjs_createNetworkingResultValuesHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers);
+            const NetworkingResultHelpers = __bjs_createNetworkingResultValuesHelpers()();
             enumHelpers.NetworkingResult = NetworkingResultHelpers;
 
-            const APIOptionalResultHelpers = __bjs_createAPIOptionalResultValuesHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers);
+            const APIOptionalResultHelpers = __bjs_createAPIOptionalResultValuesHelpers()();
             enumHelpers.APIOptionalResult = APIOptionalResultHelpers;
 
-            const TypedPayloadResultHelpers = __bjs_createTypedPayloadResultValuesHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers);
+            const TypedPayloadResultHelpers = __bjs_createTypedPayloadResultValuesHelpers()();
             enumHelpers.TypedPayloadResult = TypedPayloadResultHelpers;
 
-            const AllTypesResultHelpers = __bjs_createAllTypesResultValuesHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers);
+            const AllTypesResultHelpers = __bjs_createAllTypesResultValuesHelpers()();
             enumHelpers.AllTypesResult = AllTypesResultHelpers;
 
-            const OptionalAllTypesResultHelpers = __bjs_createOptionalAllTypesResultValuesHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers);
+            const OptionalAllTypesResultHelpers = __bjs_createOptionalAllTypesResultValuesHelpers()();
             enumHelpers.OptionalAllTypesResult = OptionalAllTypesResultHelpers;
 
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
@@ -35,7 +35,7 @@ export async function createInstantiator(options, swift) {
     let _exports = null;
     let bjs = null;
     const __bjs_createFooContainerHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 let id;
                 if (value.foo != null) {
@@ -184,7 +184,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_FooContainer"] = function() {
-                const value = structHelpers.FooContainer.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.FooContainer.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
@@ -298,7 +298,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-            const FooContainerHelpers = __bjs_createFooContainerHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const FooContainerHelpers = __bjs_createFooContainerHelpers()();
             structHelpers.FooContainer = FooContainerHelpers;
 
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
@@ -59,7 +59,7 @@ export async function createInstantiator(options, swift) {
     let _exports = null;
     let bjs = null;
     const __bjs_createResultValuesHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const enumTag = value.tag;
                 switch (enumTag) {
@@ -723,7 +723,7 @@ export async function createInstantiator(options, swift) {
                     for (const cleanup of arrayCleanups) { cleanup(); }
                 }
             }
-            const ResultHelpers = __bjs_createResultValuesHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers);
+            const ResultHelpers = __bjs_createResultValuesHelpers()();
             enumHelpers.Result = ResultHelpers;
 
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
@@ -46,7 +46,7 @@ export async function createInstantiator(options, swift) {
     let _exports = null;
     let bjs = null;
     const __bjs_createAPIResultValuesHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const enumTag = value.tag;
                 switch (enumTag) {
@@ -312,7 +312,7 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 }
             }
-            const APIResultHelpers = __bjs_createAPIResultValuesHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers);
+            const APIResultHelpers = __bjs_createAPIResultValuesHelpers()();
             enumHelpers.APIResult = APIResultHelpers;
 
             if (typeof globalThis.Utils === 'undefined') {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
@@ -46,7 +46,7 @@ export async function createInstantiator(options, swift) {
     let _exports = null;
     let bjs = null;
     const __bjs_createAPIResultValuesHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const enumTag = value.tag;
                 switch (enumTag) {
@@ -312,7 +312,7 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 }
             }
-            const APIResultHelpers = __bjs_createAPIResultValuesHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers);
+            const APIResultHelpers = __bjs_createAPIResultValuesHelpers()();
             enumHelpers.APIResult = APIResultHelpers;
 
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -65,7 +65,7 @@ export async function createInstantiator(options, swift) {
     let _exports = null;
     let bjs = null;
     const __bjs_createAPIResultValuesHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const enumTag = value.tag;
                 switch (enumTag) {
@@ -926,7 +926,7 @@ export async function createInstantiator(options, swift) {
                     return bjs["lower_closure_TestModule_10TestModuleSq9DirectionO_SS"](ret);
                 }
             }
-            const APIResultHelpers = __bjs_createAPIResultValuesHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, structHelpers, enumHelpers);
+            const APIResultHelpers = __bjs_createAPIResultValuesHelpers()();
             enumHelpers.APIResult = APIResultHelpers;
 
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
@@ -40,7 +40,7 @@ export async function createInstantiator(options, swift) {
     let _exports = null;
     let bjs = null;
     const __bjs_createDataPointHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 tmpParamF64s.push(value.x);
                 tmpParamF64s.push(value.y);
@@ -92,7 +92,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createAddressHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const bytes = textEncoder.encode(value.street);
                 const id = swift.memory.retain(bytes);
@@ -131,7 +131,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createPersonHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 const bytes = textEncoder.encode(value.name);
                 const id = swift.memory.retain(bytes);
@@ -175,7 +175,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createSessionHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 tmpParamInts.push((value.id | 0));
                 tmpParamPointers.push(value.owner.pointer);
@@ -190,7 +190,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createMeasurementHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 tmpParamF64s.push(value.value);
                 tmpParamF32s.push(Math.fround(value.precision));
@@ -219,7 +219,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createConfigStructHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 return { cleanup: undefined };
             },
@@ -229,7 +229,7 @@ export async function createInstantiator(options, swift) {
         });
     };
     const __bjs_createContainerHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 let id;
                 if (value.object != null) {
@@ -377,7 +377,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_DataPoint"] = function() {
-                const value = structHelpers.DataPoint.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.DataPoint.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Address"] = function(objectId) {
@@ -388,7 +388,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_Address"] = function() {
-                const value = structHelpers.Address.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.Address.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Person"] = function(objectId) {
@@ -399,7 +399,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_Person"] = function() {
-                const value = structHelpers.Person.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.Person.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Session"] = function(objectId) {
@@ -410,7 +410,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_Session"] = function() {
-                const value = structHelpers.Session.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.Session.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Measurement"] = function(objectId) {
@@ -421,7 +421,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_Measurement"] = function() {
-                const value = structHelpers.Measurement.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.Measurement.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_ConfigStruct"] = function(objectId) {
@@ -432,7 +432,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_ConfigStruct"] = function() {
-                const value = structHelpers.ConfigStruct.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.ConfigStruct.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Container"] = function(objectId) {
@@ -443,7 +443,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_Container"] = function() {
-                const value = structHelpers.Container.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.Container.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
@@ -606,25 +606,25 @@ export async function createInstantiator(options, swift) {
                     swift.memory.release(valueId);
                 }
             }
-            const DataPointHelpers = __bjs_createDataPointHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const DataPointHelpers = __bjs_createDataPointHelpers()();
             structHelpers.DataPoint = DataPointHelpers;
 
-            const AddressHelpers = __bjs_createAddressHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const AddressHelpers = __bjs_createAddressHelpers()();
             structHelpers.Address = AddressHelpers;
 
-            const PersonHelpers = __bjs_createPersonHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const PersonHelpers = __bjs_createPersonHelpers()();
             structHelpers.Person = PersonHelpers;
 
-            const SessionHelpers = __bjs_createSessionHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const SessionHelpers = __bjs_createSessionHelpers()();
             structHelpers.Session = SessionHelpers;
 
-            const MeasurementHelpers = __bjs_createMeasurementHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const MeasurementHelpers = __bjs_createMeasurementHelpers()();
             structHelpers.Measurement = MeasurementHelpers;
 
-            const ConfigStructHelpers = __bjs_createConfigStructHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const ConfigStructHelpers = __bjs_createConfigStructHelpers()();
             structHelpers.ConfigStruct = ConfigStructHelpers;
 
-            const ContainerHelpers = __bjs_createContainerHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const ContainerHelpers = __bjs_createContainerHelpers()();
             structHelpers.Container = ContainerHelpers;
 
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
@@ -35,7 +35,7 @@ export async function createInstantiator(options, swift) {
     let _exports = null;
     let bjs = null;
     const __bjs_createPointHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 tmpParamInts.push((value.x | 0));
                 tmpParamInts.push((value.y | 0));
@@ -134,7 +134,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_Point"] = function() {
-                const value = structHelpers.Point.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.Point.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
@@ -250,7 +250,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-            const PointHelpers = __bjs_createPointHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const PointHelpers = __bjs_createPointHelpers()();
             structHelpers.Point = PointHelpers;
 
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
@@ -35,7 +35,7 @@ export async function createInstantiator(options, swift) {
     let _exports = null;
     let bjs = null;
     const __bjs_createPointerFieldsHelpers = () => {
-        return (tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers) => ({
+        return () => ({
             lower: (value) => {
                 tmpParamPointers.push((value.raw | 0));
                 tmpParamPointers.push((value.mutRaw | 0));
@@ -139,7 +139,7 @@ export async function createInstantiator(options, swift) {
                 return 0;
             }
             bjs["swift_js_struct_lift_PointerFields"] = function() {
-                const value = structHelpers.PointerFields.lift(tmpRetStrings, tmpRetInts, tmpRetF32s, tmpRetF64s, tmpRetPointers);
+                const value = structHelpers.PointerFields.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
@@ -244,7 +244,7 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-            const PointerFieldsHelpers = __bjs_createPointerFieldsHelpers()(tmpParamInts, tmpParamF32s, tmpParamF64s, tmpParamPointers, tmpRetPointers, textEncoder, swift, enumHelpers);
+            const PointerFieldsHelpers = __bjs_createPointerFieldsHelpers()();
             structHelpers.PointerFields = PointerFieldsHelpers;
 
             const exports = {


### PR DESCRIPTION
Follow up on https://github.com/swiftwasm/JavaScriptKit/pull/588