### PR TITLE
PackageToJS: Fix skeleton file discovery path for build plugin output

### DIFF
--- a/Plugins/PackageToJS/Sources/PackageToJSPlugin.swift
+++ b/Plugins/PackageToJS/Sources/PackageToJSPlugin.swift
@@ -751,9 +751,9 @@ class SkeletonCollector {
             let directories = [
                 target.directoryURL.appending(path: "Generated/JavaScript"),
                 // context.pluginWorkDirectoryURL: ".build/plugins/PackageToJS/outputs/"
-                // .build/plugins/outputs/exportswift/MyApp/destination/BridgeJS/BridgeJS.ExportSwift.json
+                // .build/plugins/outputs/[package]/[target]/destination/BridgeJS/JavaScript/BridgeJS.json
                 context.pluginWorkDirectoryURL.deletingLastPathComponent().deletingLastPathComponent()
-                    .appending(path: "outputs/\(package.id)/\(target.name)/destination/BridgeJS"),
+                    .appending(path: "outputs/\(package.id)/\(target.name)/destination/BridgeJS/JavaScript"),
             ]
             for directory in directories {
                 let skeletonURL = directory.appending(path: skeletonFile)


### PR DESCRIPTION
## Overview

Fixes skeleton file discovery in `SkeletonCollector` for projects using the BridgeJS build plugin workflow.

Since commit 91d2f061, `BridgeJSTool` writes skeleton files to `destination/BridgeJS/JavaScript/BridgeJS.json`, but `PackageToJS` was searching in `destination/BridgeJS/BridgeJS.json` (missing the `JavaScript/` subdirectory).

## Issue

Projects using the BridgeJS **build plugin** for automatic code generation fail to produce `bridge-js.js` because PackageToJS cannot find the skeleton files:

```
# Build plugin outputs to:
.build/plugins/outputs/[pkg]/[target]/destination/BridgeJS/JavaScript/BridgeJS.json

# PackageToJS searched in:
.build/plugins/outputs/[pkg]/[target]/destination/BridgeJS/BridgeJS.json
```

This results in `HAS_BRIDGE=false` and stub implementations in `instantiate.js`.

### Example

A project using the build plugin workflow:

```swift
// Package.swift
.executableTarget(
    name: "MyApp",
    dependencies: ["JavaScriptKit"],
    swiftSettings: [
        .enableExperimentalFeature("Extern")
    ],
    plugins: [
        .plugin(name: "BridgeJS", package: "JavaScriptKit")  // Using build plugin
    ]
)
```

```swift
// Sources/MyApp/Greeter.swift
@JS(namespace: "MyApp")
public enum Greeter {
    @JS
    public static func hello(name: String) -> String {
        return "Hello, \(name)!"
    }
}
```

When building with `swift package js`, the skeleton is generated but not discovered, resulting in missing exports in `bridge-js.js`.

## Root Cause

When the unified `generate` subcommand was introduced in 91d2f061, the output path was changed to include `JavaScript/` subdirectory, but only one of the two search paths in `SkeletonCollector` was updated:

- ✅ Path 1 (source directory): `target.directoryURL/Generated/JavaScript` - works for command plugin / pre-generated files
- ❌ Path 2 (build output): `destination/BridgeJS` - missing `/JavaScript`

## Fix

Add `/JavaScript` to the second search path to match the actual output location.

## Testing

Tested with a project using the BridgeJS build plugin workflow. After the fix, `bridge-js.js` is correctly generated with exported functions at the specified namespace.