### PR TITLE
BridgeJS: Add missing `function` keyword for namespace function declarations in TypeScript

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -3094,7 +3094,7 @@ extension BridgeJSLink {
                         let sortedFunctions = childNode.content.functions.sorted { $0.name < $1.name }
                         for function in sortedFunctions {
                             let signature =
-                                "\(function.name)\(renderTSSignatureCallback(function.parameters, function.returnType, function.effects));"
+                                "function \(function.name)\(renderTSSignatureCallback(function.parameters, function.returnType, function.effects));"
                             printer.write(signature)
                         }
                         let sortedProperties = childNode.content.staticProperties.sorted { $0.name < $1.name }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.d.ts
@@ -61,9 +61,9 @@ declare global {
     namespace Services {
         namespace Graph {
             namespace GraphOperations {
-                createGraph(rootId: number): number;
-                nodeCount(graphId: number): number;
-                validate(graphId: number): boolean;
+                function createGraph(rootId: number): number;
+                function nodeCount(graphId: number): number;
+                function validate(graphId: number): boolean;
             }
         }
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.d.ts
@@ -12,7 +12,7 @@ declare global {
             constructor();
             greet(): string;
         }
-        globalFunction(): string;
+        function globalFunction(): string;
     }
 }
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.d.ts
@@ -9,7 +9,7 @@ export {};
 declare global {
     namespace MyModule {
         namespace Utils {
-            namespacedFunction(): string;
+            function namespacedFunction(): string;
         }
     }
     namespace Utils {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.d.ts
@@ -33,7 +33,7 @@ export {};
 declare global {
     namespace Utils {
         namespace String {
-            uppercase(text: string): string;
+            function uppercase(text: string): string;
         }
     }
 }

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Static-Functions.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Static-Functions.md
@@ -140,7 +140,7 @@ Generated TypeScript definitions:
 declare global {
     namespace Utils {
         namespace String {
-            uppercase(text: string): string;
+            function uppercase(text: string): string;
         }
     }
 }


### PR DESCRIPTION
## Overview 

TIL 😅 
BridgeJS was generating invalid TypeScript declarations for functions inside `namespace` blocks. The generated code looked like:

```typescript
declare global {
    namespace Utils {
        namespace String {
            uppercase(text: string): string;  // ❌ Invalid TypeScript
        }
    }
}
```

This is a syntax error in TypeScript. Unlike class methods, functions inside TypeScript `namespace` declarations require the explicit `function` keyword.

**Why this wasn't caught:**
JavaScriptKit's `tsconfig.json` uses `"skipLibCheck": true`, which skips type-checking of declaration files (`.d.ts`). The JavaScript E2E tests also passed because JavaScript doesn't have `namespace` - it only sees the compiled runtime objects.

Project which runs strict TypeScript type-checking (`tsc --noEmit`) without `skipLibCheck` fails due to that

## Fix
Added the `function` keyword prefix when generating function declarations inside namespaces:

```typescript
declare global {
    namespace Utils {
        namespace String {
            function uppercase(text: string): string;  // ✅ Valid TypeScript
        }
    }
}
```