### PR TITLE
BridgeJS: Improve diagnostics and fix-its for macros

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSMacros/JSMacroSupport.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSMacros/JSMacroSupport.swift
@@ -11,26 +11,41 @@ enum JSMacroMessage: String, DiagnosticMessage {
     case invalidSetterName =
         "@JSSetter function name must start with 'set' followed by a property name (e.g., 'setFoo')."
     case setterRequiresParameter = "@JSSetter function must have at least one parameter."
+    case setterRequiresThrows = "@JSSetter function must declare throws(JSException)."
+    case jsFunctionRequiresThrows = "@JSFunction throws must be declared as throws(JSException)."
+    case requiresJSClass = "JavaScript members must be declared inside a @JSClass struct."
 
     var message: String { rawValue }
     var diagnosticID: MessageID { MessageID(domain: "JavaScriptKitMacros", id: rawValue) }
     var severity: DiagnosticSeverity { .error }
 }
 
+struct JSMacroNoteMessage: NoteMessage {
+    let message: String
+    var noteID: MessageID { MessageID(domain: "JavaScriptKitMacros", id: message) }
+}
+
+struct JSMacroFixItMessage: FixItMessage {
+    let message: String
+    var fixItID: MessageID { MessageID(domain: "JavaScriptKitMacros", id: message) }
+}
+
+enum JSMacroText {
+    static let jsExceptionPropagation = "@JSFunction must propagate JavaScript errors as JSException."
+    static let jsSetterExceptionPropagation = "@JSSetter must propagate JavaScript errors as JSException."
+}
+
 enum JSMacroHelper {
     static func enclosingTypeName(from context: some MacroExpansionContext) -> String? {
+        enclosingTypeSyntax(from: context).flatMap(typeName(of:))
+    }
+
+    static func enclosingTypeSyntax(from context: some MacroExpansionContext) -> Syntax? {
         for syntax in context.lexicalContext {
-            if let decl = syntax.as(ClassDeclSyntax.self) {
-                return decl.name.text
-            }
-            if let decl = syntax.as(StructDeclSyntax.self) {
-                return decl.name.text
-            }
-            if let decl = syntax.as(EnumDeclSyntax.self) {
-                return decl.name.text
-            }
-            if let decl = syntax.as(ActorDeclSyntax.self) {
-                return decl.name.text
+            if syntax.is(ClassDeclSyntax.self) || syntax.is(StructDeclSyntax.self)
+                || syntax.is(EnumDeclSyntax.self) || syntax.is(ActorDeclSyntax.self)
+            {
+                return Syntax(syntax)
             }
         }
         return nil
@@ -97,5 +112,156 @@ enum JSMacroHelper {
             return String(name.dropFirst().dropLast())
         }
         return name
+    }
+
+    static func capitalizingFirstLetter(_ value: String) -> String {
+        guard let first = value.first else { return value }
+        return first.uppercased() + value.dropFirst()
+    }
+
+    static func hasJSClassAttribute(_ typeSyntax: Syntax) -> Bool {
+        guard let attributes = attributes(of: typeSyntax) else { return false }
+        for attribute in attributes.compactMap({ $0.as(AttributeSyntax.self) }) {
+            let name = attribute.attributeName.trimmedDescription
+            if name == "JSClass" || name == "@JSClass" {
+                return true
+            }
+        }
+        return false
+    }
+
+    static func typeName(of syntax: Syntax) -> String? {
+        switch syntax.as(SyntaxEnum.self) {
+        case .structDecl(let decl): return decl.name.text
+        case .classDecl(let decl): return decl.name.text
+        case .enumDecl(let decl): return decl.name.text
+        case .actorDecl(let decl): return decl.name.text
+        default: return nil
+        }
+    }
+
+    private static func attributes(of syntax: Syntax) -> AttributeListSyntax? {
+        switch syntax.as(SyntaxEnum.self) {
+        case .structDecl(let decl): return decl.attributes
+        case .classDecl(let decl): return decl.attributes
+        case .enumDecl(let decl): return decl.attributes
+        case .actorDecl(let decl): return decl.attributes
+        default: return nil
+        }
+    }
+
+    static func diagnoseThrowsRequiresJSException(
+        signature: FunctionSignatureSyntax,
+        on node: Syntax,
+        in context: some MacroExpansionContext,
+        additionalNotes: [Note] = []
+    ) {
+        let throwsClause = signature.effectSpecifiers?.throwsClause
+        let throwsTypeName = throwsClause?.type?.as(IdentifierTypeSyntax.self)?.name.text
+        let isJSException = throwsTypeName == "JSException"
+        let isAllowedGenericError =
+            throwsClause != nil
+            && (throwsTypeName == nil || throwsTypeName == "Error" || throwsTypeName == "Swift.Error")
+        guard !isJSException else { return }
+        guard !isAllowedGenericError else { return }
+
+        let newThrowsClause = jsExceptionThrowsClause(from: throwsClause)
+
+        let fixIt: FixIt
+        if let throwsClause = signature.effectSpecifiers?.throwsClause {
+            fixIt = FixIt(
+                message: JSMacroFixItMessage(message: "Declare throws(JSException)"),
+                changes: [.replace(oldNode: Syntax(throwsClause), newNode: Syntax(newThrowsClause))]
+            )
+        } else {
+            let adjustedParameterClause = signature.parameterClause.with(\.rightParen.trailingTrivia, .spaces(0))
+            let newEffects = FunctionEffectSpecifiersSyntax(
+                asyncSpecifier: signature.effectSpecifiers?.asyncSpecifier,
+                throwsClause: newThrowsClause
+            )
+            let newSignature =
+                signature
+                .with(\.parameterClause, adjustedParameterClause)
+                .with(\.effectSpecifiers, newEffects)
+            fixIt = FixIt(
+                message: JSMacroFixItMessage(message: "Declare throws(JSException)"),
+                changes: [.replace(oldNode: Syntax(signature), newNode: Syntax(newSignature))]
+            )
+        }
+
+        var notes: [Note] = [
+            jsExceptionPropagationNote(on: node)
+        ]
+        notes.append(contentsOf: additionalNotes)
+
+        context.diagnose(
+            Diagnostic(
+                node: node,
+                message: JSMacroMessage.jsFunctionRequiresThrows,
+                notes: notes,
+                fixIts: [fixIt]
+            )
+        )
+    }
+
+    static func diagnoseMissingJSClass(
+        node: some SyntaxProtocol,
+        for macroName: String,
+        in context: some MacroExpansionContext
+    ) {
+        guard let typeSyntax = enclosingTypeSyntax(from: context) else { return }
+        guard !hasJSClassAttribute(typeSyntax) else { return }
+        context.diagnose(Diagnostic(node: node, message: JSMacroMessage.requiresJSClass))
+    }
+
+    static func setterPropertyBase(from parameter: FunctionParameterSyntax?) -> String? {
+        guard let parameter else { return nil }
+        let candidateNames = [
+            parameter.secondName,
+            parameter.firstName.tokenKind == .wildcard ? nil : parameter.firstName,
+        ].compactMap { $0?.text }.filter { $0 != "_" }
+        if let explicitName = candidateNames.first(where: { name in name != "value" && name != "newValue" }) {
+            return explicitName
+        }
+        if let identifierType = parameter.type.as(IdentifierTypeSyntax.self) {
+            let typeName = identifierType.name.text
+            guard let first = typeName.first else { return nil }
+            return first.lowercased() + typeName.dropFirst()
+        }
+        return candidateNames.first
+    }
+
+    static func suggestedSetterName(rawFunctionName: String, firstParameter: FunctionParameterSyntax?) -> String? {
+        guard let base = setterPropertyBase(from: firstParameter) else { return nil }
+        return "set" + capitalizingFirstLetter(base)
+    }
+
+    /// Build a typed throws(JSException) clause preserving trivia when possible.
+    static func jsExceptionThrowsClause(from throwsClause: ThrowsClauseSyntax?) -> ThrowsClauseSyntax {
+        let throwsSpecifier = (throwsClause?.throwsSpecifier ?? .keyword(.throws, leadingTrivia: .space))
+            .with(\.trailingTrivia, .spaces(0))
+            .with(\.leadingTrivia, throwsClause?.throwsSpecifier.leadingTrivia ?? .space)
+        let leftParen = throwsClause?.leftParen ?? .leftParenToken()
+        let rightParen = (throwsClause?.rightParen ?? .rightParenToken())
+            .with(\.trailingTrivia, throwsClause?.rightParen?.trailingTrivia ?? .space)
+
+        return ThrowsClauseSyntax(
+            throwsSpecifier: throwsSpecifier,
+            leftParen: leftParen,
+            type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("JSException"))),
+            rightParen: rightParen
+        )
+    }
+
+    static func jsExceptionPropagationNote(
+        on node: Syntax,
+        message: String = JSMacroText.jsExceptionPropagation
+    ) -> Note {
+        Note(
+            node: node,
+            message: JSMacroNoteMessage(
+                message: message
+            )
+        )
     }
 }

--- a/Plugins/BridgeJS/Sources/BridgeJSMacros/JSSetterMacro.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSMacros/JSSetterMacro.swift
@@ -13,18 +13,86 @@ extension JSSetterMacro: BodyMacro {
     ) throws -> [CodeBlockItemSyntax] {
         guard let functionDecl = declaration.as(FunctionDeclSyntax.self) else {
             context.diagnose(
-                Diagnostic(node: Syntax(declaration), message: JSMacroMessage.unsupportedSetterDeclaration)
+                Diagnostic(
+                    node: Syntax(declaration),
+                    message: JSMacroMessage.unsupportedSetterDeclaration,
+                    notes: [
+                        Note(
+                            node: Syntax(declaration),
+                            message: JSMacroNoteMessage(
+                                message: "@JSSetter can only be used on methods that set a JavaScript property."
+                            )
+                        )
+                    ]
+                )
             )
             return []
         }
 
         let functionName = functionDecl.name.text
+        let parameters = functionDecl.signature.parameterClause.parameters
+        let suggestedSetterName = JSMacroHelper.suggestedSetterName(
+            rawFunctionName: JSMacroHelper.stripBackticks(functionName),
+            firstParameter: parameters.first
+        )
+        let renameFixIts: [FixIt]
+        if let name = suggestedSetterName {
+            let replacement = functionDecl.name.with(\.tokenKind, .identifier(name))
+                .with(\.leadingTrivia, functionDecl.name.leadingTrivia)
+                .with(\.trailingTrivia, functionDecl.name.trailingTrivia)
+            renameFixIts = [
+                FixIt(
+                    message: JSMacroFixItMessage(message: "Rename setter to '\(name)'"),
+                    changes: [.replace(oldNode: Syntax(functionDecl.name), newNode: Syntax(replacement))]
+                )
+            ]
+        } else {
+            renameFixIts = []
+        }
+        let addParameterFixIts: [FixIt] = {
+            let placeholderParameter = FunctionParameterSyntax(
+                firstName: .wildcardToken(trailingTrivia: .space),
+                secondName: .identifier("value"),
+                colon: .colonToken(trailingTrivia: .space),
+                type: TypeSyntax(stringLiteral: "<#Type#>")
+            )
+            let newClause = FunctionParameterClauseSyntax(
+                leftParen: .leftParenToken(),
+                parameters: FunctionParameterListSyntax([placeholderParameter]),
+                rightParen: .rightParenToken(trailingTrivia: .space)
+            )
+            return [
+                FixIt(
+                    message: JSMacroFixItMessage(message: "Add a value parameter to the setter"),
+                    changes: [
+                        .replace(
+                            oldNode: Syntax(functionDecl.signature.parameterClause),
+                            newNode: Syntax(newClause)
+                        )
+                    ]
+                )
+            ]
+        }()
 
         // Extract property name from setter function name (e.g., "setFoo" -> "foo")
         // Strip backticks if present (e.g., "set`prefix`" -> "prefix")
         let rawFunctionName = JSMacroHelper.stripBackticks(functionName)
         guard rawFunctionName.hasPrefix("set"), rawFunctionName.count > 3 else {
-            context.diagnose(Diagnostic(node: Syntax(declaration), message: JSMacroMessage.invalidSetterName))
+            context.diagnose(
+                Diagnostic(
+                    node: Syntax(declaration),
+                    message: JSMacroMessage.invalidSetterName,
+                    notes: [
+                        Note(
+                            node: Syntax(functionDecl.name),
+                            message: JSMacroNoteMessage(
+                                message: "Setter names must start with 'set' followed by the property name."
+                            )
+                        )
+                    ],
+                    fixIts: renameFixIts
+                )
+            )
             return [
                 CodeBlockItemSyntax(
                     stringLiteral:
@@ -35,7 +103,21 @@ extension JSSetterMacro: BodyMacro {
 
         let propertyName = String(rawFunctionName.dropFirst(3))
         guard !propertyName.isEmpty else {
-            context.diagnose(Diagnostic(node: Syntax(declaration), message: JSMacroMessage.invalidSetterName))
+            context.diagnose(
+                Diagnostic(
+                    node: Syntax(declaration),
+                    message: JSMacroMessage.invalidSetterName,
+                    notes: [
+                        Note(
+                            node: Syntax(functionDecl.name),
+                            message: JSMacroNoteMessage(
+                                message: "Setter names must include the property after 'set'."
+                            )
+                        )
+                    ],
+                    fixIts: renameFixIts
+                )
+            )
             return [
                 CodeBlockItemSyntax(
                     stringLiteral:
@@ -49,7 +131,11 @@ extension JSSetterMacro: BodyMacro {
 
         let enclosingTypeName = JSMacroHelper.enclosingTypeName(from: context)
         let isStatic = JSMacroHelper.isStatic(functionDecl.modifiers)
-        let isInstanceMember = enclosingTypeName != nil && !isStatic
+        let isTopLevel = enclosingTypeName == nil
+        let isInstanceMember = !isTopLevel && !isStatic
+        if !isTopLevel {
+            JSMacroHelper.diagnoseMissingJSClass(node: node, for: "JSSetter", in: context)
+        }
 
         let glueName = JSMacroHelper.glueName(
             baseName: baseName,
@@ -63,9 +149,22 @@ extension JSSetterMacro: BodyMacro {
         }
 
         // Get the parameter name(s) - setters typically have one parameter
-        let parameters = functionDecl.signature.parameterClause.parameters
         guard let firstParam = parameters.first else {
-            context.diagnose(Diagnostic(node: Syntax(declaration), message: JSMacroMessage.setterRequiresParameter))
+            context.diagnose(
+                Diagnostic(
+                    node: Syntax(declaration),
+                    message: JSMacroMessage.setterRequiresParameter,
+                    notes: [
+                        Note(
+                            node: Syntax(declaration),
+                            message: JSMacroNoteMessage(
+                                message: "@JSSetter needs a parameter for the value being assigned."
+                            )
+                        )
+                    ],
+                    fixIts: addParameterFixIts
+                )
+            )
             return [
                 CodeBlockItemSyntax(
                     stringLiteral: "fatalError(\"@JSSetter function must have at least one parameter\")"
@@ -75,6 +174,44 @@ extension JSSetterMacro: BodyMacro {
 
         let paramName = firstParam.secondName ?? firstParam.firstName
         arguments.append(paramName.text)
+
+        // Ensure throws(JSException) is declared to match the generated body.
+        let existingThrowsClause = functionDecl.signature.effectSpecifiers?.throwsClause
+        let existingThrowsType = existingThrowsClause?.type
+            .flatMap { $0.as(IdentifierTypeSyntax.self)?.name.text }
+        let hasTypedJSException = existingThrowsType == "JSException"
+        let isAllowedGenericError =
+            existingThrowsClause != nil
+            && (existingThrowsType == nil || existingThrowsType == "Error" || existingThrowsType == "Swift.Error")
+
+        if !hasTypedJSException && !isAllowedGenericError {
+            let throwsClause = JSMacroHelper.jsExceptionThrowsClause(
+                from: existingThrowsClause
+            )
+            let newEffects =
+                (functionDecl.signature.effectSpecifiers
+                ?? FunctionEffectSpecifiersSyntax(asyncSpecifier: nil, throwsClause: nil))
+                .with(\.throwsClause, throwsClause)
+            let newSignature = functionDecl.signature.with(\.effectSpecifiers, newEffects)
+            let fixIt = FixIt(
+                message: JSMacroFixItMessage(message: "Declare throws(JSException)"),
+                changes: [.replace(oldNode: Syntax(functionDecl.signature), newNode: Syntax(newSignature))]
+            )
+            let notes: [Note] = [
+                JSMacroHelper.jsExceptionPropagationNote(
+                    on: Syntax(functionDecl),
+                    message: JSMacroText.jsSetterExceptionPropagation
+                )
+            ]
+            context.diagnose(
+                Diagnostic(
+                    node: Syntax(functionDecl),
+                    message: JSMacroMessage.setterRequiresThrows,
+                    notes: notes,
+                    fixIts: [fixIt]
+                )
+            )
+        }
 
         let argsJoined = arguments.joined(separator: ", ")
         let call = "\(glueName)(\(argsJoined))"
@@ -94,7 +231,18 @@ extension JSSetterMacro: PeerMacro {
     ) throws -> [DeclSyntax] {
         guard declaration.is(FunctionDeclSyntax.self) else {
             context.diagnose(
-                Diagnostic(node: Syntax(declaration), message: JSMacroMessage.unsupportedSetterDeclaration)
+                Diagnostic(
+                    node: Syntax(declaration),
+                    message: JSMacroMessage.unsupportedSetterDeclaration,
+                    notes: [
+                        Note(
+                            node: Syntax(declaration),
+                            message: JSMacroNoteMessage(
+                                message: "@JSSetter should be attached to a method that writes a JavaScript property."
+                            )
+                        )
+                    ]
+                )
             )
             return []
         }

--- a/Plugins/BridgeJS/Tests/BridgeJSMacrosTests/JSClassMacroTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSMacrosTests/JSClassMacroTests.swift
@@ -159,7 +159,17 @@ import BridgeJSMacros
                 DiagnosticSpec(
                     message: "@JSClass can only be applied to structs.",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    notes: [
+                        NoteSpec(
+                            message: "Use @JSClass on a struct wrapper to synthesize jsObject and JS bridging members.",
+                            line: 1,
+                            column: 1
+                        )
+                    ],
+                    fixIts: [
+                        FixItSpec(message: "Change 'class' to 'struct'")
+                    ]
                 )
             ],
             macroSpecs: macroSpecs,
@@ -182,7 +192,14 @@ import BridgeJSMacros
                 DiagnosticSpec(
                     message: "@JSClass can only be applied to structs.",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    notes: [
+                        NoteSpec(
+                            message: "Use @JSClass on a struct wrapper to synthesize jsObject and JS bridging members.",
+                            line: 1,
+                            column: 1
+                        )
+                    ]
                 )
             ],
             macroSpecs: macroSpecs,
@@ -205,7 +222,14 @@ import BridgeJSMacros
                 DiagnosticSpec(
                     message: "@JSClass can only be applied to structs.",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    notes: [
+                        NoteSpec(
+                            message: "Use @JSClass on a struct wrapper to synthesize jsObject and JS bridging members.",
+                            line: 1,
+                            column: 1
+                        )
+                    ]
                 )
             ],
             macroSpecs: macroSpecs,

--- a/Plugins/BridgeJS/Tests/BridgeJSMacrosTests/JSGetterMacroTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSMacrosTests/JSGetterMacroTests.swift
@@ -50,6 +50,30 @@ import BridgeJSMacros
     @Test func instanceProperty() {
         TestSupport.assertMacroExpansion(
             """
+            @JSClass
+            struct MyClass {
+                @JSGetter
+                var name: String
+            }
+            """,
+            expandedSource: """
+                @JSClass
+                struct MyClass {
+                    var name: String {
+                        get throws(JSException) {
+                            return try _$MyClass_name_get(self.jsObject)
+                        }
+                    }
+                }
+                """,
+            macroSpecs: macroSpecs,
+            indentationWidth: indentationWidth,
+        )
+    }
+
+    @Test func instancePropertyRequiresJSClass() {
+        TestSupport.assertMacroExpansion(
+            """
             struct MyClass {
                 @JSGetter
                 var name: String
@@ -64,6 +88,13 @@ import BridgeJSMacros
                     }
                 }
                 """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "JavaScript members must be declared inside a @JSClass struct.",
+                    line: 2,
+                    column: 5
+                )
+            ],
             macroSpecs: macroSpecs,
             indentationWidth: indentationWidth,
         )
@@ -72,12 +103,14 @@ import BridgeJSMacros
     @Test func instanceLetProperty() {
         TestSupport.assertMacroExpansion(
             """
+            @JSClass
             struct MyClass {
                 @JSGetter
                 let id: Int
             }
             """,
             expandedSource: """
+                @JSClass
                 struct MyClass {
                     let id: Int {
                         get throws(JSException) {
@@ -108,6 +141,13 @@ import BridgeJSMacros
                     }
                 }
                 """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "JavaScript members must be declared inside a @JSClass struct.",
+                    line: 2,
+                    column: 5
+                )
+            ],
             macroSpecs: macroSpecs,
             indentationWidth: indentationWidth,
         )
@@ -130,6 +170,13 @@ import BridgeJSMacros
                     }
                 }
                 """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "JavaScript members must be declared inside a @JSClass struct.",
+                    line: 2,
+                    column: 5
+                )
+            ],
             macroSpecs: macroSpecs,
             indentationWidth: indentationWidth,
         )
@@ -138,12 +185,14 @@ import BridgeJSMacros
     @Test func enumProperty() {
         TestSupport.assertMacroExpansion(
             """
+            @JSClass
             enum MyEnum {
                 @JSGetter
                 var value: Int
             }
             """,
             expandedSource: """
+                @JSClass
                 enum MyEnum {
                     var value: Int {
                         get throws(JSException) {
@@ -160,12 +209,14 @@ import BridgeJSMacros
     @Test func actorProperty() {
         TestSupport.assertMacroExpansion(
             """
+            @JSClass
             actor MyActor {
                 @JSGetter
                 var state: String
             }
             """,
             expandedSource: """
+                @JSClass
                 actor MyActor {
                     var state: String {
                         get throws(JSException) {
@@ -262,7 +313,14 @@ import BridgeJSMacros
                     message: "@JSGetter can only be applied to single-variable declarations.",
                     line: 1,
                     column: 1,
-                    severity: .error
+                    severity: .error,
+                    notes: [
+                        NoteSpec(
+                            message: "@JSGetter must be attached to a single stored or computed property.",
+                            line: 1,
+                            column: 1
+                        )
+                    ]
                 )
             ],
             macroSpecs: macroSpecs,

--- a/Sources/JavaScriptKit/Macros.swift
+++ b/Sources/JavaScriptKit/Macros.swift
@@ -202,7 +202,7 @@ public macro JSFunction(jsName: String? = nil, from: JSImportFrom? = nil) =
 ///
 /// - Parameter from: Selects where the constructor is looked up from.
 ///   Use `.global` to construct globals like `WebSocket` via `globalThis`.
-@attached(member, names: arbitrary)
+@attached(member, names: named(jsObject), named(init(unsafelyWrapping:)))
 @attached(extension, conformances: _JSBridgedClass)
 @_spi(Experimental)
 public macro JSClass(jsName: String? = nil, from: JSImportFrom? = nil) =


### PR DESCRIPTION
Examples added/covered in this change:
- @JSFunction: enforce throws(JSException) (missing or wrong type) with note + fix-it ("Declare throws(JSException)").
- @JSFunction: instance members outside @JSClass emit a clear diagnostic.
- @JSGetter/@JSSetter: members (instance/static/class) outside @JSClass emit a clear diagnostic.
- @JSSetter: invalid setter names (e.g. updateFoo) emit a diagnostic and suggest a rename fix-it (e.g. setFoo).
- @JSSetter: missing value parameter emits a diagnostic and suggests adding a placeholder parameter.
- @JSClass: using @JSClass on non-struct declarations emits a diagnostic; for "class" also suggests "Change 'class' to 'struct'".
