### PR TITLE
BridgeJS: Check generated TypeScript validity in test suites

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,8 @@ jobs:
           git diff --exit-code Sources/JavaScriptKit/Runtime
       - run: swift test --package-path ./Plugins/PackageToJS
       - run: swift test --package-path ./Plugins/BridgeJS
+      - name: Validate BridgeJS TypeScript declarations
+        run: npm run check:bridgejs-dts
 
   test-bridgejs-against-swift-versions:
     name: Test BridgeJS against Swift versions
@@ -90,6 +92,8 @@ jobs:
           node-version: '20'
       - name: Install TypeScript
         run: npm install
+      - name: Validate BridgeJS TypeScript declarations
+        run: npm run check:bridgejs-dts
       - name: Run BridgeJS tests
         # NOTE: Seems like the prebuilt SwiftSyntax binaries are not compatible with
         # non-macro dependents, so disable experimental prebuilts for now.

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/tsconfig.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": false,
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["*.d.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:clean": "rm -rf Runtime/lib",
     "build:ts": "cd Runtime; rollup -c",
     "prepublishOnly": "npm run build",
-    "format": "prettier --write Runtime/src"
+    "format": "prettier --write Runtime/src",
+    "check:bridgejs-dts": "tsc --project Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/tsconfig.json"
   },
   "keywords": [
     "Swift",


### PR DESCRIPTION
Should close: https://github.com/swiftwasm/JavaScriptKit/issues/593 

## Overview

BridgeJS generates `.d.ts` TypeScript declaration files, but nothing validates they are actually valid TypeScript. [PR #592](https://github.com/swiftwasm/JavaScriptKit/pull/592) fixed a bug where the `function` keyword was missing from namespace function declarations.

Any project running strict TypeScript type-checking (`tsc --noEmit`) without `skipLibCheck` would fail on the generated declarations (and it did 😅 ).

## Approach

Add a `tsc --noEmit` check against all `.d.ts` snapshot files using the already-installed `typescript` (^5.8.2) from the root `package.json`, so no new dependencies.

- ** why an npm script rather than a Swift test?** The BridgeJS Swift tests have no precedent for shelling out to Node tools. The `test-bridgejs-against-swift-versions` CI job runs in containers where tool availability differs. Keeping TypeScript validation in TypeScript tooling seems like the cleanest approach, but not an expert on that, so maybe there is better way.

- **why not integrated into snapshot assertions?** The `assertSnapshot()` helper is a clean, general-purpose utility. Adding `tsc` coupling would slow every assertion and require handling "tsc not found" inside what should be a simple file comparison.

## Usage

```bash
npm ci
npm run check:bridgejs-dts
```

## Notes

This check immediately surfaced existing codegen bugs - issues with type definitions for `PointTag`, `TSDirectionTag`, `TSThemeTag`, and `TSHttpStatusTag` in 3 snapshot files. I'll add separate issue for that, will fix in separate PR, then rebase this one, so we'll know that this approach actually works for us 👌🏻 

So failing CI for this one is actual sign it works, not a bug 😅 