### PR TITLE
NCF: BridgeJS: Generalize Optional stack ABI for Array, Dictionary, and Struct types

### DIFF
--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -1762,11 +1762,7 @@ public func _bjs_ArrayRoundtrip_makeOptionalPointArray(_ _self: UnsafeMutableRaw
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalPointArray()
     for __bjs_elem_ret in ret {
-    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
-    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
+    __bjs_elem_ret.bridgeJSLowerReturn()
     }
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -1789,11 +1785,7 @@ public func _bjs_ArrayRoundtrip_roundtripOptionalPointArray(_ _self: UnsafeMutab
         return __result
     }())
     for __bjs_elem_ret in ret {
-    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
-    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
+    __bjs_elem_ret.bridgeJSLowerReturn()
     }
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -1803,15 +1795,9 @@ public func _bjs_ArrayRoundtrip_roundtripOptionalPointArray(_ _self: UnsafeMutab
 
 @_expose(wasm, "bjs_ArrayRoundtrip_takeOptionalArray")
 @_cdecl("bjs_ArrayRoundtrip_takeOptionalArray")
-public func _bjs_ArrayRoundtrip_takeOptionalArray(_ _self: UnsafeMutableRawPointer, _ values: Int32) -> Void {
+public func _bjs_ArrayRoundtrip_takeOptionalArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeOptionalArray(_: {
-        if values == 0 {
-            return Optional<[Int]>.none
-        } else {
-            return [Int].bridgeJSLiftParameter()
-        }
-    }())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeOptionalArray(_: Optional<[Int]>.bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1822,11 +1808,7 @@ public func _bjs_ArrayRoundtrip_takeOptionalArray(_ _self: UnsafeMutableRawPoint
 public func _bjs_ArrayRoundtrip_makeOptionalArraySome(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalArraySome()
-    let __bjs_isSome_ret = ret != nil
-    if let __bjs_unwrapped_ret = ret {
-    __bjs_unwrapped_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1837,11 +1819,7 @@ public func _bjs_ArrayRoundtrip_makeOptionalArraySome(_ _self: UnsafeMutableRawP
 public func _bjs_ArrayRoundtrip_makeOptionalArrayNone(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalArrayNone()
-    let __bjs_isSome_ret = ret != nil
-    if let __bjs_unwrapped_ret = ret {
-    __bjs_unwrapped_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1849,20 +1827,10 @@ public func _bjs_ArrayRoundtrip_makeOptionalArrayNone(_ _self: UnsafeMutableRawP
 
 @_expose(wasm, "bjs_ArrayRoundtrip_roundtripOptionalArray")
 @_cdecl("bjs_ArrayRoundtrip_roundtripOptionalArray")
-public func _bjs_ArrayRoundtrip_roundtripOptionalArray(_ _self: UnsafeMutableRawPointer, _ values: Int32) -> Void {
+public func _bjs_ArrayRoundtrip_roundtripOptionalArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripOptionalArray(_: {
-        if values == 0 {
-            return Optional<[Int]>.none
-        } else {
-            return [Int].bridgeJSLiftParameter()
-        }
-    }())
-    let __bjs_isSome_ret = ret != nil
-    if let __bjs_unwrapped_ret = ret {
-    __bjs_unwrapped_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripOptionalArray(_: Optional<[Int]>.bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -832,7 +832,8 @@ struct IntrinsicJSFragment: Sendable {
                     }
                     printer.write("}")
                     cleanupCode.write("if (\(cleanupVar)) { \(cleanupVar)(); }")
-                    return ["+\(isSomeVar)"]
+                    printer.write("\(JSGlueVariableScope.reservedI32Stack).push(+\(isSomeVar));")
+                    return []
                 case .string, .rawValueEnum(_, .string):
                     let bytesVar = scope.variable("\(value)Bytes")
                     let idVar = scope.variable("\(value)Id")
@@ -895,7 +896,8 @@ struct IntrinsicJSFragment: Sendable {
                     }
                     printer.write("}")
                     cleanupCode.write("for (const cleanup of \(cleanupArrayVar)) { cleanup(); }")
-                    return ["+\(isSomeVar)"]
+                    printer.write("\(JSGlueVariableScope.reservedI32Stack).push(+\(isSomeVar));")
+                    return []
                 case .dictionary(let valueType):
                     let cleanupArrayVar = scope.variable("\(value)Cleanups")
                     printer.write("const \(cleanupArrayVar) = [];")
@@ -915,7 +917,8 @@ struct IntrinsicJSFragment: Sendable {
                     }
                     printer.write("}")
                     cleanupCode.write("for (const cleanup of \(cleanupArrayVar)) { cleanup(); }")
-                    return ["+\(isSomeVar)"]
+                    printer.write("\(JSGlueVariableScope.reservedI32Stack).push(+\(isSomeVar));")
+                    return []
                 default:
                     switch wrappedType {
                     case .swiftHeapObject:

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
@@ -277,20 +277,10 @@ public func _bjs_processOptionalStringArray() -> Void {
 
 @_expose(wasm, "bjs_processOptionalArray")
 @_cdecl("bjs_processOptionalArray")
-public func _bjs_processOptionalArray(_ values: Int32) -> Void {
+public func _bjs_processOptionalArray() -> Void {
     #if arch(wasm32)
-    let ret = processOptionalArray(_: {
-        if values == 0 {
-            return Optional<[Int]>.none
-        } else {
-            return [Int].bridgeJSLiftParameter()
-        }
-    }())
-    let __bjs_isSome_ret = ret != nil
-    if let __bjs_unwrapped_ret = ret {
-    __bjs_unwrapped_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
+    let ret = processOptionalArray(_: Optional<[Int]>.bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -311,11 +301,7 @@ public func _bjs_processOptionalPointArray() -> Void {
         return __result
     }())
     for __bjs_elem_ret in ret {
-    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
-    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
+    __bjs_elem_ret.bridgeJSLowerReturn()
     }
     _swift_js_push_i32(Int32(ret.count))
     #else

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.swift
@@ -294,9 +294,9 @@ public func _bjs_testEmptyInit(_ greeter: UnsafeMutableRawPointer) -> UnsafeMuta
 
 @_expose(wasm, "bjs_testOptionalStructDefault")
 @_cdecl("bjs_testOptionalStructDefault")
-public func _bjs_testOptionalStructDefault(_ point: Int32) -> Void {
+public func _bjs_testOptionalStructDefault() -> Void {
     #if arch(wasm32)
-    let ret = testOptionalStructDefault(point: Optional<Config>.bridgeJSLiftParameter(point))
+    let ret = testOptionalStructDefault(point: Optional<Config>.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -305,9 +305,9 @@ public func _bjs_testOptionalStructDefault(_ point: Int32) -> Void {
 
 @_expose(wasm, "bjs_testOptionalStructWithValueDefault")
 @_cdecl("bjs_testOptionalStructWithValueDefault")
-public func _bjs_testOptionalStructWithValueDefault(_ point: Int32) -> Void {
+public func _bjs_testOptionalStructWithValueDefault() -> Void {
     #if arch(wasm32)
-    let ret = testOptionalStructWithValueDefault(point: Optional<Config>.bridgeJSLiftParameter(point))
+    let ret = testOptionalStructWithValueDefault(point: Optional<Config>.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DictionaryTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DictionaryTypes.swift
@@ -11,9 +11,9 @@ public func _bjs_mirrorDictionary() -> Void {
 
 @_expose(wasm, "bjs_optionalDictionary")
 @_cdecl("bjs_optionalDictionary")
-public func _bjs_optionalDictionary(_ values: Int32) -> Void {
+public func _bjs_optionalDictionary() -> Void {
     #if arch(wasm32)
-    let ret = optionalDictionary(_: Optional<[String: String]>.bridgeJSLiftParameter(values))
+    let ret = optionalDictionary(_: Optional<[String: String]>.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
@@ -617,14 +617,7 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
         case 3:
             return .optNestedEnum(Optional<APIResult>.bridgeJSLiftParameter())
         case 4:
-            return .optArray({
-    let __isSome = _swift_js_pop_i32()
-    if __isSome == 0 {
-        return Optional<[Int]>.none
-    } else {
-        return [Int].bridgeJSLiftParameter()
-    }
-}())
+            return .optArray(Optional<[Int]>.bridgeJSLiftParameter())
         case 5:
             return .empty
         default:
@@ -637,11 +630,7 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .optStruct(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            param0.bridgeJSLowerReturn()
             return Int32(0)
         case .optClass(let param0):
             let __bjs_isSome_param0 = param0 != nil
@@ -665,11 +654,7 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(3)
         case .optArray(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            param0.bridgeJSLowerReturn()
             return Int32(4)
         case .empty:
             return Int32(5)
@@ -689,11 +674,7 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
         switch self {
         case .optStruct(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            param0.bridgeJSLowerReturn()
             _swift_js_push_tag(Int32(0))
         case .optClass(let param0):
             let __bjs_isSome_param0 = param0 != nil
@@ -717,11 +698,7 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             _swift_js_push_tag(Int32(3))
         case .optArray(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            param0.bridgeJSLowerReturn()
             _swift_js_push_tag(Int32(4))
         case .empty:
             _swift_js_push_tag(Int32(5))

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSValue.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSValue.swift
@@ -33,20 +33,10 @@ public func _bjs_roundTripJSValueArray() -> Void {
 
 @_expose(wasm, "bjs_roundTripOptionalJSValueArray")
 @_cdecl("bjs_roundTripOptionalJSValueArray")
-public func _bjs_roundTripOptionalJSValueArray(_ values: Int32) -> Void {
+public func _bjs_roundTripOptionalJSValueArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalJSValueArray(_: {
-        if values == 0 {
-            return Optional<[JSValue]>.none
-        } else {
-            return [JSValue].bridgeJSLiftParameter()
-        }
-    }())
-    let __bjs_isSome_ret = ret != nil
-    if let __bjs_unwrapped_ret = ret {
-    __bjs_unwrapped_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
+    let ret = roundTripOptionalJSValueArray(_: Optional<[JSValue]>.bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
@@ -673,7 +673,8 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(values.length);
                         valuesCleanups.push(() => { for (const cleanup of arrayCleanups) { cleanup(); } });
                     }
-                    instance.exports.bjs_processOptionalArray(+isSome);
+                    i32Stack.push(+isSome);
+                    instance.exports.bjs_processOptionalArray();
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
@@ -521,7 +521,8 @@ export async function createInstantiator(options, swift) {
                         const structResult = structHelpers.Config.lower(point);
                         pointCleanup = structResult.cleanup;
                     }
-                    instance.exports.bjs_testOptionalStructDefault(+isSome);
+                    i32Stack.push(+isSome);
+                    instance.exports.bjs_testOptionalStructDefault();
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {
@@ -539,7 +540,8 @@ export async function createInstantiator(options, swift) {
                         const structResult = structHelpers.Config.lower(point);
                         pointCleanup = structResult.cleanup;
                     }
-                    instance.exports.bjs_testOptionalStructWithValueDefault(+isSome);
+                    i32Stack.push(+isSome);
+                    instance.exports.bjs_testOptionalStructWithValueDefault();
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
@@ -327,7 +327,8 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(entries.length);
                         valuesCleanups.push(() => { for (const cleanup of arrayCleanups) { cleanup(); } });
                     }
-                    instance.exports.bjs_optionalDictionary(+isSome);
+                    i32Stack.push(+isSome);
+                    instance.exports.bjs_optionalDictionary();
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
@@ -507,7 +507,8 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(values.length);
                         valuesCleanups.push(() => { for (const cleanup of arrayCleanups) { cleanup(); } });
                     }
-                    instance.exports.bjs_roundTripOptionalJSValueArray(+isSome);
+                    i32Stack.push(+isSome);
+                    instance.exports.bjs_roundTripOptionalJSValueArray();
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -2814,14 +2814,7 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
         case 3:
             return .optNestedEnum(Optional<APIResult>.bridgeJSLiftParameter())
         case 4:
-            return .optArray({
-    let __isSome = _swift_js_pop_i32()
-    if __isSome == 0 {
-        return Optional<[Int]>.none
-    } else {
-        return [Int].bridgeJSLiftParameter()
-    }
-}())
+            return .optArray(Optional<[Int]>.bridgeJSLiftParameter())
         case 5:
             return .optJsClass(Optional<JSObject>.bridgeJSLiftParameter().map { Foo(unsafelyWrapping: $0) })
         case 6:
@@ -2836,11 +2829,7 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         switch self {
         case .optStruct(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            param0.bridgeJSLowerReturn()
             return Int32(0)
         case .optClass(let param0):
             let __bjs_isSome_param0 = param0 != nil
@@ -2864,11 +2853,7 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(3)
         case .optArray(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            param0.bridgeJSLowerReturn()
             return Int32(4)
         case .optJsClass(let param0):
             let __bjs_isSome_param0 = param0 != nil
@@ -2895,11 +2880,7 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
         switch self {
         case .optStruct(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            param0.bridgeJSLowerReturn()
             _swift_js_push_tag(Int32(0))
         case .optClass(let param0):
             let __bjs_isSome_param0 = param0 != nil
@@ -2923,11 +2904,7 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             _swift_js_push_tag(Int32(3))
         case .optArray(let param0):
-            let __bjs_isSome_param0 = param0 != nil
-            if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerReturn()
-            }
-            _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
+            param0.bridgeJSLowerReturn()
             _swift_js_push_tag(Int32(4))
         case .optJsClass(let param0):
             let __bjs_isSome_param0 = param0 != nil
@@ -3298,11 +3275,7 @@ extension Contact: _BridgedSwiftStruct {
         __bjs_unwrapped_email.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_email ? 1 : 0)
-        let __bjs_isSome_secondaryAddress = self.secondaryAddress != nil
-        if let __bjs_unwrapped_secondaryAddress = self.secondaryAddress {
-        __bjs_unwrapped_secondaryAddress.bridgeJSLowerReturn()
-        }
-        _swift_js_push_i32(__bjs_isSome_secondaryAddress ? 1 : 0)
+        self.secondaryAddress.bridgeJSLowerReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -3532,17 +3505,9 @@ extension AdvancedConfig: _BridgedSwiftStruct {
         __bjs_unwrapped_metadata.bridgeJSLowerStackReturn()
         }
         _swift_js_push_i32(__bjs_isSome_metadata ? 1 : 0)
-        let __bjs_isSome_location = self.location != nil
-        if let __bjs_unwrapped_location = self.location {
-        __bjs_unwrapped_location.bridgeJSLowerReturn()
-        }
-        _swift_js_push_i32(__bjs_isSome_location ? 1 : 0)
+        self.location.bridgeJSLowerReturn()
         self.defaults.bridgeJSLowerReturn()
-        let __bjs_isSome_overrideDefaults = self.overrideDefaults != nil
-        if let __bjs_unwrapped_overrideDefaults = self.overrideDefaults {
-        __bjs_unwrapped_overrideDefaults.bridgeJSLowerReturn()
-        }
-        _swift_js_push_i32(__bjs_isSome_overrideDefaults ? 1 : 0)
+        self.overrideDefaults.bridgeJSLowerReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -3838,11 +3803,7 @@ extension CopyableNestedCart: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
         self.id.bridgeJSLowerStackReturn()
         self.item.bridgeJSLowerReturn()
-        let __bjs_isSome_shippingAddress = self.shippingAddress != nil
-        if let __bjs_unwrapped_shippingAddress = self.shippingAddress {
-        __bjs_unwrapped_shippingAddress.bridgeJSLowerReturn()
-        }
-        _swift_js_push_i32(__bjs_isSome_shippingAddress ? 1 : 0)
+        self.shippingAddress.bridgeJSLowerReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -4098,25 +4059,14 @@ fileprivate func _bjs_struct_lift_FooContainer() -> Int32 {
 
 extension ArrayMembers: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ArrayMembers {
-        let optStrings = {
-    let __isSome = _swift_js_pop_i32()
-    if __isSome == 0 {
-        return Optional<[String]>.none
-    } else {
-        return [String].bridgeJSLiftParameter()
-    }
-}()
+        let optStrings = Optional<[String]>.bridgeJSLiftParameter()
         let ints = [Int].bridgeJSLiftParameter()
         return ArrayMembers(ints: ints, optStrings: optStrings)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
         self.ints.bridgeJSLowerReturn()
-        let __bjs_isSome_optStrings = self.optStrings != nil
-        if let __bjs_unwrapped_optStrings = self.optStrings {
-        __bjs_unwrapped_optStrings.bridgeJSLowerReturn()
-        }
-        _swift_js_push_i32(__bjs_isSome_optStrings ? 1 : 0)
+        self.optStrings.bridgeJSLowerReturn()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -4340,9 +4290,9 @@ public func _bjs_roundTripDictionaryExport() -> Void {
 
 @_expose(wasm, "bjs_roundTripOptionalDictionaryExport")
 @_cdecl("bjs_roundTripOptionalDictionaryExport")
-public func _bjs_roundTripOptionalDictionaryExport(_ v: Int32) -> Void {
+public func _bjs_roundTripOptionalDictionaryExport() -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalDictionaryExport(v: Optional<[String: String]>.bridgeJSLiftParameter(v))
+    let ret = roundTripOptionalDictionaryExport(v: Optional<[String: String]>.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -4384,20 +4334,10 @@ public func _bjs_roundTripJSValueArray() -> Void {
 
 @_expose(wasm, "bjs_roundTripOptionalJSValueArray")
 @_cdecl("bjs_roundTripOptionalJSValueArray")
-public func _bjs_roundTripOptionalJSValueArray(_ v: Int32) -> Void {
+public func _bjs_roundTripOptionalJSValueArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalJSValueArray(v: {
-        if v == 0 {
-            return Optional<[JSValue]>.none
-        } else {
-            return [JSValue].bridgeJSLiftParameter()
-        }
-    }())
-    let __bjs_isSome_ret = ret != nil
-    if let __bjs_unwrapped_ret = ret {
-    __bjs_unwrapped_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
+    let ret = roundTripOptionalJSValueArray(v: Optional<[JSValue]>.bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5413,15 +5353,9 @@ public func _bjs_arrayWithDefault() -> Int32 {
 
 @_expose(wasm, "bjs_arrayWithOptionalDefault")
 @_cdecl("bjs_arrayWithOptionalDefault")
-public func _bjs_arrayWithOptionalDefault(_ values: Int32) -> Int32 {
+public func _bjs_arrayWithOptionalDefault() -> Int32 {
     #if arch(wasm32)
-    let ret = arrayWithOptionalDefault(_: {
-        if values == 0 {
-            return Optional<[Int]>.none
-        } else {
-            return [Int].bridgeJSLiftParameter()
-        }
-    }())
+    let ret = arrayWithOptionalDefault(_: Optional<[Int]>.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -5651,11 +5585,7 @@ public func _bjs_roundTripOptionalDataPointArray() -> Void {
         return __result
     }())
     for __bjs_elem_ret in ret {
-    let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
-    if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
+    __bjs_elem_ret.bridgeJSLowerReturn()
     }
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -5719,20 +5649,10 @@ public func _bjs_roundTripOptionalStatusArray() -> Void {
 
 @_expose(wasm, "bjs_roundTripOptionalIntArrayType")
 @_cdecl("bjs_roundTripOptionalIntArrayType")
-public func _bjs_roundTripOptionalIntArrayType(_ values: Int32) -> Void {
+public func _bjs_roundTripOptionalIntArrayType() -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalIntArrayType(_: {
-        if values == 0 {
-            return Optional<[Int]>.none
-        } else {
-            return [Int].bridgeJSLiftParameter()
-        }
-    }())
-    let __bjs_isSome_ret = ret != nil
-    if let __bjs_unwrapped_ret = ret {
-    __bjs_unwrapped_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
+    let ret = roundTripOptionalIntArrayType(_: Optional<[Int]>.bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5740,20 +5660,10 @@ public func _bjs_roundTripOptionalIntArrayType(_ values: Int32) -> Void {
 
 @_expose(wasm, "bjs_roundTripOptionalStringArrayType")
 @_cdecl("bjs_roundTripOptionalStringArrayType")
-public func _bjs_roundTripOptionalStringArrayType(_ values: Int32) -> Void {
+public func _bjs_roundTripOptionalStringArrayType() -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalStringArrayType(_: {
-        if values == 0 {
-            return Optional<[String]>.none
-        } else {
-            return [String].bridgeJSLiftParameter()
-        }
-    }())
-    let __bjs_isSome_ret = ret != nil
-    if let __bjs_unwrapped_ret = ret {
-    __bjs_unwrapped_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
+    let ret = roundTripOptionalStringArrayType(_: Optional<[String]>.bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5761,20 +5671,10 @@ public func _bjs_roundTripOptionalStringArrayType(_ values: Int32) -> Void {
 
 @_expose(wasm, "bjs_roundTripOptionalGreeterArrayType")
 @_cdecl("bjs_roundTripOptionalGreeterArrayType")
-public func _bjs_roundTripOptionalGreeterArrayType(_ greeters: Int32) -> Void {
+public func _bjs_roundTripOptionalGreeterArrayType() -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalGreeterArrayType(_: {
-        if greeters == 0 {
-            return Optional<[Greeter]>.none
-        } else {
-            return [Greeter].bridgeJSLiftParameter()
-        }
-    }())
-    let __bjs_isSome_ret = ret != nil
-    if let __bjs_unwrapped_ret = ret {
-    __bjs_unwrapped_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(__bjs_isSome_ret ? 1 : 0)
+    let ret = roundTripOptionalGreeterArrayType(_: Optional<[Greeter]>.bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -9006,9 +8906,9 @@ fileprivate func _bjs_OptionalPropertyHolder_wrap(_ pointer: UnsafeMutableRawPoi
 
 @_expose(wasm, "bjs_Container_init")
 @_cdecl("bjs_Container_init")
-public func _bjs_Container_init(_ config: Int32) -> UnsafeMutableRawPointer {
+public func _bjs_Container_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let _tmp_config = Optional<Config>.bridgeJSLiftParameter(config)
+    let _tmp_config = Optional<Config>.bridgeJSLiftParameter()
     let _tmp_location = DataPoint.bridgeJSLiftParameter()
     let ret = Container(location: _tmp_location, config: _tmp_config)
     return ret.bridgeJSLowerReturn()
@@ -9051,9 +8951,9 @@ public func _bjs_Container_config_get(_ _self: UnsafeMutableRawPointer) -> Void 
 
 @_expose(wasm, "bjs_Container_config_set")
 @_cdecl("bjs_Container_config_set")
-public func _bjs_Container_config_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+public func _bjs_Container_config_set(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Container.bridgeJSLiftParameter(_self).config = Optional<Config>.bridgeJSLiftParameter(value)
+    Container.bridgeJSLiftParameter(_self).config = Optional<Config>.bridgeJSLiftParameter()
     #else
     fatalError("Only available on WebAssembly")
     #endif


### PR DESCRIPTION
## Overview

First part of attempts to simplify codegen a bit. This PR introduces a generic `Optional: _BridgedSwiftStackType` conformance for stack-based types (Array, Dictionary, Struct), replacing inline codegen with unified `bridgeJSLiftParameter()` / `bridgeJSLowerReturn()` calls. This reduces codegen complexity by not requiring type-specific Optional handling each time.

## Changes

### `BridgeJSIntrinsics.swift`

- `_BridgedSwiftGenericOptionalStackType` marker protocol - inherits `_BridgedSwiftStackType where StackLiftResult == Self`. Only Array, Dictionary, and `_BridgedSwiftStruct` conform. This keeps the generic Optional conformance scoped to stack-based types while primitives, enums, and heap objects retain their existing type-specific Optional extensions.

- Generic `Optional: _BridgedSwiftStackType` conformance - provides `bridgeJSLiftParameter()` (pops isSome from stack, delegates to `Wrapped.bridgeJSLiftParameter()`) and `bridgeJSLowerReturn()` (pushes wrapped value then isSome flag).
- Removed duplicate/dead code replaced by generic conformance

### `ExportSwift.swift`

- Simplified `liftNullableExpression` - removed the `.array` special case that generated inline if-else blocks; arrays now go through the same `Optional<T>.bridgeJSLiftParameter()` path as other types.
- Simplified `lowerOptionalStatements` - `.array`, `.dictionary`, `.swiftStruct` cases now emit a single `accessor.bridgeJSLowerReturn()` instead of 5-line inline if-let + push patterns.
- Simplified `liftParameterInfo` - `Optional` wrapping a stack-based type (empty params) returns empty params (fully stack-based), while `Optional<primitive>` keeps direct WASM params.

### `JSGlueGen.swift`

- Optional struct/array/dictionary parameters now push `isSome` to `i32Stack` instead of passing as a direct WASM argument, matching the fully stack-based ABI