### PR TITLE
NFC: BridgeJS: Delegate nested container codegen to generic runtime conformances

### DIFF
--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -1565,16 +1565,7 @@ public func _bjs_ArrayRoundtrip_makePointArrayLarge(_ _self: UnsafeMutableRawPoi
 @_cdecl("bjs_ArrayRoundtrip_takeNestedIntArray")
 public func _bjs_ArrayRoundtrip_takeNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedIntArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[Int]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([Int].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedIntArray(_: [[Int]].bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1585,10 +1576,7 @@ public func _bjs_ArrayRoundtrip_takeNestedIntArray(_ _self: UnsafeMutableRawPoin
 public func _bjs_ArrayRoundtrip_makeNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeNestedIntArray()
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1598,20 +1586,8 @@ public func _bjs_ArrayRoundtrip_makeNestedIntArray(_ _self: UnsafeMutableRawPoin
 @_cdecl("bjs_ArrayRoundtrip_roundtripNestedIntArray")
 public func _bjs_ArrayRoundtrip_roundtripNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedIntArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[Int]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([Int].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedIntArray(_: [[Int]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1621,16 +1597,7 @@ public func _bjs_ArrayRoundtrip_roundtripNestedIntArray(_ _self: UnsafeMutableRa
 @_cdecl("bjs_ArrayRoundtrip_takeNestedPointArray")
 public func _bjs_ArrayRoundtrip_takeNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedPointArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[Point]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([Point].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedPointArray(_: [[Point]].bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1641,10 +1608,7 @@ public func _bjs_ArrayRoundtrip_takeNestedPointArray(_ _self: UnsafeMutableRawPo
 public func _bjs_ArrayRoundtrip_makeNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeNestedPointArray()
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1654,20 +1618,8 @@ public func _bjs_ArrayRoundtrip_makeNestedPointArray(_ _self: UnsafeMutableRawPo
 @_cdecl("bjs_ArrayRoundtrip_roundtripNestedPointArray")
 public func _bjs_ArrayRoundtrip_roundtripNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedPointArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[Point]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([Point].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedPointArray(_: [[Point]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -838,18 +838,16 @@ struct StackCodegen {
 
     func liftArrayExpression(elementType: BridgeType) -> ExprSyntax {
         switch elementType {
-        case .int, .uint, .float, .double, .string, .bool, .jsValue,
-            .jsObject(nil), .swiftStruct, .caseEnum, .swiftHeapObject,
-            .unsafePointer, .rawValueEnum, .associatedValueEnum:
-            return "[\(raw: elementType.swiftType)].bridgeJSLiftParameter()"
-        case .jsObject(_?):
+        case .jsObject(let className?) where className != "JSObject":
             return liftArrayExpressionInline(elementType: elementType)
         case .swiftProtocol(let protocolName):
             return "[Any\(raw: protocolName)].bridgeJSLiftParameter()"
-        case .nullable, .array, .closure, .dictionary:
+        case .nullable, .closure:
             return liftArrayExpressionInline(elementType: elementType)
         case .void, .namespaceEnum:
             fatalError("Invalid array element type: \(elementType)")
+        default:
+            return "[\(raw: elementType.swiftType)].bridgeJSLiftParameter()"
         }
     }
 
@@ -872,11 +870,7 @@ struct StackCodegen {
 
     func liftDictionaryExpression(valueType: BridgeType) -> ExprSyntax {
         switch valueType {
-        case .int, .uint, .float, .double, .string, .bool, .jsValue,
-            .jsObject(nil), .swiftStruct, .caseEnum, .swiftHeapObject,
-            .unsafePointer, .rawValueEnum, .associatedValueEnum:
-            return "[String: \(raw: valueType.swiftType)].bridgeJSLiftParameter()"
-        case .jsObject(let className?):
+        case .jsObject(let className?) where className != "JSObject":
             return """
                 {
                     let __dict = [String: JSObject].bridgeJSLiftParameter()
@@ -890,10 +884,12 @@ struct StackCodegen {
                     return __dict.mapValues { $0 as! Any\(raw: protocolName) }
                 }()
                 """
-        case .nullable, .array, .dictionary, .closure:
+        case .nullable, .closure:
             return liftDictionaryExpressionInline(valueType: valueType)
         case .void, .namespaceEnum:
             fatalError("Invalid dictionary value type: \(valueType)")
+        default:
+            return "[String: \(raw: valueType.swiftType)].bridgeJSLiftParameter()"
         }
     }
 
@@ -1005,15 +1001,11 @@ struct StackCodegen {
         varPrefix: String
     ) -> [CodeBlockItemSyntax] {
         switch elementType {
-        case .int, .uint, .float, .double, .string, .bool, .jsValue,
-            .jsObject(nil), .swiftStruct, .caseEnum, .swiftHeapObject,
-            .unsafePointer, .rawValueEnum, .associatedValueEnum:
-            return ["\(raw: accessor).bridgeJSLowerReturn()"]
-        case .jsObject(_?):
+        case .jsObject(let className?) where className != "JSObject":
             return ["\(raw: accessor).map { $0.jsObject }.bridgeJSLowerReturn()"]
         case .swiftProtocol(let protocolName):
             return ["\(raw: accessor).map { $0 as! Any\(raw: protocolName) }.bridgeJSLowerReturn()"]
-        case .nullable, .array, .closure, .dictionary:
+        case .nullable, .closure:
             return lowerArrayStatementsInline(
                 elementType: elementType,
                 accessor: accessor,
@@ -1021,6 +1013,8 @@ struct StackCodegen {
             )
         case .void, .namespaceEnum:
             fatalError("Invalid array element type: \(elementType)")
+        default:
+            return ["\(raw: accessor).bridgeJSLowerReturn()"]
         }
     }
 
@@ -1054,15 +1048,11 @@ struct StackCodegen {
         varPrefix: String
     ) -> [CodeBlockItemSyntax] {
         switch valueType {
-        case .int, .uint, .float, .double, .string, .bool, .jsValue,
-            .jsObject(nil), .swiftStruct, .caseEnum, .swiftHeapObject,
-            .unsafePointer, .rawValueEnum, .associatedValueEnum:
-            return ["\(raw: accessor).bridgeJSLowerReturn()"]
-        case .jsObject(_?):
+        case .jsObject(let className?) where className != "JSObject":
             return ["\(raw: accessor).mapValues { $0.jsObject }.bridgeJSLowerReturn()"]
         case .swiftProtocol(let protocolName):
             return ["\(raw: accessor).mapValues { $0 as! Any\(raw: protocolName) }.bridgeJSLowerReturn()"]
-        case .nullable, .array, .dictionary, .closure:
+        case .nullable, .closure:
             return lowerDictionaryStatementsInline(
                 valueType: valueType,
                 accessor: accessor,
@@ -1070,6 +1060,8 @@ struct StackCodegen {
             )
         case .void, .namespaceEnum:
             fatalError("Invalid dictionary value type: \(valueType)")
+        default:
+            return ["\(raw: accessor).bridgeJSLowerReturn()"]
         }
     }
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
@@ -381,20 +381,8 @@ public func _bjs_processOptionalStatusArray() -> Void {
 @_cdecl("bjs_processNestedIntArray")
 public func _bjs_processNestedIntArray() -> Void {
     #if arch(wasm32)
-    let ret = processNestedIntArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[Int]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([Int].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processNestedIntArray(_: [[Int]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -404,20 +392,8 @@ public func _bjs_processNestedIntArray() -> Void {
 @_cdecl("bjs_processNestedStringArray")
 public func _bjs_processNestedStringArray() -> Void {
     #if arch(wasm32)
-    let ret = processNestedStringArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[String]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([String].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processNestedStringArray(_: [[String]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -427,20 +403,8 @@ public func _bjs_processNestedStringArray() -> Void {
 @_cdecl("bjs_processNestedPointArray")
 public func _bjs_processNestedPointArray() -> Void {
     #if arch(wasm32)
-    let ret = processNestedPointArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[Point]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([Point].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processNestedPointArray(_: [[Point]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -461,20 +425,8 @@ public func _bjs_processItemArray() -> Void {
 @_cdecl("bjs_processNestedItemArray")
 public func _bjs_processNestedItemArray() -> Void {
     #if arch(wasm32)
-    let ret = processNestedItemArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[Item]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([Item].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processNestedItemArray(_: [[Item]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -522,20 +474,8 @@ public func _bjs_processOptionalJSObjectArray() -> Void {
 @_cdecl("bjs_processNestedJSObjectArray")
 public func _bjs_processNestedJSObjectArray() -> Void {
     #if arch(wasm32)
-    let ret = processNestedJSObjectArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[JSObject]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([JSObject].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = processNestedJSObjectArray(_: [[JSObject]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -5784,20 +5784,8 @@ public func _bjs_roundTripOptionalGreeterArrayType(_ greeters: Int32) -> Void {
 @_cdecl("bjs_roundTripNestedIntArray")
 public func _bjs_roundTripNestedIntArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedIntArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[Int]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([Int].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripNestedIntArray(_: [[Int]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5807,20 +5795,8 @@ public func _bjs_roundTripNestedIntArray() -> Void {
 @_cdecl("bjs_roundTripNestedStringArray")
 public func _bjs_roundTripNestedStringArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedStringArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[String]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([String].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripNestedStringArray(_: [[String]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5830,20 +5806,8 @@ public func _bjs_roundTripNestedStringArray() -> Void {
 @_cdecl("bjs_roundTripNestedDoubleArray")
 public func _bjs_roundTripNestedDoubleArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedDoubleArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[Double]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([Double].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripNestedDoubleArray(_: [[Double]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5853,20 +5817,8 @@ public func _bjs_roundTripNestedDoubleArray() -> Void {
 @_cdecl("bjs_roundTripNestedBoolArray")
 public func _bjs_roundTripNestedBoolArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedBoolArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[Bool]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([Bool].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripNestedBoolArray(_: [[Bool]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5876,20 +5828,8 @@ public func _bjs_roundTripNestedBoolArray() -> Void {
 @_cdecl("bjs_roundTripNestedDataPointArray")
 public func _bjs_roundTripNestedDataPointArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedDataPointArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[DataPoint]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([DataPoint].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripNestedDataPointArray(_: [[DataPoint]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5899,20 +5839,8 @@ public func _bjs_roundTripNestedDataPointArray() -> Void {
 @_cdecl("bjs_roundTripNestedDirectionArray")
 public func _bjs_roundTripNestedDirectionArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedDirectionArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[Direction]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([Direction].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripNestedDirectionArray(_: [[Direction]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5922,20 +5850,8 @@ public func _bjs_roundTripNestedDirectionArray() -> Void {
 @_cdecl("bjs_roundTripNestedGreeterArray")
 public func _bjs_roundTripNestedGreeterArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedGreeterArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [[Greeter]] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append([Greeter].bridgeJSLiftParameter())
-        }
-        __result.reverse()
-        return __result
-    }())
-    for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
-    }
-    _swift_js_push_i32(Int32(ret.count))
+    let ret = roundTripNestedGreeterArray(_: [[Greeter]].bridgeJSLiftParameter())
+    ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif


### PR DESCRIPTION
## Overview

This PR aims to simplify codegen for nested container types (`[[Int]]`, `[String: [Double]]`, etc.) by delegating to existing generic runtime conformances (`Array: _BridgedSwiftStackType`, `Dictionary: _BridgedSwiftStackType`) instead of generating inline for-loops in Swift thunks.

Previously, when the element type of an array (or value type of a dictionary) was itself an array or dictionary, the codegen emitted inline loops that manually iterated and pushed/popped each element. The runtime already has generic conformances that do exactly this - `Array<Element>.bridgeJSLiftParameter()` and `.bridgeJSLowerReturn()` handle recursion through the generic `Element: _BridgedSwiftStackType` constraint. This PR routes those cases through the generic conformance path instead.