### PR TITLE
[NFC] BridgeJS: Remove tag stack and use i32 stack for enum case tags

### DIFF
--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -65,21 +65,21 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .flag(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .rate(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .precise(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         case .info:
-            _swift_js_push_tag(Int32(5))
+            _swift_js_push_i32(Int32(5))
         }
     }
 }
@@ -162,26 +162,26 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .error(let param0, let param1):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .location(let param0, let param1, let param2):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
             param2.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .status(let param0, let param1, let param2):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
             param2.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .coordinates(let param0, let param1, let param2):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
             param2.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         case .comprehensive(let param0, let param1, let param2, let param3, let param4, let param5, let param6, let param7, let param8):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
@@ -192,9 +192,9 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
             param6.bridgeJSLowerStackReturn()
             param7.bridgeJSLowerStackReturn()
             param8.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(5))
+            _swift_js_push_i32(Int32(5))
         case .info:
-            _swift_js_push_tag(Int32(6))
+            _swift_js_push_i32(Int32(6))
         }
     }
 }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -1323,7 +1323,7 @@ struct EnumCodegen {
             if enumCase.associatedValues.isEmpty {
                 printer.write("case .\(enumCase.name):")
                 printer.indent {
-                    printer.write("_swift_js_push_tag(Int32(\(caseIndex)))")
+                    printer.write("_swift_js_push_i32(Int32(\(caseIndex)))")
                 }
             } else {
                 let pattern = enumCase.associatedValues.enumerated()
@@ -1334,7 +1334,7 @@ struct EnumCodegen {
                     generatePayloadPushingCode(printer: printer, associatedValues: enumCase.associatedValues)
                     // Push tag AFTER payloads so it's popped first (LIFO) by the JS lift function.
                     // This ensures nested enum tags don't overwrite the outer tag.
-                    printer.write("_swift_js_push_tag(Int32(\(caseIndex)))")
+                    printer.write("_swift_js_push_i32(Int32(\(caseIndex)))")
                 }
             }
         }

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -246,7 +246,6 @@ public struct BridgeJSLink {
             "let \(JSGlueVariableScope.reservedStorageToReturnOptionalFloat);",
             "let \(JSGlueVariableScope.reservedStorageToReturnOptionalDouble);",
             "let \(JSGlueVariableScope.reservedStorageToReturnOptionalHeapObject);",
-            "let \(JSGlueVariableScope.reservedTagStack) = [];",
             "let \(JSGlueVariableScope.reservedStringStack) = [];",
             "let \(JSGlueVariableScope.reservedI32Stack) = [];",
             "let \(JSGlueVariableScope.reservedF32Stack) = [];",
@@ -340,11 +339,6 @@ public struct BridgeJSLink {
                 printer.write("bjs[\"swift_js_release\"] = function(id) {")
                 printer.indent {
                     printer.write("\(JSGlueVariableScope.reservedSwift).memory.release(id);")
-                }
-                printer.write("}")
-                printer.write("bjs[\"swift_js_push_tag\"] = function(tag) {")
-                printer.indent {
-                    printer.write("\(JSGlueVariableScope.reservedTagStack).push(tag);")
                 }
                 printer.write("}")
                 printer.write("bjs[\"swift_js_push_i32\"] = function(v) {")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
@@ -56,21 +56,21 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .flag(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .rate(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .precise(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         case .info:
-            _swift_js_push_tag(Int32(5))
+            _swift_js_push_i32(Int32(5))
         }
     }
 }
@@ -146,21 +146,21 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .error(let param0, let param1):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .status(let param0, let param1, let param2):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
             param2.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .coordinates(let param0, let param1, let param2):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
             param2.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .comprehensive(let param0, let param1, let param2, let param3, let param4, let param5, let param6, let param7, let param8):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
@@ -171,9 +171,9 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
             param6.bridgeJSLowerStackReturn()
             param7.bridgeJSLowerStackReturn()
             param8.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         case .info:
-            _swift_js_push_tag(Int32(5))
+            _swift_js_push_i32(Int32(5))
         }
     }
 }
@@ -225,16 +225,16 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0, let param1):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .status(let param0, let param1, let param2):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
             param2.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         }
     }
 }
@@ -279,11 +279,11 @@ extension NetworkingResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0, let param1):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         }
     }
 }
@@ -363,7 +363,7 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
             __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0, let param1):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
@@ -375,7 +375,7 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
             __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .status(let param0, let param1, let param2):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
@@ -392,7 +392,7 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
             __bjs_unwrapped_param2.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param2 ? 1 : 0)
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         }
     }
 }
@@ -504,26 +504,26 @@ extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .precision(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .direction(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .optPrecision(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
             __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .optDirection(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
             __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .empty:
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         }
     }
 }
@@ -586,21 +586,21 @@ extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .structPayload(let param0):
             param0.bridgeJSLowerReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .classPayload(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .jsObjectPayload(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .nestedEnum(let param0):
             param0.bridgeJSLowerReturn()
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .arrayPayload(let param0):
             param0.bridgeJSLowerReturn()
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         case .empty:
-            _swift_js_push_tag(Int32(5))
+            _swift_js_push_i32(Int32(5))
         }
     }
 }
@@ -675,33 +675,33 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .optStruct(let param0):
             param0.bridgeJSLowerReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .optClass(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
             __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .optJSObject(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
             __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .optNestedEnum(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
             _swift_js_push_i32(__bjs_unwrapped_param0.bridgeJSLowerParameter())
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .optArray(let param0):
             param0.bridgeJSLowerReturn()
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         case .empty:
-            _swift_js_push_tag(Int32(5))
+            _swift_js_push_i32(Int32(5))
         }
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
@@ -401,10 +401,10 @@ extension Result: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         }
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.Global.swift
@@ -83,10 +83,10 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         }
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.swift
@@ -83,10 +83,10 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         }
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
@@ -1245,21 +1245,21 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .flag(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .rate(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .precise(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         case .info:
-            _swift_js_push_tag(Int32(5))
+            _swift_js_push_i32(Int32(5))
         }
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
@@ -31,7 +31,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -92,9 +91,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -64,9 +63,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
@@ -24,7 +24,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -117,9 +116,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
@@ -99,7 +99,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -698,7 +697,7 @@ export async function createInstantiator(options, swift) {
                         return { tag: AllTypesResultValues.Tag.JsObjectPayload, param0: obj };
                     }
                     case AllTypesResultValues.Tag.NestedEnum: {
-                        const enumValue = enumHelpers.APIResult.lift(tagStack.pop(), );
+                        const enumValue = enumHelpers.APIResult.lift(i32Stack.pop(), );
                         return { tag: AllTypesResultValues.Tag.NestedEnum, param0: enumValue };
                     }
                     case AllTypesResultValues.Tag.ArrayPayload: {
@@ -910,9 +909,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);
@@ -1136,13 +1132,13 @@ export async function createInstantiator(options, swift) {
                 },
                 getResult: function bjs_getResult() {
                     instance.exports.bjs_getResult();
-                    const ret = enumHelpers.APIResult.lift(tagStack.pop());
+                    const ret = enumHelpers.APIResult.lift(i32Stack.pop());
                     return ret;
                 },
                 roundtripAPIResult: function bjs_roundtripAPIResult(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.APIResult.lower(result);
                     instance.exports.bjs_roundtripAPIResult(resultCaseId);
-                    const ret = enumHelpers.APIResult.lift(tagStack.pop());
+                    const ret = enumHelpers.APIResult.lift(i32Stack.pop());
                     if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
@@ -1155,7 +1151,7 @@ export async function createInstantiator(options, swift) {
                         resultCleanup = enumResult.cleanup;
                     }
                     instance.exports.bjs_roundTripOptionalAPIResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = tagStack.pop();
+                    const tag = i32Stack.pop();
                     const isNull = (tag === -1);
                     let optResult;
                     if (isNull) {
@@ -1173,13 +1169,13 @@ export async function createInstantiator(options, swift) {
                 },
                 getComplexResult: function bjs_getComplexResult() {
                     instance.exports.bjs_getComplexResult();
-                    const ret = enumHelpers.ComplexResult.lift(tagStack.pop());
+                    const ret = enumHelpers.ComplexResult.lift(i32Stack.pop());
                     return ret;
                 },
                 roundtripComplexResult: function bjs_roundtripComplexResult(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.ComplexResult.lower(result);
                     instance.exports.bjs_roundtripComplexResult(resultCaseId);
-                    const ret = enumHelpers.ComplexResult.lift(tagStack.pop());
+                    const ret = enumHelpers.ComplexResult.lift(i32Stack.pop());
                     if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
@@ -1192,7 +1188,7 @@ export async function createInstantiator(options, swift) {
                         resultCleanup = enumResult.cleanup;
                     }
                     instance.exports.bjs_roundTripOptionalComplexResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = tagStack.pop();
+                    const tag = i32Stack.pop();
                     const isNull = (tag === -1);
                     let optResult;
                     if (isNull) {
@@ -1212,7 +1208,7 @@ export async function createInstantiator(options, swift) {
                         resultCleanup = enumResult.cleanup;
                     }
                     instance.exports.bjs_roundTripOptionalUtilitiesResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = tagStack.pop();
+                    const tag = i32Stack.pop();
                     const isNull = (tag === -1);
                     let optResult;
                     if (isNull) {
@@ -1232,7 +1228,7 @@ export async function createInstantiator(options, swift) {
                         resultCleanup = enumResult.cleanup;
                     }
                     instance.exports.bjs_roundTripOptionalNetworkingResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = tagStack.pop();
+                    const tag = i32Stack.pop();
                     const isNull = (tag === -1);
                     let optResult;
                     if (isNull) {
@@ -1252,7 +1248,7 @@ export async function createInstantiator(options, swift) {
                         resultCleanup = enumResult.cleanup;
                     }
                     instance.exports.bjs_roundTripOptionalAPIOptionalResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = tagStack.pop();
+                    const tag = i32Stack.pop();
                     const isNull = (tag === -1);
                     let optResult;
                     if (isNull) {
@@ -1279,7 +1275,7 @@ export async function createInstantiator(options, swift) {
                         result2Cleanup = enumResult1.cleanup;
                     }
                     instance.exports.bjs_compareAPIResults(+isSome, isSome ? result1CaseId : 0, +isSome1, isSome1 ? result2CaseId : 0);
-                    const tag = tagStack.pop();
+                    const tag = i32Stack.pop();
                     const isNull = (tag === -1);
                     let optResult;
                     if (isNull) {
@@ -1294,7 +1290,7 @@ export async function createInstantiator(options, swift) {
                 roundTripTypedPayloadResult: function bjs_roundTripTypedPayloadResult(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.TypedPayloadResult.lower(result);
                     instance.exports.bjs_roundTripTypedPayloadResult(resultCaseId);
-                    const ret = enumHelpers.TypedPayloadResult.lift(tagStack.pop());
+                    const ret = enumHelpers.TypedPayloadResult.lift(i32Stack.pop());
                     if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
@@ -1307,7 +1303,7 @@ export async function createInstantiator(options, swift) {
                         resultCleanup = enumResult.cleanup;
                     }
                     instance.exports.bjs_roundTripOptionalTypedPayloadResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = tagStack.pop();
+                    const tag = i32Stack.pop();
                     const isNull = (tag === -1);
                     let optResult;
                     if (isNull) {
@@ -1321,7 +1317,7 @@ export async function createInstantiator(options, swift) {
                 roundTripAllTypesResult: function bjs_roundTripAllTypesResult(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.AllTypesResult.lower(result);
                     instance.exports.bjs_roundTripAllTypesResult(resultCaseId);
-                    const ret = enumHelpers.AllTypesResult.lift(tagStack.pop());
+                    const ret = enumHelpers.AllTypesResult.lift(i32Stack.pop());
                     if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
@@ -1334,7 +1330,7 @@ export async function createInstantiator(options, swift) {
                         resultCleanup = enumResult.cleanup;
                     }
                     instance.exports.bjs_roundTripOptionalAllTypesResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = tagStack.pop();
+                    const tag = i32Stack.pop();
                     const isNull = (tag === -1);
                     let optResult;
                     if (isNull) {
@@ -1348,7 +1344,7 @@ export async function createInstantiator(options, swift) {
                 roundTripOptionalPayloadResult: function bjs_roundTripOptionalPayloadResult(result) {
                     const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.OptionalAllTypesResult.lower(result);
                     instance.exports.bjs_roundTripOptionalPayloadResult(resultCaseId);
-                    const ret = enumHelpers.OptionalAllTypesResult.lift(tagStack.pop());
+                    const ret = enumHelpers.OptionalAllTypesResult.lift(i32Stack.pop());
                     if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
@@ -1361,7 +1357,7 @@ export async function createInstantiator(options, swift) {
                         resultCleanup = enumResult.cleanup;
                     }
                     instance.exports.bjs_roundTripOptionalPayloadResultOpt(+isSome, isSome ? resultCaseId : 0);
-                    const tag = tagStack.pop();
+                    const tag = i32Stack.pop();
                     const isNull = (tag === -1);
                     let optResult;
                     if (isNull) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
@@ -42,7 +42,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -88,9 +87,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
@@ -62,7 +62,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -108,9 +107,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
@@ -43,7 +43,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -89,9 +88,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
@@ -93,7 +93,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -140,9 +139,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -64,9 +63,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -129,9 +128,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -154,9 +153,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -64,9 +63,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -64,9 +63,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -64,9 +63,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -64,9 +63,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -64,9 +63,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -64,9 +63,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
@@ -42,7 +42,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -127,9 +126,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
@@ -29,7 +29,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -114,9 +113,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);
@@ -332,7 +328,7 @@ export async function createInstantiator(options, swift) {
                     roundtrip: function(value) {
                         const { caseId: valueCaseId, cleanup: valueCleanup } = enumHelpers.APIResult.lower(value);
                         instance.exports.bjs_APIResult_static_roundtrip(valueCaseId);
-                        const ret = enumHelpers.APIResult.lift(tagStack.pop());
+                        const ret = enumHelpers.APIResult.lift(i32Stack.pop());
                         if (valueCleanup) { valueCleanup(); }
                         return ret;
                     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
@@ -29,7 +29,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -114,9 +113,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);
@@ -326,7 +322,7 @@ export async function createInstantiator(options, swift) {
                     roundtrip: function(value) {
                         const { caseId: valueCaseId, cleanup: valueCleanup } = enumHelpers.APIResult.lower(value);
                         instance.exports.bjs_APIResult_static_roundtrip(valueCaseId);
-                        const ret = enumHelpers.APIResult.lift(tagStack.pop());
+                        const ret = enumHelpers.APIResult.lift(i32Stack.pop());
                         if (valueCleanup) { valueCleanup(); }
                         return ret;
                     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -69,9 +68,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -69,9 +68,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -48,7 +48,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -190,9 +189,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);
@@ -419,7 +415,7 @@ export async function createInstantiator(options, swift) {
                 const lower_closure_TestModule_10TestModule9APIResultO_9APIResultO = function(param0) {
                     const { caseId: param0CaseId, cleanup: param0Cleanup } = enumHelpers.APIResult.lower(param0);
                     instance.exports.invoke_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO(boxPtr, param0CaseId);
-                    const ret = enumHelpers.APIResult.lift(tagStack.pop());
+                    const ret = enumHelpers.APIResult.lift(i32Stack.pop());
                     if (param0Cleanup) { param0Cleanup(); }
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
@@ -701,7 +697,7 @@ export async function createInstantiator(options, swift) {
                         param0Cleanup = enumResult.cleanup;
                     }
                     instance.exports.invoke_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO(boxPtr, +isSome, isSome ? param0CaseId : 0);
-                    const tag = tagStack.pop();
+                    const tag = i32Stack.pop();
                     const isNull = (tag === -1);
                     let optResult;
                     if (isNull) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -90,9 +89,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -322,9 +321,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -79,9 +78,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -64,9 +63,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -84,9 +83,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
@@ -18,7 +18,6 @@ export async function createInstantiator(options, swift) {
     let tmpRetOptionalFloat;
     let tmpRetOptionalDouble;
     let tmpRetOptionalHeapObject;
-    let tagStack = [];
     let strStack = [];
     let i32Stack = [];
     let f32Stack = [];
@@ -65,9 +64,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_release"] = function(id) {
                 swift.memory.release(id);
-            }
-            bjs["swift_js_push_tag"] = function(tag) {
-                tagStack.push(tag);
             }
             bjs["swift_js_push_i32"] = function(v) {
                 i32Stack.push(v | 0);

--- a/Plugins/PackageToJS/Templates/instantiate.js
+++ b/Plugins/PackageToJS/Templates/instantiate.js
@@ -39,7 +39,6 @@ async function createInstantiator(options, swift) {
                 swift_js_throw: unexpectedBjsCall,
                 swift_js_retain: unexpectedBjsCall,
                 swift_js_release: unexpectedBjsCall,
-                swift_js_push_tag: unexpectedBjsCall,
                 swift_js_push_i32: unexpectedBjsCall,
                 swift_js_push_f32: unexpectedBjsCall,
                 swift_js_push_f64: unexpectedBjsCall,

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -695,15 +695,6 @@ where Self: RawRepresentable, RawValue: _BridgedSwiftTypeLoweredIntoSingleWasmCo
 #endif
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_push_tag")
-@_spi(BridgeJS) public func _swift_js_push_tag(_ tag: Int32)
-#else
-@_spi(BridgeJS) public func _swift_js_push_tag(_ tag: Int32) {
-    _onlyAvailableOnWasm()
-}
-#endif
-
-#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_push_string")
 @_spi(BridgeJS) public func _swift_js_push_string(_ ptr: UnsafePointer<UInt8>?, _ len: Int32)
 #else
@@ -1963,7 +1954,7 @@ extension Optional where Wrapped: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Void {
         switch consume self {
         case .none:
-            _swift_js_push_tag(-1)  // Use -1 as sentinel for null
+            _swift_js_push_i32(-1)  // Use -1 as sentinel for null
         case .some(let value):
             value.bridgeJSLowerReturn()
         }

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -2083,21 +2083,21 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .flag(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .rate(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .precise(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         case .info:
-            _swift_js_push_tag(Int32(5))
+            _swift_js_push_i32(Int32(5))
         }
     }
 }
@@ -2180,26 +2180,26 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .error(let param0, let param1):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .location(let param0, let param1, let param2):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
             param2.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .status(let param0, let param1, let param2):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
             param2.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .coordinates(let param0, let param1, let param2):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
             param2.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         case .comprehensive(let param0, let param1, let param2, let param3, let param4, let param5, let param6, let param7, let param8):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
@@ -2210,9 +2210,9 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
             param6.bridgeJSLowerStackReturn()
             param7.bridgeJSLowerStackReturn()
             param8.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(5))
+            _swift_js_push_i32(Int32(5))
         case .info:
-            _swift_js_push_tag(Int32(6))
+            _swift_js_push_i32(Int32(6))
         }
     }
 }
@@ -2264,16 +2264,16 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0, let param1):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .status(let param0, let param1, let param2):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
             param2.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         }
     }
 }
@@ -2318,11 +2318,11 @@ extension API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .success(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0, let param1):
             param0.bridgeJSLowerStackReturn()
             param1.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         }
     }
 }
@@ -2390,24 +2390,24 @@ extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .structPayload(let param0):
             param0.bridgeJSLowerReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .classPayload(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .jsObjectPayload(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .nestedEnum(let param0):
             param0.bridgeJSLowerReturn()
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .arrayPayload(let param0):
             param0.bridgeJSLowerReturn()
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         case .jsClassPayload(let param0):
             param0.jsObject.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(5))
+            _swift_js_push_i32(Int32(5))
         case .empty:
-            _swift_js_push_tag(Int32(6))
+            _swift_js_push_i32(Int32(6))
         }
     }
 }
@@ -2473,26 +2473,26 @@ extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .precision(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .direction(let param0):
             param0.bridgeJSLowerStackReturn()
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .optPrecision(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
             __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .optDirection(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
             __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .empty:
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         }
     }
 }
@@ -2881,40 +2881,40 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
         switch self {
         case .optStruct(let param0):
             param0.bridgeJSLowerReturn()
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .optClass(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
             __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .optJSObject(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
             __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         case .optNestedEnum(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
             _swift_js_push_i32(__bjs_unwrapped_param0.bridgeJSLowerParameter())
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(3))
+            _swift_js_push_i32(Int32(3))
         case .optArray(let param0):
             param0.bridgeJSLowerReturn()
-            _swift_js_push_tag(Int32(4))
+            _swift_js_push_i32(Int32(4))
         case .optJsClass(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
             __bjs_unwrapped_param0.jsObject.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(5))
+            _swift_js_push_i32(Int32(5))
         case .empty:
-            _swift_js_push_tag(Int32(6))
+            _swift_js_push_i32(Int32(6))
         }
     }
 }
@@ -2994,7 +2994,7 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
             __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
-            _swift_js_push_tag(Int32(0))
+            _swift_js_push_i32(Int32(0))
         case .failure(let param0, let param1):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
@@ -3006,7 +3006,7 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
             __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
-            _swift_js_push_tag(Int32(1))
+            _swift_js_push_i32(Int32(1))
         case .status(let param0, let param1, let param2):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
@@ -3023,7 +3023,7 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
             __bjs_unwrapped_param2.bridgeJSLowerStackReturn()
             }
             _swift_js_push_i32(__bjs_isSome_param2 ? 1 : 0)
-            _swift_js_push_tag(Int32(2))
+            _swift_js_push_i32(Int32(2))
         }
     }
 }


### PR DESCRIPTION
After the tag push/pop ordering fix, we no longer need the separate stack for enum tag.