### PR TITLE
NFC: BridgeJS: Centralize type info on BridgeType, remove dead cleanup infrastructure

### DIFF
--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -132,10 +132,7 @@ extension SimpleStruct: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_SimpleStruct(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_SimpleStruct(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -148,9 +145,9 @@ extension SimpleStruct: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_SimpleStruct")
-fileprivate func _bjs_struct_lower_SimpleStruct(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_SimpleStruct(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_SimpleStruct(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_SimpleStruct(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -179,10 +176,7 @@ extension Address: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -195,9 +189,9 @@ extension Address: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Address")
-fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -232,10 +226,7 @@ extension Person: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Person(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Person(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -248,9 +239,9 @@ extension Person: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Person")
-fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -285,10 +276,7 @@ extension ComplexStruct: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_ComplexStruct(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_ComplexStruct(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -301,9 +289,9 @@ extension ComplexStruct: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ComplexStruct")
-fileprivate func _bjs_struct_lower_ComplexStruct(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_ComplexStruct(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ComplexStruct(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_ComplexStruct(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -330,10 +318,7 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -346,9 +331,9 @@ extension Point: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.swift
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.swift
@@ -24,10 +24,7 @@ extension PlayBridgeJSOutput: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_PlayBridgeJSOutput(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_PlayBridgeJSOutput(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -40,9 +37,9 @@ extension PlayBridgeJSOutput: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PlayBridgeJSOutput")
-fileprivate func _bjs_struct_lower_PlayBridgeJSOutput(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_PlayBridgeJSOutput(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PlayBridgeJSOutput(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_PlayBridgeJSOutput(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -77,10 +74,7 @@ extension PlayBridgeJSDiagnostic: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_PlayBridgeJSDiagnostic(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_PlayBridgeJSDiagnostic(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -93,9 +87,9 @@ extension PlayBridgeJSDiagnostic: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PlayBridgeJSDiagnostic")
-fileprivate func _bjs_struct_lower_PlayBridgeJSDiagnostic(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_PlayBridgeJSDiagnostic(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PlayBridgeJSDiagnostic(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_PlayBridgeJSDiagnostic(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -122,10 +116,7 @@ extension PlayBridgeJSResult: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_PlayBridgeJSResult(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_PlayBridgeJSResult(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -138,9 +129,9 @@ extension PlayBridgeJSResult: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PlayBridgeJSResult")
-fileprivate func _bjs_struct_lower_PlayBridgeJSResult(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_PlayBridgeJSResult(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PlayBridgeJSResult(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_PlayBridgeJSResult(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ClosureCodegen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ClosureCodegen.swift
@@ -123,23 +123,23 @@ public struct ClosureCodegen {
 
         for (index, paramType) in signature.parameters.enumerated() {
             let paramName = "param\(index)"
-            let liftInfo = try paramType.liftParameterInfo()
+            let liftParams = try paramType.liftParameterInfo()
 
-            for (argName, wasmType) in liftInfo.parameters {
+            for (argName, wasmType) in liftParams {
                 let fullName =
-                    liftInfo.parameters.count > 1 ? "\(paramName)\(argName.capitalizedFirstLetter)" : paramName
+                    liftParams.count > 1 ? "\(paramName)\(argName.capitalizedFirstLetter)" : paramName
                 abiParams.append((fullName, wasmType))
             }
 
-            let argNames = liftInfo.parameters.map { (argName, _) in
-                liftInfo.parameters.count > 1 ? "\(paramName)\(argName.capitalizedFirstLetter)" : paramName
+            let argNames = liftParams.map { (argName, _) in
+                liftParams.count > 1 ? "\(paramName)\(argName.capitalizedFirstLetter)" : paramName
             }
             liftedParams.append("\(paramType.swiftType).bridgeJSLiftParameter(\(argNames.joined(separator: ", ")))")
         }
 
         let closureCallExpr = ExprSyntax("closure(\(raw: liftedParams.joined(separator: ", ")))")
 
-        let abiReturnWasmType = try signature.returnType.loweringReturnInfo().returnType
+        let abiReturnWasmType = try signature.returnType.loweringReturnInfo()
 
         // Build signature using SwiftSignatureBuilder
         let funcSignature = SwiftSignatureBuilder.buildABIFunctionSignature(

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
@@ -57,10 +57,7 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -73,9 +70,9 @@ extension Point: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.ReverseOrder.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.ReverseOrder.swift
@@ -11,9 +11,9 @@ public func _bjs_ClassA_linkedB_get(_ _self: UnsafeMutableRawPointer) -> Void {
 
 @_expose(wasm, "bjs_ClassA_linkedB_set")
 @_cdecl("bjs_ClassA_linkedB_set")
-public func _bjs_ClassA_linkedB_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+public func _bjs_ClassA_linkedB_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valuePointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ClassA.bridgeJSLiftParameter(_self).linkedB = Optional<ClassB>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    ClassA.bridgeJSLiftParameter(_self).linkedB = Optional<ClassB>.bridgeJSLiftParameter(valueIsSome, valuePointer)
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.swift
@@ -47,9 +47,9 @@ public func _bjs_ClassA_linkedB_get(_ _self: UnsafeMutableRawPointer) -> Void {
 
 @_expose(wasm, "bjs_ClassA_linkedB_set")
 @_cdecl("bjs_ClassA_linkedB_set")
-public func _bjs_ClassA_linkedB_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+public func _bjs_ClassA_linkedB_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valuePointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ClassA.bridgeJSLiftParameter(_self).linkedB = Optional<ClassB>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    ClassA.bridgeJSLiftParameter(_self).linkedB = Optional<ClassB>.bridgeJSLiftParameter(valueIsSome, valuePointer)
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.swift
@@ -52,10 +52,7 @@ extension Config: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Config(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Config(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -68,9 +65,9 @@ extension Config: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Config")
-fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -95,10 +92,7 @@ extension MathOperations: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_MathOperations(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_MathOperations(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -111,9 +105,9 @@ extension MathOperations: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_MathOperations")
-fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
@@ -413,10 +413,7 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -429,9 +426,9 @@ extension Point: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.swift
@@ -15,10 +15,7 @@ extension FooContainer: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_FooContainer(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_FooContainer(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -31,9 +28,9 @@ extension FooContainer: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_FooContainer")
-fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.swift
@@ -1,8 +1,8 @@
 @_expose(wasm, "bjs_roundTripOptionalClass")
 @_cdecl("bjs_roundTripOptionalClass")
-public func _bjs_roundTripOptionalClass(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+public func _bjs_roundTripOptionalClass(_ valueIsSome: Int32, _ valuePointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalClass(value: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    let ret = roundTripOptionalClass(value: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valuePointer))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -11,9 +11,9 @@ public func _bjs_roundTripOptionalClass(_ valueIsSome: Int32, _ valueValue: Unsa
 
 @_expose(wasm, "bjs_testOptionalPropertyRoundtrip")
 @_cdecl("bjs_testOptionalPropertyRoundtrip")
-public func _bjs_testOptionalPropertyRoundtrip(_ holderIsSome: Int32, _ holderValue: UnsafeMutableRawPointer) -> Void {
+public func _bjs_testOptionalPropertyRoundtrip(_ holderIsSome: Int32, _ holderPointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = testOptionalPropertyRoundtrip(_: Optional<OptionalPropertyHolder>.bridgeJSLiftParameter(holderIsSome, holderValue))
+    let ret = testOptionalPropertyRoundtrip(_: Optional<OptionalPropertyHolder>.bridgeJSLiftParameter(holderIsSome, holderPointer))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -307,9 +307,9 @@ public func _bjs_OptionalPropertyHolder_optionalGreeter_get(_ _self: UnsafeMutab
 
 @_expose(wasm, "bjs_OptionalPropertyHolder_optionalGreeter_set")
 @_cdecl("bjs_OptionalPropertyHolder_optionalGreeter_set")
-public func _bjs_OptionalPropertyHolder_optionalGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+public func _bjs_OptionalPropertyHolder_optionalGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valuePointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valuePointer)
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
@@ -544,7 +544,7 @@ public func _bjs_MyViewController_sendHelper(_ _self: UnsafeMutableRawPointer, _
 @_cdecl("bjs_MyViewController_delegate_get")
 public func _bjs_MyViewController_delegate_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = MyViewController.bridgeJSLiftParameter(_self).delegate as! AnyMyViewControllerDelegate
+    let ret = (MyViewController.bridgeJSLiftParameter(_self).delegate as! AnyMyViewControllerDelegate)
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
@@ -729,10 +729,10 @@ extension JSTypedClosure where Signature == (Optional<Person>) -> Optional<Perso
 
 @_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC")
 @_cdecl("invoke_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC")
-public func _invoke_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: UnsafeMutableRawPointer) -> Void {
+public func _invoke_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<Person>) -> Optional<Person>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<Person>.bridgeJSLiftParameter(param0IsSome, param0Value))
+    let result = closure(Optional<Person>.bridgeJSLiftParameter(param0IsSome, param0Pointer))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.swift
@@ -28,10 +28,7 @@ extension DataPoint: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_DataPoint(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_DataPoint(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -44,9 +41,9 @@ extension DataPoint: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_DataPoint")
-fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -90,10 +87,7 @@ extension Address: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -106,9 +100,9 @@ extension Address: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Address")
-fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -143,10 +137,7 @@ extension Person: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Person(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Person(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -159,9 +150,9 @@ extension Person: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Person")
-fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -188,10 +179,7 @@ extension Session: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Session(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Session(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -204,9 +192,9 @@ extension Session: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Session")
-fileprivate func _bjs_struct_lower_Session(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Session(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Session(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Session(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -239,10 +227,7 @@ extension Measurement: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Measurement(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Measurement(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -255,9 +240,9 @@ extension Measurement: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Measurement")
-fileprivate func _bjs_struct_lower_Measurement(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Measurement(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Measurement(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Measurement(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -280,10 +265,7 @@ extension ConfigStruct: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_ConfigStruct(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_ConfigStruct(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -296,9 +278,9 @@ extension ConfigStruct: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ConfigStruct")
-fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -404,10 +386,7 @@ extension Container: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Container(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Container(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -420,9 +399,9 @@ extension Container: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Container")
-fileprivate func _bjs_struct_lower_Container(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Container(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Container(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Container(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
@@ -11,10 +11,7 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -27,9 +24,9 @@ extension Point: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/UnsafePointer.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/UnsafePointer.swift
@@ -17,10 +17,7 @@ extension PointerFields: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_PointerFields(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_PointerFields(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -33,9 +30,9 @@ extension PointerFields: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PointerFields")
-fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -76,8 +75,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -93,16 +91,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
@@ -104,573 +104,645 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createPointHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                f64Stack.push(value.x);
-                f64Stack.push(value.y);
-                return { cleanup: undefined };
-            },
-            lift: () => {
-                const f64 = f64Stack.pop();
-                const f641 = f64Stack.pop();
-                return { x: f641, y: f64 };
-            }
-        });
-    };
-    const __bjs_createAPIResultValuesHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                const enumTag = value.tag;
-                switch (enumTag) {
-                    case APIResultValues.Tag.Success: {
-                        const bytes = textEncoder.encode(value.param0);
-                        const id = swift.memory.retain(bytes);
-                        i32Stack.push(bytes.length);
-                        i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Success, cleanup };
-                    }
-                    case APIResultValues.Tag.Failure: {
-                        i32Stack.push((value.param0 | 0));
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Failure, cleanup };
-                    }
-                    case APIResultValues.Tag.Flag: {
-                        i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Flag, cleanup };
-                    }
-                    case APIResultValues.Tag.Rate: {
-                        f32Stack.push(Math.fround(value.param0));
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Rate, cleanup };
-                    }
-                    case APIResultValues.Tag.Precise: {
-                        f64Stack.push(value.param0);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Precise, cleanup };
-                    }
-                    case APIResultValues.Tag.Info: {
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Info, cleanup };
-                    }
-                    default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
+    const __bjs_createPointHelpers = () => ({
+        lower: (value) => {
+            f64Stack.push(value.x);
+            f64Stack.push(value.y);
+        },
+        lift: () => {
+            const f64 = f64Stack.pop();
+            const f641 = f64Stack.pop();
+            return { x: f641, y: f64 };
+        }
+    });
+    const __bjs_createAPIResultValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case APIResultValues.Tag.Success: {
+                    const bytes = textEncoder.encode(value.param0);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    return APIResultValues.Tag.Success;
                 }
-            },
-            lift: (tag) => {
-                tag = tag | 0;
-                switch (tag) {
-                    case APIResultValues.Tag.Success: {
-                        const string = strStack.pop();
-                        return { tag: APIResultValues.Tag.Success, param0: string };
-                    }
-                    case APIResultValues.Tag.Failure: {
-                        const int = i32Stack.pop();
-                        return { tag: APIResultValues.Tag.Failure, param0: int };
-                    }
-                    case APIResultValues.Tag.Flag: {
-                        const bool = i32Stack.pop() !== 0;
-                        return { tag: APIResultValues.Tag.Flag, param0: bool };
-                    }
-                    case APIResultValues.Tag.Rate: {
-                        const f32 = f32Stack.pop();
-                        return { tag: APIResultValues.Tag.Rate, param0: f32 };
-                    }
-                    case APIResultValues.Tag.Precise: {
-                        const f64 = f64Stack.pop();
-                        return { tag: APIResultValues.Tag.Precise, param0: f64 };
-                    }
-                    case APIResultValues.Tag.Info: return { tag: APIResultValues.Tag.Info };
-                    default: throw new Error("Unknown APIResultValues tag returned from Swift: " + String(tag));
+                case APIResultValues.Tag.Failure: {
+                    i32Stack.push((value.param0 | 0));
+                    return APIResultValues.Tag.Failure;
                 }
+                case APIResultValues.Tag.Flag: {
+                    i32Stack.push(value.param0 ? 1 : 0);
+                    return APIResultValues.Tag.Flag;
+                }
+                case APIResultValues.Tag.Rate: {
+                    f32Stack.push(Math.fround(value.param0));
+                    return APIResultValues.Tag.Rate;
+                }
+                case APIResultValues.Tag.Precise: {
+                    f64Stack.push(value.param0);
+                    return APIResultValues.Tag.Precise;
+                }
+                case APIResultValues.Tag.Info: {
+                    return APIResultValues.Tag.Info;
+                }
+                default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
             }
-        });
-    };
-    const __bjs_createComplexResultValuesHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                const enumTag = value.tag;
-                switch (enumTag) {
-                    case ComplexResultValues.Tag.Success: {
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case APIResultValues.Tag.Success: {
+                    const string = strStack.pop();
+                    return { tag: APIResultValues.Tag.Success, param0: string };
+                }
+                case APIResultValues.Tag.Failure: {
+                    const int = i32Stack.pop();
+                    return { tag: APIResultValues.Tag.Failure, param0: int };
+                }
+                case APIResultValues.Tag.Flag: {
+                    const bool = i32Stack.pop() !== 0;
+                    return { tag: APIResultValues.Tag.Flag, param0: bool };
+                }
+                case APIResultValues.Tag.Rate: {
+                    const f32 = f32Stack.pop();
+                    return { tag: APIResultValues.Tag.Rate, param0: f32 };
+                }
+                case APIResultValues.Tag.Precise: {
+                    const f64 = f64Stack.pop();
+                    return { tag: APIResultValues.Tag.Precise, param0: f64 };
+                }
+                case APIResultValues.Tag.Info: return { tag: APIResultValues.Tag.Info };
+                default: throw new Error("Unknown APIResultValues tag returned from Swift: " + String(tag));
+            }
+        }
+    });
+    const __bjs_createComplexResultValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case ComplexResultValues.Tag.Success: {
+                    const bytes = textEncoder.encode(value.param0);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    return ComplexResultValues.Tag.Success;
+                }
+                case ComplexResultValues.Tag.Error: {
+                    i32Stack.push((value.param1 | 0));
+                    const bytes = textEncoder.encode(value.param0);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    return ComplexResultValues.Tag.Error;
+                }
+                case ComplexResultValues.Tag.Status: {
+                    const bytes = textEncoder.encode(value.param2);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    i32Stack.push((value.param1 | 0));
+                    i32Stack.push(value.param0 ? 1 : 0);
+                    return ComplexResultValues.Tag.Status;
+                }
+                case ComplexResultValues.Tag.Coordinates: {
+                    f64Stack.push(value.param2);
+                    f64Stack.push(value.param1);
+                    f64Stack.push(value.param0);
+                    return ComplexResultValues.Tag.Coordinates;
+                }
+                case ComplexResultValues.Tag.Comprehensive: {
+                    const bytes = textEncoder.encode(value.param8);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    const bytes1 = textEncoder.encode(value.param7);
+                    const id1 = swift.memory.retain(bytes1);
+                    i32Stack.push(bytes1.length);
+                    i32Stack.push(id1);
+                    const bytes2 = textEncoder.encode(value.param6);
+                    const id2 = swift.memory.retain(bytes2);
+                    i32Stack.push(bytes2.length);
+                    i32Stack.push(id2);
+                    f64Stack.push(value.param5);
+                    f64Stack.push(value.param4);
+                    i32Stack.push((value.param3 | 0));
+                    i32Stack.push((value.param2 | 0));
+                    i32Stack.push(value.param1 ? 1 : 0);
+                    i32Stack.push(value.param0 ? 1 : 0);
+                    return ComplexResultValues.Tag.Comprehensive;
+                }
+                case ComplexResultValues.Tag.Info: {
+                    return ComplexResultValues.Tag.Info;
+                }
+                default: throw new Error("Unknown ComplexResultValues tag: " + String(enumTag));
+            }
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case ComplexResultValues.Tag.Success: {
+                    const string = strStack.pop();
+                    return { tag: ComplexResultValues.Tag.Success, param0: string };
+                }
+                case ComplexResultValues.Tag.Error: {
+                    const int = i32Stack.pop();
+                    const string = strStack.pop();
+                    return { tag: ComplexResultValues.Tag.Error, param0: string, param1: int };
+                }
+                case ComplexResultValues.Tag.Status: {
+                    const string = strStack.pop();
+                    const int = i32Stack.pop();
+                    const bool = i32Stack.pop() !== 0;
+                    return { tag: ComplexResultValues.Tag.Status, param0: bool, param1: int, param2: string };
+                }
+                case ComplexResultValues.Tag.Coordinates: {
+                    const f64 = f64Stack.pop();
+                    const f641 = f64Stack.pop();
+                    const f642 = f64Stack.pop();
+                    return { tag: ComplexResultValues.Tag.Coordinates, param0: f642, param1: f641, param2: f64 };
+                }
+                case ComplexResultValues.Tag.Comprehensive: {
+                    const string = strStack.pop();
+                    const string1 = strStack.pop();
+                    const string2 = strStack.pop();
+                    const f64 = f64Stack.pop();
+                    const f641 = f64Stack.pop();
+                    const int = i32Stack.pop();
+                    const int1 = i32Stack.pop();
+                    const bool = i32Stack.pop() !== 0;
+                    const bool1 = i32Stack.pop() !== 0;
+                    return { tag: ComplexResultValues.Tag.Comprehensive, param0: bool1, param1: bool, param2: int1, param3: int, param4: f641, param5: f64, param6: string2, param7: string1, param8: string };
+                }
+                case ComplexResultValues.Tag.Info: return { tag: ComplexResultValues.Tag.Info };
+                default: throw new Error("Unknown ComplexResultValues tag returned from Swift: " + String(tag));
+            }
+        }
+    });
+    const __bjs_createResultValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case ResultValues.Tag.Success: {
+                    const bytes = textEncoder.encode(value.param0);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    return ResultValues.Tag.Success;
+                }
+                case ResultValues.Tag.Failure: {
+                    i32Stack.push((value.param1 | 0));
+                    const bytes = textEncoder.encode(value.param0);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    return ResultValues.Tag.Failure;
+                }
+                case ResultValues.Tag.Status: {
+                    const bytes = textEncoder.encode(value.param2);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    i32Stack.push((value.param1 | 0));
+                    i32Stack.push(value.param0 ? 1 : 0);
+                    return ResultValues.Tag.Status;
+                }
+                default: throw new Error("Unknown ResultValues tag: " + String(enumTag));
+            }
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case ResultValues.Tag.Success: {
+                    const string = strStack.pop();
+                    return { tag: ResultValues.Tag.Success, param0: string };
+                }
+                case ResultValues.Tag.Failure: {
+                    const int = i32Stack.pop();
+                    const string = strStack.pop();
+                    return { tag: ResultValues.Tag.Failure, param0: string, param1: int };
+                }
+                case ResultValues.Tag.Status: {
+                    const string = strStack.pop();
+                    const int = i32Stack.pop();
+                    const bool = i32Stack.pop() !== 0;
+                    return { tag: ResultValues.Tag.Status, param0: bool, param1: int, param2: string };
+                }
+                default: throw new Error("Unknown ResultValues tag returned from Swift: " + String(tag));
+            }
+        }
+    });
+    const __bjs_createNetworkingResultValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case NetworkingResultValues.Tag.Success: {
+                    const bytes = textEncoder.encode(value.param0);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    return NetworkingResultValues.Tag.Success;
+                }
+                case NetworkingResultValues.Tag.Failure: {
+                    i32Stack.push((value.param1 | 0));
+                    const bytes = textEncoder.encode(value.param0);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    return NetworkingResultValues.Tag.Failure;
+                }
+                default: throw new Error("Unknown NetworkingResultValues tag: " + String(enumTag));
+            }
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case NetworkingResultValues.Tag.Success: {
+                    const string = strStack.pop();
+                    return { tag: NetworkingResultValues.Tag.Success, param0: string };
+                }
+                case NetworkingResultValues.Tag.Failure: {
+                    const int = i32Stack.pop();
+                    const string = strStack.pop();
+                    return { tag: NetworkingResultValues.Tag.Failure, param0: string, param1: int };
+                }
+                default: throw new Error("Unknown NetworkingResultValues tag returned from Swift: " + String(tag));
+            }
+        }
+    });
+    const __bjs_createAPIOptionalResultValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case APIOptionalResultValues.Tag.Success: {
+                    const isSome = value.param0 != null;
+                    if (isSome) {
                         const bytes = textEncoder.encode(value.param0);
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: ComplexResultValues.Tag.Success, cleanup };
+                    } else {
+                        i32Stack.push(0);
+                        i32Stack.push(0);
                     }
-                    case ComplexResultValues.Tag.Error: {
-                        i32Stack.push((value.param1 | 0));
-                        const bytes = textEncoder.encode(value.param0);
-                        const id = swift.memory.retain(bytes);
-                        i32Stack.push(bytes.length);
-                        i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: ComplexResultValues.Tag.Error, cleanup };
-                    }
-                    case ComplexResultValues.Tag.Status: {
+                    i32Stack.push(isSome ? 1 : 0);
+                    return APIOptionalResultValues.Tag.Success;
+                }
+                case APIOptionalResultValues.Tag.Failure: {
+                    const isSome = value.param1 != null;
+                    i32Stack.push(isSome ? (value.param1 ? 1 : 0) : 0);
+                    i32Stack.push(isSome ? 1 : 0);
+                    const isSome1 = value.param0 != null;
+                    i32Stack.push(isSome1 ? (value.param0 | 0) : 0);
+                    i32Stack.push(isSome1 ? 1 : 0);
+                    return APIOptionalResultValues.Tag.Failure;
+                }
+                case APIOptionalResultValues.Tag.Status: {
+                    const isSome = value.param2 != null;
+                    if (isSome) {
                         const bytes = textEncoder.encode(value.param2);
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        i32Stack.push((value.param1 | 0));
-                        i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: ComplexResultValues.Tag.Status, cleanup };
+                    } else {
+                        i32Stack.push(0);
+                        i32Stack.push(0);
                     }
-                    case ComplexResultValues.Tag.Coordinates: {
-                        f64Stack.push(value.param2);
-                        f64Stack.push(value.param1);
-                        f64Stack.push(value.param0);
-                        const cleanup = undefined;
-                        return { caseId: ComplexResultValues.Tag.Coordinates, cleanup };
-                    }
-                    case ComplexResultValues.Tag.Comprehensive: {
-                        const bytes = textEncoder.encode(value.param8);
-                        const id = swift.memory.retain(bytes);
-                        i32Stack.push(bytes.length);
-                        i32Stack.push(id);
-                        const bytes1 = textEncoder.encode(value.param7);
-                        const id1 = swift.memory.retain(bytes1);
-                        i32Stack.push(bytes1.length);
-                        i32Stack.push(id1);
-                        const bytes2 = textEncoder.encode(value.param6);
-                        const id2 = swift.memory.retain(bytes2);
-                        i32Stack.push(bytes2.length);
-                        i32Stack.push(id2);
-                        f64Stack.push(value.param5);
-                        f64Stack.push(value.param4);
-                        i32Stack.push((value.param3 | 0));
-                        i32Stack.push((value.param2 | 0));
-                        i32Stack.push(value.param1 ? 1 : 0);
-                        i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: ComplexResultValues.Tag.Comprehensive, cleanup };
-                    }
-                    case ComplexResultValues.Tag.Info: {
-                        const cleanup = undefined;
-                        return { caseId: ComplexResultValues.Tag.Info, cleanup };
-                    }
-                    default: throw new Error("Unknown ComplexResultValues tag: " + String(enumTag));
+                    i32Stack.push(isSome ? 1 : 0);
+                    const isSome1 = value.param1 != null;
+                    i32Stack.push(isSome1 ? (value.param1 | 0) : 0);
+                    i32Stack.push(isSome1 ? 1 : 0);
+                    const isSome2 = value.param0 != null;
+                    i32Stack.push(isSome2 ? (value.param0 ? 1 : 0) : 0);
+                    i32Stack.push(isSome2 ? 1 : 0);
+                    return APIOptionalResultValues.Tag.Status;
                 }
-            },
-            lift: (tag) => {
-                tag = tag | 0;
-                switch (tag) {
-                    case ComplexResultValues.Tag.Success: {
+                default: throw new Error("Unknown APIOptionalResultValues tag: " + String(enumTag));
+            }
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case APIOptionalResultValues.Tag.Success: {
+                    const isSome = i32Stack.pop();
+                    let optional;
+                    if (isSome) {
                         const string = strStack.pop();
-                        return { tag: ComplexResultValues.Tag.Success, param0: string };
+                        optional = string;
+                    } else {
+                        optional = null;
                     }
-                    case ComplexResultValues.Tag.Error: {
-                        const int = i32Stack.pop();
-                        const string = strStack.pop();
-                        return { tag: ComplexResultValues.Tag.Error, param0: string, param1: int };
-                    }
-                    case ComplexResultValues.Tag.Status: {
-                        const string = strStack.pop();
-                        const int = i32Stack.pop();
+                    return { tag: APIOptionalResultValues.Tag.Success, param0: optional };
+                }
+                case APIOptionalResultValues.Tag.Failure: {
+                    const isSome = i32Stack.pop();
+                    let optional;
+                    if (isSome) {
                         const bool = i32Stack.pop() !== 0;
-                        return { tag: ComplexResultValues.Tag.Status, param0: bool, param1: int, param2: string };
+                        optional = bool;
+                    } else {
+                        optional = null;
                     }
-                    case ComplexResultValues.Tag.Coordinates: {
-                        const f64 = f64Stack.pop();
-                        const f641 = f64Stack.pop();
-                        const f642 = f64Stack.pop();
-                        return { tag: ComplexResultValues.Tag.Coordinates, param0: f642, param1: f641, param2: f64 };
-                    }
-                    case ComplexResultValues.Tag.Comprehensive: {
-                        const string = strStack.pop();
-                        const string1 = strStack.pop();
-                        const string2 = strStack.pop();
-                        const f64 = f64Stack.pop();
-                        const f641 = f64Stack.pop();
+                    const isSome1 = i32Stack.pop();
+                    let optional1;
+                    if (isSome1) {
                         const int = i32Stack.pop();
-                        const int1 = i32Stack.pop();
+                        optional1 = int;
+                    } else {
+                        optional1 = null;
+                    }
+                    return { tag: APIOptionalResultValues.Tag.Failure, param0: optional1, param1: optional };
+                }
+                case APIOptionalResultValues.Tag.Status: {
+                    const isSome = i32Stack.pop();
+                    let optional;
+                    if (isSome) {
+                        const string = strStack.pop();
+                        optional = string;
+                    } else {
+                        optional = null;
+                    }
+                    const isSome1 = i32Stack.pop();
+                    let optional1;
+                    if (isSome1) {
+                        const int = i32Stack.pop();
+                        optional1 = int;
+                    } else {
+                        optional1 = null;
+                    }
+                    const isSome2 = i32Stack.pop();
+                    let optional2;
+                    if (isSome2) {
                         const bool = i32Stack.pop() !== 0;
-                        const bool1 = i32Stack.pop() !== 0;
-                        return { tag: ComplexResultValues.Tag.Comprehensive, param0: bool1, param1: bool, param2: int1, param3: int, param4: f641, param5: f64, param6: string2, param7: string1, param8: string };
+                        optional2 = bool;
+                    } else {
+                        optional2 = null;
                     }
-                    case ComplexResultValues.Tag.Info: return { tag: ComplexResultValues.Tag.Info };
-                    default: throw new Error("Unknown ComplexResultValues tag returned from Swift: " + String(tag));
+                    return { tag: APIOptionalResultValues.Tag.Status, param0: optional2, param1: optional1, param2: optional };
                 }
+                default: throw new Error("Unknown APIOptionalResultValues tag returned from Swift: " + String(tag));
             }
-        });
-    };
-    const __bjs_createResultValuesHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                const enumTag = value.tag;
-                switch (enumTag) {
-                    case ResultValues.Tag.Success: {
-                        const bytes = textEncoder.encode(value.param0);
-                        const id = swift.memory.retain(bytes);
-                        i32Stack.push(bytes.length);
-                        i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: ResultValues.Tag.Success, cleanup };
-                    }
-                    case ResultValues.Tag.Failure: {
-                        i32Stack.push((value.param1 | 0));
-                        const bytes = textEncoder.encode(value.param0);
-                        const id = swift.memory.retain(bytes);
-                        i32Stack.push(bytes.length);
-                        i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: ResultValues.Tag.Failure, cleanup };
-                    }
-                    case ResultValues.Tag.Status: {
-                        const bytes = textEncoder.encode(value.param2);
-                        const id = swift.memory.retain(bytes);
-                        i32Stack.push(bytes.length);
-                        i32Stack.push(id);
-                        i32Stack.push((value.param1 | 0));
-                        i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: ResultValues.Tag.Status, cleanup };
-                    }
-                    default: throw new Error("Unknown ResultValues tag: " + String(enumTag));
+        }
+    });
+    const __bjs_createTypedPayloadResultValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case TypedPayloadResultValues.Tag.Precision: {
+                    f32Stack.push(Math.fround(value.param0));
+                    return TypedPayloadResultValues.Tag.Precision;
                 }
-            },
-            lift: (tag) => {
-                tag = tag | 0;
-                switch (tag) {
-                    case ResultValues.Tag.Success: {
-                        const string = strStack.pop();
-                        return { tag: ResultValues.Tag.Success, param0: string };
-                    }
-                    case ResultValues.Tag.Failure: {
-                        const int = i32Stack.pop();
-                        const string = strStack.pop();
-                        return { tag: ResultValues.Tag.Failure, param0: string, param1: int };
-                    }
-                    case ResultValues.Tag.Status: {
-                        const string = strStack.pop();
-                        const int = i32Stack.pop();
-                        const bool = i32Stack.pop() !== 0;
-                        return { tag: ResultValues.Tag.Status, param0: bool, param1: int, param2: string };
-                    }
-                    default: throw new Error("Unknown ResultValues tag returned from Swift: " + String(tag));
+                case TypedPayloadResultValues.Tag.Direction: {
+                    i32Stack.push((value.param0 | 0));
+                    return TypedPayloadResultValues.Tag.Direction;
                 }
+                case TypedPayloadResultValues.Tag.OptPrecision: {
+                    const isSome = value.param0 != null;
+                    f32Stack.push(isSome ? Math.fround(value.param0) : 0.0);
+                    i32Stack.push(isSome ? 1 : 0);
+                    return TypedPayloadResultValues.Tag.OptPrecision;
+                }
+                case TypedPayloadResultValues.Tag.OptDirection: {
+                    const isSome = value.param0 != null;
+                    i32Stack.push(isSome ? (value.param0 | 0) : 0);
+                    i32Stack.push(isSome ? 1 : 0);
+                    return TypedPayloadResultValues.Tag.OptDirection;
+                }
+                case TypedPayloadResultValues.Tag.Empty: {
+                    return TypedPayloadResultValues.Tag.Empty;
+                }
+                default: throw new Error("Unknown TypedPayloadResultValues tag: " + String(enumTag));
             }
-        });
-    };
-    const __bjs_createNetworkingResultValuesHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                const enumTag = value.tag;
-                switch (enumTag) {
-                    case NetworkingResultValues.Tag.Success: {
-                        const bytes = textEncoder.encode(value.param0);
-                        const id = swift.memory.retain(bytes);
-                        i32Stack.push(bytes.length);
-                        i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: NetworkingResultValues.Tag.Success, cleanup };
-                    }
-                    case NetworkingResultValues.Tag.Failure: {
-                        i32Stack.push((value.param1 | 0));
-                        const bytes = textEncoder.encode(value.param0);
-                        const id = swift.memory.retain(bytes);
-                        i32Stack.push(bytes.length);
-                        i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: NetworkingResultValues.Tag.Failure, cleanup };
-                    }
-                    default: throw new Error("Unknown NetworkingResultValues tag: " + String(enumTag));
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case TypedPayloadResultValues.Tag.Precision: {
+                    const rawValue = f32Stack.pop();
+                    return { tag: TypedPayloadResultValues.Tag.Precision, param0: rawValue };
                 }
-            },
-            lift: (tag) => {
-                tag = tag | 0;
-                switch (tag) {
-                    case NetworkingResultValues.Tag.Success: {
-                        const string = strStack.pop();
-                        return { tag: NetworkingResultValues.Tag.Success, param0: string };
-                    }
-                    case NetworkingResultValues.Tag.Failure: {
-                        const int = i32Stack.pop();
-                        const string = strStack.pop();
-                        return { tag: NetworkingResultValues.Tag.Failure, param0: string, param1: int };
-                    }
-                    default: throw new Error("Unknown NetworkingResultValues tag returned from Swift: " + String(tag));
+                case TypedPayloadResultValues.Tag.Direction: {
+                    const caseId = i32Stack.pop();
+                    return { tag: TypedPayloadResultValues.Tag.Direction, param0: caseId };
                 }
-            }
-        });
-    };
-    const __bjs_createAPIOptionalResultValuesHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                const enumTag = value.tag;
-                switch (enumTag) {
-                    case APIOptionalResultValues.Tag.Success: {
-                        const isSome = value.param0 != null;
-                        let id;
-                        if (isSome) {
-                            let bytes = textEncoder.encode(value.param0);
-                            id = swift.memory.retain(bytes);
-                            i32Stack.push(bytes.length);
-                            i32Stack.push(id);
-                        } else {
-                            i32Stack.push(0);
-                            i32Stack.push(0);
-                        }
-                        i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: APIOptionalResultValues.Tag.Success, cleanup };
-                    }
-                    case APIOptionalResultValues.Tag.Failure: {
-                        const isSome = value.param1 != null;
-                        i32Stack.push(isSome ? (value.param1 ? 1 : 0) : 0);
-                        i32Stack.push(isSome ? 1 : 0);
-                        const isSome1 = value.param0 != null;
-                        i32Stack.push(isSome1 ? (value.param0 | 0) : 0);
-                        i32Stack.push(isSome1 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: APIOptionalResultValues.Tag.Failure, cleanup };
-                    }
-                    case APIOptionalResultValues.Tag.Status: {
-                        const isSome = value.param2 != null;
-                        let id;
-                        if (isSome) {
-                            let bytes = textEncoder.encode(value.param2);
-                            id = swift.memory.retain(bytes);
-                            i32Stack.push(bytes.length);
-                            i32Stack.push(id);
-                        } else {
-                            i32Stack.push(0);
-                            i32Stack.push(0);
-                        }
-                        i32Stack.push(isSome ? 1 : 0);
-                        const isSome1 = value.param1 != null;
-                        i32Stack.push(isSome1 ? (value.param1 | 0) : 0);
-                        i32Stack.push(isSome1 ? 1 : 0);
-                        const isSome2 = value.param0 != null;
-                        i32Stack.push(isSome2 ? (value.param0 ? 1 : 0) : 0);
-                        i32Stack.push(isSome2 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: APIOptionalResultValues.Tag.Status, cleanup };
-                    }
-                    default: throw new Error("Unknown APIOptionalResultValues tag: " + String(enumTag));
-                }
-            },
-            lift: (tag) => {
-                tag = tag | 0;
-                switch (tag) {
-                    case APIOptionalResultValues.Tag.Success: {
-                        const isSome = i32Stack.pop();
-                        let optional;
-                        if (isSome) {
-                            const string = strStack.pop();
-                            optional = string;
-                        } else {
-                            optional = null;
-                        }
-                        return { tag: APIOptionalResultValues.Tag.Success, param0: optional };
-                    }
-                    case APIOptionalResultValues.Tag.Failure: {
-                        const isSome = i32Stack.pop();
-                        let optional;
-                        if (isSome) {
-                            const bool = i32Stack.pop() !== 0;
-                            optional = bool;
-                        } else {
-                            optional = null;
-                        }
-                        const isSome1 = i32Stack.pop();
-                        let optional1;
-                        if (isSome1) {
-                            const int = i32Stack.pop();
-                            optional1 = int;
-                        } else {
-                            optional1 = null;
-                        }
-                        return { tag: APIOptionalResultValues.Tag.Failure, param0: optional1, param1: optional };
-                    }
-                    case APIOptionalResultValues.Tag.Status: {
-                        const isSome = i32Stack.pop();
-                        let optional;
-                        if (isSome) {
-                            const string = strStack.pop();
-                            optional = string;
-                        } else {
-                            optional = null;
-                        }
-                        const isSome1 = i32Stack.pop();
-                        let optional1;
-                        if (isSome1) {
-                            const int = i32Stack.pop();
-                            optional1 = int;
-                        } else {
-                            optional1 = null;
-                        }
-                        const isSome2 = i32Stack.pop();
-                        let optional2;
-                        if (isSome2) {
-                            const bool = i32Stack.pop() !== 0;
-                            optional2 = bool;
-                        } else {
-                            optional2 = null;
-                        }
-                        return { tag: APIOptionalResultValues.Tag.Status, param0: optional2, param1: optional1, param2: optional };
-                    }
-                    default: throw new Error("Unknown APIOptionalResultValues tag returned from Swift: " + String(tag));
-                }
-            }
-        });
-    };
-    const __bjs_createTypedPayloadResultValuesHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                const enumTag = value.tag;
-                switch (enumTag) {
-                    case TypedPayloadResultValues.Tag.Precision: {
-                        f32Stack.push(Math.fround(value.param0));
-                        const cleanup = undefined;
-                        return { caseId: TypedPayloadResultValues.Tag.Precision, cleanup };
-                    }
-                    case TypedPayloadResultValues.Tag.Direction: {
-                        i32Stack.push((value.param0 | 0));
-                        const cleanup = undefined;
-                        return { caseId: TypedPayloadResultValues.Tag.Direction, cleanup };
-                    }
-                    case TypedPayloadResultValues.Tag.OptPrecision: {
-                        const isSome = value.param0 != null;
-                        f32Stack.push(isSome ? Math.fround(value.param0) : 0.0);
-                        i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: TypedPayloadResultValues.Tag.OptPrecision, cleanup };
-                    }
-                    case TypedPayloadResultValues.Tag.OptDirection: {
-                        const isSome = value.param0 != null;
-                        i32Stack.push(isSome ? (value.param0 | 0) : 0);
-                        i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: TypedPayloadResultValues.Tag.OptDirection, cleanup };
-                    }
-                    case TypedPayloadResultValues.Tag.Empty: {
-                        const cleanup = undefined;
-                        return { caseId: TypedPayloadResultValues.Tag.Empty, cleanup };
-                    }
-                    default: throw new Error("Unknown TypedPayloadResultValues tag: " + String(enumTag));
-                }
-            },
-            lift: (tag) => {
-                tag = tag | 0;
-                switch (tag) {
-                    case TypedPayloadResultValues.Tag.Precision: {
+                case TypedPayloadResultValues.Tag.OptPrecision: {
+                    const isSome = i32Stack.pop();
+                    let optional;
+                    if (isSome) {
                         const rawValue = f32Stack.pop();
-                        return { tag: TypedPayloadResultValues.Tag.Precision, param0: rawValue };
+                        optional = rawValue;
+                    } else {
+                        optional = null;
                     }
-                    case TypedPayloadResultValues.Tag.Direction: {
-                        const caseId = i32Stack.pop();
-                        return { tag: TypedPayloadResultValues.Tag.Direction, param0: caseId };
-                    }
-                    case TypedPayloadResultValues.Tag.OptPrecision: {
-                        const isSome = i32Stack.pop();
-                        let optional;
-                        if (isSome) {
-                            const rawValue = f32Stack.pop();
-                            optional = rawValue;
-                        } else {
-                            optional = null;
-                        }
-                        return { tag: TypedPayloadResultValues.Tag.OptPrecision, param0: optional };
-                    }
-                    case TypedPayloadResultValues.Tag.OptDirection: {
-                        const isSome = i32Stack.pop();
-                        let optional;
-                        if (isSome) {
-                            const caseId = i32Stack.pop();
-                            optional = caseId;
-                        } else {
-                            optional = null;
-                        }
-                        return { tag: TypedPayloadResultValues.Tag.OptDirection, param0: optional };
-                    }
-                    case TypedPayloadResultValues.Tag.Empty: return { tag: TypedPayloadResultValues.Tag.Empty };
-                    default: throw new Error("Unknown TypedPayloadResultValues tag returned from Swift: " + String(tag));
+                    return { tag: TypedPayloadResultValues.Tag.OptPrecision, param0: optional };
                 }
+                case TypedPayloadResultValues.Tag.OptDirection: {
+                    const isSome = i32Stack.pop();
+                    let optional;
+                    if (isSome) {
+                        const caseId = i32Stack.pop();
+                        optional = caseId;
+                    } else {
+                        optional = null;
+                    }
+                    return { tag: TypedPayloadResultValues.Tag.OptDirection, param0: optional };
+                }
+                case TypedPayloadResultValues.Tag.Empty: return { tag: TypedPayloadResultValues.Tag.Empty };
+                default: throw new Error("Unknown TypedPayloadResultValues tag returned from Swift: " + String(tag));
             }
-        });
-    };
-    const __bjs_createAllTypesResultValuesHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                const enumTag = value.tag;
-                switch (enumTag) {
-                    case AllTypesResultValues.Tag.StructPayload: {
-                        const { cleanup: structCleanup } = structHelpers.Point.lower(value.param0);
-                        const cleanup = () => {
-                            if (structCleanup) { structCleanup(); }
-                        };
-                        return { caseId: AllTypesResultValues.Tag.StructPayload, cleanup };
+        }
+    });
+    const __bjs_createAllTypesResultValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case AllTypesResultValues.Tag.StructPayload: {
+                    structHelpers.Point.lower(value.param0);
+                    return AllTypesResultValues.Tag.StructPayload;
+                }
+                case AllTypesResultValues.Tag.ClassPayload: {
+                    ptrStack.push(value.param0.pointer);
+                    return AllTypesResultValues.Tag.ClassPayload;
+                }
+                case AllTypesResultValues.Tag.JsObjectPayload: {
+                    const objId = swift.memory.retain(value.param0);
+                    i32Stack.push(objId);
+                    return AllTypesResultValues.Tag.JsObjectPayload;
+                }
+                case AllTypesResultValues.Tag.NestedEnum: {
+                    const caseId = enumHelpers.APIResult.lower(value.param0);
+                    i32Stack.push(caseId);
+                    return AllTypesResultValues.Tag.NestedEnum;
+                }
+                case AllTypesResultValues.Tag.ArrayPayload: {
+                    for (const elem of value.param0) {
+                        i32Stack.push((elem | 0));
                     }
-                    case AllTypesResultValues.Tag.ClassPayload: {
+                    i32Stack.push(value.param0.length);
+                    return AllTypesResultValues.Tag.ArrayPayload;
+                }
+                case AllTypesResultValues.Tag.Empty: {
+                    return AllTypesResultValues.Tag.Empty;
+                }
+                default: throw new Error("Unknown AllTypesResultValues tag: " + String(enumTag));
+            }
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case AllTypesResultValues.Tag.StructPayload: {
+                    const struct = structHelpers.Point.lift();
+                    return { tag: AllTypesResultValues.Tag.StructPayload, param0: struct };
+                }
+                case AllTypesResultValues.Tag.ClassPayload: {
+                    const ptr = ptrStack.pop();
+                    const obj = _exports['User'].__construct(ptr);
+                    return { tag: AllTypesResultValues.Tag.ClassPayload, param0: obj };
+                }
+                case AllTypesResultValues.Tag.JsObjectPayload: {
+                    const objId = i32Stack.pop();
+                    const obj = swift.memory.getObject(objId);
+                    swift.memory.release(objId);
+                    return { tag: AllTypesResultValues.Tag.JsObjectPayload, param0: obj };
+                }
+                case AllTypesResultValues.Tag.NestedEnum: {
+                    const enumValue = enumHelpers.APIResult.lift(i32Stack.pop());
+                    return { tag: AllTypesResultValues.Tag.NestedEnum, param0: enumValue };
+                }
+                case AllTypesResultValues.Tag.ArrayPayload: {
+                    const arrayLen = i32Stack.pop();
+                    const arrayResult = [];
+                    for (let i = 0; i < arrayLen; i++) {
+                        const int = i32Stack.pop();
+                        arrayResult.push(int);
+                    }
+                    arrayResult.reverse();
+                    return { tag: AllTypesResultValues.Tag.ArrayPayload, param0: arrayResult };
+                }
+                case AllTypesResultValues.Tag.Empty: return { tag: AllTypesResultValues.Tag.Empty };
+                default: throw new Error("Unknown AllTypesResultValues tag returned from Swift: " + String(tag));
+            }
+        }
+    });
+    const __bjs_createOptionalAllTypesResultValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case OptionalAllTypesResultValues.Tag.OptStruct: {
+                    const isSome = value.param0 != null;
+                    if (isSome) {
+                        structHelpers.Point.lower(value.param0);
+                    }
+                    i32Stack.push(isSome ? 1 : 0);
+                    return OptionalAllTypesResultValues.Tag.OptStruct;
+                }
+                case OptionalAllTypesResultValues.Tag.OptClass: {
+                    const isSome = value.param0 != null;
+                    if (isSome) {
                         ptrStack.push(value.param0.pointer);
-                        const cleanup = undefined;
-                        return { caseId: AllTypesResultValues.Tag.ClassPayload, cleanup };
+                    } else {
+                        ptrStack.push(0);
                     }
-                    case AllTypesResultValues.Tag.JsObjectPayload: {
+                    i32Stack.push(isSome ? 1 : 0);
+                    return OptionalAllTypesResultValues.Tag.OptClass;
+                }
+                case OptionalAllTypesResultValues.Tag.OptJSObject: {
+                    const isSome = value.param0 != null;
+                    if (isSome) {
                         const objId = swift.memory.retain(value.param0);
                         i32Stack.push(objId);
-                        const cleanup = undefined;
-                        return { caseId: AllTypesResultValues.Tag.JsObjectPayload, cleanup };
+                    } else {
+                        i32Stack.push(0);
                     }
-                    case AllTypesResultValues.Tag.NestedEnum: {
-                        const { caseId: caseId, cleanup: enumCleanup } = enumHelpers.APIResult.lower(value.param0);
+                    i32Stack.push(isSome ? 1 : 0);
+                    return OptionalAllTypesResultValues.Tag.OptJSObject;
+                }
+                case OptionalAllTypesResultValues.Tag.OptNestedEnum: {
+                    const isSome = value.param0 != null;
+                    if (isSome) {
+                        const caseId = enumHelpers.APIResult.lower(value.param0);
                         i32Stack.push(caseId);
-                        const cleanup = () => {
-                            if (enumCleanup) { enumCleanup(); }
-                        };
-                        return { caseId: AllTypesResultValues.Tag.NestedEnum, cleanup };
+                    } else {
+                        i32Stack.push(0);
                     }
-                    case AllTypesResultValues.Tag.ArrayPayload: {
-                        const arrayCleanups = [];
+                    i32Stack.push(isSome ? 1 : 0);
+                    return OptionalAllTypesResultValues.Tag.OptNestedEnum;
+                }
+                case OptionalAllTypesResultValues.Tag.OptArray: {
+                    const isSome = value.param0 != null;
+                    if (isSome) {
                         for (const elem of value.param0) {
                             i32Stack.push((elem | 0));
                         }
                         i32Stack.push(value.param0.length);
-                        const cleanup = () => {
-                            for (const cleanup of arrayCleanups) { cleanup(); }
-                        };
-                        return { caseId: AllTypesResultValues.Tag.ArrayPayload, cleanup };
                     }
-                    case AllTypesResultValues.Tag.Empty: {
-                        const cleanup = undefined;
-                        return { caseId: AllTypesResultValues.Tag.Empty, cleanup };
-                    }
-                    default: throw new Error("Unknown AllTypesResultValues tag: " + String(enumTag));
+                    i32Stack.push(isSome ? 1 : 0);
+                    return OptionalAllTypesResultValues.Tag.OptArray;
                 }
-            },
-            lift: (tag) => {
-                tag = tag | 0;
-                switch (tag) {
-                    case AllTypesResultValues.Tag.StructPayload: {
+                case OptionalAllTypesResultValues.Tag.Empty: {
+                    return OptionalAllTypesResultValues.Tag.Empty;
+                }
+                default: throw new Error("Unknown OptionalAllTypesResultValues tag: " + String(enumTag));
+            }
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case OptionalAllTypesResultValues.Tag.OptStruct: {
+                    const isSome = i32Stack.pop();
+                    let optional;
+                    if (isSome) {
                         const struct = structHelpers.Point.lift();
-                        return { tag: AllTypesResultValues.Tag.StructPayload, param0: struct };
+                        optional = struct;
+                    } else {
+                        optional = null;
                     }
-                    case AllTypesResultValues.Tag.ClassPayload: {
+                    return { tag: OptionalAllTypesResultValues.Tag.OptStruct, param0: optional };
+                }
+                case OptionalAllTypesResultValues.Tag.OptClass: {
+                    const isSome = i32Stack.pop();
+                    let optional;
+                    if (isSome) {
                         const ptr = ptrStack.pop();
                         const obj = _exports['User'].__construct(ptr);
-                        return { tag: AllTypesResultValues.Tag.ClassPayload, param0: obj };
+                        optional = obj;
+                    } else {
+                        optional = null;
                     }
-                    case AllTypesResultValues.Tag.JsObjectPayload: {
+                    return { tag: OptionalAllTypesResultValues.Tag.OptClass, param0: optional };
+                }
+                case OptionalAllTypesResultValues.Tag.OptJSObject: {
+                    const isSome = i32Stack.pop();
+                    let optional;
+                    if (isSome) {
                         const objId = i32Stack.pop();
                         const obj = swift.memory.getObject(objId);
                         swift.memory.release(objId);
-                        return { tag: AllTypesResultValues.Tag.JsObjectPayload, param0: obj };
+                        optional = obj;
+                    } else {
+                        optional = null;
                     }
-                    case AllTypesResultValues.Tag.NestedEnum: {
-                        const enumValue = enumHelpers.APIResult.lift(i32Stack.pop(), );
-                        return { tag: AllTypesResultValues.Tag.NestedEnum, param0: enumValue };
+                    return { tag: OptionalAllTypesResultValues.Tag.OptJSObject, param0: optional };
+                }
+                case OptionalAllTypesResultValues.Tag.OptNestedEnum: {
+                    const isSome = i32Stack.pop();
+                    let optional;
+                    if (isSome) {
+                        const caseId = i32Stack.pop();
+                        optional = enumHelpers.APIResult.lift(caseId);
+                    } else {
+                        optional = null;
                     }
-                    case AllTypesResultValues.Tag.ArrayPayload: {
+                    return { tag: OptionalAllTypesResultValues.Tag.OptNestedEnum, param0: optional };
+                }
+                case OptionalAllTypesResultValues.Tag.OptArray: {
+                    const isSome = i32Stack.pop();
+                    let optional;
+                    if (isSome) {
                         const arrayLen = i32Stack.pop();
                         const arrayResult = [];
                         for (let i = 0; i < arrayLen; i++) {
@@ -678,173 +750,17 @@ export async function createInstantiator(options, swift) {
                             arrayResult.push(int);
                         }
                         arrayResult.reverse();
-                        return { tag: AllTypesResultValues.Tag.ArrayPayload, param0: arrayResult };
+                        optional = arrayResult;
+                    } else {
+                        optional = null;
                     }
-                    case AllTypesResultValues.Tag.Empty: return { tag: AllTypesResultValues.Tag.Empty };
-                    default: throw new Error("Unknown AllTypesResultValues tag returned from Swift: " + String(tag));
+                    return { tag: OptionalAllTypesResultValues.Tag.OptArray, param0: optional };
                 }
+                case OptionalAllTypesResultValues.Tag.Empty: return { tag: OptionalAllTypesResultValues.Tag.Empty };
+                default: throw new Error("Unknown OptionalAllTypesResultValues tag returned from Swift: " + String(tag));
             }
-        });
-    };
-    const __bjs_createOptionalAllTypesResultValuesHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                const enumTag = value.tag;
-                switch (enumTag) {
-                    case OptionalAllTypesResultValues.Tag.OptStruct: {
-                        const isSome = value.param0 != null;
-                        let nestedCleanup;
-                        if (isSome) {
-                            const structResult = structHelpers.Point.lower(value.param0);
-                            nestedCleanup = structResult.cleanup;
-                        }
-                        i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = () => {
-                            if (nestedCleanup) { nestedCleanup(); }
-                        };
-                        return { caseId: OptionalAllTypesResultValues.Tag.OptStruct, cleanup };
-                    }
-                    case OptionalAllTypesResultValues.Tag.OptClass: {
-                        const isSome = value.param0 != null;
-                        if (isSome) {
-                            ptrStack.push(value.param0.pointer);
-                        } else {
-                            ptrStack.push(0);
-                        }
-                        i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: OptionalAllTypesResultValues.Tag.OptClass, cleanup };
-                    }
-                    case OptionalAllTypesResultValues.Tag.OptJSObject: {
-                        const isSome = value.param0 != null;
-                        let id;
-                        if (isSome) {
-                            id = swift.memory.retain(value.param0);
-                            i32Stack.push(id);
-                        } else {
-                            id = undefined;
-                            i32Stack.push(0);
-                        }
-                        i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: OptionalAllTypesResultValues.Tag.OptJSObject, cleanup };
-                    }
-                    case OptionalAllTypesResultValues.Tag.OptNestedEnum: {
-                        const isSome = value.param0 != null;
-                        let enumCaseId, enumCleanup;
-                        if (isSome) {
-                            const enumResult = enumHelpers.APIResult.lower(value.param0);
-                            enumCaseId = enumResult.caseId;
-                            enumCleanup = enumResult.cleanup;
-                            i32Stack.push(enumCaseId);
-                        } else {
-                            i32Stack.push(0);
-                        }
-                        i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = () => {
-                            if (enumCleanup) { enumCleanup(); }
-                        };
-                        return { caseId: OptionalAllTypesResultValues.Tag.OptNestedEnum, cleanup };
-                    }
-                    case OptionalAllTypesResultValues.Tag.OptArray: {
-                        const isSome = value.param0 != null;
-                        let arrCleanup;
-                        if (isSome) {
-                            const arrayCleanups = [];
-                            for (const elem of value.param0) {
-                                i32Stack.push((elem | 0));
-                            }
-                            i32Stack.push(value.param0.length);
-                            arrCleanup = () => {
-                                for (const cleanup of arrayCleanups) { cleanup(); }
-                            };
-                        }
-                        i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = () => {
-                            if (arrCleanup) { arrCleanup(); }
-                        };
-                        return { caseId: OptionalAllTypesResultValues.Tag.OptArray, cleanup };
-                    }
-                    case OptionalAllTypesResultValues.Tag.Empty: {
-                        const cleanup = undefined;
-                        return { caseId: OptionalAllTypesResultValues.Tag.Empty, cleanup };
-                    }
-                    default: throw new Error("Unknown OptionalAllTypesResultValues tag: " + String(enumTag));
-                }
-            },
-            lift: (tag) => {
-                tag = tag | 0;
-                switch (tag) {
-                    case OptionalAllTypesResultValues.Tag.OptStruct: {
-                        const isSome = i32Stack.pop();
-                        let optional;
-                        if (isSome) {
-                            const struct = structHelpers.Point.lift();
-                            optional = struct;
-                        } else {
-                            optional = null;
-                        }
-                        return { tag: OptionalAllTypesResultValues.Tag.OptStruct, param0: optional };
-                    }
-                    case OptionalAllTypesResultValues.Tag.OptClass: {
-                        const isSome = i32Stack.pop();
-                        let optional;
-                        if (isSome) {
-                            const ptr = ptrStack.pop();
-                            const obj = _exports['User'].__construct(ptr);
-                            optional = obj;
-                        } else {
-                            optional = null;
-                        }
-                        return { tag: OptionalAllTypesResultValues.Tag.OptClass, param0: optional };
-                    }
-                    case OptionalAllTypesResultValues.Tag.OptJSObject: {
-                        const isSome = i32Stack.pop();
-                        let optional;
-                        if (isSome) {
-                            const objId = i32Stack.pop();
-                            const obj = swift.memory.getObject(objId);
-                            swift.memory.release(objId);
-                            optional = obj;
-                        } else {
-                            optional = null;
-                        }
-                        return { tag: OptionalAllTypesResultValues.Tag.OptJSObject, param0: optional };
-                    }
-                    case OptionalAllTypesResultValues.Tag.OptNestedEnum: {
-                        const isSome = i32Stack.pop();
-                        let optional;
-                        if (isSome) {
-                            const caseId = i32Stack.pop();
-                            optional = enumHelpers.APIResult.lift(caseId);
-                        } else {
-                            optional = null;
-                        }
-                        return { tag: OptionalAllTypesResultValues.Tag.OptNestedEnum, param0: optional };
-                    }
-                    case OptionalAllTypesResultValues.Tag.OptArray: {
-                        const isSome = i32Stack.pop();
-                        let optional;
-                        if (isSome) {
-                            const arrayLen = i32Stack.pop();
-                            const arrayResult = [];
-                            for (let i = 0; i < arrayLen; i++) {
-                                const int = i32Stack.pop();
-                                arrayResult.push(int);
-                            }
-                            arrayResult.reverse();
-                            optional = arrayResult;
-                        } else {
-                            optional = null;
-                        }
-                        return { tag: OptionalAllTypesResultValues.Tag.OptArray, param0: optional };
-                    }
-                    case OptionalAllTypesResultValues.Tag.Empty: return { tag: OptionalAllTypesResultValues.Tag.Empty };
-                    default: throw new Error("Unknown OptionalAllTypesResultValues tag returned from Swift: " + String(tag));
-                }
-            }
-        });
-    };
+        }
+    });
 
     return {
         /**
@@ -892,8 +808,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -910,22 +825,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
             }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
-            }
             bjs["swift_js_struct_lower_Point"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Point.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Point.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Point"] = function() {
                 const value = structHelpers.Point.lift();
@@ -1067,39 +968,38 @@ export async function createInstantiator(options, swift) {
                 }
 
             }
-            const PointHelpers = __bjs_createPointHelpers()();
+            const PointHelpers = __bjs_createPointHelpers();
             structHelpers.Point = PointHelpers;
 
-            const APIResultHelpers = __bjs_createAPIResultValuesHelpers()();
+            const APIResultHelpers = __bjs_createAPIResultValuesHelpers();
             enumHelpers.APIResult = APIResultHelpers;
 
-            const ComplexResultHelpers = __bjs_createComplexResultValuesHelpers()();
+            const ComplexResultHelpers = __bjs_createComplexResultValuesHelpers();
             enumHelpers.ComplexResult = ComplexResultHelpers;
 
-            const ResultHelpers = __bjs_createResultValuesHelpers()();
+            const ResultHelpers = __bjs_createResultValuesHelpers();
             enumHelpers.Result = ResultHelpers;
 
-            const NetworkingResultHelpers = __bjs_createNetworkingResultValuesHelpers()();
+            const NetworkingResultHelpers = __bjs_createNetworkingResultValuesHelpers();
             enumHelpers.NetworkingResult = NetworkingResultHelpers;
 
-            const APIOptionalResultHelpers = __bjs_createAPIOptionalResultValuesHelpers()();
+            const APIOptionalResultHelpers = __bjs_createAPIOptionalResultValuesHelpers();
             enumHelpers.APIOptionalResult = APIOptionalResultHelpers;
 
-            const TypedPayloadResultHelpers = __bjs_createTypedPayloadResultValuesHelpers()();
+            const TypedPayloadResultHelpers = __bjs_createTypedPayloadResultValuesHelpers();
             enumHelpers.TypedPayloadResult = TypedPayloadResultHelpers;
 
-            const AllTypesResultHelpers = __bjs_createAllTypesResultValuesHelpers()();
+            const AllTypesResultHelpers = __bjs_createAllTypesResultValuesHelpers();
             enumHelpers.AllTypesResult = AllTypesResultHelpers;
 
-            const OptionalAllTypesResultHelpers = __bjs_createOptionalAllTypesResultValuesHelpers()();
+            const OptionalAllTypesResultHelpers = __bjs_createOptionalAllTypesResultValuesHelpers();
             enumHelpers.OptionalAllTypesResult = OptionalAllTypesResultHelpers;
 
             const exports = {
                 User,
                 handle: function bjs_handle(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.APIResult.lower(result);
+                    const resultCaseId = enumHelpers.APIResult.lower(result);
                     instance.exports.bjs_handle(resultCaseId);
-                    if (resultCleanup) { resultCleanup(); }
                 },
                 getResult: function bjs_getResult() {
                     instance.exports.bjs_getResult();
@@ -1107,36 +1007,28 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 },
                 roundtripAPIResult: function bjs_roundtripAPIResult(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.APIResult.lower(result);
+                    const resultCaseId = enumHelpers.APIResult.lower(result);
                     instance.exports.bjs_roundtripAPIResult(resultCaseId);
                     const ret = enumHelpers.APIResult.lift(i32Stack.pop());
-                    if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
                 roundTripOptionalAPIResult: function bjs_roundTripOptionalAPIResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let result1;
                     if (isSome) {
-                        const enumResult = enumHelpers.APIResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
-                    }
-                    instance.exports.bjs_roundTripOptionalAPIResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = i32Stack.pop();
-                    const isNull = (tag === -1);
-                    let optResult;
-                    if (isNull) {
-                        optResult = null;
+                        const resultCaseId = enumHelpers.APIResult.lower(result);
+                        result1 = resultCaseId;
                     } else {
-                        optResult = enumHelpers.APIResult.lift(tag);
+                        result1 = 0;
                     }
-                    if (resultCleanup) { resultCleanup(); }
+                    instance.exports.bjs_roundTripOptionalAPIResult(+isSome, result1);
+                    const tag = i32Stack.pop();
+                    const optResult = tag === -1 ? null : enumHelpers.APIResult.lift(tag);
                     return optResult;
                 },
                 handleComplex: function bjs_handleComplex(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.ComplexResult.lower(result);
+                    const resultCaseId = enumHelpers.ComplexResult.lower(result);
                     instance.exports.bjs_handleComplex(resultCaseId);
-                    if (resultCleanup) { resultCleanup(); }
                 },
                 getComplexResult: function bjs_getComplexResult() {
                     instance.exports.bjs_getComplexResult();
@@ -1144,199 +1036,147 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 },
                 roundtripComplexResult: function bjs_roundtripComplexResult(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.ComplexResult.lower(result);
+                    const resultCaseId = enumHelpers.ComplexResult.lower(result);
                     instance.exports.bjs_roundtripComplexResult(resultCaseId);
                     const ret = enumHelpers.ComplexResult.lift(i32Stack.pop());
-                    if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
                 roundTripOptionalComplexResult: function bjs_roundTripOptionalComplexResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let result1;
                     if (isSome) {
-                        const enumResult = enumHelpers.ComplexResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
-                    }
-                    instance.exports.bjs_roundTripOptionalComplexResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = i32Stack.pop();
-                    const isNull = (tag === -1);
-                    let optResult;
-                    if (isNull) {
-                        optResult = null;
+                        const resultCaseId = enumHelpers.ComplexResult.lower(result);
+                        result1 = resultCaseId;
                     } else {
-                        optResult = enumHelpers.ComplexResult.lift(tag);
+                        result1 = 0;
                     }
-                    if (resultCleanup) { resultCleanup(); }
+                    instance.exports.bjs_roundTripOptionalComplexResult(+isSome, result1);
+                    const tag = i32Stack.pop();
+                    const optResult = tag === -1 ? null : enumHelpers.ComplexResult.lift(tag);
                     return optResult;
                 },
                 roundTripOptionalUtilitiesResult: function bjs_roundTripOptionalUtilitiesResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let result1;
                     if (isSome) {
-                        const enumResult = enumHelpers.Result.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
-                    }
-                    instance.exports.bjs_roundTripOptionalUtilitiesResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = i32Stack.pop();
-                    const isNull = (tag === -1);
-                    let optResult;
-                    if (isNull) {
-                        optResult = null;
+                        const resultCaseId = enumHelpers.Result.lower(result);
+                        result1 = resultCaseId;
                     } else {
-                        optResult = enumHelpers.Result.lift(tag);
+                        result1 = 0;
                     }
-                    if (resultCleanup) { resultCleanup(); }
+                    instance.exports.bjs_roundTripOptionalUtilitiesResult(+isSome, result1);
+                    const tag = i32Stack.pop();
+                    const optResult = tag === -1 ? null : enumHelpers.Result.lift(tag);
                     return optResult;
                 },
                 roundTripOptionalNetworkingResult: function bjs_roundTripOptionalNetworkingResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let result1;
                     if (isSome) {
-                        const enumResult = enumHelpers.NetworkingResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
-                    }
-                    instance.exports.bjs_roundTripOptionalNetworkingResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = i32Stack.pop();
-                    const isNull = (tag === -1);
-                    let optResult;
-                    if (isNull) {
-                        optResult = null;
+                        const resultCaseId = enumHelpers.NetworkingResult.lower(result);
+                        result1 = resultCaseId;
                     } else {
-                        optResult = enumHelpers.NetworkingResult.lift(tag);
+                        result1 = 0;
                     }
-                    if (resultCleanup) { resultCleanup(); }
+                    instance.exports.bjs_roundTripOptionalNetworkingResult(+isSome, result1);
+                    const tag = i32Stack.pop();
+                    const optResult = tag === -1 ? null : enumHelpers.NetworkingResult.lift(tag);
                     return optResult;
                 },
                 roundTripOptionalAPIOptionalResult: function bjs_roundTripOptionalAPIOptionalResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let result1;
                     if (isSome) {
-                        const enumResult = enumHelpers.APIOptionalResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
-                    }
-                    instance.exports.bjs_roundTripOptionalAPIOptionalResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = i32Stack.pop();
-                    const isNull = (tag === -1);
-                    let optResult;
-                    if (isNull) {
-                        optResult = null;
+                        const resultCaseId = enumHelpers.APIOptionalResult.lower(result);
+                        result1 = resultCaseId;
                     } else {
-                        optResult = enumHelpers.APIOptionalResult.lift(tag);
+                        result1 = 0;
                     }
-                    if (resultCleanup) { resultCleanup(); }
+                    instance.exports.bjs_roundTripOptionalAPIOptionalResult(+isSome, result1);
+                    const tag = i32Stack.pop();
+                    const optResult = tag === -1 ? null : enumHelpers.APIOptionalResult.lift(tag);
                     return optResult;
                 },
                 compareAPIResults: function bjs_compareAPIResults(result1, result2) {
                     const isSome = result1 != null;
-                    let result1CaseId, result1Cleanup;
+                    let result;
                     if (isSome) {
-                        const enumResult = enumHelpers.APIOptionalResult.lower(result1);
-                        result1CaseId = enumResult.caseId;
-                        result1Cleanup = enumResult.cleanup;
+                        const result1CaseId = enumHelpers.APIOptionalResult.lower(result1);
+                        result = result1CaseId;
+                    } else {
+                        result = 0;
                     }
                     const isSome1 = result2 != null;
-                    let result2CaseId, result2Cleanup;
+                    let result3;
                     if (isSome1) {
-                        const enumResult1 = enumHelpers.APIOptionalResult.lower(result2);
-                        result2CaseId = enumResult1.caseId;
-                        result2Cleanup = enumResult1.cleanup;
-                    }
-                    instance.exports.bjs_compareAPIResults(+isSome, isSome ? result1CaseId : 0, +isSome1, isSome1 ? result2CaseId : 0);
-                    const tag = i32Stack.pop();
-                    const isNull = (tag === -1);
-                    let optResult;
-                    if (isNull) {
-                        optResult = null;
+                        const result2CaseId = enumHelpers.APIOptionalResult.lower(result2);
+                        result3 = result2CaseId;
                     } else {
-                        optResult = enumHelpers.APIOptionalResult.lift(tag);
+                        result3 = 0;
                     }
-                    if (result1Cleanup) { result1Cleanup(); }
-                    if (result2Cleanup) { result2Cleanup(); }
+                    instance.exports.bjs_compareAPIResults(+isSome, result, +isSome1, result3);
+                    const tag = i32Stack.pop();
+                    const optResult = tag === -1 ? null : enumHelpers.APIOptionalResult.lift(tag);
                     return optResult;
                 },
                 roundTripTypedPayloadResult: function bjs_roundTripTypedPayloadResult(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.TypedPayloadResult.lower(result);
+                    const resultCaseId = enumHelpers.TypedPayloadResult.lower(result);
                     instance.exports.bjs_roundTripTypedPayloadResult(resultCaseId);
                     const ret = enumHelpers.TypedPayloadResult.lift(i32Stack.pop());
-                    if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
                 roundTripOptionalTypedPayloadResult: function bjs_roundTripOptionalTypedPayloadResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let result1;
                     if (isSome) {
-                        const enumResult = enumHelpers.TypedPayloadResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
-                    }
-                    instance.exports.bjs_roundTripOptionalTypedPayloadResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = i32Stack.pop();
-                    const isNull = (tag === -1);
-                    let optResult;
-                    if (isNull) {
-                        optResult = null;
+                        const resultCaseId = enumHelpers.TypedPayloadResult.lower(result);
+                        result1 = resultCaseId;
                     } else {
-                        optResult = enumHelpers.TypedPayloadResult.lift(tag);
+                        result1 = 0;
                     }
-                    if (resultCleanup) { resultCleanup(); }
+                    instance.exports.bjs_roundTripOptionalTypedPayloadResult(+isSome, result1);
+                    const tag = i32Stack.pop();
+                    const optResult = tag === -1 ? null : enumHelpers.TypedPayloadResult.lift(tag);
                     return optResult;
                 },
                 roundTripAllTypesResult: function bjs_roundTripAllTypesResult(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.AllTypesResult.lower(result);
+                    const resultCaseId = enumHelpers.AllTypesResult.lower(result);
                     instance.exports.bjs_roundTripAllTypesResult(resultCaseId);
                     const ret = enumHelpers.AllTypesResult.lift(i32Stack.pop());
-                    if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
                 roundTripOptionalAllTypesResult: function bjs_roundTripOptionalAllTypesResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let result1;
                     if (isSome) {
-                        const enumResult = enumHelpers.AllTypesResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
-                    }
-                    instance.exports.bjs_roundTripOptionalAllTypesResult(+isSome, isSome ? resultCaseId : 0);
-                    const tag = i32Stack.pop();
-                    const isNull = (tag === -1);
-                    let optResult;
-                    if (isNull) {
-                        optResult = null;
+                        const resultCaseId = enumHelpers.AllTypesResult.lower(result);
+                        result1 = resultCaseId;
                     } else {
-                        optResult = enumHelpers.AllTypesResult.lift(tag);
+                        result1 = 0;
                     }
-                    if (resultCleanup) { resultCleanup(); }
+                    instance.exports.bjs_roundTripOptionalAllTypesResult(+isSome, result1);
+                    const tag = i32Stack.pop();
+                    const optResult = tag === -1 ? null : enumHelpers.AllTypesResult.lift(tag);
                     return optResult;
                 },
                 roundTripOptionalPayloadResult: function bjs_roundTripOptionalPayloadResult(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.OptionalAllTypesResult.lower(result);
+                    const resultCaseId = enumHelpers.OptionalAllTypesResult.lower(result);
                     instance.exports.bjs_roundTripOptionalPayloadResult(resultCaseId);
                     const ret = enumHelpers.OptionalAllTypesResult.lift(i32Stack.pop());
-                    if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
                 roundTripOptionalPayloadResultOpt: function bjs_roundTripOptionalPayloadResultOpt(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let result1;
                     if (isSome) {
-                        const enumResult = enumHelpers.OptionalAllTypesResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
-                    }
-                    instance.exports.bjs_roundTripOptionalPayloadResultOpt(+isSome, isSome ? resultCaseId : 0);
-                    const tag = i32Stack.pop();
-                    const isNull = (tag === -1);
-                    let optResult;
-                    if (isNull) {
-                        optResult = null;
+                        const resultCaseId = enumHelpers.OptionalAllTypesResult.lower(result);
+                        result1 = resultCaseId;
                     } else {
-                        optResult = enumHelpers.OptionalAllTypesResult.lift(tag);
+                        result1 = 0;
                     }
-                    if (resultCleanup) { resultCleanup(); }
+                    instance.exports.bjs_roundTripOptionalPayloadResultOpt(+isSome, result1);
+                    const tag = i32Stack.pop();
+                    const optResult = tag === -1 ? null : enumHelpers.OptionalAllTypesResult.lift(tag);
                     return optResult;
                 },
                 APIResult: APIResultValues,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
@@ -47,7 +47,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -100,8 +99,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -117,16 +115,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
@@ -67,7 +67,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -120,8 +119,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -137,16 +135,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
@@ -48,7 +48,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -101,8 +100,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -118,16 +116,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
@@ -98,7 +98,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -152,8 +151,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -169,16 +167,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -316,12 +304,18 @@ export async function createInstantiator(options, swift) {
                 },
                 roundTripOptionalTheme: function bjs_roundTripOptionalTheme(input) {
                     const isSome = input != null;
-                    let inputId, inputBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        inputBytes = textEncoder.encode(input);
-                        inputId = swift.memory.retain(inputBytes);
+                        const inputBytes = textEncoder.encode(input);
+                        const inputId = swift.memory.retain(inputBytes);
+                        result = inputId;
+                        result1 = inputBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalTheme(+isSome, isSome ? inputId : 0, isSome ? inputBytes.length : 0);
+                    instance.exports.bjs_roundTripOptionalTheme(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
@@ -339,12 +333,18 @@ export async function createInstantiator(options, swift) {
                 },
                 roundTripOptionalTSTheme: function bjs_roundTripOptionalTSTheme(input) {
                     const isSome = input != null;
-                    let inputId, inputBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        inputBytes = textEncoder.encode(input);
-                        inputId = swift.memory.retain(inputBytes);
+                        const inputBytes = textEncoder.encode(input);
+                        const inputId = swift.memory.retain(inputBytes);
+                        result = inputId;
+                        result1 = inputBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalTSTheme(+isSome, isSome ? inputId : 0, isSome ? inputBytes.length : 0);
+                    instance.exports.bjs_roundTripOptionalTSTheme(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
@@ -362,12 +362,18 @@ export async function createInstantiator(options, swift) {
                 },
                 roundTripOptionalFeatureFlag: function bjs_roundTripOptionalFeatureFlag(input) {
                     const isSome = input != null;
-                    let inputId, inputBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        inputBytes = textEncoder.encode(input);
-                        inputId = swift.memory.retain(inputBytes);
+                        const inputBytes = textEncoder.encode(input);
+                        const inputId = swift.memory.retain(inputBytes);
+                        result = inputId;
+                        result1 = inputBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalFeatureFlag(+isSome, isSome ? inputId : 0, isSome ? inputBytes.length : 0);
+                    instance.exports.bjs_roundTripOptionalFeatureFlag(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
@@ -479,7 +485,7 @@ export async function createInstantiator(options, swift) {
                 },
                 roundTripOptionalPrecision: function bjs_roundTripOptionalPrecision(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalPrecision(+isSome, isSome ? input : 0);
+                    instance.exports.bjs_roundTripOptionalPrecision(+isSome, isSome ? input : 0.0);
                     const optResult = tmpRetOptionalFloat;
                     tmpRetOptionalFloat = undefined;
                     return optResult;
@@ -493,7 +499,7 @@ export async function createInstantiator(options, swift) {
                 },
                 roundTripOptionalRatio: function bjs_roundTripOptionalRatio(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalRatio(+isSome, isSome ? input : 0);
+                    instance.exports.bjs_roundTripOptionalRatio(+isSome, isSome ? input : 0.0);
                     const optResult = tmpRetOptionalDouble;
                     tmpRetOptionalDouble = undefined;
                     return optResult;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -77,8 +76,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -94,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -76,8 +75,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -93,16 +91,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -77,8 +76,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -94,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -207,7 +195,6 @@ export async function createInstantiator(options, swift) {
                     }
                     arrayResult.reverse();
                     let ret = imports.roundtrip(arrayResult);
-                    const arrayCleanups = [];
                     for (const elem of ret) {
                         i32Stack.push((elem | 0));
                     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -77,8 +76,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -94,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -77,8 +76,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -94,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -77,8 +76,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -94,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -166,8 +165,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -183,16 +181,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -319,7 +307,6 @@ export async function createInstantiator(options, swift) {
                     }
                     arrayResult.reverse();
                     let ret = imports.jsEchoJSValueArray(arrayResult);
-                    const arrayCleanups = [];
                     for (const elem of ret) {
                         const [elemKind, elemPayload1, elemPayload2] = __bjs_jsValueLower(elem);
                         i32Stack.push(elemKind);
@@ -370,15 +357,39 @@ export async function createInstantiator(options, swift) {
                 constructor(value, optionalValue) {
                     const [valueKind, valuePayload1, valuePayload2] = __bjs_jsValueLower(value);
                     const isSome = optionalValue != null;
-                    const [optionalValueKind, optionalValuePayload1, optionalValuePayload2] = __bjs_jsValueLower(optionalValue);
-                    const ret = instance.exports.bjs_JSValueHolder_init(valueKind, valuePayload1, valuePayload2, +isSome, optionalValueKind, optionalValuePayload1, optionalValuePayload2);
+                    let result;
+                    let result1;
+                    let result2;
+                    if (isSome) {
+                        const [optionalValueKind, optionalValuePayload1, optionalValuePayload2] = __bjs_jsValueLower(optionalValue);
+                        result = optionalValueKind;
+                        result1 = optionalValuePayload1;
+                        result2 = optionalValuePayload2;
+                    } else {
+                        result = 0;
+                        result1 = 0;
+                        result2 = 0.0;
+                    }
+                    const ret = instance.exports.bjs_JSValueHolder_init(valueKind, valuePayload1, valuePayload2, +isSome, result, result1, result2);
                     return JSValueHolder.__construct(ret);
                 }
                 update(value, optionalValue) {
                     const [valueKind, valuePayload1, valuePayload2] = __bjs_jsValueLower(value);
                     const isSome = optionalValue != null;
-                    const [optionalValueKind, optionalValuePayload1, optionalValuePayload2] = __bjs_jsValueLower(optionalValue);
-                    instance.exports.bjs_JSValueHolder_update(this.pointer, valueKind, valuePayload1, valuePayload2, +isSome, optionalValueKind, optionalValuePayload1, optionalValuePayload2);
+                    let result;
+                    let result1;
+                    let result2;
+                    if (isSome) {
+                        const [optionalValueKind, optionalValuePayload1, optionalValuePayload2] = __bjs_jsValueLower(optionalValue);
+                        result = optionalValueKind;
+                        result1 = optionalValuePayload1;
+                        result2 = optionalValuePayload2;
+                    } else {
+                        result = 0;
+                        result1 = 0;
+                        result2 = 0.0;
+                    }
+                    instance.exports.bjs_JSValueHolder_update(this.pointer, valueKind, valuePayload1, valuePayload2, +isSome, result, result1, result2);
                 }
                 echo(value) {
                     const [valueKind, valuePayload1, valuePayload2] = __bjs_jsValueLower(value);
@@ -391,8 +402,20 @@ export async function createInstantiator(options, swift) {
                 }
                 echoOptional(value) {
                     const isSome = value != null;
-                    const [valueKind, valuePayload1, valuePayload2] = __bjs_jsValueLower(value);
-                    instance.exports.bjs_JSValueHolder_echoOptional(this.pointer, +isSome, valueKind, valuePayload1, valuePayload2);
+                    let result;
+                    let result1;
+                    let result2;
+                    if (isSome) {
+                        const [valueKind, valuePayload1, valuePayload2] = __bjs_jsValueLower(value);
+                        result = valueKind;
+                        result1 = valuePayload1;
+                        result2 = valuePayload2;
+                    } else {
+                        result = 0;
+                        result1 = 0;
+                        result2 = 0.0;
+                    }
+                    instance.exports.bjs_JSValueHolder_echoOptional(this.pointer, +isSome, result, result1, result2);
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {
@@ -435,8 +458,20 @@ export async function createInstantiator(options, swift) {
                 }
                 set optionalValue(value) {
                     const isSome = value != null;
-                    const [valueKind, valuePayload1, valuePayload2] = __bjs_jsValueLower(value);
-                    instance.exports.bjs_JSValueHolder_optionalValue_set(this.pointer, +isSome, valueKind, valuePayload1, valuePayload2);
+                    let result;
+                    let result1;
+                    let result2;
+                    if (isSome) {
+                        const [valueKind, valuePayload1, valuePayload2] = __bjs_jsValueLower(value);
+                        result = valueKind;
+                        result1 = valuePayload1;
+                        result2 = valuePayload2;
+                    } else {
+                        result = 0;
+                        result1 = 0;
+                        result2 = 0.0;
+                    }
+                    instance.exports.bjs_JSValueHolder_optionalValue_set(this.pointer, +isSome, result, result1, result2);
                 }
             }
             const exports = {
@@ -452,8 +487,20 @@ export async function createInstantiator(options, swift) {
                 },
                 roundTripOptionalJSValue: function bjs_roundTripOptionalJSValue(value) {
                     const isSome = value != null;
-                    const [valueKind, valuePayload1, valuePayload2] = __bjs_jsValueLower(value);
-                    instance.exports.bjs_roundTripOptionalJSValue(+isSome, valueKind, valuePayload1, valuePayload2);
+                    let result;
+                    let result1;
+                    let result2;
+                    if (isSome) {
+                        const [valueKind, valuePayload1, valuePayload2] = __bjs_jsValueLower(value);
+                        result = valueKind;
+                        result1 = valuePayload1;
+                        result2 = valuePayload2;
+                    } else {
+                        result = 0;
+                        result1 = 0;
+                        result2 = 0.0;
+                    }
+                    instance.exports.bjs_roundTripOptionalJSValue(+isSome, result, result1, result2);
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {
@@ -468,7 +515,6 @@ export async function createInstantiator(options, swift) {
                     return optResult;
                 },
                 roundTripJSValueArray: function bjs_roundTripJSValueArray(values) {
-                    const arrayCleanups = [];
                     for (const elem of values) {
                         const [elemKind, elemPayload1, elemPayload2] = __bjs_jsValueLower(elem);
                         i32Stack.push(elemKind);
@@ -487,14 +533,11 @@ export async function createInstantiator(options, swift) {
                         arrayResult.push(jsValue);
                     }
                     arrayResult.reverse();
-                    for (const cleanup of arrayCleanups) { cleanup(); }
                     return arrayResult;
                 },
                 roundTripOptionalJSValueArray: function bjs_roundTripOptionalJSValueArray(values) {
                     const isSome = values != null;
-                    const valuesCleanups = [];
                     if (isSome) {
-                        const arrayCleanups = [];
                         for (const elem of values) {
                             const [elemKind, elemPayload1, elemPayload2] = __bjs_jsValueLower(elem);
                             i32Stack.push(elemKind);
@@ -502,7 +545,6 @@ export async function createInstantiator(options, swift) {
                             f64Stack.push(elemPayload2);
                         }
                         i32Stack.push(values.length);
-                        valuesCleanups.push(() => { for (const cleanup of arrayCleanups) { cleanup(); } });
                     }
                     i32Stack.push(+isSome);
                     instance.exports.bjs_roundTripOptionalJSValueArray();
@@ -523,7 +565,6 @@ export async function createInstantiator(options, swift) {
                     } else {
                         optResult = null;
                     }
-                    for (const cleanup of valuesCleanups) { cleanup(); }
                     return optResult;
                 },
             };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -76,8 +75,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -93,16 +91,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -76,8 +75,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -93,16 +91,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -76,8 +75,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -93,16 +91,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -76,8 +75,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -93,16 +91,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -76,8 +75,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -93,16 +91,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -77,8 +76,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -94,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -209,19 +197,25 @@ export async function createInstantiator(options, swift) {
                 return swift.memory.retain(obj);
             };
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
-            TestModule["bjs_WithOptionalJSClass_init"] = function bjs_WithOptionalJSClass_init(valueOrNullIsSome, valueOrNullWrappedValue, valueOrUndefinedIsSome, valueOrUndefinedWrappedValue) {
+            TestModule["bjs_WithOptionalJSClass_init"] = function bjs_WithOptionalJSClass_init(valueOrNullIsSome, valueOrNullObjectId, valueOrUndefinedIsSome, valueOrUndefinedObjectId) {
                 try {
-                    let obj;
+                    let optResult;
                     if (valueOrNullIsSome) {
-                        obj = swift.memory.getObject(valueOrNullWrappedValue);
-                        swift.memory.release(valueOrNullWrappedValue);
+                        const valueOrNullObjectIdObject = swift.memory.getObject(valueOrNullObjectId);
+                        swift.memory.release(valueOrNullObjectId);
+                        optResult = valueOrNullObjectIdObject;
+                    } else {
+                        optResult = null;
                     }
-                    let obj1;
+                    let optResult1;
                     if (valueOrUndefinedIsSome) {
-                        obj1 = swift.memory.getObject(valueOrUndefinedWrappedValue);
-                        swift.memory.release(valueOrUndefinedWrappedValue);
+                        const valueOrUndefinedObjectIdObject = swift.memory.getObject(valueOrUndefinedObjectId);
+                        swift.memory.release(valueOrUndefinedObjectId);
+                        optResult1 = valueOrUndefinedObjectIdObject;
+                    } else {
+                        optResult1 = undefined;
                     }
-                    return swift.memory.retain(new imports.WithOptionalJSClass(valueOrNullIsSome ? obj : null, valueOrUndefinedIsSome ? obj1 : undefined));
+                    return swift.memory.retain(new imports.WithOptionalJSClass(optResult, optResult1));
                 } catch (error) {
                     setException(error);
                     return 0
@@ -231,11 +225,7 @@ export async function createInstantiator(options, swift) {
                 try {
                     let ret = swift.memory.getObject(self).stringOrNull;
                     const isSome = ret != null;
-                    if (isSome) {
-                        tmpRetString = ret;
-                    } else {
-                        tmpRetString = null;
-                    }
+                    tmpRetString = isSome ? ret : null;
                 } catch (error) {
                     setException(error);
                 }
@@ -244,11 +234,7 @@ export async function createInstantiator(options, swift) {
                 try {
                     let ret = swift.memory.getObject(self).stringOrUndefined;
                     const isSome = ret !== undefined;
-                    if (isSome) {
-                        tmpRetString = ret;
-                    } else {
-                        tmpRetString = null;
-                    }
+                    tmpRetString = isSome ? ret : undefined;
                 } catch (error) {
                     setException(error);
                 }
@@ -307,26 +293,32 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            TestModule["bjs_WithOptionalJSClass_stringOrNull_set"] = function bjs_WithOptionalJSClass_stringOrNull_set(self, newValueIsSome, newValueWrappedValue) {
+            TestModule["bjs_WithOptionalJSClass_stringOrNull_set"] = function bjs_WithOptionalJSClass_stringOrNull_set(self, newValueIsSome, newValueObjectId) {
                 try {
-                    let obj;
+                    let optResult;
                     if (newValueIsSome) {
-                        obj = swift.memory.getObject(newValueWrappedValue);
-                        swift.memory.release(newValueWrappedValue);
+                        const newValueObjectIdObject = swift.memory.getObject(newValueObjectId);
+                        swift.memory.release(newValueObjectId);
+                        optResult = newValueObjectIdObject;
+                    } else {
+                        optResult = null;
                     }
-                    swift.memory.getObject(self).stringOrNull = newValueIsSome ? obj : null;
+                    swift.memory.getObject(self).stringOrNull = optResult;
                 } catch (error) {
                     setException(error);
                 }
             }
-            TestModule["bjs_WithOptionalJSClass_stringOrUndefined_set"] = function bjs_WithOptionalJSClass_stringOrUndefined_set(self, newValueIsSome, newValueWrappedValue) {
+            TestModule["bjs_WithOptionalJSClass_stringOrUndefined_set"] = function bjs_WithOptionalJSClass_stringOrUndefined_set(self, newValueIsSome, newValueObjectId) {
                 try {
-                    let obj;
+                    let optResult;
                     if (newValueIsSome) {
-                        obj = swift.memory.getObject(newValueWrappedValue);
-                        swift.memory.release(newValueWrappedValue);
+                        const newValueObjectIdObject = swift.memory.getObject(newValueObjectId);
+                        swift.memory.release(newValueObjectId);
+                        optResult = newValueObjectIdObject;
+                    } else {
+                        optResult = undefined;
                     }
-                    swift.memory.getObject(self).stringOrUndefined = newValueIsSome ? obj : undefined;
+                    swift.memory.getObject(self).stringOrUndefined = optResult;
                 } catch (error) {
                     setException(error);
                 }
@@ -373,38 +365,36 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            TestModule["bjs_WithOptionalJSClass_roundTripStringOrNull"] = function bjs_WithOptionalJSClass_roundTripStringOrNull(self, valueIsSome, valueWrappedValue) {
+            TestModule["bjs_WithOptionalJSClass_roundTripStringOrNull"] = function bjs_WithOptionalJSClass_roundTripStringOrNull(self, valueIsSome, valueObjectId) {
                 try {
-                    let obj;
+                    let optResult;
                     if (valueIsSome) {
-                        obj = swift.memory.getObject(valueWrappedValue);
-                        swift.memory.release(valueWrappedValue);
-                    }
-                    let ret = swift.memory.getObject(self).roundTripStringOrNull(valueIsSome ? obj : null);
-                    const isSome = ret != null;
-                    if (isSome) {
-                        tmpRetString = ret;
+                        const valueObjectIdObject = swift.memory.getObject(valueObjectId);
+                        swift.memory.release(valueObjectId);
+                        optResult = valueObjectIdObject;
                     } else {
-                        tmpRetString = null;
+                        optResult = null;
                     }
+                    let ret = swift.memory.getObject(self).roundTripStringOrNull(optResult);
+                    const isSome = ret != null;
+                    tmpRetString = isSome ? ret : null;
                 } catch (error) {
                     setException(error);
                 }
             }
-            TestModule["bjs_WithOptionalJSClass_roundTripStringOrUndefined"] = function bjs_WithOptionalJSClass_roundTripStringOrUndefined(self, valueIsSome, valueWrappedValue) {
+            TestModule["bjs_WithOptionalJSClass_roundTripStringOrUndefined"] = function bjs_WithOptionalJSClass_roundTripStringOrUndefined(self, valueIsSome, valueObjectId) {
                 try {
-                    let obj;
+                    let optResult;
                     if (valueIsSome) {
-                        obj = swift.memory.getObject(valueWrappedValue);
-                        swift.memory.release(valueWrappedValue);
-                    }
-                    let ret = swift.memory.getObject(self).roundTripStringOrUndefined(valueIsSome ? obj : undefined);
-                    const isSome = ret !== undefined;
-                    if (isSome) {
-                        tmpRetString = ret;
+                        const valueObjectIdObject = swift.memory.getObject(valueObjectId);
+                        swift.memory.release(valueObjectId);
+                        optResult = valueObjectIdObject;
                     } else {
-                        tmpRetString = null;
+                        optResult = undefined;
                     }
+                    let ret = swift.memory.getObject(self).roundTripStringOrUndefined(optResult);
+                    const isSome = ret !== undefined;
+                    tmpRetString = isSome ? ret : undefined;
                 } catch (error) {
                     setException(error);
                 }
@@ -501,12 +491,18 @@ export async function createInstantiator(options, swift) {
 
                 constructor(name) {
                     const isSome = name != null;
-                    let nameId, nameBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        nameBytes = textEncoder.encode(name);
-                        nameId = swift.memory.retain(nameBytes);
+                        const nameBytes = textEncoder.encode(name);
+                        const nameId = swift.memory.retain(nameBytes);
+                        result = nameId;
+                        result1 = nameBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    const ret = instance.exports.bjs_Greeter_init(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
+                    const ret = instance.exports.bjs_Greeter_init(+isSome, result, result1);
                     return Greeter.__construct(ret);
                 }
                 greet() {
@@ -517,12 +513,18 @@ export async function createInstantiator(options, swift) {
                 }
                 changeName(name) {
                     const isSome = name != null;
-                    let nameId, nameBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        nameBytes = textEncoder.encode(name);
-                        nameId = swift.memory.retain(nameBytes);
+                        const nameBytes = textEncoder.encode(name);
+                        const nameId = swift.memory.retain(nameBytes);
+                        result = nameId;
+                        result1 = nameBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_Greeter_changeName(this.pointer, +isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
+                    instance.exports.bjs_Greeter_changeName(this.pointer, +isSome, result, result1);
                 }
                 get name() {
                     instance.exports.bjs_Greeter_name_get(this.pointer);
@@ -532,12 +534,18 @@ export async function createInstantiator(options, swift) {
                 }
                 set name(value) {
                     const isSome = value != null;
-                    let valueId, valueBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        valueBytes = textEncoder.encode(value);
-                        valueId = swift.memory.retain(valueBytes);
+                        const valueBytes = textEncoder.encode(value);
+                        const valueId = swift.memory.retain(valueBytes);
+                        result = valueId;
+                        result1 = valueBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_Greeter_name_set(this.pointer, +isSome, isSome ? valueId : 0, isSome ? valueBytes.length : 0);
+                    instance.exports.bjs_Greeter_name_set(this.pointer, +isSome, result, result1);
                 }
             }
             class OptionalPropertyHolder extends SwiftHeapObject {
@@ -557,12 +565,18 @@ export async function createInstantiator(options, swift) {
                 }
                 set optionalName(value) {
                     const isSome = value != null;
-                    let valueId, valueBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        valueBytes = textEncoder.encode(value);
-                        valueId = swift.memory.retain(valueBytes);
+                        const valueBytes = textEncoder.encode(value);
+                        const valueId = swift.memory.retain(valueBytes);
+                        result = valueId;
+                        result1 = valueBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_OptionalPropertyHolder_optionalName_set(this.pointer, +isSome, isSome ? valueId : 0, isSome ? valueBytes.length : 0);
+                    instance.exports.bjs_OptionalPropertyHolder_optionalName_set(this.pointer, +isSome, result, result1);
                 }
                 get optionalAge() {
                     instance.exports.bjs_OptionalPropertyHolder_optionalAge_get(this.pointer);
@@ -583,7 +597,13 @@ export async function createInstantiator(options, swift) {
                 }
                 set optionalGreeter(value) {
                     const isSome = value != null;
-                    instance.exports.bjs_OptionalPropertyHolder_optionalGreeter_set(this.pointer, +isSome, isSome ? value.pointer : 0);
+                    let result;
+                    if (isSome) {
+                        result = value.pointer;
+                    } else {
+                        result = 0;
+                    }
+                    instance.exports.bjs_OptionalPropertyHolder_optionalGreeter_set(this.pointer, +isSome, result);
                 }
             }
             const exports = {
@@ -591,7 +611,13 @@ export async function createInstantiator(options, swift) {
                 OptionalPropertyHolder,
                 roundTripOptionalClass: function bjs_roundTripOptionalClass(value) {
                     const isSome = value != null;
-                    instance.exports.bjs_roundTripOptionalClass(+isSome, isSome ? value.pointer : 0);
+                    let result;
+                    if (isSome) {
+                        result = value.pointer;
+                    } else {
+                        result = 0;
+                    }
+                    instance.exports.bjs_roundTripOptionalClass(+isSome, result);
                     const pointer = tmpRetOptionalHeapObject;
                     tmpRetOptionalHeapObject = undefined;
                     const optResult = pointer === null ? null : Greeter.__construct(pointer);
@@ -599,7 +625,13 @@ export async function createInstantiator(options, swift) {
                 },
                 testOptionalPropertyRoundtrip: function bjs_testOptionalPropertyRoundtrip(holder) {
                     const isSome = holder != null;
-                    instance.exports.bjs_testOptionalPropertyRoundtrip(+isSome, isSome ? holder.pointer : 0);
+                    let result;
+                    if (isSome) {
+                        result = holder.pointer;
+                    } else {
+                        result = 0;
+                    }
+                    instance.exports.bjs_testOptionalPropertyRoundtrip(+isSome, result);
                     const pointer = tmpRetOptionalHeapObject;
                     tmpRetOptionalHeapObject = undefined;
                     const optResult = pointer === null ? null : OptionalPropertyHolder.__construct(pointer);
@@ -607,12 +639,18 @@ export async function createInstantiator(options, swift) {
                 },
                 roundTripString: function bjs_roundTripString(name) {
                     const isSome = name != null;
-                    let nameId, nameBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        nameBytes = textEncoder.encode(name);
-                        nameId = swift.memory.retain(nameBytes);
+                        const nameBytes = textEncoder.encode(name);
+                        const nameId = swift.memory.retain(nameBytes);
+                        result = nameId;
+                        result1 = nameBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_roundTripString(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
+                    instance.exports.bjs_roundTripString(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
@@ -626,76 +664,100 @@ export async function createInstantiator(options, swift) {
                 },
                 roundTripBool: function bjs_roundTripBool(flag) {
                     const isSome = flag != null;
-                    instance.exports.bjs_roundTripBool(+isSome, isSome ? flag : 0);
+                    instance.exports.bjs_roundTripBool(+isSome, isSome ? flag ? 1 : 0 : 0);
                     const optResult = tmpRetOptionalBool;
                     tmpRetOptionalBool = undefined;
                     return optResult;
                 },
                 roundTripFloat: function bjs_roundTripFloat(number) {
                     const isSome = number != null;
-                    instance.exports.bjs_roundTripFloat(+isSome, isSome ? number : 0);
+                    instance.exports.bjs_roundTripFloat(+isSome, isSome ? number : 0.0);
                     const optResult = tmpRetOptionalFloat;
                     tmpRetOptionalFloat = undefined;
                     return optResult;
                 },
                 roundTripDouble: function bjs_roundTripDouble(precision) {
                     const isSome = precision != null;
-                    instance.exports.bjs_roundTripDouble(+isSome, isSome ? precision : 0);
+                    instance.exports.bjs_roundTripDouble(+isSome, isSome ? precision : 0.0);
                     const optResult = tmpRetOptionalDouble;
                     tmpRetOptionalDouble = undefined;
                     return optResult;
                 },
                 roundTripSyntax: function bjs_roundTripSyntax(name) {
                     const isSome = name != null;
-                    let nameId, nameBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        nameBytes = textEncoder.encode(name);
-                        nameId = swift.memory.retain(nameBytes);
+                        const nameBytes = textEncoder.encode(name);
+                        const nameId = swift.memory.retain(nameBytes);
+                        result = nameId;
+                        result1 = nameBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_roundTripSyntax(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
+                    instance.exports.bjs_roundTripSyntax(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
                 roundTripMixSyntax: function bjs_roundTripMixSyntax(name) {
                     const isSome = name != null;
-                    let nameId, nameBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        nameBytes = textEncoder.encode(name);
-                        nameId = swift.memory.retain(nameBytes);
+                        const nameBytes = textEncoder.encode(name);
+                        const nameId = swift.memory.retain(nameBytes);
+                        result = nameId;
+                        result1 = nameBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_roundTripMixSyntax(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
+                    instance.exports.bjs_roundTripMixSyntax(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
                 roundTripSwiftSyntax: function bjs_roundTripSwiftSyntax(name) {
                     const isSome = name != null;
-                    let nameId, nameBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        nameBytes = textEncoder.encode(name);
-                        nameId = swift.memory.retain(nameBytes);
+                        const nameBytes = textEncoder.encode(name);
+                        const nameId = swift.memory.retain(nameBytes);
+                        result = nameId;
+                        result1 = nameBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_roundTripSwiftSyntax(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
+                    instance.exports.bjs_roundTripSwiftSyntax(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
                 roundTripMixedSwiftSyntax: function bjs_roundTripMixedSwiftSyntax(name) {
                     const isSome = name != null;
-                    let nameId, nameBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        nameBytes = textEncoder.encode(name);
-                        nameId = swift.memory.retain(nameBytes);
+                        const nameBytes = textEncoder.encode(name);
+                        const nameId = swift.memory.retain(nameBytes);
+                        result = nameId;
+                        result1 = nameBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_roundTripMixedSwiftSyntax(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
+                    instance.exports.bjs_roundTripMixedSwiftSyntax(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
                 roundTripWithSpaces: function bjs_roundTripWithSpaces(value) {
                     const isSome = value != null;
-                    instance.exports.bjs_roundTripWithSpaces(+isSome, isSome ? value : 0);
+                    instance.exports.bjs_roundTripWithSpaces(+isSome, isSome ? value : 0.0);
                     const optResult = tmpRetOptionalDouble;
                     tmpRetOptionalDouble = undefined;
                     return optResult;
@@ -709,31 +771,49 @@ export async function createInstantiator(options, swift) {
                 },
                 roundTripOptionalAlias: function bjs_roundTripOptionalAlias(name) {
                     const isSome = name != null;
-                    let nameId, nameBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        nameBytes = textEncoder.encode(name);
-                        nameId = swift.memory.retain(nameBytes);
+                        const nameBytes = textEncoder.encode(name);
+                        const nameId = swift.memory.retain(nameBytes);
+                        result = nameId;
+                        result1 = nameBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalAlias(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
+                    instance.exports.bjs_roundTripOptionalAlias(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
                 testMixedOptionals: function bjs_testMixedOptionals(firstName, lastName, age, active) {
                     const isSome = firstName != null;
-                    let firstNameId, firstNameBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        firstNameBytes = textEncoder.encode(firstName);
-                        firstNameId = swift.memory.retain(firstNameBytes);
+                        const firstNameBytes = textEncoder.encode(firstName);
+                        const firstNameId = swift.memory.retain(firstNameBytes);
+                        result = firstNameId;
+                        result1 = firstNameBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
                     const isSome1 = lastName != null;
-                    let lastNameId, lastNameBytes;
+                    let result2;
+                    let result3;
                     if (isSome1) {
-                        lastNameBytes = textEncoder.encode(lastName);
-                        lastNameId = swift.memory.retain(lastNameBytes);
+                        const lastNameBytes = textEncoder.encode(lastName);
+                        const lastNameId = swift.memory.retain(lastNameBytes);
+                        result2 = lastNameId;
+                        result3 = lastNameBytes.length;
+                    } else {
+                        result2 = 0;
+                        result3 = 0;
                     }
                     const isSome2 = age != null;
-                    instance.exports.bjs_testMixedOptionals(+isSome, isSome ? firstNameId : 0, isSome ? firstNameBytes.length : 0, +isSome1, isSome1 ? lastNameId : 0, isSome1 ? lastNameBytes.length : 0, +isSome2, isSome2 ? age : 0, active);
+                    instance.exports.bjs_testMixedOptionals(+isSome, result, result1, +isSome1, result2, result3, +isSome2, isSome2 ? age : 0, active);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -77,8 +76,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -94,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -77,8 +76,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -94,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -76,8 +75,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -93,16 +91,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
@@ -34,49 +34,44 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createAPIResultValuesHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                const enumTag = value.tag;
-                switch (enumTag) {
-                    case APIResultValues.Tag.Success: {
-                        const bytes = textEncoder.encode(value.param0);
-                        const id = swift.memory.retain(bytes);
-                        i32Stack.push(bytes.length);
-                        i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Success, cleanup };
-                    }
-                    case APIResultValues.Tag.Failure: {
-                        i32Stack.push((value.param0 | 0));
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Failure, cleanup };
-                    }
-                    default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
+    const __bjs_createAPIResultValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case APIResultValues.Tag.Success: {
+                    const bytes = textEncoder.encode(value.param0);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    return APIResultValues.Tag.Success;
                 }
-            },
-            lift: (tag) => {
-                tag = tag | 0;
-                switch (tag) {
-                    case APIResultValues.Tag.Success: {
-                        const string = strStack.pop();
-                        return { tag: APIResultValues.Tag.Success, param0: string };
-                    }
-                    case APIResultValues.Tag.Failure: {
-                        const int = i32Stack.pop();
-                        return { tag: APIResultValues.Tag.Failure, param0: int };
-                    }
-                    default: throw new Error("Unknown APIResultValues tag returned from Swift: " + String(tag));
+                case APIResultValues.Tag.Failure: {
+                    i32Stack.push((value.param0 | 0));
+                    return APIResultValues.Tag.Failure;
                 }
+                default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
             }
-        });
-    };
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case APIResultValues.Tag.Success: {
+                    const string = strStack.pop();
+                    return { tag: APIResultValues.Tag.Success, param0: string };
+                }
+                case APIResultValues.Tag.Failure: {
+                    const int = i32Stack.pop();
+                    return { tag: APIResultValues.Tag.Failure, param0: int };
+                }
+                default: throw new Error("Unknown APIResultValues tag returned from Swift: " + String(tag));
+            }
+        }
+    });
 
     return {
         /**
@@ -124,8 +119,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -141,16 +135,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -304,7 +288,7 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 }
             }
-            const APIResultHelpers = __bjs_createAPIResultValuesHelpers()();
+            const APIResultHelpers = __bjs_createAPIResultValuesHelpers();
             enumHelpers.APIResult = APIResultHelpers;
 
             const exports = {
@@ -319,10 +303,9 @@ export async function createInstantiator(options, swift) {
                 APIResult: {
                     ...APIResultValues,
                     roundtrip: function(value) {
-                        const { caseId: valueCaseId, cleanup: valueCleanup } = enumHelpers.APIResult.lower(value);
+                        const valueCaseId = enumHelpers.APIResult.lower(value);
                         instance.exports.bjs_APIResult_static_roundtrip(valueCaseId);
                         const ret = enumHelpers.APIResult.lift(i32Stack.pop());
-                        if (valueCleanup) { valueCleanup(); }
                         return ret;
                     }
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
@@ -28,7 +28,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -81,8 +80,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -98,16 +96,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -304,12 +292,18 @@ export async function createInstantiator(options, swift) {
                 }
                 static set optionalProperty(value) {
                     const isSome = value != null;
-                    let valueId, valueBytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        valueBytes = textEncoder.encode(value);
-                        valueId = swift.memory.retain(valueBytes);
+                        const valueBytes = textEncoder.encode(value);
+                        const valueId = swift.memory.retain(valueBytes);
+                        result = valueId;
+                        result1 = valueBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.bjs_PropertyClass_static_optionalProperty_set(+isSome, isSome ? valueId : 0, isSome ? valueBytes.length : 0);
+                    instance.exports.bjs_PropertyClass_static_optionalProperty_set(+isSome, result, result1);
                 }
             }
             if (typeof globalThis.PropertyNamespace === 'undefined') {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -77,8 +76,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -94,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -77,8 +76,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -94,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -77,8 +76,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -94,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -222,9 +210,9 @@ export async function createInstantiator(options, swift) {
                     return 0
                 }
             }
-            TestModule["bjs_jsRoundTripOptionalGreeter"] = function bjs_jsRoundTripOptionalGreeter(greeterIsSome, greeterWrappedValue) {
+            TestModule["bjs_jsRoundTripOptionalGreeter"] = function bjs_jsRoundTripOptionalGreeter(greeterIsSome, greeterPointer) {
                 try {
-                    let ret = imports.jsRoundTripOptionalGreeter(greeterIsSome ? _exports['Greeter'].__construct(greeterWrappedValue) : null);
+                    let ret = imports.jsRoundTripOptionalGreeter(greeterIsSome ? _exports['Greeter'].__construct(greeterPointer) : null);
                     const isSome = ret != null;
                     return isSome ? ret.pointer : 0;
                 } catch (error) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -53,7 +53,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -84,75 +83,67 @@ export async function createInstantiator(options, swift) {
         return swift.memory.retain(real);
     };
 
-    const __bjs_createAPIResultValuesHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                const enumTag = value.tag;
-                switch (enumTag) {
-                    case APIResultValues.Tag.Success: {
-                        const bytes = textEncoder.encode(value.param0);
-                        const id = swift.memory.retain(bytes);
-                        i32Stack.push(bytes.length);
-                        i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Success, cleanup };
-                    }
-                    case APIResultValues.Tag.Failure: {
-                        i32Stack.push((value.param0 | 0));
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Failure, cleanup };
-                    }
-                    case APIResultValues.Tag.Flag: {
-                        i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Flag, cleanup };
-                    }
-                    case APIResultValues.Tag.Rate: {
-                        f32Stack.push(Math.fround(value.param0));
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Rate, cleanup };
-                    }
-                    case APIResultValues.Tag.Precise: {
-                        f64Stack.push(value.param0);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Precise, cleanup };
-                    }
-                    case APIResultValues.Tag.Info: {
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Info, cleanup };
-                    }
-                    default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
+    const __bjs_createAPIResultValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case APIResultValues.Tag.Success: {
+                    const bytes = textEncoder.encode(value.param0);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    return APIResultValues.Tag.Success;
                 }
-            },
-            lift: (tag) => {
-                tag = tag | 0;
-                switch (tag) {
-                    case APIResultValues.Tag.Success: {
-                        const string = strStack.pop();
-                        return { tag: APIResultValues.Tag.Success, param0: string };
-                    }
-                    case APIResultValues.Tag.Failure: {
-                        const int = i32Stack.pop();
-                        return { tag: APIResultValues.Tag.Failure, param0: int };
-                    }
-                    case APIResultValues.Tag.Flag: {
-                        const bool = i32Stack.pop() !== 0;
-                        return { tag: APIResultValues.Tag.Flag, param0: bool };
-                    }
-                    case APIResultValues.Tag.Rate: {
-                        const f32 = f32Stack.pop();
-                        return { tag: APIResultValues.Tag.Rate, param0: f32 };
-                    }
-                    case APIResultValues.Tag.Precise: {
-                        const f64 = f64Stack.pop();
-                        return { tag: APIResultValues.Tag.Precise, param0: f64 };
-                    }
-                    case APIResultValues.Tag.Info: return { tag: APIResultValues.Tag.Info };
-                    default: throw new Error("Unknown APIResultValues tag returned from Swift: " + String(tag));
+                case APIResultValues.Tag.Failure: {
+                    i32Stack.push((value.param0 | 0));
+                    return APIResultValues.Tag.Failure;
                 }
+                case APIResultValues.Tag.Flag: {
+                    i32Stack.push(value.param0 ? 1 : 0);
+                    return APIResultValues.Tag.Flag;
+                }
+                case APIResultValues.Tag.Rate: {
+                    f32Stack.push(Math.fround(value.param0));
+                    return APIResultValues.Tag.Rate;
+                }
+                case APIResultValues.Tag.Precise: {
+                    f64Stack.push(value.param0);
+                    return APIResultValues.Tag.Precise;
+                }
+                case APIResultValues.Tag.Info: {
+                    return APIResultValues.Tag.Info;
+                }
+                default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
             }
-        });
-    };
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case APIResultValues.Tag.Success: {
+                    const string = strStack.pop();
+                    return { tag: APIResultValues.Tag.Success, param0: string };
+                }
+                case APIResultValues.Tag.Failure: {
+                    const int = i32Stack.pop();
+                    return { tag: APIResultValues.Tag.Failure, param0: int };
+                }
+                case APIResultValues.Tag.Flag: {
+                    const bool = i32Stack.pop() !== 0;
+                    return { tag: APIResultValues.Tag.Flag, param0: bool };
+                }
+                case APIResultValues.Tag.Rate: {
+                    const f32 = f32Stack.pop();
+                    return { tag: APIResultValues.Tag.Rate, param0: f32 };
+                }
+                case APIResultValues.Tag.Precise: {
+                    const f64 = f64Stack.pop();
+                    return { tag: APIResultValues.Tag.Precise, param0: f64 };
+                }
+                case APIResultValues.Tag.Info: return { tag: APIResultValues.Tag.Info };
+                default: throw new Error("Unknown APIResultValues tag returned from Swift: " + String(tag));
+            }
+        }
+    });
 
     return {
         /**
@@ -200,8 +191,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -217,16 +207,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -403,7 +383,7 @@ export async function createInstantiator(options, swift) {
                     const callback = swift.memory.getObject(callbackId);
                     const enumValue = enumHelpers.APIResult.lift(param0);
                     let ret = callback(enumValue);
-                    const { caseId: caseId, cleanup: cleanup } = enumHelpers.APIResult.lower(ret);
+                    const caseId = enumHelpers.APIResult.lower(ret);
                     return caseId;
                 } catch (error) {
                     setException(error);
@@ -411,10 +391,9 @@ export async function createInstantiator(options, swift) {
             }
             bjs["make_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO"] = function(boxPtr, file, line) {
                 const lower_closure_TestModule_10TestModule9APIResultO_9APIResultO = function(param0) {
-                    const { caseId: param0CaseId, cleanup: param0Cleanup } = enumHelpers.APIResult.lower(param0);
+                    const param0CaseId = enumHelpers.APIResult.lower(param0);
                     instance.exports.invoke_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO(boxPtr, param0CaseId);
                     const ret = enumHelpers.APIResult.lift(i32Stack.pop());
-                    if (param0Cleanup) { param0Cleanup(); }
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -595,21 +574,20 @@ export async function createInstantiator(options, swift) {
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO"] = function(callbackId, param0IsSome, param0WrappedValue) {
+            bjs["invoke_js_callback_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO"] = function(callbackId, param0IsSome, param0ObjectId) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
-                    let obj;
+                    let optResult;
                     if (param0IsSome) {
-                        obj = swift.memory.getObject(param0WrappedValue);
-                        swift.memory.release(param0WrappedValue);
-                    }
-                    let ret = callback(param0IsSome ? obj : null);
-                    const isSome = ret != null;
-                    if (isSome) {
-                        tmpRetString = ret;
+                        const param0ObjectIdObject = swift.memory.getObject(param0ObjectId);
+                        swift.memory.release(param0ObjectId);
+                        optResult = param0ObjectIdObject;
                     } else {
-                        tmpRetString = null;
+                        optResult = null;
                     }
+                    let ret = callback(optResult);
+                    const isSome = ret != null;
+                    tmpRetString = isSome ? ret : null;
                 } catch (error) {
                     setException(error);
                 }
@@ -617,12 +595,18 @@ export async function createInstantiator(options, swift) {
             bjs["make_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO"] = function(boxPtr, file, line) {
                 const lower_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO = function(param0) {
                     const isSome = param0 != null;
-                    let param0Id, param0Bytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        param0Bytes = textEncoder.encode(param0);
-                        param0Id = swift.memory.retain(param0Bytes);
+                        const param0Bytes = textEncoder.encode(param0);
+                        const param0Id = swift.memory.retain(param0Bytes);
+                        result = param0Id;
+                        result1 = param0Bytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO(boxPtr, +isSome, isSome ? param0Id : 0, isSome ? param0Bytes.length : 0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO(boxPtr, +isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     if (tmpRetException) {
@@ -635,10 +619,10 @@ export async function createInstantiator(options, swift) {
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC"] = function(callbackId, param0IsSome, param0WrappedValue) {
+            bjs["invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC"] = function(callbackId, param0IsSome, param0Pointer) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
-                    let ret = callback(param0IsSome ? _exports['Person'].__construct(param0WrappedValue) : null);
+                    let ret = callback(param0IsSome ? _exports['Person'].__construct(param0Pointer) : null);
                     const isSome = ret != null;
                     return isSome ? ret.pointer : 0;
                 } catch (error) {
@@ -648,7 +632,13 @@ export async function createInstantiator(options, swift) {
             bjs["make_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC"] = function(boxPtr, file, line) {
                 const lower_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC = function(param0) {
                     const isSome = param0 != null;
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC(boxPtr, +isSome, isSome ? param0.pointer : 0);
+                    let result;
+                    if (isSome) {
+                        result = param0.pointer;
+                    } else {
+                        result = 0;
+                    }
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC(boxPtr, +isSome, result);
                     const pointer = tmpRetOptionalHeapObject;
                     tmpRetOptionalHeapObject = undefined;
                     const optResult = pointer === null ? null : _exports['Person'].__construct(pointer);
@@ -662,17 +652,20 @@ export async function createInstantiator(options, swift) {
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO"] = function(callbackId, param0IsSome, param0WrappedValue) {
+            bjs["invoke_js_callback_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO"] = function(callbackId, param0IsSome, param0CaseId) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
-                    let enumValue;
+                    let optResult;
                     if (param0IsSome) {
-                        enumValue = enumHelpers.APIResult.lift(param0WrappedValue);
+                        const enumValue = enumHelpers.APIResult.lift(param0CaseId);
+                        optResult = enumValue;
+                    } else {
+                        optResult = null;
                     }
-                    let ret = callback(param0IsSome ? enumValue : null);
+                    let ret = callback(optResult);
                     const isSome = ret != null;
                     if (isSome) {
-                        const { caseId: caseId, cleanup: cleanup } = enumHelpers.APIResult.lower(ret);
+                        const caseId = enumHelpers.APIResult.lower(ret);
                         return caseId;
                     } else {
                         return -1;
@@ -684,22 +677,16 @@ export async function createInstantiator(options, swift) {
             bjs["make_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO"] = function(boxPtr, file, line) {
                 const lower_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO = function(param0) {
                     const isSome = param0 != null;
-                    let param0CaseId, param0Cleanup;
+                    let result;
                     if (isSome) {
-                        const enumResult = enumHelpers.APIResult.lower(param0);
-                        param0CaseId = enumResult.caseId;
-                        param0Cleanup = enumResult.cleanup;
-                    }
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO(boxPtr, +isSome, isSome ? param0CaseId : 0);
-                    const tag = i32Stack.pop();
-                    const isNull = (tag === -1);
-                    let optResult;
-                    if (isNull) {
-                        optResult = null;
+                        const param0CaseId = enumHelpers.APIResult.lower(param0);
+                        result = param0CaseId;
                     } else {
-                        optResult = enumHelpers.APIResult.lift(tag);
+                        result = 0;
                     }
-                    if (param0Cleanup) { param0Cleanup(); }
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO(boxPtr, +isSome, result);
+                    const tag = i32Stack.pop();
+                    const optResult = tag === -1 ? null : enumHelpers.APIResult.lift(tag);
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -715,7 +702,7 @@ export async function createInstantiator(options, swift) {
                     const callback = swift.memory.getObject(callbackId);
                     let ret = callback(param0IsSome ? param0WrappedValue : null);
                     const isSome = ret != null;
-                    return isSome ? (ret | 0) : -1;
+                    return isSome ? ret : -1;
                 } catch (error) {
                     setException(error);
                 }
@@ -736,21 +723,20 @@ export async function createInstantiator(options, swift) {
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleSqSS_SqSS"] = function(callbackId, param0IsSome, param0WrappedValue) {
+            bjs["invoke_js_callback_TestModule_10TestModuleSqSS_SqSS"] = function(callbackId, param0IsSome, param0ObjectId) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
-                    let obj;
+                    let optResult;
                     if (param0IsSome) {
-                        obj = swift.memory.getObject(param0WrappedValue);
-                        swift.memory.release(param0WrappedValue);
-                    }
-                    let ret = callback(param0IsSome ? obj : null);
-                    const isSome = ret != null;
-                    if (isSome) {
-                        tmpRetString = ret;
+                        const param0ObjectIdObject = swift.memory.getObject(param0ObjectId);
+                        swift.memory.release(param0ObjectId);
+                        optResult = param0ObjectIdObject;
                     } else {
-                        tmpRetString = null;
+                        optResult = null;
                     }
+                    let ret = callback(optResult);
+                    const isSome = ret != null;
+                    tmpRetString = isSome ? ret : null;
                 } catch (error) {
                     setException(error);
                 }
@@ -758,12 +744,18 @@ export async function createInstantiator(options, swift) {
             bjs["make_swift_closure_TestModule_10TestModuleSqSS_SqSS"] = function(boxPtr, file, line) {
                 const lower_closure_TestModule_10TestModuleSqSS_SqSS = function(param0) {
                     const isSome = param0 != null;
-                    let param0Id, param0Bytes;
+                    let result;
+                    let result1;
                     if (isSome) {
-                        param0Bytes = textEncoder.encode(param0);
-                        param0Id = swift.memory.retain(param0Bytes);
+                        const param0Bytes = textEncoder.encode(param0);
+                        const param0Id = swift.memory.retain(param0Bytes);
+                        result = param0Id;
+                        result1 = param0Bytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
                     }
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSqSS_SqSS(boxPtr, +isSome, isSome ? param0Id : 0, isSome ? param0Bytes.length : 0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSqSS_SqSS(boxPtr, +isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     if (tmpRetException) {
@@ -789,7 +781,7 @@ export async function createInstantiator(options, swift) {
             bjs["make_swift_closure_TestModule_10TestModuleSqSb_SqSb"] = function(boxPtr, file, line) {
                 const lower_closure_TestModule_10TestModuleSqSb_SqSb = function(param0) {
                     const isSome = param0 != null;
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSqSb_SqSb(boxPtr, +isSome, isSome ? param0 : 0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSqSb_SqSb(boxPtr, +isSome, isSome ? param0 ? 1 : 0 : 0);
                     const optResult = tmpRetOptionalBool;
                     tmpRetOptionalBool = undefined;
                     if (tmpRetException) {
@@ -815,7 +807,7 @@ export async function createInstantiator(options, swift) {
             bjs["make_swift_closure_TestModule_10TestModuleSqSd_SqSd"] = function(boxPtr, file, line) {
                 const lower_closure_TestModule_10TestModuleSqSd_SqSd = function(param0) {
                     const isSome = param0 != null;
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSqSd_SqSd(boxPtr, +isSome, isSome ? param0 : 0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSqSd_SqSd(boxPtr, +isSome, isSome ? param0 : 0.0);
                     const optResult = tmpRetOptionalDouble;
                     tmpRetOptionalDouble = undefined;
                     if (tmpRetException) {
@@ -841,7 +833,7 @@ export async function createInstantiator(options, swift) {
             bjs["make_swift_closure_TestModule_10TestModuleSqSf_SqSf"] = function(boxPtr, file, line) {
                 const lower_closure_TestModule_10TestModuleSqSf_SqSf = function(param0) {
                     const isSome = param0 != null;
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSqSf_SqSf(boxPtr, +isSome, isSome ? param0 : 0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSqSf_SqSf(boxPtr, +isSome, isSome ? param0 : 0.0);
                     const optResult = tmpRetOptionalFloat;
                     tmpRetOptionalFloat = undefined;
                     if (tmpRetException) {
@@ -946,7 +938,7 @@ export async function createInstantiator(options, swift) {
                     return TestProcessor.__construct(ret);
                 }
             }
-            const APIResultHelpers = __bjs_createAPIResultValuesHelpers()();
+            const APIResultHelpers = __bjs_createAPIResultValuesHelpers();
             enumHelpers.APIResult = APIResultHelpers;
 
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -102,8 +101,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -119,16 +117,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
@@ -28,242 +28,219 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createDataPointHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                f64Stack.push(value.x);
-                f64Stack.push(value.y);
-                const bytes = textEncoder.encode(value.label);
-                const id = swift.memory.retain(bytes);
-                i32Stack.push(bytes.length);
-                i32Stack.push(id);
-                const isSome = value.optCount != null;
-                if (isSome) {
-                    i32Stack.push(value.optCount | 0);
-                } else {
-                    i32Stack.push(0);
-                }
-                i32Stack.push(isSome ? 1 : 0);
-                const isSome1 = value.optFlag != null;
-                if (isSome1) {
-                    i32Stack.push(value.optFlag ? 1 : 0);
-                } else {
-                    i32Stack.push(0);
-                }
-                i32Stack.push(isSome1 ? 1 : 0);
-                return { cleanup: undefined };
-            },
-            lift: () => {
-                const isSome = i32Stack.pop();
-                let optional;
-                if (isSome) {
-                    const bool = i32Stack.pop() !== 0;
-                    optional = bool;
-                } else {
-                    optional = null;
-                }
-                const isSome1 = i32Stack.pop();
-                let optional1;
-                if (isSome1) {
-                    const int = i32Stack.pop();
-                    optional1 = int;
-                } else {
-                    optional1 = null;
-                }
-                const string = strStack.pop();
-                const f64 = f64Stack.pop();
-                const f641 = f64Stack.pop();
-                return { x: f641, y: f64, label: string, optCount: optional1, optFlag: optional };
+    const __bjs_createDataPointHelpers = () => ({
+        lower: (value) => {
+            f64Stack.push(value.x);
+            f64Stack.push(value.y);
+            const bytes = textEncoder.encode(value.label);
+            const id = swift.memory.retain(bytes);
+            i32Stack.push(bytes.length);
+            i32Stack.push(id);
+            const isSome = value.optCount != null;
+            if (isSome) {
+                i32Stack.push((value.optCount | 0));
+            } else {
+                i32Stack.push(0);
             }
-        });
-    };
-    const __bjs_createAddressHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                const bytes = textEncoder.encode(value.street);
-                const id = swift.memory.retain(bytes);
-                i32Stack.push(bytes.length);
-                i32Stack.push(id);
-                const bytes1 = textEncoder.encode(value.city);
+            i32Stack.push(isSome ? 1 : 0);
+            const isSome1 = value.optFlag != null;
+            if (isSome1) {
+                i32Stack.push(value.optFlag ? 1 : 0);
+            } else {
+                i32Stack.push(0);
+            }
+            i32Stack.push(isSome1 ? 1 : 0);
+        },
+        lift: () => {
+            const isSome = i32Stack.pop();
+            let optional;
+            if (isSome) {
+                const bool = i32Stack.pop() !== 0;
+                optional = bool;
+            } else {
+                optional = null;
+            }
+            const isSome1 = i32Stack.pop();
+            let optional1;
+            if (isSome1) {
+                const int = i32Stack.pop();
+                optional1 = int;
+            } else {
+                optional1 = null;
+            }
+            const string = strStack.pop();
+            const f64 = f64Stack.pop();
+            const f641 = f64Stack.pop();
+            return { x: f641, y: f64, label: string, optCount: optional1, optFlag: optional };
+        }
+    });
+    const __bjs_createAddressHelpers = () => ({
+        lower: (value) => {
+            const bytes = textEncoder.encode(value.street);
+            const id = swift.memory.retain(bytes);
+            i32Stack.push(bytes.length);
+            i32Stack.push(id);
+            const bytes1 = textEncoder.encode(value.city);
+            const id1 = swift.memory.retain(bytes1);
+            i32Stack.push(bytes1.length);
+            i32Stack.push(id1);
+            const isSome = value.zipCode != null;
+            if (isSome) {
+                i32Stack.push((value.zipCode | 0));
+            } else {
+                i32Stack.push(0);
+            }
+            i32Stack.push(isSome ? 1 : 0);
+        },
+        lift: () => {
+            const isSome = i32Stack.pop();
+            let optional;
+            if (isSome) {
+                const int = i32Stack.pop();
+                optional = int;
+            } else {
+                optional = null;
+            }
+            const string = strStack.pop();
+            const string1 = strStack.pop();
+            return { street: string1, city: string, zipCode: optional };
+        }
+    });
+    const __bjs_createPersonHelpers = () => ({
+        lower: (value) => {
+            const bytes = textEncoder.encode(value.name);
+            const id = swift.memory.retain(bytes);
+            i32Stack.push(bytes.length);
+            i32Stack.push(id);
+            i32Stack.push((value.age | 0));
+            structHelpers.Address.lower(value.address);
+            const isSome = value.email != null;
+            if (isSome) {
+                const bytes1 = textEncoder.encode(value.email);
                 const id1 = swift.memory.retain(bytes1);
                 i32Stack.push(bytes1.length);
                 i32Stack.push(id1);
-                const isSome = value.zipCode != null;
-                if (isSome) {
-                    i32Stack.push(value.zipCode | 0);
-                } else {
-                    i32Stack.push(0);
-                }
-                i32Stack.push(isSome ? 1 : 0);
-                return { cleanup: undefined };
-            },
-            lift: () => {
-                const isSome = i32Stack.pop();
-                let optional;
-                if (isSome) {
-                    const int = i32Stack.pop();
-                    optional = int;
-                } else {
-                    optional = null;
-                }
+            } else {
+                i32Stack.push(0);
+                i32Stack.push(0);
+            }
+            i32Stack.push(isSome ? 1 : 0);
+        },
+        lift: () => {
+            const isSome = i32Stack.pop();
+            let optional;
+            if (isSome) {
                 const string = strStack.pop();
-                const string1 = strStack.pop();
-                return { street: string1, city: string, zipCode: optional };
+                optional = string;
+            } else {
+                optional = null;
             }
-        });
-    };
-    const __bjs_createPersonHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                const bytes = textEncoder.encode(value.name);
-                const id = swift.memory.retain(bytes);
-                i32Stack.push(bytes.length);
-                i32Stack.push(id);
-                i32Stack.push((value.age | 0));
-                const structResult = structHelpers.Address.lower(value.address);
-                const isSome = value.email != null;
+            const struct = structHelpers.Address.lift();
+            const int = i32Stack.pop();
+            const string1 = strStack.pop();
+            return { name: string1, age: int, address: struct, email: optional };
+        }
+    });
+    const __bjs_createSessionHelpers = () => ({
+        lower: (value) => {
+            i32Stack.push((value.id | 0));
+            ptrStack.push(value.owner.pointer);
+        },
+        lift: () => {
+            const ptr = ptrStack.pop();
+            const obj = _exports['Greeter'].__construct(ptr);
+            const int = i32Stack.pop();
+            return { id: int, owner: obj };
+        }
+    });
+    const __bjs_createMeasurementHelpers = () => ({
+        lower: (value) => {
+            f64Stack.push(value.value);
+            f32Stack.push(Math.fround(value.precision));
+            const isSome = value.optionalPrecision != null;
+            if (isSome) {
+                f32Stack.push(Math.fround(value.optionalPrecision));
+            } else {
+                f32Stack.push(0.0);
+            }
+            i32Stack.push(isSome ? 1 : 0);
+        },
+        lift: () => {
+            const isSome = i32Stack.pop();
+            let optional;
+            if (isSome) {
+                const rawValue = f32Stack.pop();
+                optional = rawValue;
+            } else {
+                optional = null;
+            }
+            const rawValue1 = f32Stack.pop();
+            const f64 = f64Stack.pop();
+            return { value: f64, precision: rawValue1, optionalPrecision: optional };
+        }
+    });
+    const __bjs_createConfigStructHelpers = () => ({
+        lower: (value) => {
+        },
+        lift: () => {
+            return {  };
+        }
+    });
+    const __bjs_createContainerHelpers = () => ({
+        lower: (value) => {
+            let id;
+            if (value.object != null) {
+                id = swift.memory.retain(value.object);
+            } else {
+                id = undefined;
+            }
+            i32Stack.push(id !== undefined ? id : 0);
+            const isSome = value.optionalObject != null;
+            if (isSome) {
                 let id1;
-                if (isSome) {
-                    const bytes1 = textEncoder.encode(value.email);
-                    id1 = swift.memory.retain(bytes1);
-                    i32Stack.push(bytes1.length);
-                    i32Stack.push(id1);
-                } else {
-                    i32Stack.push(0);
-                    i32Stack.push(0);
-                }
-                i32Stack.push(isSome ? 1 : 0);
-                const cleanup = () => {
-                    if (structResult.cleanup) { structResult.cleanup(); }
-                };
-                return { cleanup };
-            },
-            lift: () => {
-                const isSome = i32Stack.pop();
-                let optional;
-                if (isSome) {
-                    const string = strStack.pop();
-                    optional = string;
-                } else {
-                    optional = null;
-                }
-                const struct = structHelpers.Address.lift();
-                const int = i32Stack.pop();
-                const string1 = strStack.pop();
-                return { name: string1, age: int, address: struct, email: optional };
-            }
-        });
-    };
-    const __bjs_createSessionHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                i32Stack.push((value.id | 0));
-                ptrStack.push(value.owner.pointer);
-                return { cleanup: undefined };
-            },
-            lift: () => {
-                const ptr = ptrStack.pop();
-                const obj = _exports['Greeter'].__construct(ptr);
-                const int = i32Stack.pop();
-                return { id: int, owner: obj };
-            }
-        });
-    };
-    const __bjs_createMeasurementHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                f64Stack.push(value.value);
-                f32Stack.push(Math.fround(value.precision));
-                const isSome = value.optionalPrecision != null;
-                if (isSome) {
-                    f32Stack.push(Math.fround(value.optionalPrecision));
-                } else {
-                    f32Stack.push(0.0);
-                }
-                i32Stack.push(isSome ? 1 : 0);
-                return { cleanup: undefined };
-            },
-            lift: () => {
-                const isSome = i32Stack.pop();
-                let optional;
-                if (isSome) {
-                    const rawValue = f32Stack.pop();
-                    optional = rawValue;
-                } else {
-                    optional = null;
-                }
-                const rawValue1 = f32Stack.pop();
-                const f64 = f64Stack.pop();
-                return { value: f64, precision: rawValue1, optionalPrecision: optional };
-            }
-        });
-    };
-    const __bjs_createConfigStructHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                return { cleanup: undefined };
-            },
-            lift: () => {
-                return {  };
-            }
-        });
-    };
-    const __bjs_createContainerHelpers = () => {
-        return () => ({
-            lower: (value) => {
-                let id;
-                if (value.object != null) {
-                    id = swift.memory.retain(value.object);
-                } else {
-                    id = undefined;
-                }
-                i32Stack.push(id !== undefined ? id : 0);
-                const isSome = value.optionalObject != null;
-                let id1;
-                if (isSome) {
+                if (value.optionalObject != null) {
                     id1 = swift.memory.retain(value.optionalObject);
-                    i32Stack.push(id1);
                 } else {
                     id1 = undefined;
-                    i32Stack.push(0);
                 }
-                i32Stack.push(isSome ? 1 : 0);
-                return { cleanup: undefined };
-            },
-            lift: () => {
-                const isSome = i32Stack.pop();
-                let optional;
-                if (isSome) {
-                    const objectId = i32Stack.pop();
-                    let value;
-                    if (objectId !== 0) {
-                        value = swift.memory.getObject(objectId);
-                        swift.memory.release(objectId);
-                    } else {
-                        value = null;
-                    }
-                    optional = value;
-                } else {
-                    optional = null;
-                }
-                const objectId1 = i32Stack.pop();
-                let value1;
-                if (objectId1 !== 0) {
-                    value1 = swift.memory.getObject(objectId1);
-                    swift.memory.release(objectId1);
-                } else {
-                    value1 = null;
-                }
-                return { object: value1, optionalObject: optional };
+                i32Stack.push(id1 !== undefined ? id1 : 0);
+            } else {
+                i32Stack.push(0);
             }
-        });
-    };
+            i32Stack.push(isSome ? 1 : 0);
+        },
+        lift: () => {
+            const isSome = i32Stack.pop();
+            let optional;
+            if (isSome) {
+                const objectId = i32Stack.pop();
+                let value;
+                if (objectId !== 0) {
+                    value = swift.memory.getObject(objectId);
+                    swift.memory.release(objectId);
+                } else {
+                    value = null;
+                }
+                optional = value;
+            } else {
+                optional = null;
+            }
+            const objectId1 = i32Stack.pop();
+            let value1;
+            if (objectId1 !== 0) {
+                value1 = swift.memory.getObject(objectId1);
+                swift.memory.release(objectId1);
+            } else {
+                value1 = null;
+            }
+            return { object: value1, optionalObject: optional };
+        }
+    });
 
     return {
         /**
@@ -311,8 +288,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -329,88 +305,50 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
             }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
-            }
             bjs["swift_js_struct_lower_DataPoint"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.DataPoint.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.DataPoint.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_DataPoint"] = function() {
                 const value = structHelpers.DataPoint.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Address"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Address.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Address.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Address"] = function() {
                 const value = structHelpers.Address.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Person"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Person.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Person.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Person"] = function() {
                 const value = structHelpers.Person.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Session"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Session.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Session.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Session"] = function() {
                 const value = structHelpers.Session.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Measurement"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Measurement.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Measurement.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Measurement"] = function() {
                 const value = structHelpers.Measurement.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_ConfigStruct"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.ConfigStruct.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.ConfigStruct.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_ConfigStruct"] = function() {
                 const value = structHelpers.ConfigStruct.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Container"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Container.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Container.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Container"] = function() {
                 const value = structHelpers.Container.lift();
@@ -575,41 +513,39 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_Greeter_name_set(this.pointer, valueId, valueBytes.length);
                 }
             }
-            const DataPointHelpers = __bjs_createDataPointHelpers()();
+            const DataPointHelpers = __bjs_createDataPointHelpers();
             structHelpers.DataPoint = DataPointHelpers;
 
-            const AddressHelpers = __bjs_createAddressHelpers()();
+            const AddressHelpers = __bjs_createAddressHelpers();
             structHelpers.Address = AddressHelpers;
 
-            const PersonHelpers = __bjs_createPersonHelpers()();
+            const PersonHelpers = __bjs_createPersonHelpers();
             structHelpers.Person = PersonHelpers;
 
-            const SessionHelpers = __bjs_createSessionHelpers()();
+            const SessionHelpers = __bjs_createSessionHelpers();
             structHelpers.Session = SessionHelpers;
 
-            const MeasurementHelpers = __bjs_createMeasurementHelpers()();
+            const MeasurementHelpers = __bjs_createMeasurementHelpers();
             structHelpers.Measurement = MeasurementHelpers;
 
-            const ConfigStructHelpers = __bjs_createConfigStructHelpers()();
+            const ConfigStructHelpers = __bjs_createConfigStructHelpers();
             structHelpers.ConfigStruct = ConfigStructHelpers;
 
-            const ContainerHelpers = __bjs_createContainerHelpers()();
+            const ContainerHelpers = __bjs_createContainerHelpers();
             structHelpers.Container = ContainerHelpers;
 
             const exports = {
                 Greeter,
                 roundtrip: function bjs_roundtrip(session) {
-                    const { cleanup: cleanup } = structHelpers.Person.lower(session);
+                    structHelpers.Person.lower(session);
                     instance.exports.bjs_roundtrip();
                     const structValue = structHelpers.Person.lift();
-                    if (cleanup) { cleanup(); }
                     return structValue;
                 },
                 roundtripContainer: function bjs_roundtripContainer(container) {
-                    const { cleanup: cleanup } = structHelpers.Container.lower(container);
+                    structHelpers.Container.lower(container);
                     instance.exports.bjs_roundtripContainer();
                     const structValue = structHelpers.Container.lift();
-                    if (cleanup) { cleanup(); }
                     return structValue;
                 },
                 Precision: PrecisionValues,
@@ -619,7 +555,7 @@ export async function createInstantiator(options, swift) {
                         const labelId = swift.memory.retain(labelBytes);
                         const isSome = optCount != null;
                         const isSome1 = optFlag != null;
-                        instance.exports.bjs_DataPoint_init(x, y, labelId, labelBytes.length, +isSome, isSome ? optCount : 0, +isSome1, isSome1 ? optFlag : 0);
+                        instance.exports.bjs_DataPoint_init(x, y, labelId, labelBytes.length, +isSome, isSome ? optCount : 0, +isSome1, isSome1 ? optFlag ? 1 : 0 : 0);
                         const structValue = structHelpers.DataPoint.lift();
                         return structValue;
                     },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -76,8 +75,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -93,16 +91,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -77,8 +76,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_push_string"] = function(ptr, len) {
                 const bytes = new Uint8Array(memory.buffer, ptr, len);
-                const value = textDecoder.decode(bytes);
-                strStack.push(value);
+                strStack.push(textDecoder.decode(bytes));
             }
             bjs["swift_js_pop_i32"] = function() {
                 return i32Stack.pop();
@@ -94,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -818,21 +818,6 @@ private func _swift_js_pop_f64_extern() -> Float64 {
     _swift_js_pop_f64_extern()
 }
 
-// MARK: Struct bridging helpers (JS-side lowering/raising)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_cleanup")
-private func _swift_js_struct_cleanup_extern(_ cleanupId: Int32)
-#else
-private func _swift_js_struct_cleanup_extern(_ cleanupId: Int32) {
-    _onlyAvailableOnWasm()
-}
-#endif
-
-@_spi(BridgeJS) @inline(never) public func _swift_js_struct_cleanup(_ cleanupId: Int32) {
-    _swift_js_struct_cleanup_extern(cleanupId)
-}
-
 // MARK: Wasm externs used by type lowering/lifting
 
 #if arch(wasm32)

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -1026,10 +1026,10 @@ extension JSTypedClosure where Signature == (Optional<Greeter>) -> String {
 
 @_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS")
 @_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: UnsafeMutableRawPointer) -> Void {
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<Greeter>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<Greeter>.bridgeJSLiftParameter(param0IsSome, param0Value))
+    let result = closure(Optional<Greeter>.bridgeJSLiftParameter(param0IsSome, param0Pointer))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -1083,10 +1083,10 @@ extension JSTypedClosure where Signature == (Optional<Greeter>) -> Optional<Gree
 
 @_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC")
 @_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: UnsafeMutableRawPointer) -> Void {
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<Greeter>) -> Optional<Greeter>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<Greeter>.bridgeJSLiftParameter(param0IsSome, param0Value))
+    let result = closure(Optional<Greeter>.bridgeJSLiftParameter(param0IsSome, param0Pointer))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -2720,10 +2720,7 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -2736,9 +2733,9 @@ extension Point: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2771,10 +2768,7 @@ extension PointerFields: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_PointerFields(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_PointerFields(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -2787,9 +2781,9 @@ extension PointerFields: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PointerFields")
-fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2841,10 +2835,7 @@ extension DataPoint: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_DataPoint(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_DataPoint(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -2857,9 +2848,9 @@ extension DataPoint: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_DataPoint")
-fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2897,10 +2888,7 @@ extension PublicPoint: _BridgedSwiftStruct {
     }
 
     public init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_PublicPoint(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_PublicPoint(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -2913,9 +2901,9 @@ extension PublicPoint: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PublicPoint")
-fileprivate func _bjs_struct_lower_PublicPoint(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_PublicPoint(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PublicPoint(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_PublicPoint(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2959,10 +2947,7 @@ extension Address: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -2975,9 +2960,9 @@ extension Address: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Address")
-fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3014,10 +2999,7 @@ extension Contact: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Contact(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Contact(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3030,9 +3012,9 @@ extension Contact: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Contact")
-fileprivate func _bjs_struct_lower_Contact(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Contact(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Contact(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Contact(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3071,10 +3053,7 @@ extension Config: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Config(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Config(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3087,9 +3066,9 @@ extension Config: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Config")
-fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3120,10 +3099,7 @@ extension SessionData: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_SessionData(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_SessionData(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3136,9 +3112,9 @@ extension SessionData: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_SessionData")
-fileprivate func _bjs_struct_lower_SessionData(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_SessionData(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_SessionData(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_SessionData(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3177,10 +3153,7 @@ extension ValidationReport: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_ValidationReport(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_ValidationReport(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3193,9 +3166,9 @@ extension ValidationReport: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ValidationReport")
-fileprivate func _bjs_struct_lower_ValidationReport(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_ValidationReport(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ValidationReport(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_ValidationReport(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3246,10 +3219,7 @@ extension AdvancedConfig: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_AdvancedConfig(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_AdvancedConfig(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3262,9 +3232,9 @@ extension AdvancedConfig: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_AdvancedConfig")
-fileprivate func _bjs_struct_lower_AdvancedConfig(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_AdvancedConfig(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_AdvancedConfig(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_AdvancedConfig(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3303,10 +3273,7 @@ extension MeasurementConfig: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_MeasurementConfig(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_MeasurementConfig(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3319,9 +3286,9 @@ extension MeasurementConfig: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_MeasurementConfig")
-fileprivate func _bjs_struct_lower_MeasurementConfig(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_MeasurementConfig(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_MeasurementConfig(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_MeasurementConfig(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3346,10 +3313,7 @@ extension MathOperations: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_MathOperations(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_MathOperations(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3362,9 +3326,9 @@ extension MathOperations: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_MathOperations")
-fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3439,10 +3403,7 @@ extension CopyableCart: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_CopyableCart(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_CopyableCart(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3455,9 +3416,9 @@ extension CopyableCart: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_CopyableCart")
-fileprivate func _bjs_struct_lower_CopyableCart(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_CopyableCart(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_CopyableCart(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_CopyableCart(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3495,10 +3456,7 @@ extension CopyableCartItem: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_CopyableCartItem(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_CopyableCartItem(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3511,9 +3469,9 @@ extension CopyableCartItem: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_CopyableCartItem")
-fileprivate func _bjs_struct_lower_CopyableCartItem(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_CopyableCartItem(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_CopyableCartItem(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_CopyableCartItem(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3542,10 +3500,7 @@ extension CopyableNestedCart: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_CopyableNestedCart(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_CopyableNestedCart(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3558,9 +3513,9 @@ extension CopyableNestedCart: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_CopyableNestedCart")
-fileprivate func _bjs_struct_lower_CopyableNestedCart(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_CopyableNestedCart(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_CopyableNestedCart(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_CopyableNestedCart(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3598,10 +3553,7 @@ extension ConfigStruct: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_ConfigStruct(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_ConfigStruct(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3614,9 +3566,9 @@ extension ConfigStruct: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ConfigStruct")
-fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3711,10 +3663,7 @@ extension JSObjectContainer: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_JSObjectContainer(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_JSObjectContainer(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3727,9 +3676,9 @@ extension JSObjectContainer: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_JSObjectContainer")
-fileprivate func _bjs_struct_lower_JSObjectContainer(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_JSObjectContainer(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_JSObjectContainer(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_JSObjectContainer(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3760,10 +3709,7 @@ extension FooContainer: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_FooContainer(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_FooContainer(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3776,9 +3722,9 @@ extension FooContainer: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_FooContainer")
-fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3805,10 +3751,7 @@ extension ArrayMembers: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_ArrayMembers(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_ArrayMembers(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3821,9 +3764,9 @@ extension ArrayMembers: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ArrayMembers")
-fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -5912,9 +5855,9 @@ public func _bjs_roundTripOptionalPayloadResultOpt(_ resultIsSome: Int32, _ resu
 
 @_expose(wasm, "bjs_roundTripOptionalClass")
 @_cdecl("bjs_roundTripOptionalClass")
-public func _bjs_roundTripOptionalClass(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+public func _bjs_roundTripOptionalClass(_ valueIsSome: Int32, _ valuePointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalClass(value: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    let ret = roundTripOptionalClass(value: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valuePointer))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -5923,9 +5866,9 @@ public func _bjs_roundTripOptionalClass(_ valueIsSome: Int32, _ valueValue: Unsa
 
 @_expose(wasm, "bjs_roundTripOptionalGreeter")
 @_cdecl("bjs_roundTripOptionalGreeter")
-public func _bjs_roundTripOptionalGreeter(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+public func _bjs_roundTripOptionalGreeter(_ valueIsSome: Int32, _ valuePointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalGreeter(_: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    let ret = roundTripOptionalGreeter(_: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valuePointer))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -5934,9 +5877,9 @@ public func _bjs_roundTripOptionalGreeter(_ valueIsSome: Int32, _ valueValue: Un
 
 @_expose(wasm, "bjs_applyOptionalGreeter")
 @_cdecl("bjs_applyOptionalGreeter")
-public func _bjs_applyOptionalGreeter(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer, _ transform: Int32) -> Void {
+public func _bjs_applyOptionalGreeter(_ valueIsSome: Int32, _ valuePointer: UnsafeMutableRawPointer, _ transform: Int32) -> Void {
     #if arch(wasm32)
-    let ret = applyOptionalGreeter(_: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue), _: _BJS_Closure_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC.bridgeJSLift(transform))
+    let ret = applyOptionalGreeter(_: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valuePointer), _: _BJS_Closure_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC.bridgeJSLift(transform))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -5945,9 +5888,9 @@ public func _bjs_applyOptionalGreeter(_ valueIsSome: Int32, _ valueValue: Unsafe
 
 @_expose(wasm, "bjs_makeOptionalHolder")
 @_cdecl("bjs_makeOptionalHolder")
-public func _bjs_makeOptionalHolder(_ nullableGreeterIsSome: Int32, _ nullableGreeterValue: UnsafeMutableRawPointer, _ undefinedNumberIsSome: Int32, _ undefinedNumberValue: Float64) -> UnsafeMutableRawPointer {
+public func _bjs_makeOptionalHolder(_ nullableGreeterIsSome: Int32, _ nullableGreeterPointer: UnsafeMutableRawPointer, _ undefinedNumberIsSome: Int32, _ undefinedNumberValue: Float64) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = makeOptionalHolder(nullableGreeter: Optional<Greeter>.bridgeJSLiftParameter(nullableGreeterIsSome, nullableGreeterValue), undefinedNumber: JSUndefinedOr<Double>.bridgeJSLiftParameter(undefinedNumberIsSome, undefinedNumberValue))
+    let ret = makeOptionalHolder(nullableGreeter: Optional<Greeter>.bridgeJSLiftParameter(nullableGreeterIsSome, nullableGreeterPointer), undefinedNumber: JSUndefinedOr<Double>.bridgeJSLiftParameter(undefinedNumberIsSome, undefinedNumberValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -7717,7 +7660,7 @@ public func _bjs_DataProcessorManager_setProcessorAPIResult(_ _self: UnsafeMutab
 @_cdecl("bjs_DataProcessorManager_processor_get")
 public func _bjs_DataProcessorManager_processor_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).processor as! AnyDataProcessor
+    let ret = (DataProcessorManager.bridgeJSLiftParameter(_self).processor as! AnyDataProcessor)
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -7868,9 +7811,9 @@ public func _bjs_SwiftDataProcessor_createGreeter(_ _self: UnsafeMutableRawPoint
 
 @_expose(wasm, "bjs_SwiftDataProcessor_processOptionalGreeter")
 @_cdecl("bjs_SwiftDataProcessor_processOptionalGreeter")
-public func _bjs_SwiftDataProcessor_processOptionalGreeter(_ _self: UnsafeMutableRawPointer, _ greeterIsSome: Int32, _ greeterValue: UnsafeMutableRawPointer) -> Void {
+public func _bjs_SwiftDataProcessor_processOptionalGreeter(_ _self: UnsafeMutableRawPointer, _ greeterIsSome: Int32, _ greeterPointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).processOptionalGreeter(_: Optional<Greeter>.bridgeJSLiftParameter(greeterIsSome, greeterValue))
+    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).processOptionalGreeter(_: Optional<Greeter>.bridgeJSLiftParameter(greeterIsSome, greeterPointer))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -8101,9 +8044,9 @@ public func _bjs_SwiftDataProcessor_optionalHelper_get(_ _self: UnsafeMutableRaw
 
 @_expose(wasm, "bjs_SwiftDataProcessor_optionalHelper_set")
 @_cdecl("bjs_SwiftDataProcessor_optionalHelper_set")
-public func _bjs_SwiftDataProcessor_optionalHelper_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+public func _bjs_SwiftDataProcessor_optionalHelper_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valuePointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalHelper = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalHelper = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valuePointer)
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8392,9 +8335,9 @@ fileprivate func _bjs_TextProcessor_wrap(_ pointer: UnsafeMutableRawPointer) -> 
 
 @_expose(wasm, "bjs_OptionalHolder_init")
 @_cdecl("bjs_OptionalHolder_init")
-public func _bjs_OptionalHolder_init(_ nullableGreeterIsSome: Int32, _ nullableGreeterValue: UnsafeMutableRawPointer, _ undefinedNumberIsSome: Int32, _ undefinedNumberValue: Float64) -> UnsafeMutableRawPointer {
+public func _bjs_OptionalHolder_init(_ nullableGreeterIsSome: Int32, _ nullableGreeterPointer: UnsafeMutableRawPointer, _ undefinedNumberIsSome: Int32, _ undefinedNumberValue: Float64) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = OptionalHolder(nullableGreeter: Optional<Greeter>.bridgeJSLiftParameter(nullableGreeterIsSome, nullableGreeterValue), undefinedNumber: JSUndefinedOr<Double>.bridgeJSLiftParameter(undefinedNumberIsSome, undefinedNumberValue))
+    let ret = OptionalHolder(nullableGreeter: Optional<Greeter>.bridgeJSLiftParameter(nullableGreeterIsSome, nullableGreeterPointer), undefinedNumber: JSUndefinedOr<Double>.bridgeJSLiftParameter(undefinedNumberIsSome, undefinedNumberValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -8414,9 +8357,9 @@ public func _bjs_OptionalHolder_nullableGreeter_get(_ _self: UnsafeMutableRawPoi
 
 @_expose(wasm, "bjs_OptionalHolder_nullableGreeter_set")
 @_cdecl("bjs_OptionalHolder_nullableGreeter_set")
-public func _bjs_OptionalHolder_nullableGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+public func _bjs_OptionalHolder_nullableGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valuePointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    OptionalHolder.bridgeJSLiftParameter(_self).nullableGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    OptionalHolder.bridgeJSLiftParameter(_self).nullableGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valuePointer)
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8534,9 +8477,9 @@ public func _bjs_OptionalPropertyHolder_optionalGreeter_get(_ _self: UnsafeMutab
 
 @_expose(wasm, "bjs_OptionalPropertyHolder_optionalGreeter_set")
 @_cdecl("bjs_OptionalPropertyHolder_optionalGreeter_set")
-public func _bjs_OptionalPropertyHolder_optionalGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+public func _bjs_OptionalPropertyHolder_optionalGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valuePointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valuePointer)
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Tests/BridgeJSRuntimeTests/JavaScript/OptionalSupportTests.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/OptionalSupportTests.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 
-import assert from 'node:assert';
+import assert from "node:assert";
 import {
     StatusValues,
     ThemeValues,
@@ -11,9 +11,9 @@ import {
     APIOptionalResultValues,
     AllTypesResultValues,
     OptionalAllTypesResultValues,
-} from '../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.js';
+} from "../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.js";
 
-import { ImportedFoo } from './Types.mjs';
+import { ImportedFoo } from "./Types.mjs";
 
 /**
  * @returns {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Imports["OptionalSupportImports"]}
@@ -34,7 +34,9 @@ export function getImports(importsContext) {
         },
         runJsOptionalSupportTests: () => {
             const exports = importsContext.getExports();
-            if (!exports) { throw new Error("No exports!?"); }
+            if (!exports) {
+                throw new Error("No exports!?");
+            }
             runJsOptionalSupportTests(exports);
         },
     };
@@ -51,50 +53,87 @@ export function runJsOptionalSupportTests(exports) {
     assert.equal(exports.roundTripOptionalFloat(null), null);
     assert.equal(exports.roundTripOptionalDouble(null), null);
 
-    assert.equal(exports.roundTripOptionalString('Hello'), 'Hello');
+    assert.equal(exports.roundTripOptionalString("Hello"), "Hello");
     assert.equal(exports.roundTripOptionalInt(42), 42);
     assert.equal(exports.roundTripOptionalBool(true), true);
-    assert.equal(exports.roundTripOptionalFloat(3.141592502593994), 3.141592502593994); // Float32 precision
+    assert.equal(
+        exports.roundTripOptionalFloat(3.141592502593994),
+        3.141592502593994,
+    ); // Float32 precision
     assert.equal(exports.roundTripOptionalDouble(2.718), 2.718);
 
     assert.equal(exports.roundTripOptionalSyntax(null), null);
-    assert.equal(exports.roundTripOptionalSyntax('Test'), 'Test');
+    assert.equal(exports.roundTripOptionalSyntax("Test"), "Test");
     assert.equal(exports.roundTripOptionalMixSyntax(null), null);
-    assert.equal(exports.roundTripOptionalMixSyntax('Mix'), 'Mix');
+    assert.equal(exports.roundTripOptionalMixSyntax("Mix"), "Mix");
     assert.equal(exports.roundTripOptionalSwiftSyntax(null), null);
-    assert.equal(exports.roundTripOptionalSwiftSyntax('Swift'), 'Swift');
+    assert.equal(exports.roundTripOptionalSwiftSyntax("Swift"), "Swift");
     assert.equal(exports.roundTripOptionalWithSpaces(null), null);
     assert.equal(exports.roundTripOptionalWithSpaces(1.618), 1.618);
     assert.equal(exports.roundTripOptionalTypeAlias(null), null);
     assert.equal(exports.roundTripOptionalTypeAlias(25), 25);
-    assert.equal(exports.roundTripOptionalStatus(exports.Status.Success), StatusValues.Success);
-    assert.equal(exports.roundTripOptionalTheme(exports.Theme.Light), ThemeValues.Light);
-    assert.equal(exports.roundTripOptionalHttpStatus(exports.HttpStatus.Ok), HttpStatusValues.Ok);
-    assert.equal(exports.roundTripOptionalTSDirection(TSDirection.North), TSDirection.North);
-    assert.equal(exports.roundTripOptionalTSTheme(TSTheme.Light), TSTheme.Light);
-    assert.equal(exports.roundTripOptionalNetworkingAPIMethod(exports.Networking.API.Method.Get), exports.Networking.API.Method.Get);
+    assert.equal(
+        exports.roundTripOptionalStatus(exports.Status.Success),
+        StatusValues.Success,
+    );
+    assert.equal(
+        exports.roundTripOptionalTheme(exports.Theme.Light),
+        ThemeValues.Light,
+    );
+    assert.equal(
+        exports.roundTripOptionalHttpStatus(exports.HttpStatus.Ok),
+        HttpStatusValues.Ok,
+    );
+    assert.equal(
+        exports.roundTripOptionalTSDirection(TSDirection.North),
+        TSDirection.North,
+    );
+    assert.equal(
+        exports.roundTripOptionalTSTheme(TSTheme.Light),
+        TSTheme.Light,
+    );
+    assert.equal(
+        exports.roundTripOptionalNetworkingAPIMethod(
+            exports.Networking.API.Method.Get,
+        ),
+        exports.Networking.API.Method.Get,
+    );
 
     const pVal = 3.141592653589793;
     const p1 = { tag: APIResultValues.Tag.Precise, param0: pVal };
-    const cl1 = { tag: exports.ComplexResult.Tag.Location, param0: 37.7749, param1: -122.4194, param2: 'San Francisco' };
+    const cl1 = {
+        tag: exports.ComplexResult.Tag.Location,
+        param0: 37.7749,
+        param1: -122.4194,
+        param2: "San Francisco",
+    };
 
     assert.deepEqual(exports.roundTripOptionalAPIResult(p1), p1);
     assert.deepEqual(exports.roundTripOptionalComplexResult(cl1), cl1);
 
-    const apiSuccess = { tag: exports.APIResult.Tag.Success, param0: 'test success' };
+    const apiSuccess = {
+        tag: exports.APIResult.Tag.Success,
+        param0: "test success",
+    };
     const apiFailure = { tag: exports.APIResult.Tag.Failure, param0: 404 };
     const apiInfo = { tag: exports.APIResult.Tag.Info };
 
-    assert.equal(exports.compareAPIResults(apiSuccess, apiFailure), 'r1:success:test success,r2:failure:404');
-    assert.equal(exports.compareAPIResults(null, apiInfo), 'r1:nil,r2:info');
-    assert.equal(exports.compareAPIResults(apiFailure, null), 'r1:failure:404,r2:nil');
-    assert.equal(exports.compareAPIResults(null, null), 'r1:nil,r2:nil');
+    assert.equal(
+        exports.compareAPIResults(apiSuccess, apiFailure),
+        "r1:success:test success,r2:failure:404",
+    );
+    assert.equal(exports.compareAPIResults(null, apiInfo), "r1:nil,r2:info");
+    assert.equal(
+        exports.compareAPIResults(apiFailure, null),
+        "r1:failure:404,r2:nil",
+    );
+    assert.equal(exports.compareAPIResults(null, null), "r1:nil,r2:nil");
 
-    const optionalGreeter = new exports.Greeter('Schrödinger');
+    const optionalGreeter = new exports.Greeter("Schrödinger");
     const optionalGreeter2 = exports.roundTripOptionalClass(optionalGreeter);
-    assert.equal(optionalGreeter2?.greet() ?? '', 'Hello, Schrödinger!');
-    assert.equal(optionalGreeter2?.name ?? '', 'Schrödinger');
-    assert.equal(optionalGreeter2?.prefix ?? '', 'Hello');
+    assert.equal(optionalGreeter2?.greet() ?? "", "Hello, Schrödinger!");
+    assert.equal(optionalGreeter2?.name ?? "", "Schrödinger");
+    assert.equal(optionalGreeter2?.prefix ?? "", "Hello");
     assert.equal(exports.roundTripOptionalClass(null), null);
     optionalGreeter.release();
     optionalGreeter2?.release();
@@ -105,15 +144,15 @@ export function runJsOptionalSupportTests(exports) {
     assert.equal(optionalsHolder.optionalAge, null);
     assert.equal(optionalsHolder.optionalGreeter, null);
 
-    optionalsHolder.optionalName = 'Alice';
+    optionalsHolder.optionalName = "Alice";
     optionalsHolder.optionalAge = 25;
-    assert.equal(optionalsHolder.optionalName, 'Alice');
+    assert.equal(optionalsHolder.optionalName, "Alice");
     assert.equal(optionalsHolder.optionalAge, 25);
 
-    const testPropertyGreeter = new exports.Greeter('Bob');
+    const testPropertyGreeter = new exports.Greeter("Bob");
     optionalsHolder.optionalGreeter = testPropertyGreeter;
-    assert.equal(optionalsHolder.optionalGreeter.greet(), 'Hello, Bob!');
-    assert.equal(optionalsHolder.optionalGreeter.name, 'Bob');
+    assert.equal(optionalsHolder.optionalGreeter.greet(), "Hello, Bob!");
+    assert.equal(optionalsHolder.optionalGreeter.name, "Bob");
 
     optionalsHolder.optionalName = null;
     optionalsHolder.optionalAge = null;
@@ -124,36 +163,79 @@ export function runJsOptionalSupportTests(exports) {
     testPropertyGreeter.release();
     optionalsHolder.release();
 
-    const optGreeter = new exports.Greeter('Optionaly');
+    const optGreeter = new exports.Greeter("Optionaly");
     assert.equal(exports.roundTripOptionalGreeter(null), null);
     const optGreeterReturned = exports.roundTripOptionalGreeter(optGreeter);
-    assert.equal(optGreeterReturned.name, 'Optionaly');
-    assert.equal(optGreeterReturned.greet(), 'Hello, Optionaly!');
+    assert.equal(optGreeterReturned.name, "Optionaly");
+    assert.equal(optGreeterReturned.greet(), "Hello, Optionaly!");
 
-    const appliedOptional = exports.applyOptionalGreeter(null, (g) => g ?? optGreeter);
-    assert.equal(appliedOptional.name, 'Optionaly');
+    const appliedOptional = exports.applyOptionalGreeter(
+        null,
+        (g) => g ?? optGreeter,
+    );
+    assert.equal(appliedOptional.name, "Optionaly");
 
     const holderOpt = exports.makeOptionalHolder(null, undefined);
     assert.equal(holderOpt.nullableGreeter, null);
     assert.equal(holderOpt.undefinedNumber, undefined);
     holderOpt.nullableGreeter = optGreeter;
     holderOpt.undefinedNumber = 123.5;
-    assert.equal(holderOpt.nullableGreeter.name, 'Optionaly');
+    assert.equal(holderOpt.nullableGreeter.name, "Optionaly");
     assert.equal(holderOpt.undefinedNumber, 123.5);
     holderOpt.release();
     optGreeterReturned.release();
     optGreeter.release();
 
-    const aor1 = { tag: APIOptionalResultValues.Tag.Success, param0: 'hello world' };
+    const aor1 = {
+        tag: APIOptionalResultValues.Tag.Success,
+        param0: "hello world",
+    };
     const aor2 = { tag: APIOptionalResultValues.Tag.Success, param0: null };
-    const aor3 = { tag: APIOptionalResultValues.Tag.Failure, param0: 404, param1: true };
-    const aor4 = { tag: APIOptionalResultValues.Tag.Failure, param0: 404, param1: null };
-    const aor5 = { tag: APIOptionalResultValues.Tag.Failure, param0: null, param1: null };
-    const aor6 = { tag: APIOptionalResultValues.Tag.Status, param0: true, param1: 200, param2: 'OK' };
-    const aor7 = { tag: APIOptionalResultValues.Tag.Status, param0: true, param1: null, param2: 'Partial' };
-    const aor8 = { tag: APIOptionalResultValues.Tag.Status, param0: null, param1: null, param2: 'Zero' };
-    const aor9 = { tag: APIOptionalResultValues.Tag.Status, param0: false, param1: 500, param2: null };
-    const aor10 = { tag: APIOptionalResultValues.Tag.Status, param0: null, param1: 0, param2: 'Zero' };
+    const aor3 = {
+        tag: APIOptionalResultValues.Tag.Failure,
+        param0: 404,
+        param1: true,
+    };
+    const aor4 = {
+        tag: APIOptionalResultValues.Tag.Failure,
+        param0: 404,
+        param1: null,
+    };
+    const aor5 = {
+        tag: APIOptionalResultValues.Tag.Failure,
+        param0: null,
+        param1: null,
+    };
+    const aor6 = {
+        tag: APIOptionalResultValues.Tag.Status,
+        param0: true,
+        param1: 200,
+        param2: "OK",
+    };
+    const aor7 = {
+        tag: APIOptionalResultValues.Tag.Status,
+        param0: true,
+        param1: null,
+        param2: "Partial",
+    };
+    const aor8 = {
+        tag: APIOptionalResultValues.Tag.Status,
+        param0: null,
+        param1: null,
+        param2: "Zero",
+    };
+    const aor9 = {
+        tag: APIOptionalResultValues.Tag.Status,
+        param0: false,
+        param1: 500,
+        param2: null,
+    };
+    const aor10 = {
+        tag: APIOptionalResultValues.Tag.Status,
+        param0: null,
+        param1: 0,
+        param2: "Zero",
+    };
 
     assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor1), aor1);
     assert.deepEqual(exports.roundTripOptionalAPIOptionalResult(aor2), aor2);
@@ -168,77 +250,206 @@ export function runJsOptionalSupportTests(exports) {
     assert.equal(exports.roundTripOptionalAPIOptionalResult(null), null);
 
     // Optional TypedPayloadResult roundtrip
-    const tpr_precision = { tag: exports.TypedPayloadResult.Tag.Precision, param0: Math.fround(0.1) };
-    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_precision), tpr_precision);
-    const tpr_direction = { tag: exports.TypedPayloadResult.Tag.Direction, param0: exports.Direction.North };
-    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_direction), tpr_direction);
-    const tpr_optPrecisionSome = { tag: exports.TypedPayloadResult.Tag.OptPrecision, param0: Math.fround(0.001) };
-    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_optPrecisionSome), tpr_optPrecisionSome);
-    const tpr_optPrecisionNull = { tag: exports.TypedPayloadResult.Tag.OptPrecision, param0: null };
-    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_optPrecisionNull), tpr_optPrecisionNull);
+    const tpr_precision = {
+        tag: exports.TypedPayloadResult.Tag.Precision,
+        param0: Math.fround(0.1),
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalTypedPayloadResult(tpr_precision),
+        tpr_precision,
+    );
+    const tpr_direction = {
+        tag: exports.TypedPayloadResult.Tag.Direction,
+        param0: exports.Direction.North,
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalTypedPayloadResult(tpr_direction),
+        tpr_direction,
+    );
+    const tpr_optPrecisionSome = {
+        tag: exports.TypedPayloadResult.Tag.OptPrecision,
+        param0: Math.fround(0.001),
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalTypedPayloadResult(tpr_optPrecisionSome),
+        tpr_optPrecisionSome,
+    );
+    const tpr_optPrecisionNull = {
+        tag: exports.TypedPayloadResult.Tag.OptPrecision,
+        param0: null,
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalTypedPayloadResult(tpr_optPrecisionNull),
+        tpr_optPrecisionNull,
+    );
     const tpr_empty = { tag: exports.TypedPayloadResult.Tag.Empty };
-    assert.deepEqual(exports.roundTripOptionalTypedPayloadResult(tpr_empty), tpr_empty);
+    assert.deepEqual(
+        exports.roundTripOptionalTypedPayloadResult(tpr_empty),
+        tpr_empty,
+    );
     assert.equal(exports.roundTripOptionalTypedPayloadResult(null), null);
 
     // Optional AllTypesResult roundtrip
-    const atr_struct = { tag: AllTypesResultValues.Tag.StructPayload, param0: { street: "100 Main St", city: "Boston", zipCode: 2101 } };
-    assert.deepEqual(exports.roundTripOptionalAllTypesResult(atr_struct), atr_struct);
-    const atr_array = { tag: AllTypesResultValues.Tag.ArrayPayload, param0: [10, 20, 30] };
-    assert.deepEqual(exports.roundTripOptionalAllTypesResult(atr_array), atr_array);
+    const atr_struct = {
+        tag: AllTypesResultValues.Tag.StructPayload,
+        param0: { street: "100 Main St", city: "Boston", zipCode: 2101 },
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalAllTypesResult(atr_struct),
+        atr_struct,
+    );
+    const atr_array = {
+        tag: AllTypesResultValues.Tag.ArrayPayload,
+        param0: [10, 20, 30],
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalAllTypesResult(atr_array),
+        atr_array,
+    );
     const atr_empty = { tag: AllTypesResultValues.Tag.Empty };
-    assert.deepEqual(exports.roundTripOptionalAllTypesResult(atr_empty), atr_empty);
+    assert.deepEqual(
+        exports.roundTripOptionalAllTypesResult(atr_empty),
+        atr_empty,
+    );
     assert.equal(exports.roundTripOptionalAllTypesResult(null), null);
 
     // OptionalAllTypesResult — optional struct, class, JSObject, nested enum, array as associated value payloads
-    const oatr_structSome = { tag: OptionalAllTypesResultValues.Tag.OptStruct, param0: { street: "200 Oak St", city: "Denver", zipCode: null } };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_structSome), oatr_structSome);
+    const oatr_structSome = {
+        tag: OptionalAllTypesResultValues.Tag.OptStruct,
+        param0: { street: "200 Oak St", city: "Denver", zipCode: null },
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResult(oatr_structSome),
+        oatr_structSome,
+    );
 
-    const oatr_structNone = { tag: OptionalAllTypesResultValues.Tag.OptStruct, param0: null };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_structNone), oatr_structNone);
+    const oatr_structNone = {
+        tag: OptionalAllTypesResultValues.Tag.OptStruct,
+        param0: null,
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResult(oatr_structNone),
+        oatr_structNone,
+    );
 
-    const oatr_classSome = { tag: OptionalAllTypesResultValues.Tag.OptClass, param0: new exports.Greeter("OptEnumUser") };
-    const oatr_classSome_result = exports.roundTripOptionalPayloadResult(oatr_classSome);
-    assert.equal(oatr_classSome_result.tag, OptionalAllTypesResultValues.Tag.OptClass);
+    const oatr_classSome = {
+        tag: OptionalAllTypesResultValues.Tag.OptClass,
+        param0: new exports.Greeter("OptEnumUser"),
+    };
+    const oatr_classSome_result =
+        exports.roundTripOptionalPayloadResult(oatr_classSome);
+    assert.equal(
+        oatr_classSome_result.tag,
+        OptionalAllTypesResultValues.Tag.OptClass,
+    );
     assert.equal(oatr_classSome_result.param0.name, "OptEnumUser");
 
-    const oatr_classNone = { tag: OptionalAllTypesResultValues.Tag.OptClass, param0: null };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_classNone), oatr_classNone);
+    const oatr_classNone = {
+        tag: OptionalAllTypesResultValues.Tag.OptClass,
+        param0: null,
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResult(oatr_classNone),
+        oatr_classNone,
+    );
 
-    const oatr_jsObjectSome = { tag: OptionalAllTypesResultValues.Tag.OptJSObject, param0: { key: "value" } };
-    const oatr_jsObjectSome_result = exports.roundTripOptionalPayloadResult(oatr_jsObjectSome);
-    assert.equal(oatr_jsObjectSome_result.tag, OptionalAllTypesResultValues.Tag.OptJSObject);
+    const oatr_jsObjectSome = {
+        tag: OptionalAllTypesResultValues.Tag.OptJSObject,
+        param0: { key: "value" },
+    };
+    const oatr_jsObjectSome_result =
+        exports.roundTripOptionalPayloadResult(oatr_jsObjectSome);
+    assert.equal(
+        oatr_jsObjectSome_result.tag,
+        OptionalAllTypesResultValues.Tag.OptJSObject,
+    );
     assert.equal(oatr_jsObjectSome_result.param0.key, "value");
 
-    const oatr_jsObjectNone = { tag: OptionalAllTypesResultValues.Tag.OptJSObject, param0: null };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_jsObjectNone), oatr_jsObjectNone);
+    const oatr_jsObjectNone = {
+        tag: OptionalAllTypesResultValues.Tag.OptJSObject,
+        param0: null,
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResult(oatr_jsObjectNone),
+        oatr_jsObjectNone,
+    );
 
-    const oatr_nestedEnumSome = { tag: OptionalAllTypesResultValues.Tag.OptNestedEnum, param0: { tag: APIResultValues.Tag.Failure, param0: 404 } };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_nestedEnumSome), oatr_nestedEnumSome);
+    const oatr_nestedEnumSome = {
+        tag: OptionalAllTypesResultValues.Tag.OptNestedEnum,
+        param0: { tag: APIResultValues.Tag.Failure, param0: 404 },
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResult(oatr_nestedEnumSome),
+        oatr_nestedEnumSome,
+    );
 
-    const oatr_nestedEnumNone = { tag: OptionalAllTypesResultValues.Tag.OptNestedEnum, param0: null };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_nestedEnumNone), oatr_nestedEnumNone);
+    const oatr_nestedEnumNone = {
+        tag: OptionalAllTypesResultValues.Tag.OptNestedEnum,
+        param0: null,
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResult(oatr_nestedEnumNone),
+        oatr_nestedEnumNone,
+    );
 
-    const oatr_arraySome = { tag: OptionalAllTypesResultValues.Tag.OptArray, param0: [1, 2, 3] };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_arraySome), oatr_arraySome);
+    const oatr_arraySome = {
+        tag: OptionalAllTypesResultValues.Tag.OptArray,
+        param0: [1, 2, 3],
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResult(oatr_arraySome),
+        oatr_arraySome,
+    );
 
-    const oatr_arrayNone = { tag: OptionalAllTypesResultValues.Tag.OptArray, param0: null };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_arrayNone), oatr_arrayNone);
+    const oatr_arrayNone = {
+        tag: OptionalAllTypesResultValues.Tag.OptArray,
+        param0: null,
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResult(oatr_arrayNone),
+        oatr_arrayNone,
+    );
 
-    const oatr_jsClassSome = { tag: OptionalAllTypesResultValues.Tag.OptJsClass, param0: new ImportedFoo("optEnumFoo") };
-    const oatr_jsClassSome_result = exports.roundTripOptionalPayloadResult(oatr_jsClassSome);
-    assert.equal(oatr_jsClassSome_result.tag, OptionalAllTypesResultValues.Tag.OptJsClass);
+    const oatr_jsClassSome = {
+        tag: OptionalAllTypesResultValues.Tag.OptJsClass,
+        param0: new ImportedFoo("optEnumFoo"),
+    };
+    const oatr_jsClassSome_result =
+        exports.roundTripOptionalPayloadResult(oatr_jsClassSome);
+    assert.equal(
+        oatr_jsClassSome_result.tag,
+        OptionalAllTypesResultValues.Tag.OptJsClass,
+    );
     assert.equal(oatr_jsClassSome_result.param0.value, "optEnumFoo");
 
-    const oatr_jsClassNone = { tag: OptionalAllTypesResultValues.Tag.OptJsClass, param0: null };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_jsClassNone), oatr_jsClassNone);
+    const oatr_jsClassNone = {
+        tag: OptionalAllTypesResultValues.Tag.OptJsClass,
+        param0: null,
+    };
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResult(oatr_jsClassNone),
+        oatr_jsClassNone,
+    );
 
     const oatr_empty = { tag: OptionalAllTypesResultValues.Tag.Empty };
-    assert.deepEqual(exports.roundTripOptionalPayloadResult(oatr_empty), oatr_empty);
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResult(oatr_empty),
+        oatr_empty,
+    );
 
     // Optional OptionalAllTypesResult roundtrip
-    assert.deepEqual(exports.roundTripOptionalPayloadResultOpt(oatr_structSome), oatr_structSome);
-    assert.deepEqual(exports.roundTripOptionalPayloadResultOpt(oatr_structNone), oatr_structNone);
-    assert.deepEqual(exports.roundTripOptionalPayloadResultOpt(oatr_empty), oatr_empty);
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResultOpt(oatr_structSome),
+        oatr_structSome,
+    );
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResultOpt(oatr_structNone),
+        oatr_structNone,
+    );
+    assert.deepEqual(
+        exports.roundTripOptionalPayloadResultOpt(oatr_empty),
+        oatr_empty,
+    );
     assert.equal(exports.roundTripOptionalPayloadResultOpt(null), null);
 
     exports.takeOptionalJSObject(null);


### PR DESCRIPTION
# NFC: BridgeJS: Centralize type info on BridgeType, remove dead cleanup infrastructure

## Summary

As recently discussed, this PR centralizes scattered type-specific knowledge as computed properties on `BridgeType`. Codegen reads these properties directly instead of re-deriving the same facts in each switch. Codegen still switches on `BridgeType` cases, grouping them when they share logic.

Also removes the cleanup infrastructure that became dead code after #635 and #636.

64 files changed, +3667/-5050, net -1383 lines.

## What changed

### BridgeType computed properties (BridgeJSSkeleton.swift)

Previously, type-specific knowledge (ABI shape, lowering method, optional convention, etc.) was scattered across switches in ExportSwift, ImportTS, BridgeJSLink, and JSGlueGen. Each file re-derived the same facts independently. This PR gathers that information into computed properties on `BridgeType` itself, so when adding or modifying a type, there's one place to look.

10 focused properties organized by consumer:

- **ABI Shape** - `wasmParams`, `wasmReturnType`, `optionalConvention`
- **ExportSwift** - `accessorTransform`, `lowerMethod`, `usesStackLifting`
- **ImportTS** - `importParams`, `importReturnType`
- **JSGlueGen** - `nilSentinel`, `optionalScalarKind`

Supporting types: `OptionalConvention`, `NilSentinel`, `OptionalScalarKind`, `AccessorTransform`, `LowerMethod`.

`NilSentinel` captures whether a type has a bit pattern that represents nil without an extra `isSome` flag:

- `jsObject`, `swiftProtocol` - sentinel `0` (object IDs start at 2)
- `swiftHeapObject` - null pointer
- `caseEnum`, `associatedValueEnum` - sentinel `-1` (never a valid case index)

### JSGlueGen helpers (JSGlueGen.swift)

Private helpers that switch on `BridgeType` for JS-side coercion: `isSingleParamScalar()`, `stackLowerCoerce()`, `liftCoerce()`, `lowerCoerce()`, `varHint()`. These consolidate the type-to-JS-coercion mapping that was previously spread across the four direction functions.

### Dead cleanup infrastructure removal

After #635 and #636, no type produces cleanup code. Removed all of it:

- `cleanupCode` printer from `IntrinsicJSFragment.PrintCodeContext`
- `tmpStructCleanups` array and `swift_js_struct_cleanup` intrinsic handler
- `_swift_js_struct_cleanup` extern and wrapper from `BridgeJSIntrinsics.swift`
- Struct helper `lower()` no longer returns `{ cleanup }` - just pushes fields
- Enum helper `lower()` returns caseId directly instead of `{ caseId, cleanup }`
- `init(unsafelyCopying:)` no longer calls struct cleanup
- All optional/array/dictionary wrappers simplified

~1680 lines removed across source and snapshots.

### Compositional optional handling

`optionalLowerParameter` and `optionalLiftParameter` compose T's existing fragment inside an `isSome` conditional instead of switching per type. New types added to `lowerParameter` or `liftParameter` get optional handling for free. Same for struct fields via `structFieldLowerFragment`.

### Other generated code improvements

- **JSValue optional lowering** - `__bjs_jsValueLower` no longer called on null values; the `isSome` guard runs before lowering
- **Struct/enum helper factory collapse** - `() => { return () => ({...}); }` simplified to `() => ({...})`; call-site `()()` becomes `()`
- **Typed defaults in optional lowering** - `0.0` for floats, `flag ? 1 : 0` for bools (previously `0` for everything)
- **Dead code removal** - unused functions in ExportSwift, JSGlueGen, BridgeJSSkeleton
