### PR TITLE
NFC: BridgeJS: Further simplify codegen and JSValue intrinsics

### DIFF
--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.swift
@@ -76,16 +76,7 @@ public func _bjs_makeFoo() -> Int32 {
 @_cdecl("bjs_processFooArray")
 public func _bjs_processFooArray() -> Void {
     #if arch(wasm32)
-    let ret = processFooArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Foo] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append(Foo(unsafelyWrapping: JSObject.bridgeJSLiftParameter()))
-        }
-        __result.reverse()
-        return __result
-    }())
+    let ret = processFooArray(_: [JSObject].bridgeJSLiftParameter().map { Foo(unsafelyWrapping: $0) })
     ret.map { $0.jsObject }.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -5555,16 +5555,7 @@ public func _bjs_roundTripOptionalJSObjectArray() -> Void {
 @_cdecl("bjs_roundTripFooArray")
 public func _bjs_roundTripFooArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripFooArray(_: {
-        let __count = Int(_swift_js_pop_i32())
-        var __result: [Foo] = []
-        __result.reserveCapacity(__count)
-        for _ in 0..<__count {
-            __result.append(Foo(unsafelyWrapping: JSObject.bridgeJSLiftParameter()))
-        }
-        __result.reverse()
-        return __result
-    }())
+    let ret = roundTripFooArray(_: [JSObject].bridgeJSLiftParameter().map { Foo(unsafelyWrapping: $0) })
     ret.map { $0.jsObject }.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")


### PR DESCRIPTION
## Overview

- Refactor `ClosureCodegen` to remove duplicate closure type construction by extracting `swiftClosureType(for:)` and reusing it in both helper and invoke thunk generation.
- Simplify closure invoke ABI return handling by directly using `loweringReturnInfo().returnType` and remove now-unused local state.
- Refactor `ExportSwift` by extracting shared helpers for static context base name, constructor thunk rendering, and method thunk rendering reused across class/struct export paths.
- Simplify class property export rendering by collapsing static vs instance context selection to a single call site.
- Simplify stack lifting for arrays of imported JS class wrappers from manual inline stack loops to `[JSObject].bridgeJSLiftParameter().map { Wrapper(unsafelyWrapping: $0) }`.
- Remove an unused parameter from optional lowering internals in `StackCodegen`.
- Deduplicate `JSValue` payload retain logic in `BridgeJSIntrinsics` via `bridgeJSRetainPayloadIfNeeded(kind:payload1:)` and reuse it in both lift and lower paths.
- Simplify `JSValue.bridgeJSLiftReturn()` to delegate to the existing no-arg `bridgeJSLiftParameter()` path.