### PR TITLE
Benchmarks: Prevent cross-module inlining of f32/f64 @_extern(wasm) functions

### DIFF
--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -723,21 +723,29 @@ where Self: RawRepresentable, RawValue: _BridgedSwiftTypeLoweredIntoSingleWasmCo
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_push_f32")
-@_spi(BridgeJS) public func _swift_js_push_f32(_ value: Float32)
+private func _swift_js_push_f32_extern(_ value: Float32)
 #else
-@_spi(BridgeJS) public func _swift_js_push_f32(_ value: Float32) {
+private func _swift_js_push_f32_extern(_ value: Float32) {
     _onlyAvailableOnWasm()
 }
 #endif
 
+@_spi(BridgeJS) @inline(never) public func _swift_js_push_f32(_ value: Float32) {
+    _swift_js_push_f32_extern(value)
+}
+
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_push_f64")
-@_spi(BridgeJS) public func _swift_js_push_f64(_ value: Float64)
+private func _swift_js_push_f64_extern(_ value: Float64)
 #else
-@_spi(BridgeJS) public func _swift_js_push_f64(_ value: Float64) {
+private func _swift_js_push_f64_extern(_ value: Float64) {
     _onlyAvailableOnWasm()
 }
 #endif
+
+@_spi(BridgeJS) @inline(never) public func _swift_js_push_f64(_ value: Float64) {
+    _swift_js_push_f64_extern(value)
+}
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_pop_i32")
@@ -750,21 +758,29 @@ where Self: RawRepresentable, RawValue: _BridgedSwiftTypeLoweredIntoSingleWasmCo
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_pop_f32")
-@_spi(BridgeJS) public func _swift_js_pop_f32() -> Float32
+private func _swift_js_pop_f32_extern() -> Float32
 #else
-@_spi(BridgeJS) public func _swift_js_pop_f32() -> Float32 {
+private func _swift_js_pop_f32_extern() -> Float32 {
     _onlyAvailableOnWasm()
 }
 #endif
 
+@_spi(BridgeJS) @inline(never) public func _swift_js_pop_f32() -> Float32 {
+    _swift_js_pop_f32_extern()
+}
+
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_pop_f64")
-@_spi(BridgeJS) public func _swift_js_pop_f64() -> Float64
+private func _swift_js_pop_f64_extern() -> Float64
 #else
-@_spi(BridgeJS) public func _swift_js_pop_f64() -> Float64 {
+private func _swift_js_pop_f64_extern() -> Float64 {
     _onlyAvailableOnWasm()
 }
 #endif
+
+@_spi(BridgeJS) @inline(never) public func _swift_js_pop_f64() -> Float64 {
+    _swift_js_pop_f64_extern()
+}
 
 // MARK: Struct bridging helpers (JS-side lowering/raising)
 


### PR DESCRIPTION
## Overview

Applies `@inline(never)` wrappers to `_swift_js_push_f32`, `_swift_js_push_f64`, `_swift_js_pop_f32`, and `_swift_js_pop_f64` to prevent a Swift 6.3-dev compiler bug where cross-module inlining of `@_extern(wasm, module: "bjs", ...)` functions causes the Wasm module name to be lost ("bjs" becomes "env"), resulting in link failures when building external packages that depend on JavaScriptKit.

This follows the same pattern already used for `_swift_js_pop_pointer`.

### Issue

```
wasm-ld: error: import module mismatch for symbol: $s13JavaScriptKit17_swift_js_pop_f32SfyF
>>> defined as env in .../Benchmarks.build/BridgeJS.swift.o
>>> defined as bjs in .../JavaScriptKit.build/BridgeJSIntrinsics.swift.o
```

All four f32/f64 functions are affected: `_swift_js_push_f32`, `_swift_js_push_f64`, `_swift_js_pop_f32`, `_swift_js_pop_f64`.

### Why CI doesn't catch this

CI runs `make unittest` and `swift test --package-path Plugins/BridgeJS`, both of which compile within the same package. The bug only manifests when a **separate SwiftPM package** depends on JavaScriptKit in release mode, triggering cross-module inlining.

### Reproduction

```bash
# Main
cd Benchmarks
swift package --swift-sdk <wasm-sdk> js -c release
# wasm-ld: error: import module mismatch for symbol ...

# This branch
cd Benchmarks
swift package --swift-sdk <wasm-sdk> js -c release
# Build of product 'Benchmarks' complete!
```