### PR TITLE
BridgeJS: add runtime coverage for `public @JS struct`

### DIFF
--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -2884,6 +2884,62 @@ public func _bjs_DataPoint_init(_ x: Float64, _ y: Float64, _ labelBytes: Int32,
     #endif
 }
 
+extension PublicPoint: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> PublicPoint {
+        let y = Int.bridgeJSLiftParameter()
+        let x = Int.bridgeJSLiftParameter()
+        return PublicPoint(x: x, y: y)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+        self.x.bridgeJSLowerStackReturn()
+        self.y.bridgeJSLowerStackReturn()
+    }
+
+    public init(unsafelyCopying jsObject: JSObject) {
+        let __bjs_cleanupId = _bjs_struct_lower_PublicPoint(jsObject.bridgeJSLowerParameter())
+        defer {
+            _swift_js_struct_cleanup(__bjs_cleanupId)
+        }
+        self = Self.bridgeJSLiftParameter()
+    }
+
+    public func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSLowerReturn()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PublicPoint()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PublicPoint")
+fileprivate func _bjs_struct_lower_PublicPoint(_ objectId: Int32) -> Int32
+#else
+fileprivate func _bjs_struct_lower_PublicPoint(_ objectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_PublicPoint")
+fileprivate func _bjs_struct_lift_PublicPoint() -> Int32
+#else
+fileprivate func _bjs_struct_lift_PublicPoint() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+@_expose(wasm, "bjs_PublicPoint_init")
+@_cdecl("bjs_PublicPoint_init")
+public func _bjs_PublicPoint_init(_ x: Int32, _ y: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = PublicPoint(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 extension Address: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Address {
         let zipCode = Optional<Int>.bridgeJSLiftParameter()
@@ -5957,6 +6013,17 @@ public func _bjs_nestedCartToJSObject() -> Int32 {
 public func _bjs_roundTripDataPoint() -> Void {
     #if arch(wasm32)
     let ret = roundTripDataPoint(_: DataPoint.bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripPublicPoint")
+@_cdecl("bjs_roundTripPublicPoint")
+public func _bjs_roundTripPublicPoint() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripPublicPoint(_: PublicPoint.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -11132,6 +11132,31 @@
         }
       },
       {
+        "abiName" : "bjs_roundTripPublicPoint",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripPublicPoint",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "point",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "PublicPoint"
+          }
+        }
+      },
+      {
         "abiName" : "bjs_roundTripContact",
         "effects" : {
           "isAsync" : false,
@@ -12195,6 +12220,64 @@
           }
         ],
         "swiftCallName" : "DataPoint"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_PublicPoint_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "x",
+              "name" : "x",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            },
+            {
+              "label" : "y",
+              "name" : "y",
+              "type" : {
+                "int" : {
+
+                }
+              }
+            }
+          ]
+        },
+        "explicitAccessControl" : "public",
+        "methods" : [
+
+        ],
+        "name" : "PublicPoint",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "x",
+            "type" : {
+              "int" : {
+
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "y",
+            "type" : {
+              "int" : {
+
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "PublicPoint"
       },
       {
         "methods" : [

--- a/Tests/BridgeJSRuntimeTests/StructAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/StructAPIs.swift
@@ -40,6 +40,16 @@
     }
 }
 
+@JS public struct PublicPoint {
+    public var x: Int
+    public var y: Int
+
+    @JS public init(x: Int, y: Int) {
+        self.x = x
+        self.y = y
+    }
+}
+
 @JS struct Address {
     var street: String
     var city: String
@@ -166,6 +176,10 @@
 
 @JS func roundTripDataPoint(_ data: DataPoint) -> DataPoint {
     return data
+}
+
+@JS public func roundTripPublicPoint(_ point: PublicPoint) -> PublicPoint {
+    point
 }
 
 @JS func roundTripContact(_ contact: Contact) -> Contact {

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -890,6 +890,9 @@ function testStructSupport(exports) {
     const data2 = { x: 0.0, y: 0.0, label: "", optCount: null, optFlag: null };
     assert.deepEqual(exports.roundTripDataPoint(data2), data2);
 
+    const publicPoint = { x: 9, y: -3 };
+    assert.deepEqual(exports.roundTripPublicPoint(publicPoint), publicPoint);
+
     const pointerFields1 = { raw: 1, mutRaw: 4, opaque: 1024, ptr: 65536, mutPtr: 2 };
     assert.deepEqual(exports.roundTripPointerFields(pointerFields1), pointerFields1);
 


### PR DESCRIPTION
Motivation:
- Ensure @JS public structs round-trip correctly at runtime to avoid regressions when exposing public Swift structs.

Overview:
- Add PublicPoint round-trip runtime fixture and JS prelude assertion.
- Regenerate BridgeJS bindings so the new public struct is reflected in generated Swift/JS artifacts.
