### PR TITLE
[NFC] BridgeJS: Rename Stack ABI operation methods

### DIFF
--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -11,15 +11,15 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter())
+            return .failure(Int.bridgeJSStackPop())
         case 2:
-            return .flag(Bool.bridgeJSLiftParameter())
+            return .flag(Bool.bridgeJSStackPop())
         case 3:
-            return .rate(Float.bridgeJSLiftParameter())
+            return .rate(Float.bridgeJSStackPop())
         case 4:
-            return .precise(Double.bridgeJSLiftParameter())
+            return .precise(Double.bridgeJSStackPop())
         case 5:
             return .info
         default:
@@ -30,19 +30,19 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .failure(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(1)
         case .flag(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(2)
         case .rate(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(3)
         case .precise(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(4)
         case .info:
             return Int32(5)
@@ -54,17 +54,17 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> ComplexResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .error(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
+            return .error(String.bridgeJSStackPop(), Int.bridgeJSStackPop())
         case 2:
-            return .location(Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
+            return .location(Double.bridgeJSStackPop(), Double.bridgeJSStackPop(), String.bridgeJSStackPop())
         case 3:
-            return .status(Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
+            return .status(Bool.bridgeJSStackPop(), Int.bridgeJSStackPop(), String.bridgeJSStackPop())
         case 4:
-            return .coordinates(Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter())
+            return .coordinates(Double.bridgeJSStackPop(), Double.bridgeJSStackPop(), Double.bridgeJSStackPop())
         case 5:
-            return .comprehensive(Bool.bridgeJSLiftParameter(), Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), String.bridgeJSLiftParameter(), String.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
+            return .comprehensive(Bool.bridgeJSStackPop(), Bool.bridgeJSStackPop(), Int.bridgeJSStackPop(), Int.bridgeJSStackPop(), Double.bridgeJSStackPop(), Double.bridgeJSStackPop(), String.bridgeJSStackPop(), String.bridgeJSStackPop(), String.bridgeJSStackPop())
         case 6:
             return .info
         default:
@@ -75,37 +75,37 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .error(let param0, let param1):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
             return Int32(1)
         case .location(let param0, let param1, let param2):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
             return Int32(2)
         case .status(let param0, let param1, let param2):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
             return Int32(3)
         case .coordinates(let param0, let param1, let param2):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
             return Int32(4)
         case .comprehensive(let param0, let param1, let param2, let param3, let param4, let param5, let param6, let param7, let param8):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
-            param3.bridgeJSLowerStackReturn()
-            param4.bridgeJSLowerStackReturn()
-            param5.bridgeJSLowerStackReturn()
-            param6.bridgeJSLowerStackReturn()
-            param7.bridgeJSLowerStackReturn()
-            param8.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
+            param3.bridgeJSStackPush()
+            param4.bridgeJSStackPush()
+            param5.bridgeJSStackPush()
+            param6.bridgeJSStackPush()
+            param7.bridgeJSStackPush()
+            param8.bridgeJSStackPush()
             return Int32(5)
         case .info:
             return Int32(6)
@@ -114,21 +114,21 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
 }
 
 extension SimpleStruct: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> SimpleStruct {
-        let precise = Double.bridgeJSLiftParameter()
-        let rate = Float.bridgeJSLiftParameter()
-        let flag = Bool.bridgeJSLiftParameter()
-        let count = Int.bridgeJSLiftParameter()
-        let name = String.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> SimpleStruct {
+        let precise = Double.bridgeJSStackPop()
+        let rate = Float.bridgeJSStackPop()
+        let flag = Bool.bridgeJSStackPop()
+        let count = Int.bridgeJSStackPop()
+        let name = String.bridgeJSStackPop()
         return SimpleStruct(name: name, count: count, flag: flag, rate: rate, precise: precise)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.name.bridgeJSLowerStackReturn()
-        self.count.bridgeJSLowerStackReturn()
-        self.flag.bridgeJSLowerStackReturn()
-        self.rate.bridgeJSLowerStackReturn()
-        self.precise.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.name.bridgeJSStackPush()
+        self.count.bridgeJSStackPush()
+        self.flag.bridgeJSStackPush()
+        self.rate.bridgeJSStackPush()
+        self.precise.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -136,12 +136,12 @@ extension SimpleStruct: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_SimpleStruct()))
     }
 }
@@ -165,17 +165,17 @@ fileprivate func _bjs_struct_lift_SimpleStruct() -> Int32 {
 #endif
 
 extension Address: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Address {
-        let zipCode = Int.bridgeJSLiftParameter()
-        let city = String.bridgeJSLiftParameter()
-        let street = String.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Address {
+        let zipCode = Int.bridgeJSStackPop()
+        let city = String.bridgeJSStackPop()
+        let street = String.bridgeJSStackPop()
         return Address(street: street, city: city, zipCode: zipCode)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.street.bridgeJSLowerStackReturn()
-        self.city.bridgeJSLowerStackReturn()
-        self.zipCode.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.street.bridgeJSStackPush()
+        self.city.bridgeJSStackPush()
+        self.zipCode.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -183,12 +183,12 @@ extension Address: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Address()))
     }
 }
@@ -212,21 +212,21 @@ fileprivate func _bjs_struct_lift_Address() -> Int32 {
 #endif
 
 extension Person: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Person {
-        let email = Optional<String>.bridgeJSLiftParameter()
-        let address = Address.bridgeJSLiftParameter()
-        let age = Int.bridgeJSLiftParameter()
-        let name = String.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Person {
+        let email = Optional<String>.bridgeJSStackPop()
+        let address = Address.bridgeJSStackPop()
+        let age = Int.bridgeJSStackPop()
+        let name = String.bridgeJSStackPop()
         return Person(name: name, age: age, address: address, email: email)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.name.bridgeJSLowerStackReturn()
-        self.age.bridgeJSLowerStackReturn()
-        self.address.bridgeJSLowerReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.name.bridgeJSStackPush()
+        self.age.bridgeJSStackPush()
+        self.address.bridgeJSStackPush()
         let __bjs_isSome_email = self.email != nil
         if let __bjs_unwrapped_email = self.email {
-        __bjs_unwrapped_email.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_email.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_email ? 1 : 0)
     }
@@ -236,12 +236,12 @@ extension Person: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Person()))
     }
 }
@@ -265,23 +265,23 @@ fileprivate func _bjs_struct_lift_Person() -> Int32 {
 #endif
 
 extension ComplexStruct: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ComplexStruct {
-        let metadata = String.bridgeJSLiftParameter()
-        let tags = String.bridgeJSLiftParameter()
-        let score = Double.bridgeJSLiftParameter()
-        let active = Bool.bridgeJSLiftParameter()
-        let title = String.bridgeJSLiftParameter()
-        let id = Int.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ComplexStruct {
+        let metadata = String.bridgeJSStackPop()
+        let tags = String.bridgeJSStackPop()
+        let score = Double.bridgeJSStackPop()
+        let active = Bool.bridgeJSStackPop()
+        let title = String.bridgeJSStackPop()
+        let id = Int.bridgeJSStackPop()
         return ComplexStruct(id: id, title: title, active: active, score: score, tags: tags, metadata: metadata)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.id.bridgeJSLowerStackReturn()
-        self.title.bridgeJSLowerStackReturn()
-        self.active.bridgeJSLowerStackReturn()
-        self.score.bridgeJSLowerStackReturn()
-        self.tags.bridgeJSLowerStackReturn()
-        self.metadata.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.id.bridgeJSStackPush()
+        self.title.bridgeJSStackPush()
+        self.active.bridgeJSStackPush()
+        self.score.bridgeJSStackPush()
+        self.tags.bridgeJSStackPush()
+        self.metadata.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -289,12 +289,12 @@ extension ComplexStruct: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ComplexStruct()))
     }
 }
@@ -318,15 +318,15 @@ fileprivate func _bjs_struct_lift_ComplexStruct() -> Int32 {
 #endif
 
 extension Point: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Point {
-        let y = Double.bridgeJSLiftParameter()
-        let x = Double.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Point {
+        let y = Double.bridgeJSStackPop()
+        let x = Double.bridgeJSStackPop()
         return Point(x: x, y: y)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.x.bridgeJSLowerStackReturn()
-        self.y.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -334,12 +334,12 @@ extension Point: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
     }
 }
@@ -1329,7 +1329,7 @@ public func _bjs_ArrayRoundtrip_init() -> UnsafeMutableRawPointer {
 @_cdecl("bjs_ArrayRoundtrip_takeIntArray")
 public func _bjs_ArrayRoundtrip_takeIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeIntArray(_: [Int].bridgeJSLiftParameter())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeIntArray(_: [Int].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1340,7 +1340,7 @@ public func _bjs_ArrayRoundtrip_takeIntArray(_ _self: UnsafeMutableRawPointer) -
 public func _bjs_ArrayRoundtrip_makeIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeIntArray()
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1350,8 +1350,8 @@ public func _bjs_ArrayRoundtrip_makeIntArray(_ _self: UnsafeMutableRawPointer) -
 @_cdecl("bjs_ArrayRoundtrip_roundtripIntArray")
 public func _bjs_ArrayRoundtrip_roundtripIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripIntArray(_: [Int].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripIntArray(_: [Int].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1362,7 +1362,7 @@ public func _bjs_ArrayRoundtrip_roundtripIntArray(_ _self: UnsafeMutableRawPoint
 public func _bjs_ArrayRoundtrip_makeIntArrayLarge(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeIntArrayLarge()
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1372,7 +1372,7 @@ public func _bjs_ArrayRoundtrip_makeIntArrayLarge(_ _self: UnsafeMutableRawPoint
 @_cdecl("bjs_ArrayRoundtrip_takeDoubleArray")
 public func _bjs_ArrayRoundtrip_takeDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeDoubleArray(_: [Double].bridgeJSLiftParameter())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeDoubleArray(_: [Double].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1383,7 +1383,7 @@ public func _bjs_ArrayRoundtrip_takeDoubleArray(_ _self: UnsafeMutableRawPointer
 public func _bjs_ArrayRoundtrip_makeDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeDoubleArray()
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1393,8 +1393,8 @@ public func _bjs_ArrayRoundtrip_makeDoubleArray(_ _self: UnsafeMutableRawPointer
 @_cdecl("bjs_ArrayRoundtrip_roundtripDoubleArray")
 public func _bjs_ArrayRoundtrip_roundtripDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripDoubleArray(_: [Double].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripDoubleArray(_: [Double].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1404,7 +1404,7 @@ public func _bjs_ArrayRoundtrip_roundtripDoubleArray(_ _self: UnsafeMutableRawPo
 @_cdecl("bjs_ArrayRoundtrip_takeStringArray")
 public func _bjs_ArrayRoundtrip_takeStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeStringArray(_: [String].bridgeJSLiftParameter())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeStringArray(_: [String].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1415,7 +1415,7 @@ public func _bjs_ArrayRoundtrip_takeStringArray(_ _self: UnsafeMutableRawPointer
 public func _bjs_ArrayRoundtrip_makeStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeStringArray()
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1425,8 +1425,8 @@ public func _bjs_ArrayRoundtrip_makeStringArray(_ _self: UnsafeMutableRawPointer
 @_cdecl("bjs_ArrayRoundtrip_roundtripStringArray")
 public func _bjs_ArrayRoundtrip_roundtripStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripStringArray(_: [String].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripStringArray(_: [String].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1436,7 +1436,7 @@ public func _bjs_ArrayRoundtrip_roundtripStringArray(_ _self: UnsafeMutableRawPo
 @_cdecl("bjs_ArrayRoundtrip_takePointArray")
 public func _bjs_ArrayRoundtrip_takePointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takePointArray(_: [Point].bridgeJSLiftParameter())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takePointArray(_: [Point].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1447,7 +1447,7 @@ public func _bjs_ArrayRoundtrip_takePointArray(_ _self: UnsafeMutableRawPointer)
 public func _bjs_ArrayRoundtrip_makePointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makePointArray()
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1457,8 +1457,8 @@ public func _bjs_ArrayRoundtrip_makePointArray(_ _self: UnsafeMutableRawPointer)
 @_cdecl("bjs_ArrayRoundtrip_roundtripPointArray")
 public func _bjs_ArrayRoundtrip_roundtripPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripPointArray(_: [Point].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripPointArray(_: [Point].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1469,7 +1469,7 @@ public func _bjs_ArrayRoundtrip_roundtripPointArray(_ _self: UnsafeMutableRawPoi
 public func _bjs_ArrayRoundtrip_makePointArrayLarge(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makePointArrayLarge()
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1479,7 +1479,7 @@ public func _bjs_ArrayRoundtrip_makePointArrayLarge(_ _self: UnsafeMutableRawPoi
 @_cdecl("bjs_ArrayRoundtrip_takeNestedIntArray")
 public func _bjs_ArrayRoundtrip_takeNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedIntArray(_: [[Int]].bridgeJSLiftParameter())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedIntArray(_: [[Int]].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1490,7 +1490,7 @@ public func _bjs_ArrayRoundtrip_takeNestedIntArray(_ _self: UnsafeMutableRawPoin
 public func _bjs_ArrayRoundtrip_makeNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeNestedIntArray()
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1500,8 +1500,8 @@ public func _bjs_ArrayRoundtrip_makeNestedIntArray(_ _self: UnsafeMutableRawPoin
 @_cdecl("bjs_ArrayRoundtrip_roundtripNestedIntArray")
 public func _bjs_ArrayRoundtrip_roundtripNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedIntArray(_: [[Int]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedIntArray(_: [[Int]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1511,7 +1511,7 @@ public func _bjs_ArrayRoundtrip_roundtripNestedIntArray(_ _self: UnsafeMutableRa
 @_cdecl("bjs_ArrayRoundtrip_takeNestedPointArray")
 public func _bjs_ArrayRoundtrip_takeNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedPointArray(_: [[Point]].bridgeJSLiftParameter())
+    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedPointArray(_: [[Point]].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1522,7 +1522,7 @@ public func _bjs_ArrayRoundtrip_takeNestedPointArray(_ _self: UnsafeMutableRawPo
 public func _bjs_ArrayRoundtrip_makeNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeNestedPointArray()
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1532,8 +1532,8 @@ public func _bjs_ArrayRoundtrip_makeNestedPointArray(_ _self: UnsafeMutableRawPo
 @_cdecl("bjs_ArrayRoundtrip_roundtripNestedPointArray")
 public func _bjs_ArrayRoundtrip_roundtripNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedPointArray(_: [[Point]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedPointArray(_: [[Point]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1548,7 +1548,7 @@ public func _bjs_ArrayRoundtrip_takeOptionalIntArray(_ _self: UnsafeMutableRawPo
         var __result: [Optional<Int>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<Int>.bridgeJSLiftParameter())
+            __result.append(Optional<Int>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -1566,7 +1566,7 @@ public func _bjs_ArrayRoundtrip_makeOptionalIntArray(_ _self: UnsafeMutableRawPo
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -1585,7 +1585,7 @@ public func _bjs_ArrayRoundtrip_roundtripOptionalIntArray(_ _self: UnsafeMutable
         var __result: [Optional<Int>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<Int>.bridgeJSLiftParameter())
+            __result.append(Optional<Int>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -1593,7 +1593,7 @@ public func _bjs_ArrayRoundtrip_roundtripOptionalIntArray(_ _self: UnsafeMutable
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -1612,7 +1612,7 @@ public func _bjs_ArrayRoundtrip_takeOptionalPointArray(_ _self: UnsafeMutableRaw
         var __result: [Optional<Point>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<Point>.bridgeJSLiftParameter())
+            __result.append(Optional<Point>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -1628,7 +1628,7 @@ public func _bjs_ArrayRoundtrip_makeOptionalPointArray(_ _self: UnsafeMutableRaw
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalPointArray()
     for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
+    __bjs_elem_ret.bridgeJSStackPush()
     }
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -1645,13 +1645,13 @@ public func _bjs_ArrayRoundtrip_roundtripOptionalPointArray(_ _self: UnsafeMutab
         var __result: [Optional<Point>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<Point>.bridgeJSLiftParameter())
+            __result.append(Optional<Point>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
     }())
     for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
+    __bjs_elem_ret.bridgeJSStackPush()
     }
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -1674,7 +1674,7 @@ public func _bjs_ArrayRoundtrip_takeOptionalArray(_ _self: UnsafeMutableRawPoint
 public func _bjs_ArrayRoundtrip_makeOptionalArraySome(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalArraySome()
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1685,7 +1685,7 @@ public func _bjs_ArrayRoundtrip_makeOptionalArraySome(_ _self: UnsafeMutableRawP
 public func _bjs_ArrayRoundtrip_makeOptionalArrayNone(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalArrayNone()
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1696,7 +1696,7 @@ public func _bjs_ArrayRoundtrip_makeOptionalArrayNone(_ _self: UnsafeMutableRawP
 public func _bjs_ArrayRoundtrip_roundtripOptionalArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripOptionalArray(_: Optional<[Int]>.bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
@@ -45,15 +45,15 @@ extension Status: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 extension Point: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Point {
-        let y = Double.bridgeJSLiftParameter()
-        let x = Double.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Point {
+        let y = Double.bridgeJSStackPop()
+        let x = Double.bridgeJSStackPop()
         return Point(x: x, y: y)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.x.bridgeJSLowerStackReturn()
-        self.y.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -61,12 +61,12 @@ extension Point: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
     }
 }
@@ -93,8 +93,8 @@ fileprivate func _bjs_struct_lift_Point() -> Int32 {
 @_cdecl("bjs_processIntArray")
 public func _bjs_processIntArray() -> Void {
     #if arch(wasm32)
-    let ret = processIntArray(_: [Int].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processIntArray(_: [Int].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -104,8 +104,8 @@ public func _bjs_processIntArray() -> Void {
 @_cdecl("bjs_processStringArray")
 public func _bjs_processStringArray() -> Void {
     #if arch(wasm32)
-    let ret = processStringArray(_: [String].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processStringArray(_: [String].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -115,8 +115,8 @@ public func _bjs_processStringArray() -> Void {
 @_cdecl("bjs_processDoubleArray")
 public func _bjs_processDoubleArray() -> Void {
     #if arch(wasm32)
-    let ret = processDoubleArray(_: [Double].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processDoubleArray(_: [Double].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -126,8 +126,8 @@ public func _bjs_processDoubleArray() -> Void {
 @_cdecl("bjs_processBoolArray")
 public func _bjs_processBoolArray() -> Void {
     #if arch(wasm32)
-    let ret = processBoolArray(_: [Bool].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processBoolArray(_: [Bool].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -137,8 +137,8 @@ public func _bjs_processBoolArray() -> Void {
 @_cdecl("bjs_processPointArray")
 public func _bjs_processPointArray() -> Void {
     #if arch(wasm32)
-    let ret = processPointArray(_: [Point].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processPointArray(_: [Point].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -148,8 +148,8 @@ public func _bjs_processPointArray() -> Void {
 @_cdecl("bjs_processDirectionArray")
 public func _bjs_processDirectionArray() -> Void {
     #if arch(wasm32)
-    let ret = processDirectionArray(_: [Direction].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processDirectionArray(_: [Direction].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -159,8 +159,8 @@ public func _bjs_processDirectionArray() -> Void {
 @_cdecl("bjs_processStatusArray")
 public func _bjs_processStatusArray() -> Void {
     #if arch(wasm32)
-    let ret = processStatusArray(_: [Status].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processStatusArray(_: [Status].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -170,7 +170,7 @@ public func _bjs_processStatusArray() -> Void {
 @_cdecl("bjs_sumIntArray")
 public func _bjs_sumIntArray() -> Int32 {
     #if arch(wasm32)
-    let ret = sumIntArray(_: [Int].bridgeJSLiftParameter())
+    let ret = sumIntArray(_: [Int].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -181,7 +181,7 @@ public func _bjs_sumIntArray() -> Int32 {
 @_cdecl("bjs_findFirstPoint")
 public func _bjs_findFirstPoint(_ matchingBytes: Int32, _ matchingLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = findFirstPoint(_: [Point].bridgeJSLiftParameter(), matching: String.bridgeJSLiftParameter(matchingBytes, matchingLength))
+    let ret = findFirstPoint(_: [Point].bridgeJSStackPop(), matching: String.bridgeJSLiftParameter(matchingBytes, matchingLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -192,8 +192,8 @@ public func _bjs_findFirstPoint(_ matchingBytes: Int32, _ matchingLength: Int32)
 @_cdecl("bjs_processUnsafeRawPointerArray")
 public func _bjs_processUnsafeRawPointerArray() -> Void {
     #if arch(wasm32)
-    let ret = processUnsafeRawPointerArray(_: [UnsafeRawPointer].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processUnsafeRawPointerArray(_: [UnsafeRawPointer].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -203,8 +203,8 @@ public func _bjs_processUnsafeRawPointerArray() -> Void {
 @_cdecl("bjs_processUnsafeMutableRawPointerArray")
 public func _bjs_processUnsafeMutableRawPointerArray() -> Void {
     #if arch(wasm32)
-    let ret = processUnsafeMutableRawPointerArray(_: [UnsafeMutableRawPointer].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processUnsafeMutableRawPointerArray(_: [UnsafeMutableRawPointer].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -214,8 +214,8 @@ public func _bjs_processUnsafeMutableRawPointerArray() -> Void {
 @_cdecl("bjs_processOpaquePointerArray")
 public func _bjs_processOpaquePointerArray() -> Void {
     #if arch(wasm32)
-    let ret = processOpaquePointerArray(_: [OpaquePointer].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processOpaquePointerArray(_: [OpaquePointer].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -230,7 +230,7 @@ public func _bjs_processOptionalIntArray() -> Void {
         var __result: [Optional<Int>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<Int>.bridgeJSLiftParameter())
+            __result.append(Optional<Int>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -238,7 +238,7 @@ public func _bjs_processOptionalIntArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -257,7 +257,7 @@ public func _bjs_processOptionalStringArray() -> Void {
         var __result: [Optional<String>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<String>.bridgeJSLiftParameter())
+            __result.append(Optional<String>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -265,7 +265,7 @@ public func _bjs_processOptionalStringArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -280,7 +280,7 @@ public func _bjs_processOptionalStringArray() -> Void {
 public func _bjs_processOptionalArray() -> Void {
     #if arch(wasm32)
     let ret = processOptionalArray(_: Optional<[Int]>.bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -295,13 +295,13 @@ public func _bjs_processOptionalPointArray() -> Void {
         var __result: [Optional<Point>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<Point>.bridgeJSLiftParameter())
+            __result.append(Optional<Point>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
     }())
     for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
+    __bjs_elem_ret.bridgeJSStackPush()
     }
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -318,7 +318,7 @@ public func _bjs_processOptionalDirectionArray() -> Void {
         var __result: [Optional<Direction>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<Direction>.bridgeJSLiftParameter())
+            __result.append(Optional<Direction>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -326,7 +326,7 @@ public func _bjs_processOptionalDirectionArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -345,7 +345,7 @@ public func _bjs_processOptionalStatusArray() -> Void {
         var __result: [Optional<Status>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<Status>.bridgeJSLiftParameter())
+            __result.append(Optional<Status>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -353,7 +353,7 @@ public func _bjs_processOptionalStatusArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -367,8 +367,8 @@ public func _bjs_processOptionalStatusArray() -> Void {
 @_cdecl("bjs_processNestedIntArray")
 public func _bjs_processNestedIntArray() -> Void {
     #if arch(wasm32)
-    let ret = processNestedIntArray(_: [[Int]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processNestedIntArray(_: [[Int]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -378,8 +378,8 @@ public func _bjs_processNestedIntArray() -> Void {
 @_cdecl("bjs_processNestedStringArray")
 public func _bjs_processNestedStringArray() -> Void {
     #if arch(wasm32)
-    let ret = processNestedStringArray(_: [[String]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processNestedStringArray(_: [[String]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -389,8 +389,8 @@ public func _bjs_processNestedStringArray() -> Void {
 @_cdecl("bjs_processNestedPointArray")
 public func _bjs_processNestedPointArray() -> Void {
     #if arch(wasm32)
-    let ret = processNestedPointArray(_: [[Point]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processNestedPointArray(_: [[Point]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -400,8 +400,8 @@ public func _bjs_processNestedPointArray() -> Void {
 @_cdecl("bjs_processItemArray")
 public func _bjs_processItemArray() -> Void {
     #if arch(wasm32)
-    let ret = processItemArray(_: [Item].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processItemArray(_: [Item].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -411,8 +411,8 @@ public func _bjs_processItemArray() -> Void {
 @_cdecl("bjs_processNestedItemArray")
 public func _bjs_processNestedItemArray() -> Void {
     #if arch(wasm32)
-    let ret = processNestedItemArray(_: [[Item]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processNestedItemArray(_: [[Item]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -422,8 +422,8 @@ public func _bjs_processNestedItemArray() -> Void {
 @_cdecl("bjs_processJSObjectArray")
 public func _bjs_processJSObjectArray() -> Void {
     #if arch(wasm32)
-    let ret = processJSObjectArray(_: [JSObject].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processJSObjectArray(_: [JSObject].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -438,7 +438,7 @@ public func _bjs_processOptionalJSObjectArray() -> Void {
         var __result: [Optional<JSObject>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<JSObject>.bridgeJSLiftParameter())
+            __result.append(Optional<JSObject>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -446,7 +446,7 @@ public func _bjs_processOptionalJSObjectArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -460,8 +460,8 @@ public func _bjs_processOptionalJSObjectArray() -> Void {
 @_cdecl("bjs_processNestedJSObjectArray")
 public func _bjs_processNestedJSObjectArray() -> Void {
     #if arch(wasm32)
-    let ret = processNestedJSObjectArray(_: [[JSObject]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = processNestedJSObjectArray(_: [[JSObject]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.swift
@@ -38,17 +38,17 @@ extension Status: _BridgedSwiftCaseEnum {
 }
 
 extension Config: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Config {
-        let enabled = Bool.bridgeJSLiftParameter()
-        let value = Int.bridgeJSLiftParameter()
-        let name = String.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Config {
+        let enabled = Bool.bridgeJSStackPop()
+        let value = Int.bridgeJSStackPop()
+        let name = String.bridgeJSStackPop()
         return Config(name: name, value: value, enabled: enabled)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.name.bridgeJSLowerStackReturn()
-        self.value.bridgeJSLowerStackReturn()
-        self.enabled.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.name.bridgeJSStackPush()
+        self.value.bridgeJSStackPush()
+        self.enabled.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -56,12 +56,12 @@ extension Config: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Config()))
     }
 }
@@ -85,13 +85,13 @@ fileprivate func _bjs_struct_lift_Config() -> Int32 {
 #endif
 
 extension MathOperations: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> MathOperations {
-        let baseValue = Double.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> MathOperations {
+        let baseValue = Double.bridgeJSStackPop()
         return MathOperations(baseValue: baseValue)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.baseValue.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.baseValue.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -99,12 +99,12 @@ extension MathOperations: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_MathOperations()))
     }
 }
@@ -318,8 +318,8 @@ public func _bjs_testOptionalStructWithValueDefault() -> Void {
 @_cdecl("bjs_testIntArrayDefault")
 public func _bjs_testIntArrayDefault() -> Void {
     #if arch(wasm32)
-    let ret = testIntArrayDefault(values: [Int].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = testIntArrayDefault(values: [Int].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -329,8 +329,8 @@ public func _bjs_testIntArrayDefault() -> Void {
 @_cdecl("bjs_testStringArrayDefault")
 public func _bjs_testStringArrayDefault() -> Void {
     #if arch(wasm32)
-    let ret = testStringArrayDefault(names: [String].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = testStringArrayDefault(names: [String].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -340,8 +340,8 @@ public func _bjs_testStringArrayDefault() -> Void {
 @_cdecl("bjs_testDoubleArrayDefault")
 public func _bjs_testDoubleArrayDefault() -> Void {
     #if arch(wasm32)
-    let ret = testDoubleArrayDefault(values: [Double].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = testDoubleArrayDefault(values: [Double].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -351,8 +351,8 @@ public func _bjs_testDoubleArrayDefault() -> Void {
 @_cdecl("bjs_testBoolArrayDefault")
 public func _bjs_testBoolArrayDefault() -> Void {
     #if arch(wasm32)
-    let ret = testBoolArrayDefault(flags: [Bool].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = testBoolArrayDefault(flags: [Bool].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -362,8 +362,8 @@ public func _bjs_testBoolArrayDefault() -> Void {
 @_cdecl("bjs_testEmptyArrayDefault")
 public func _bjs_testEmptyArrayDefault() -> Void {
     #if arch(wasm32)
-    let ret = testEmptyArrayDefault(items: [Int].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = testEmptyArrayDefault(items: [Int].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -373,7 +373,7 @@ public func _bjs_testEmptyArrayDefault() -> Void {
 @_cdecl("bjs_testMixedWithArrayDefault")
 public func _bjs_testMixedWithArrayDefault(_ nameBytes: Int32, _ nameLength: Int32, _ enabled: Int32) -> Void {
     #if arch(wasm32)
-    let ret = testMixedWithArrayDefault(name: String.bridgeJSLiftParameter(nameBytes, nameLength), values: [Int].bridgeJSLiftParameter(), enabled: Bool.bridgeJSLiftParameter(enabled))
+    let ret = testMixedWithArrayDefault(name: String.bridgeJSLiftParameter(nameBytes, nameLength), values: [Int].bridgeJSStackPop(), enabled: Bool.bridgeJSLiftParameter(enabled))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
@@ -2,15 +2,15 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter())
+            return .failure(Int.bridgeJSStackPop())
         case 2:
-            return .flag(Bool.bridgeJSLiftParameter())
+            return .flag(Bool.bridgeJSStackPop())
         case 3:
-            return .rate(Float.bridgeJSLiftParameter())
+            return .rate(Float.bridgeJSStackPop())
         case 4:
-            return .precise(Double.bridgeJSLiftParameter())
+            return .precise(Double.bridgeJSStackPop())
         case 5:
             return .info
         default:
@@ -21,19 +21,19 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .failure(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(1)
         case .flag(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(2)
         case .rate(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(3)
         case .precise(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(4)
         case .info:
             return Int32(5)
@@ -45,15 +45,15 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> ComplexResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .error(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
+            return .error(String.bridgeJSStackPop(), Int.bridgeJSStackPop())
         case 2:
-            return .status(Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
+            return .status(Bool.bridgeJSStackPop(), Int.bridgeJSStackPop(), String.bridgeJSStackPop())
         case 3:
-            return .coordinates(Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter())
+            return .coordinates(Double.bridgeJSStackPop(), Double.bridgeJSStackPop(), Double.bridgeJSStackPop())
         case 4:
-            return .comprehensive(Bool.bridgeJSLiftParameter(), Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), String.bridgeJSLiftParameter(), String.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
+            return .comprehensive(Bool.bridgeJSStackPop(), Bool.bridgeJSStackPop(), Int.bridgeJSStackPop(), Int.bridgeJSStackPop(), Double.bridgeJSStackPop(), Double.bridgeJSStackPop(), String.bridgeJSStackPop(), String.bridgeJSStackPop(), String.bridgeJSStackPop())
         case 5:
             return .info
         default:
@@ -64,32 +64,32 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .error(let param0, let param1):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
             return Int32(1)
         case .status(let param0, let param1, let param2):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
             return Int32(2)
         case .coordinates(let param0, let param1, let param2):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
             return Int32(3)
         case .comprehensive(let param0, let param1, let param2, let param3, let param4, let param5, let param6, let param7, let param8):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
-            param3.bridgeJSLowerStackReturn()
-            param4.bridgeJSLowerStackReturn()
-            param5.bridgeJSLowerStackReturn()
-            param6.bridgeJSLowerStackReturn()
-            param7.bridgeJSLowerStackReturn()
-            param8.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
+            param3.bridgeJSStackPush()
+            param4.bridgeJSStackPush()
+            param5.bridgeJSStackPush()
+            param6.bridgeJSStackPush()
+            param7.bridgeJSStackPush()
+            param8.bridgeJSStackPush()
             return Int32(4)
         case .info:
             return Int32(5)
@@ -101,11 +101,11 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Utilities.Result {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .failure(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
+            return .failure(String.bridgeJSStackPop(), Int.bridgeJSStackPop())
         case 2:
-            return .status(Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
+            return .status(Bool.bridgeJSStackPop(), Int.bridgeJSStackPop(), String.bridgeJSStackPop())
         default:
             fatalError("Unknown Utilities.Result case ID: \(caseId)")
         }
@@ -114,16 +114,16 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .failure(let param0, let param1):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
             return Int32(1)
         case .status(let param0, let param1, let param2):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
             return Int32(2)
         }
     }
@@ -133,9 +133,9 @@ extension NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> NetworkingResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .failure(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
+            return .failure(String.bridgeJSStackPop(), Int.bridgeJSStackPop())
         default:
             fatalError("Unknown NetworkingResult case ID: \(caseId)")
         }
@@ -144,11 +144,11 @@ extension NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .failure(let param0, let param1):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
             return Int32(1)
         }
     }
@@ -158,11 +158,11 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIOptionalResult {
         switch caseId {
         case 0:
-            return .success(Optional<String>.bridgeJSLiftParameter())
+            return .success(Optional<String>.bridgeJSStackPop())
         case 1:
-            return .failure(Optional<Int>.bridgeJSLiftParameter(), Optional<Bool>.bridgeJSLiftParameter())
+            return .failure(Optional<Int>.bridgeJSStackPop(), Optional<Bool>.bridgeJSStackPop())
         case 2:
-            return .status(Optional<Bool>.bridgeJSLiftParameter(), Optional<Int>.bridgeJSLiftParameter(), Optional<String>.bridgeJSLiftParameter())
+            return .status(Optional<Bool>.bridgeJSStackPop(), Optional<Int>.bridgeJSStackPop(), Optional<String>.bridgeJSStackPop())
         default:
             fatalError("Unknown APIOptionalResult case ID: \(caseId)")
         }
@@ -173,36 +173,36 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
         case .success(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(0)
         case .failure(let param0, let param1):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             let __bjs_isSome_param1 = param1 != nil
             if let __bjs_unwrapped_param1 = param1 {
-            __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param1.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
             return Int32(1)
         case .status(let param0, let param1, let param2):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             let __bjs_isSome_param1 = param1 != nil
             if let __bjs_unwrapped_param1 = param1 {
-            __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param1.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
             let __bjs_isSome_param2 = param2 != nil
             if let __bjs_unwrapped_param2 = param2 {
-            __bjs_unwrapped_param2.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param2.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param2 ? 1 : 0)
             return Int32(2)
@@ -260,13 +260,13 @@ extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TypedPayloadResult {
         switch caseId {
         case 0:
-            return .precision(Precision.bridgeJSLiftParameter())
+            return .precision(Precision.bridgeJSStackPop())
         case 1:
-            return .direction(CardinalDirection.bridgeJSLiftParameter())
+            return .direction(CardinalDirection.bridgeJSStackPop())
         case 2:
-            return .optPrecision(Optional<Precision>.bridgeJSLiftParameter())
+            return .optPrecision(Optional<Precision>.bridgeJSStackPop())
         case 3:
-            return .optDirection(Optional<CardinalDirection>.bridgeJSLiftParameter())
+            return .optDirection(Optional<CardinalDirection>.bridgeJSStackPop())
         case 4:
             return .empty
         default:
@@ -277,22 +277,22 @@ extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .precision(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .direction(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(1)
         case .optPrecision(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(2)
         case .optDirection(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(3)
@@ -306,15 +306,15 @@ extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> AllTypesResult {
         switch caseId {
         case 0:
-            return .structPayload(Point.bridgeJSLiftParameter())
+            return .structPayload(Point.bridgeJSStackPop())
         case 1:
-            return .classPayload(User.bridgeJSLiftParameter())
+            return .classPayload(User.bridgeJSStackPop())
         case 2:
-            return .jsObjectPayload(JSObject.bridgeJSLiftParameter())
+            return .jsObjectPayload(JSObject.bridgeJSStackPop())
         case 3:
-            return .nestedEnum(APIResult.bridgeJSLiftParameter())
+            return .nestedEnum(APIResult.bridgeJSStackPop())
         case 4:
-            return .arrayPayload([Int].bridgeJSLiftParameter())
+            return .arrayPayload([Int].bridgeJSStackPop())
         case 5:
             return .empty
         default:
@@ -325,19 +325,19 @@ extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .structPayload(let param0):
-            param0.bridgeJSLowerReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .classPayload(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(1)
         case .jsObjectPayload(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(2)
         case .nestedEnum(let param0):
-            param0.bridgeJSLowerReturn()
+            param0.bridgeJSStackPush()
             return Int32(3)
         case .arrayPayload(let param0):
-            param0.bridgeJSLowerReturn()
+            param0.bridgeJSStackPush()
             return Int32(4)
         case .empty:
             return Int32(5)
@@ -349,15 +349,15 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> OptionalAllTypesResult {
         switch caseId {
         case 0:
-            return .optStruct(Optional<Point>.bridgeJSLiftParameter())
+            return .optStruct(Optional<Point>.bridgeJSStackPop())
         case 1:
-            return .optClass(Optional<User>.bridgeJSLiftParameter())
+            return .optClass(Optional<User>.bridgeJSStackPop())
         case 2:
-            return .optJSObject(Optional<JSObject>.bridgeJSLiftParameter())
+            return .optJSObject(Optional<JSObject>.bridgeJSStackPop())
         case 3:
-            return .optNestedEnum(Optional<APIResult>.bridgeJSLiftParameter())
+            return .optNestedEnum(Optional<APIResult>.bridgeJSStackPop())
         case 4:
-            return .optArray(Optional<[Int]>.bridgeJSLiftParameter())
+            return .optArray(Optional<[Int]>.bridgeJSStackPop())
         case 5:
             return .empty
         default:
@@ -368,31 +368,31 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .optStruct(let param0):
-            param0.bridgeJSLowerReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .optClass(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(1)
         case .optJSObject(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(2)
         case .optNestedEnum(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(3)
         case .optArray(let param0):
-            param0.bridgeJSLowerReturn()
+            param0.bridgeJSStackPush()
             return Int32(4)
         case .empty:
             return Int32(5)
@@ -401,15 +401,15 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
 }
 
 extension Point: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Point {
-        let y = Double.bridgeJSLiftParameter()
-        let x = Double.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Point {
+        let y = Double.bridgeJSStackPop()
+        let x = Double.bridgeJSStackPop()
         return Point(x: x, y: y)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.x.bridgeJSLowerStackReturn()
-        self.y.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -417,12 +417,12 @@ extension Point: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.swift
@@ -1,15 +1,15 @@
 extension FooContainer: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> FooContainer {
-        let optionalFoo = Optional<JSObject>.bridgeJSLiftParameter().map { Foo(unsafelyWrapping: $0) }
-        let foo = Foo(unsafelyWrapping: JSObject.bridgeJSLiftParameter())
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> FooContainer {
+        let optionalFoo = Optional<JSObject>.bridgeJSStackPop().map { Foo(unsafelyWrapping: $0) }
+        let foo = Foo(unsafelyWrapping: JSObject.bridgeJSStackPop())
         return FooContainer(foo: foo, optionalFoo: optionalFoo)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.foo.jsObject.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.foo.jsObject.bridgeJSStackPush()
         let __bjs_isSome_optionalFoo = self.optionalFoo != nil
         if let __bjs_unwrapped_optionalFoo = self.optionalFoo {
-        __bjs_unwrapped_optionalFoo.jsObject.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_optionalFoo.jsObject.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_optionalFoo ? 1 : 0)
     }
@@ -19,12 +19,12 @@ extension FooContainer: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_FooContainer()))
     }
 }
@@ -76,8 +76,8 @@ public func _bjs_makeFoo() -> Int32 {
 @_cdecl("bjs_processFooArray")
 public func _bjs_processFooArray() -> Void {
     #if arch(wasm32)
-    let ret = processFooArray(_: [JSObject].bridgeJSLiftParameter().map { Foo(unsafelyWrapping: $0) })
-    ret.map { $0.jsObject }.bridgeJSLowerReturn()
+    let ret = processFooArray(_: [JSObject].bridgeJSStackPop().map { Foo(unsafelyWrapping: $0) })
+    ret.map { $0.jsObject }.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -92,7 +92,7 @@ public func _bjs_processOptionalFooArray() -> Void {
         var __result: [Optional<Foo>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<JSObject>.bridgeJSLiftParameter().map { Foo(unsafelyWrapping: $0) })
+            __result.append(Optional<JSObject>.bridgeJSStackPop().map { Foo(unsafelyWrapping: $0) })
         }
         __result.reverse()
         return __result
@@ -100,7 +100,7 @@ public func _bjs_processOptionalFooArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.jsObject.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.jsObject.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSValue.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSValue.swift
@@ -24,8 +24,8 @@ public func _bjs_roundTripOptionalJSValue(_ valueIsSome: Int32, _ valueKind: Int
 @_cdecl("bjs_roundTripJSValueArray")
 public func _bjs_roundTripJSValueArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripJSValueArray(_: [JSValue].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripJSValueArray(_: [JSValue].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -36,7 +36,7 @@ public func _bjs_roundTripJSValueArray() -> Void {
 public func _bjs_roundTripOptionalJSValueArray() -> Void {
     #if arch(wasm32)
     let ret = roundTripOptionalJSValueArray(_: Optional<[JSValue]>.bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
@@ -366,9 +366,9 @@ extension Result: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Result {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter())
+            return .failure(Int.bridgeJSStackPop())
         default:
             fatalError("Unknown Result case ID: \(caseId)")
         }
@@ -377,10 +377,10 @@ extension Result: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .failure(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(1)
         }
     }
@@ -393,8 +393,8 @@ extension Priority: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 @_cdecl("bjs_processDelegates")
 public func _bjs_processDelegates() -> Void {
     #if arch(wasm32)
-    let ret = processDelegates(_: [AnyMyViewControllerDelegate].bridgeJSLiftParameter())
-    ret.map { $0 as! AnyMyViewControllerDelegate }.bridgeJSLowerReturn()
+    let ret = processDelegates(_: [AnyMyViewControllerDelegate].bridgeJSStackPop())
+    ret.map { $0 as! AnyMyViewControllerDelegate }.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -611,7 +611,7 @@ fileprivate func _bjs_MyViewController_wrap(_ pointer: UnsafeMutableRawPointer) 
 @_cdecl("bjs_DelegateManager_init")
 public func _bjs_DelegateManager_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = DelegateManager(delegates: [AnyMyViewControllerDelegate].bridgeJSLiftParameter())
+    let ret = DelegateManager(delegates: [AnyMyViewControllerDelegate].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -633,7 +633,7 @@ public func _bjs_DelegateManager_notifyAll(_ _self: UnsafeMutableRawPointer) -> 
 public func _bjs_DelegateManager_delegates_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     let ret = DelegateManager.bridgeJSLiftParameter(_self).delegates
-    ret.map { $0 as! AnyMyViewControllerDelegate }.bridgeJSLowerReturn()
+    ret.map { $0 as! AnyMyViewControllerDelegate }.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -643,7 +643,7 @@ public func _bjs_DelegateManager_delegates_get(_ _self: UnsafeMutableRawPointer)
 @_cdecl("bjs_DelegateManager_delegates_set")
 public func _bjs_DelegateManager_delegates_set(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    DelegateManager.bridgeJSLiftParameter(_self).delegates = [AnyMyViewControllerDelegate].bridgeJSLiftParameter()
+    DelegateManager.bridgeJSLiftParameter(_self).delegates = [AnyMyViewControllerDelegate].bridgeJSStackPop()
     #else
     fatalError("Only available on WebAssembly")
     #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.Global.swift
@@ -48,9 +48,9 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter())
+            return .failure(Int.bridgeJSStackPop())
         default:
             fatalError("Unknown APIResult case ID: \(caseId)")
         }
@@ -59,10 +59,10 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .failure(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(1)
         }
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.swift
@@ -48,9 +48,9 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter())
+            return .failure(Int.bridgeJSStackPop())
         default:
             fatalError("Unknown APIResult case ID: \(caseId)")
         }
@@ -59,10 +59,10 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .failure(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(1)
         }
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
@@ -1191,15 +1191,15 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter())
+            return .failure(Int.bridgeJSStackPop())
         case 2:
-            return .flag(Bool.bridgeJSLiftParameter())
+            return .flag(Bool.bridgeJSStackPop())
         case 3:
-            return .rate(Float.bridgeJSLiftParameter())
+            return .rate(Float.bridgeJSStackPop())
         case 4:
-            return .precise(Double.bridgeJSLiftParameter())
+            return .precise(Double.bridgeJSStackPop())
         case 5:
             return .info
         default:
@@ -1210,19 +1210,19 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .failure(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(1)
         case .flag(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(2)
         case .rate(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(3)
         case .precise(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(4)
         case .info:
             return Int32(5)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.swift
@@ -2,27 +2,27 @@ extension Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
 extension DataPoint: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> DataPoint {
-        let optFlag = Optional<Bool>.bridgeJSLiftParameter()
-        let optCount = Optional<Int>.bridgeJSLiftParameter()
-        let label = String.bridgeJSLiftParameter()
-        let y = Double.bridgeJSLiftParameter()
-        let x = Double.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> DataPoint {
+        let optFlag = Optional<Bool>.bridgeJSStackPop()
+        let optCount = Optional<Int>.bridgeJSStackPop()
+        let label = String.bridgeJSStackPop()
+        let y = Double.bridgeJSStackPop()
+        let x = Double.bridgeJSStackPop()
         return DataPoint(x: x, y: y, label: label, optCount: optCount, optFlag: optFlag)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.x.bridgeJSLowerStackReturn()
-        self.y.bridgeJSLowerStackReturn()
-        self.label.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
+        self.label.bridgeJSStackPush()
         let __bjs_isSome_optCount = self.optCount != nil
         if let __bjs_unwrapped_optCount = self.optCount {
-        __bjs_unwrapped_optCount.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_optCount.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_optCount ? 1 : 0)
         let __bjs_isSome_optFlag = self.optFlag != nil
         if let __bjs_unwrapped_optFlag = self.optFlag {
-        __bjs_unwrapped_optFlag.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_optFlag.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_optFlag ? 1 : 0)
     }
@@ -32,12 +32,12 @@ extension DataPoint: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_DataPoint()))
     }
 }
@@ -72,19 +72,19 @@ public func _bjs_DataPoint_init(_ x: Float64, _ y: Float64, _ labelBytes: Int32,
 }
 
 extension Address: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Address {
-        let zipCode = Optional<Int>.bridgeJSLiftParameter()
-        let city = String.bridgeJSLiftParameter()
-        let street = String.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Address {
+        let zipCode = Optional<Int>.bridgeJSStackPop()
+        let city = String.bridgeJSStackPop()
+        let street = String.bridgeJSStackPop()
         return Address(street: street, city: city, zipCode: zipCode)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.street.bridgeJSLowerStackReturn()
-        self.city.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.street.bridgeJSStackPush()
+        self.city.bridgeJSStackPush()
         let __bjs_isSome_zipCode = self.zipCode != nil
         if let __bjs_unwrapped_zipCode = self.zipCode {
-        __bjs_unwrapped_zipCode.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_zipCode.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_zipCode ? 1 : 0)
     }
@@ -94,12 +94,12 @@ extension Address: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Address()))
     }
 }
@@ -123,21 +123,21 @@ fileprivate func _bjs_struct_lift_Address() -> Int32 {
 #endif
 
 extension Person: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Person {
-        let email = Optional<String>.bridgeJSLiftParameter()
-        let address = Address.bridgeJSLiftParameter()
-        let age = Int.bridgeJSLiftParameter()
-        let name = String.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Person {
+        let email = Optional<String>.bridgeJSStackPop()
+        let address = Address.bridgeJSStackPop()
+        let age = Int.bridgeJSStackPop()
+        let name = String.bridgeJSStackPop()
         return Person(name: name, age: age, address: address, email: email)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.name.bridgeJSLowerStackReturn()
-        self.age.bridgeJSLowerStackReturn()
-        self.address.bridgeJSLowerReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.name.bridgeJSStackPush()
+        self.age.bridgeJSStackPush()
+        self.address.bridgeJSStackPush()
         let __bjs_isSome_email = self.email != nil
         if let __bjs_unwrapped_email = self.email {
-        __bjs_unwrapped_email.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_email.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_email ? 1 : 0)
     }
@@ -147,12 +147,12 @@ extension Person: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Person()))
     }
 }
@@ -176,15 +176,15 @@ fileprivate func _bjs_struct_lift_Person() -> Int32 {
 #endif
 
 extension Session: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Session {
-        let owner = Greeter.bridgeJSLiftParameter()
-        let id = Int.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Session {
+        let owner = Greeter.bridgeJSStackPop()
+        let id = Int.bridgeJSStackPop()
         return Session(id: id, owner: owner)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.id.bridgeJSLowerStackReturn()
-        self.owner.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.id.bridgeJSStackPush()
+        self.owner.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -192,12 +192,12 @@ extension Session: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Session()))
     }
 }
@@ -221,19 +221,19 @@ fileprivate func _bjs_struct_lift_Session() -> Int32 {
 #endif
 
 extension Measurement: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Measurement {
-        let optionalPrecision = Optional<Precision>.bridgeJSLiftParameter()
-        let precision = Precision.bridgeJSLiftParameter()
-        let value = Double.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Measurement {
+        let optionalPrecision = Optional<Precision>.bridgeJSStackPop()
+        let precision = Precision.bridgeJSStackPop()
+        let value = Double.bridgeJSStackPop()
         return Measurement(value: value, precision: precision, optionalPrecision: optionalPrecision)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.value.bridgeJSLowerStackReturn()
-        self.precision.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.value.bridgeJSStackPush()
+        self.precision.bridgeJSStackPush()
         let __bjs_isSome_optionalPrecision = self.optionalPrecision != nil
         if let __bjs_unwrapped_optionalPrecision = self.optionalPrecision {
-        __bjs_unwrapped_optionalPrecision.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_optionalPrecision.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_optionalPrecision ? 1 : 0)
     }
@@ -243,12 +243,12 @@ extension Measurement: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Measurement()))
     }
 }
@@ -272,11 +272,11 @@ fileprivate func _bjs_struct_lift_Measurement() -> Int32 {
 #endif
 
 extension ConfigStruct: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ConfigStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ConfigStruct {
         return ConfigStruct()
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -284,12 +284,12 @@ extension ConfigStruct: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ConfigStruct()))
     }
 }
@@ -388,17 +388,17 @@ public func _bjs_ConfigStruct_static_update(_ timeout: Float64) -> Float64 {
 }
 
 extension Container: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Container {
-        let optionalObject = Optional<JSObject>.bridgeJSLiftParameter()
-        let object = JSObject.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Container {
+        let optionalObject = Optional<JSObject>.bridgeJSStackPop()
+        let object = JSObject.bridgeJSStackPop()
         return Container(object: object, optionalObject: optionalObject)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.object.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.object.bridgeJSStackPush()
         let __bjs_isSome_optionalObject = self.optionalObject != nil
         if let __bjs_unwrapped_optionalObject = self.optionalObject {
-        __bjs_unwrapped_optionalObject.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_optionalObject.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_optionalObject ? 1 : 0)
     }
@@ -408,12 +408,12 @@ extension Container: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Container()))
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
@@ -1,13 +1,13 @@
 extension Point: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Point {
-        let y = Int.bridgeJSLiftParameter()
-        let x = Int.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Point {
+        let y = Int.bridgeJSStackPop()
+        let x = Int.bridgeJSStackPop()
         return Point(x: x, y: y)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.x.bridgeJSLowerStackReturn()
-        self.y.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -15,12 +15,12 @@ extension Point: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/UnsafePointer.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/UnsafePointer.swift
@@ -1,19 +1,19 @@
 extension PointerFields: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> PointerFields {
-        let mutPtr = UnsafeMutablePointer<UInt8>.bridgeJSLiftParameter()
-        let ptr = UnsafePointer<UInt8>.bridgeJSLiftParameter()
-        let opaque = OpaquePointer.bridgeJSLiftParameter()
-        let mutRaw = UnsafeMutableRawPointer.bridgeJSLiftParameter()
-        let raw = UnsafeRawPointer.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> PointerFields {
+        let mutPtr = UnsafeMutablePointer<UInt8>.bridgeJSStackPop()
+        let ptr = UnsafePointer<UInt8>.bridgeJSStackPop()
+        let opaque = OpaquePointer.bridgeJSStackPop()
+        let mutRaw = UnsafeMutableRawPointer.bridgeJSStackPop()
+        let raw = UnsafeRawPointer.bridgeJSStackPop()
         return PointerFields(raw: raw, mutRaw: mutRaw, opaque: opaque, ptr: ptr, mutPtr: mutPtr)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.raw.bridgeJSLowerStackReturn()
-        self.mutRaw.bridgeJSLowerStackReturn()
-        self.opaque.bridgeJSLowerStackReturn()
-        self.ptr.bridgeJSLowerStackReturn()
-        self.mutPtr.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.raw.bridgeJSStackPush()
+        self.mutRaw.bridgeJSStackPush()
+        self.opaque.bridgeJSStackPush()
+        self.ptr.bridgeJSStackPush()
+        self.mutPtr.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -21,12 +21,12 @@ extension PointerFields: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PointerFields()))
     }
 }

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -2029,15 +2029,15 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .failure(Int.bridgeJSLiftParameter())
+            return .failure(Int.bridgeJSStackPop())
         case 2:
-            return .flag(Bool.bridgeJSLiftParameter())
+            return .flag(Bool.bridgeJSStackPop())
         case 3:
-            return .rate(Float.bridgeJSLiftParameter())
+            return .rate(Float.bridgeJSStackPop())
         case 4:
-            return .precise(Double.bridgeJSLiftParameter())
+            return .precise(Double.bridgeJSStackPop())
         case 5:
             return .info
         default:
@@ -2048,19 +2048,19 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .failure(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(1)
         case .flag(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(2)
         case .rate(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(3)
         case .precise(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(4)
         case .info:
             return Int32(5)
@@ -2072,17 +2072,17 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> ComplexResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .error(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
+            return .error(String.bridgeJSStackPop(), Int.bridgeJSStackPop())
         case 2:
-            return .location(Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
+            return .location(Double.bridgeJSStackPop(), Double.bridgeJSStackPop(), String.bridgeJSStackPop())
         case 3:
-            return .status(Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
+            return .status(Bool.bridgeJSStackPop(), Int.bridgeJSStackPop(), String.bridgeJSStackPop())
         case 4:
-            return .coordinates(Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter())
+            return .coordinates(Double.bridgeJSStackPop(), Double.bridgeJSStackPop(), Double.bridgeJSStackPop())
         case 5:
-            return .comprehensive(Bool.bridgeJSLiftParameter(), Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), Double.bridgeJSLiftParameter(), String.bridgeJSLiftParameter(), String.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
+            return .comprehensive(Bool.bridgeJSStackPop(), Bool.bridgeJSStackPop(), Int.bridgeJSStackPop(), Int.bridgeJSStackPop(), Double.bridgeJSStackPop(), Double.bridgeJSStackPop(), String.bridgeJSStackPop(), String.bridgeJSStackPop(), String.bridgeJSStackPop())
         case 6:
             return .info
         default:
@@ -2093,37 +2093,37 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .error(let param0, let param1):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
             return Int32(1)
         case .location(let param0, let param1, let param2):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
             return Int32(2)
         case .status(let param0, let param1, let param2):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
             return Int32(3)
         case .coordinates(let param0, let param1, let param2):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
             return Int32(4)
         case .comprehensive(let param0, let param1, let param2, let param3, let param4, let param5, let param6, let param7, let param8):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
-            param3.bridgeJSLowerStackReturn()
-            param4.bridgeJSLowerStackReturn()
-            param5.bridgeJSLowerStackReturn()
-            param6.bridgeJSLowerStackReturn()
-            param7.bridgeJSLowerStackReturn()
-            param8.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
+            param3.bridgeJSStackPush()
+            param4.bridgeJSStackPush()
+            param5.bridgeJSStackPush()
+            param6.bridgeJSStackPush()
+            param7.bridgeJSStackPush()
+            param8.bridgeJSStackPush()
             return Int32(5)
         case .info:
             return Int32(6)
@@ -2135,11 +2135,11 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Utilities.Result {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .failure(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
+            return .failure(String.bridgeJSStackPop(), Int.bridgeJSStackPop())
         case 2:
-            return .status(Bool.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter(), String.bridgeJSLiftParameter())
+            return .status(Bool.bridgeJSStackPop(), Int.bridgeJSStackPop(), String.bridgeJSStackPop())
         default:
             fatalError("Unknown Utilities.Result case ID: \(caseId)")
         }
@@ -2148,16 +2148,16 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .failure(let param0, let param1):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
             return Int32(1)
         case .status(let param0, let param1, let param2):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
-            param2.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
+            param2.bridgeJSStackPush()
             return Int32(2)
         }
     }
@@ -2167,9 +2167,9 @@ extension API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> API.NetworkingResult {
         switch caseId {
         case 0:
-            return .success(String.bridgeJSLiftParameter())
+            return .success(String.bridgeJSStackPop())
         case 1:
-            return .failure(String.bridgeJSLiftParameter(), Int.bridgeJSLiftParameter())
+            return .failure(String.bridgeJSStackPop(), Int.bridgeJSStackPop())
         default:
             fatalError("Unknown API.NetworkingResult case ID: \(caseId)")
         }
@@ -2178,11 +2178,11 @@ extension API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .success(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .failure(let param0, let param1):
-            param0.bridgeJSLowerStackReturn()
-            param1.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
+            param1.bridgeJSStackPush()
             return Int32(1)
         }
     }
@@ -2192,17 +2192,17 @@ extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> AllTypesResult {
         switch caseId {
         case 0:
-            return .structPayload(Address.bridgeJSLiftParameter())
+            return .structPayload(Address.bridgeJSStackPop())
         case 1:
-            return .classPayload(Greeter.bridgeJSLiftParameter())
+            return .classPayload(Greeter.bridgeJSStackPop())
         case 2:
-            return .jsObjectPayload(JSObject.bridgeJSLiftParameter())
+            return .jsObjectPayload(JSObject.bridgeJSStackPop())
         case 3:
-            return .nestedEnum(APIResult.bridgeJSLiftParameter())
+            return .nestedEnum(APIResult.bridgeJSStackPop())
         case 4:
-            return .arrayPayload([Int].bridgeJSLiftParameter())
+            return .arrayPayload([Int].bridgeJSStackPop())
         case 5:
-            return .jsClassPayload(Foo(unsafelyWrapping: JSObject.bridgeJSLiftParameter()))
+            return .jsClassPayload(Foo(unsafelyWrapping: JSObject.bridgeJSStackPop()))
         case 6:
             return .empty
         default:
@@ -2213,22 +2213,22 @@ extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .structPayload(let param0):
-            param0.bridgeJSLowerReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .classPayload(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(1)
         case .jsObjectPayload(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(2)
         case .nestedEnum(let param0):
-            param0.bridgeJSLowerReturn()
+            param0.bridgeJSStackPush()
             return Int32(3)
         case .arrayPayload(let param0):
-            param0.bridgeJSLowerReturn()
+            param0.bridgeJSStackPush()
             return Int32(4)
         case .jsClassPayload(let param0):
-            param0.jsObject.bridgeJSLowerStackReturn()
+            param0.jsObject.bridgeJSStackPush()
             return Int32(5)
         case .empty:
             return Int32(6)
@@ -2240,13 +2240,13 @@ extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TypedPayloadResult {
         switch caseId {
         case 0:
-            return .precision(Precision.bridgeJSLiftParameter())
+            return .precision(Precision.bridgeJSStackPop())
         case 1:
-            return .direction(Direction.bridgeJSLiftParameter())
+            return .direction(Direction.bridgeJSStackPop())
         case 2:
-            return .optPrecision(Optional<Precision>.bridgeJSLiftParameter())
+            return .optPrecision(Optional<Precision>.bridgeJSStackPop())
         case 3:
-            return .optDirection(Optional<Direction>.bridgeJSLiftParameter())
+            return .optDirection(Optional<Direction>.bridgeJSStackPop())
         case 4:
             return .empty
         default:
@@ -2257,22 +2257,22 @@ extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .precision(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .direction(let param0):
-            param0.bridgeJSLowerStackReturn()
+            param0.bridgeJSStackPush()
             return Int32(1)
         case .optPrecision(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(2)
         case .optDirection(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(3)
@@ -2591,17 +2591,17 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> OptionalAllTypesResult {
         switch caseId {
         case 0:
-            return .optStruct(Optional<Address>.bridgeJSLiftParameter())
+            return .optStruct(Optional<Address>.bridgeJSStackPop())
         case 1:
-            return .optClass(Optional<Greeter>.bridgeJSLiftParameter())
+            return .optClass(Optional<Greeter>.bridgeJSStackPop())
         case 2:
-            return .optJSObject(Optional<JSObject>.bridgeJSLiftParameter())
+            return .optJSObject(Optional<JSObject>.bridgeJSStackPop())
         case 3:
-            return .optNestedEnum(Optional<APIResult>.bridgeJSLiftParameter())
+            return .optNestedEnum(Optional<APIResult>.bridgeJSStackPop())
         case 4:
-            return .optArray(Optional<[Int]>.bridgeJSLiftParameter())
+            return .optArray(Optional<[Int]>.bridgeJSStackPop())
         case 5:
-            return .optJsClass(Optional<JSObject>.bridgeJSLiftParameter().map { Foo(unsafelyWrapping: $0) })
+            return .optJsClass(Optional<JSObject>.bridgeJSStackPop().map { Foo(unsafelyWrapping: $0) })
         case 6:
             return .empty
         default:
@@ -2612,36 +2612,36 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .optStruct(let param0):
-            param0.bridgeJSLowerReturn()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .optClass(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(1)
         case .optJSObject(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(2)
         case .optNestedEnum(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(3)
         case .optArray(let param0):
-            param0.bridgeJSLowerReturn()
+            param0.bridgeJSStackPush()
             return Int32(4)
         case .optJsClass(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.jsObject.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.jsObject.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(5)
@@ -2655,11 +2655,11 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIOptionalResult {
         switch caseId {
         case 0:
-            return .success(Optional<String>.bridgeJSLiftParameter())
+            return .success(Optional<String>.bridgeJSStackPop())
         case 1:
-            return .failure(Optional<Int>.bridgeJSLiftParameter(), Optional<Bool>.bridgeJSLiftParameter())
+            return .failure(Optional<Int>.bridgeJSStackPop(), Optional<Bool>.bridgeJSStackPop())
         case 2:
-            return .status(Optional<Bool>.bridgeJSLiftParameter(), Optional<Int>.bridgeJSLiftParameter(), Optional<String>.bridgeJSLiftParameter())
+            return .status(Optional<Bool>.bridgeJSStackPop(), Optional<Int>.bridgeJSStackPop(), Optional<String>.bridgeJSStackPop())
         default:
             fatalError("Unknown APIOptionalResult case ID: \(caseId)")
         }
@@ -2670,36 +2670,36 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
         case .success(let param0):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             return Int32(0)
         case .failure(let param0, let param1):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             let __bjs_isSome_param1 = param1 != nil
             if let __bjs_unwrapped_param1 = param1 {
-            __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param1.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
             return Int32(1)
         case .status(let param0, let param1, let param2):
             let __bjs_isSome_param0 = param0 != nil
             if let __bjs_unwrapped_param0 = param0 {
-            __bjs_unwrapped_param0.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param0.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param0 ? 1 : 0)
             let __bjs_isSome_param1 = param1 != nil
             if let __bjs_unwrapped_param1 = param1 {
-            __bjs_unwrapped_param1.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param1.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param1 ? 1 : 0)
             let __bjs_isSome_param2 = param2 != nil
             if let __bjs_unwrapped_param2 = param2 {
-            __bjs_unwrapped_param2.bridgeJSLowerStackReturn()
+            __bjs_unwrapped_param2.bridgeJSStackPush()
             }
             _swift_js_push_i32(__bjs_isSome_param2 ? 1 : 0)
             return Int32(2)
@@ -2708,15 +2708,15 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
 }
 
 extension Point: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Point {
-        let y = Int.bridgeJSLiftParameter()
-        let x = Int.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Point {
+        let y = Int.bridgeJSStackPop()
+        let x = Int.bridgeJSStackPop()
         return Point(x: x, y: y)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.x.bridgeJSLowerStackReturn()
-        self.y.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -2724,12 +2724,12 @@ extension Point: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
     }
 }
@@ -2753,21 +2753,21 @@ fileprivate func _bjs_struct_lift_Point() -> Int32 {
 #endif
 
 extension PointerFields: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> PointerFields {
-        let mutPtr = UnsafeMutablePointer<UInt8>.bridgeJSLiftParameter()
-        let ptr = UnsafePointer<UInt8>.bridgeJSLiftParameter()
-        let opaque = OpaquePointer.bridgeJSLiftParameter()
-        let mutRaw = UnsafeMutableRawPointer.bridgeJSLiftParameter()
-        let raw = UnsafeRawPointer.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> PointerFields {
+        let mutPtr = UnsafeMutablePointer<UInt8>.bridgeJSStackPop()
+        let ptr = UnsafePointer<UInt8>.bridgeJSStackPop()
+        let opaque = OpaquePointer.bridgeJSStackPop()
+        let mutRaw = UnsafeMutableRawPointer.bridgeJSStackPop()
+        let raw = UnsafeRawPointer.bridgeJSStackPop()
         return PointerFields(raw: raw, mutRaw: mutRaw, opaque: opaque, ptr: ptr, mutPtr: mutPtr)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.raw.bridgeJSLowerStackReturn()
-        self.mutRaw.bridgeJSLowerStackReturn()
-        self.opaque.bridgeJSLowerStackReturn()
-        self.ptr.bridgeJSLowerStackReturn()
-        self.mutPtr.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.raw.bridgeJSStackPush()
+        self.mutRaw.bridgeJSStackPush()
+        self.opaque.bridgeJSStackPush()
+        self.ptr.bridgeJSStackPush()
+        self.mutPtr.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -2775,12 +2775,12 @@ extension PointerFields: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PointerFields()))
     }
 }
@@ -2815,27 +2815,27 @@ public func _bjs_PointerFields_init(_ raw: UnsafeMutableRawPointer, _ mutRaw: Un
 }
 
 extension DataPoint: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> DataPoint {
-        let optFlag = Optional<Bool>.bridgeJSLiftParameter()
-        let optCount = Optional<Int>.bridgeJSLiftParameter()
-        let label = String.bridgeJSLiftParameter()
-        let y = Double.bridgeJSLiftParameter()
-        let x = Double.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> DataPoint {
+        let optFlag = Optional<Bool>.bridgeJSStackPop()
+        let optCount = Optional<Int>.bridgeJSStackPop()
+        let label = String.bridgeJSStackPop()
+        let y = Double.bridgeJSStackPop()
+        let x = Double.bridgeJSStackPop()
         return DataPoint(x: x, y: y, label: label, optCount: optCount, optFlag: optFlag)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.x.bridgeJSLowerStackReturn()
-        self.y.bridgeJSLowerStackReturn()
-        self.label.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
+        self.label.bridgeJSStackPush()
         let __bjs_isSome_optCount = self.optCount != nil
         if let __bjs_unwrapped_optCount = self.optCount {
-        __bjs_unwrapped_optCount.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_optCount.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_optCount ? 1 : 0)
         let __bjs_isSome_optFlag = self.optFlag != nil
         if let __bjs_unwrapped_optFlag = self.optFlag {
-        __bjs_unwrapped_optFlag.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_optFlag.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_optFlag ? 1 : 0)
     }
@@ -2845,12 +2845,12 @@ extension DataPoint: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_DataPoint()))
     }
 }
@@ -2885,15 +2885,15 @@ public func _bjs_DataPoint_init(_ x: Float64, _ y: Float64, _ labelBytes: Int32,
 }
 
 extension PublicPoint: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> PublicPoint {
-        let y = Int.bridgeJSLiftParameter()
-        let x = Int.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> PublicPoint {
+        let y = Int.bridgeJSStackPop()
+        let x = Int.bridgeJSStackPop()
         return PublicPoint(x: x, y: y)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.x.bridgeJSLowerStackReturn()
-        self.y.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
     }
 
     public init(unsafelyCopying jsObject: JSObject) {
@@ -2901,12 +2901,12 @@ extension PublicPoint: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     public func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PublicPoint()))
     }
 }
@@ -2941,19 +2941,19 @@ public func _bjs_PublicPoint_init(_ x: Int32, _ y: Int32) -> Void {
 }
 
 extension Address: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Address {
-        let zipCode = Optional<Int>.bridgeJSLiftParameter()
-        let city = String.bridgeJSLiftParameter()
-        let street = String.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Address {
+        let zipCode = Optional<Int>.bridgeJSStackPop()
+        let city = String.bridgeJSStackPop()
+        let street = String.bridgeJSStackPop()
         return Address(street: street, city: city, zipCode: zipCode)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.street.bridgeJSLowerStackReturn()
-        self.city.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.street.bridgeJSStackPush()
+        self.city.bridgeJSStackPush()
         let __bjs_isSome_zipCode = self.zipCode != nil
         if let __bjs_unwrapped_zipCode = self.zipCode {
-        __bjs_unwrapped_zipCode.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_zipCode.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_zipCode ? 1 : 0)
     }
@@ -2963,12 +2963,12 @@ extension Address: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Address()))
     }
 }
@@ -2992,25 +2992,25 @@ fileprivate func _bjs_struct_lift_Address() -> Int32 {
 #endif
 
 extension Contact: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Contact {
-        let secondaryAddress = Optional<Address>.bridgeJSLiftParameter()
-        let email = Optional<String>.bridgeJSLiftParameter()
-        let address = Address.bridgeJSLiftParameter()
-        let age = Int.bridgeJSLiftParameter()
-        let name = String.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Contact {
+        let secondaryAddress = Optional<Address>.bridgeJSStackPop()
+        let email = Optional<String>.bridgeJSStackPop()
+        let address = Address.bridgeJSStackPop()
+        let age = Int.bridgeJSStackPop()
+        let name = String.bridgeJSStackPop()
         return Contact(name: name, age: age, address: address, email: email, secondaryAddress: secondaryAddress)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.name.bridgeJSLowerStackReturn()
-        self.age.bridgeJSLowerStackReturn()
-        self.address.bridgeJSLowerReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.name.bridgeJSStackPush()
+        self.age.bridgeJSStackPush()
+        self.address.bridgeJSStackPush()
         let __bjs_isSome_email = self.email != nil
         if let __bjs_unwrapped_email = self.email {
-        __bjs_unwrapped_email.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_email.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_email ? 1 : 0)
-        self.secondaryAddress.bridgeJSLowerReturn()
+        self.secondaryAddress.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -3018,12 +3018,12 @@ extension Contact: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Contact()))
     }
 }
@@ -3047,27 +3047,27 @@ fileprivate func _bjs_struct_lift_Contact() -> Int32 {
 #endif
 
 extension Config: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> Config {
-        let status = Status.bridgeJSLiftParameter()
-        let direction = Optional<Direction>.bridgeJSLiftParameter()
-        let theme = Optional<Theme>.bridgeJSLiftParameter()
-        let name = String.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Config {
+        let status = Status.bridgeJSStackPop()
+        let direction = Optional<Direction>.bridgeJSStackPop()
+        let theme = Optional<Theme>.bridgeJSStackPop()
+        let name = String.bridgeJSStackPop()
         return Config(name: name, theme: theme, direction: direction, status: status)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.name.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.name.bridgeJSStackPush()
         let __bjs_isSome_theme = self.theme != nil
         if let __bjs_unwrapped_theme = self.theme {
-        __bjs_unwrapped_theme.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_theme.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_theme ? 1 : 0)
         let __bjs_isSome_direction = self.direction != nil
         if let __bjs_unwrapped_direction = self.direction {
-        __bjs_unwrapped_direction.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_direction.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_direction ? 1 : 0)
-        self.status.bridgeJSLowerStackReturn()
+        self.status.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -3075,12 +3075,12 @@ extension Config: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Config()))
     }
 }
@@ -3104,17 +3104,17 @@ fileprivate func _bjs_struct_lift_Config() -> Int32 {
 #endif
 
 extension SessionData: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> SessionData {
-        let owner = Optional<Greeter>.bridgeJSLiftParameter()
-        let id = Int.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> SessionData {
+        let owner = Optional<Greeter>.bridgeJSStackPop()
+        let id = Int.bridgeJSStackPop()
         return SessionData(id: id, owner: owner)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.id.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.id.bridgeJSStackPush()
         let __bjs_isSome_owner = self.owner != nil
         if let __bjs_unwrapped_owner = self.owner {
-        __bjs_unwrapped_owner.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_owner.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_owner ? 1 : 0)
     }
@@ -3124,12 +3124,12 @@ extension SessionData: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_SessionData()))
     }
 }
@@ -3153,25 +3153,25 @@ fileprivate func _bjs_struct_lift_SessionData() -> Int32 {
 #endif
 
 extension ValidationReport: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ValidationReport {
-        let outcome = Optional<APIResult>.bridgeJSLiftParameter()
-        let status = Optional<Status>.bridgeJSLiftParameter()
-        let result = APIResult.bridgeJSLiftParameter()
-        let id = Int.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ValidationReport {
+        let outcome = Optional<APIResult>.bridgeJSStackPop()
+        let status = Optional<Status>.bridgeJSStackPop()
+        let result = APIResult.bridgeJSStackPop()
+        let id = Int.bridgeJSStackPop()
         return ValidationReport(id: id, result: result, status: status, outcome: outcome)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.id.bridgeJSLowerStackReturn()
-        self.result.bridgeJSLowerReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.id.bridgeJSStackPush()
+        self.result.bridgeJSStackPush()
         let __bjs_isSome_status = self.status != nil
         if let __bjs_unwrapped_status = self.status {
-        __bjs_unwrapped_status.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_status.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_status ? 1 : 0)
         let __bjs_isSome_outcome = self.outcome != nil
         if let __bjs_unwrapped_outcome = self.outcome {
-        __bjs_unwrapped_outcome.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_outcome.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_outcome ? 1 : 0)
     }
@@ -3181,12 +3181,12 @@ extension ValidationReport: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ValidationReport()))
     }
 }
@@ -3210,39 +3210,39 @@ fileprivate func _bjs_struct_lift_ValidationReport() -> Int32 {
 #endif
 
 extension AdvancedConfig: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> AdvancedConfig {
-        let overrideDefaults = Optional<ConfigStruct>.bridgeJSLiftParameter()
-        let defaults = ConfigStruct.bridgeJSLiftParameter()
-        let location = Optional<DataPoint>.bridgeJSLiftParameter()
-        let metadata = Optional<JSObject>.bridgeJSLiftParameter()
-        let result = Optional<APIResult>.bridgeJSLiftParameter()
-        let status = Status.bridgeJSLiftParameter()
-        let theme = Theme.bridgeJSLiftParameter()
-        let enabled = Bool.bridgeJSLiftParameter()
-        let title = String.bridgeJSLiftParameter()
-        let id = Int.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> AdvancedConfig {
+        let overrideDefaults = Optional<ConfigStruct>.bridgeJSStackPop()
+        let defaults = ConfigStruct.bridgeJSStackPop()
+        let location = Optional<DataPoint>.bridgeJSStackPop()
+        let metadata = Optional<JSObject>.bridgeJSStackPop()
+        let result = Optional<APIResult>.bridgeJSStackPop()
+        let status = Status.bridgeJSStackPop()
+        let theme = Theme.bridgeJSStackPop()
+        let enabled = Bool.bridgeJSStackPop()
+        let title = String.bridgeJSStackPop()
+        let id = Int.bridgeJSStackPop()
         return AdvancedConfig(id: id, title: title, enabled: enabled, theme: theme, status: status, result: result, metadata: metadata, location: location, defaults: defaults, overrideDefaults: overrideDefaults)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.id.bridgeJSLowerStackReturn()
-        self.title.bridgeJSLowerStackReturn()
-        self.enabled.bridgeJSLowerStackReturn()
-        self.theme.bridgeJSLowerStackReturn()
-        self.status.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.id.bridgeJSStackPush()
+        self.title.bridgeJSStackPush()
+        self.enabled.bridgeJSStackPush()
+        self.theme.bridgeJSStackPush()
+        self.status.bridgeJSStackPush()
         let __bjs_isSome_result = self.result != nil
         if let __bjs_unwrapped_result = self.result {
-        __bjs_unwrapped_result.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_result.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_result ? 1 : 0)
         let __bjs_isSome_metadata = self.metadata != nil
         if let __bjs_unwrapped_metadata = self.metadata {
-        __bjs_unwrapped_metadata.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_metadata.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_metadata ? 1 : 0)
-        self.location.bridgeJSLowerReturn()
-        self.defaults.bridgeJSLowerReturn()
-        self.overrideDefaults.bridgeJSLowerReturn()
+        self.location.bridgeJSStackPush()
+        self.defaults.bridgeJSStackPush()
+        self.overrideDefaults.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -3250,12 +3250,12 @@ extension AdvancedConfig: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_AdvancedConfig()))
     }
 }
@@ -3279,25 +3279,25 @@ fileprivate func _bjs_struct_lift_AdvancedConfig() -> Int32 {
 #endif
 
 extension MeasurementConfig: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> MeasurementConfig {
-        let optionalRatio = Optional<Ratio>.bridgeJSLiftParameter()
-        let optionalPrecision = Optional<Precision>.bridgeJSLiftParameter()
-        let ratio = Ratio.bridgeJSLiftParameter()
-        let precision = Precision.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> MeasurementConfig {
+        let optionalRatio = Optional<Ratio>.bridgeJSStackPop()
+        let optionalPrecision = Optional<Precision>.bridgeJSStackPop()
+        let ratio = Ratio.bridgeJSStackPop()
+        let precision = Precision.bridgeJSStackPop()
         return MeasurementConfig(precision: precision, ratio: ratio, optionalPrecision: optionalPrecision, optionalRatio: optionalRatio)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.precision.bridgeJSLowerStackReturn()
-        self.ratio.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.precision.bridgeJSStackPush()
+        self.ratio.bridgeJSStackPush()
         let __bjs_isSome_optionalPrecision = self.optionalPrecision != nil
         if let __bjs_unwrapped_optionalPrecision = self.optionalPrecision {
-        __bjs_unwrapped_optionalPrecision.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_optionalPrecision.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_optionalPrecision ? 1 : 0)
         let __bjs_isSome_optionalRatio = self.optionalRatio != nil
         if let __bjs_unwrapped_optionalRatio = self.optionalRatio {
-        __bjs_unwrapped_optionalRatio.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_optionalRatio.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_optionalRatio ? 1 : 0)
     }
@@ -3307,12 +3307,12 @@ extension MeasurementConfig: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_MeasurementConfig()))
     }
 }
@@ -3336,13 +3336,13 @@ fileprivate func _bjs_struct_lift_MeasurementConfig() -> Int32 {
 #endif
 
 extension MathOperations: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> MathOperations {
-        let baseValue = Double.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> MathOperations {
+        let baseValue = Double.bridgeJSStackPop()
         return MathOperations(baseValue: baseValue)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.baseValue.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.baseValue.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -3350,12 +3350,12 @@ extension MathOperations: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_MathOperations()))
     }
 }
@@ -3423,17 +3423,17 @@ public func _bjs_MathOperations_static_subtract(_ a: Float64, _ b: Float64) -> F
 }
 
 extension CopyableCart: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> CopyableCart {
-        let note = Optional<String>.bridgeJSLiftParameter()
-        let x = Int.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> CopyableCart {
+        let note = Optional<String>.bridgeJSStackPop()
+        let x = Int.bridgeJSStackPop()
         return CopyableCart(x: x, note: note)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.x.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
         let __bjs_isSome_note = self.note != nil
         if let __bjs_unwrapped_note = self.note {
-        __bjs_unwrapped_note.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_note.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_note ? 1 : 0)
     }
@@ -3443,12 +3443,12 @@ extension CopyableCart: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_CopyableCart()))
     }
 }
@@ -3483,15 +3483,15 @@ public func _bjs_CopyableCart_static_fromJSObject(_ object: Int32) -> Void {
 }
 
 extension CopyableCartItem: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> CopyableCartItem {
-        let quantity = Int.bridgeJSLiftParameter()
-        let sku = String.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> CopyableCartItem {
+        let quantity = Int.bridgeJSStackPop()
+        let sku = String.bridgeJSStackPop()
         return CopyableCartItem(sku: sku, quantity: quantity)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.sku.bridgeJSLowerStackReturn()
-        self.quantity.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.sku.bridgeJSStackPush()
+        self.quantity.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -3499,12 +3499,12 @@ extension CopyableCartItem: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_CopyableCartItem()))
     }
 }
@@ -3528,17 +3528,17 @@ fileprivate func _bjs_struct_lift_CopyableCartItem() -> Int32 {
 #endif
 
 extension CopyableNestedCart: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> CopyableNestedCart {
-        let shippingAddress = Optional<Address>.bridgeJSLiftParameter()
-        let item = CopyableCartItem.bridgeJSLiftParameter()
-        let id = Int.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> CopyableNestedCart {
+        let shippingAddress = Optional<Address>.bridgeJSStackPop()
+        let item = CopyableCartItem.bridgeJSStackPop()
+        let id = Int.bridgeJSStackPop()
         return CopyableNestedCart(id: id, item: item, shippingAddress: shippingAddress)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.id.bridgeJSLowerStackReturn()
-        self.item.bridgeJSLowerReturn()
-        self.shippingAddress.bridgeJSLowerReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.id.bridgeJSStackPush()
+        self.item.bridgeJSStackPush()
+        self.shippingAddress.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -3546,12 +3546,12 @@ extension CopyableNestedCart: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_CopyableNestedCart()))
     }
 }
@@ -3586,15 +3586,15 @@ public func _bjs_CopyableNestedCart_static_fromJSObject(_ object: Int32) -> Void
 }
 
 extension ConfigStruct: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ConfigStruct {
-        let value = Int.bridgeJSLiftParameter()
-        let name = String.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ConfigStruct {
+        let value = Int.bridgeJSStackPop()
+        let name = String.bridgeJSStackPop()
         return ConfigStruct(name: name, value: value)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.name.bridgeJSLowerStackReturn()
-        self.value.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.name.bridgeJSStackPush()
+        self.value.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -3602,12 +3602,12 @@ extension ConfigStruct: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ConfigStruct()))
     }
 }
@@ -3695,17 +3695,17 @@ public func _bjs_ConfigStruct_static_computedSetting_get() -> Void {
 }
 
 extension JSObjectContainer: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> JSObjectContainer {
-        let optionalObject = Optional<JSObject>.bridgeJSLiftParameter()
-        let object = JSObject.bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> JSObjectContainer {
+        let optionalObject = Optional<JSObject>.bridgeJSStackPop()
+        let object = JSObject.bridgeJSStackPop()
         return JSObjectContainer(object: object, optionalObject: optionalObject)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.object.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.object.bridgeJSStackPush()
         let __bjs_isSome_optionalObject = self.optionalObject != nil
         if let __bjs_unwrapped_optionalObject = self.optionalObject {
-        __bjs_unwrapped_optionalObject.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_optionalObject.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_optionalObject ? 1 : 0)
     }
@@ -3715,12 +3715,12 @@ extension JSObjectContainer: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_JSObjectContainer()))
     }
 }
@@ -3744,17 +3744,17 @@ fileprivate func _bjs_struct_lift_JSObjectContainer() -> Int32 {
 #endif
 
 extension FooContainer: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> FooContainer {
-        let optionalFoo = Optional<JSObject>.bridgeJSLiftParameter().map { Foo(unsafelyWrapping: $0) }
-        let foo = Foo(unsafelyWrapping: JSObject.bridgeJSLiftParameter())
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> FooContainer {
+        let optionalFoo = Optional<JSObject>.bridgeJSStackPop().map { Foo(unsafelyWrapping: $0) }
+        let foo = Foo(unsafelyWrapping: JSObject.bridgeJSStackPop())
         return FooContainer(foo: foo, optionalFoo: optionalFoo)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.foo.jsObject.bridgeJSLowerStackReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.foo.jsObject.bridgeJSStackPush()
         let __bjs_isSome_optionalFoo = self.optionalFoo != nil
         if let __bjs_unwrapped_optionalFoo = self.optionalFoo {
-        __bjs_unwrapped_optionalFoo.jsObject.bridgeJSLowerStackReturn()
+        __bjs_unwrapped_optionalFoo.jsObject.bridgeJSStackPush()
         }
         _swift_js_push_i32(__bjs_isSome_optionalFoo ? 1 : 0)
     }
@@ -3764,12 +3764,12 @@ extension FooContainer: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_FooContainer()))
     }
 }
@@ -3793,15 +3793,15 @@ fileprivate func _bjs_struct_lift_FooContainer() -> Int32 {
 #endif
 
 extension ArrayMembers: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter() -> ArrayMembers {
-        let optStrings = Optional<[String]>.bridgeJSLiftParameter()
-        let ints = [Int].bridgeJSLiftParameter()
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ArrayMembers {
+        let optStrings = Optional<[String]>.bridgeJSStackPop()
+        let ints = [Int].bridgeJSStackPop()
         return ArrayMembers(ints: ints, optStrings: optStrings)
     }
 
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() {
-        self.ints.bridgeJSLowerReturn()
-        self.optStrings.bridgeJSLowerReturn()
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.ints.bridgeJSStackPush()
+        self.optStrings.bridgeJSStackPush()
     }
 
     init(unsafelyCopying jsObject: JSObject) {
@@ -3809,12 +3809,12 @@ extension ArrayMembers: _BridgedSwiftStruct {
         defer {
             _swift_js_struct_cleanup(__bjs_cleanupId)
         }
-        self = Self.bridgeJSLiftParameter()
+        self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
-        __bjs_self.bridgeJSLowerReturn()
+        __bjs_self.bridgeJSStackPush()
         return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ArrayMembers()))
     }
 }
@@ -3841,7 +3841,7 @@ fileprivate func _bjs_struct_lift_ArrayMembers() -> Int32 {
 @_cdecl("bjs_ArrayMembers_sumValues")
 public func _bjs_ArrayMembers_sumValues() -> Int32 {
     #if arch(wasm32)
-    let ret = ArrayMembers.bridgeJSLiftParameter().sumValues(_: [Int].bridgeJSLiftParameter())
+    let ret = ArrayMembers.bridgeJSLiftParameter().sumValues(_: [Int].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -3852,7 +3852,7 @@ public func _bjs_ArrayMembers_sumValues() -> Int32 {
 @_cdecl("bjs_ArrayMembers_firstString")
 public func _bjs_ArrayMembers_firstString() -> Void {
     #if arch(wasm32)
-    let ret = ArrayMembers.bridgeJSLiftParameter().firstString(_: [String].bridgeJSLiftParameter())
+    let ret = ArrayMembers.bridgeJSLiftParameter().firstString(_: [String].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -4060,8 +4060,8 @@ public func _bjs_roundTripOptionalJSValue(_ vIsSome: Int32, _ vKind: Int32, _ vP
 @_cdecl("bjs_roundTripJSValueArray")
 public func _bjs_roundTripJSValueArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripJSValueArray(v: [JSValue].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripJSValueArray(v: [JSValue].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -4072,7 +4072,7 @@ public func _bjs_roundTripJSValueArray() -> Void {
 public func _bjs_roundTripOptionalJSValueArray() -> Void {
     #if arch(wasm32)
     let ret = roundTripOptionalJSValueArray(v: Optional<[JSValue]>.bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5079,7 +5079,7 @@ public func _bjs_testEmptyInit(_ object: UnsafeMutableRawPointer) -> UnsafeMutab
 @_cdecl("bjs_arrayWithDefault")
 public func _bjs_arrayWithDefault() -> Int32 {
     #if arch(wasm32)
-    let ret = arrayWithDefault(_: [Int].bridgeJSLiftParameter())
+    let ret = arrayWithDefault(_: [Int].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -5101,7 +5101,7 @@ public func _bjs_arrayWithOptionalDefault() -> Int32 {
 @_cdecl("bjs_arrayMixedDefaults")
 public func _bjs_arrayMixedDefaults(_ prefixBytes: Int32, _ prefixLength: Int32, _ suffixBytes: Int32, _ suffixLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = arrayMixedDefaults(prefix: String.bridgeJSLiftParameter(prefixBytes, prefixLength), values: [Int].bridgeJSLiftParameter(), suffix: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
+    let ret = arrayMixedDefaults(prefix: String.bridgeJSLiftParameter(prefixBytes, prefixLength), values: [Int].bridgeJSStackPop(), suffix: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -5145,8 +5145,8 @@ public func _bjs_makeAdder(_ base: Int32) -> Int32 {
 @_cdecl("bjs_roundTripIntArray")
 public func _bjs_roundTripIntArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripIntArray(_: [Int].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripIntArray(_: [Int].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5156,8 +5156,8 @@ public func _bjs_roundTripIntArray() -> Void {
 @_cdecl("bjs_roundTripStringArray")
 public func _bjs_roundTripStringArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripStringArray(_: [String].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripStringArray(_: [String].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5167,8 +5167,8 @@ public func _bjs_roundTripStringArray() -> Void {
 @_cdecl("bjs_roundTripDoubleArray")
 public func _bjs_roundTripDoubleArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripDoubleArray(_: [Double].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripDoubleArray(_: [Double].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5178,8 +5178,8 @@ public func _bjs_roundTripDoubleArray() -> Void {
 @_cdecl("bjs_roundTripBoolArray")
 public func _bjs_roundTripBoolArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripBoolArray(_: [Bool].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripBoolArray(_: [Bool].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5189,8 +5189,8 @@ public func _bjs_roundTripBoolArray() -> Void {
 @_cdecl("bjs_roundTripDirectionArray")
 public func _bjs_roundTripDirectionArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripDirectionArray(_: [Direction].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripDirectionArray(_: [Direction].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5200,8 +5200,8 @@ public func _bjs_roundTripDirectionArray() -> Void {
 @_cdecl("bjs_roundTripStatusArray")
 public func _bjs_roundTripStatusArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripStatusArray(_: [Status].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripStatusArray(_: [Status].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5211,8 +5211,8 @@ public func _bjs_roundTripStatusArray() -> Void {
 @_cdecl("bjs_roundTripThemeArray")
 public func _bjs_roundTripThemeArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripThemeArray(_: [Theme].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripThemeArray(_: [Theme].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5222,8 +5222,8 @@ public func _bjs_roundTripThemeArray() -> Void {
 @_cdecl("bjs_roundTripHttpStatusArray")
 public func _bjs_roundTripHttpStatusArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripHttpStatusArray(_: [HttpStatus].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripHttpStatusArray(_: [HttpStatus].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5233,8 +5233,8 @@ public func _bjs_roundTripHttpStatusArray() -> Void {
 @_cdecl("bjs_roundTripDataPointArray")
 public func _bjs_roundTripDataPointArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripDataPointArray(_: [DataPoint].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripDataPointArray(_: [DataPoint].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5244,8 +5244,8 @@ public func _bjs_roundTripDataPointArray() -> Void {
 @_cdecl("bjs_roundTripGreeterArray")
 public func _bjs_roundTripGreeterArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripGreeterArray(_: [Greeter].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripGreeterArray(_: [Greeter].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5260,7 +5260,7 @@ public func _bjs_roundTripOptionalIntArray() -> Void {
         var __result: [Optional<Int>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<Int>.bridgeJSLiftParameter())
+            __result.append(Optional<Int>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -5268,7 +5268,7 @@ public func _bjs_roundTripOptionalIntArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -5287,7 +5287,7 @@ public func _bjs_roundTripOptionalStringArray() -> Void {
         var __result: [Optional<String>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<String>.bridgeJSLiftParameter())
+            __result.append(Optional<String>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -5295,7 +5295,7 @@ public func _bjs_roundTripOptionalStringArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -5314,13 +5314,13 @@ public func _bjs_roundTripOptionalDataPointArray() -> Void {
         var __result: [Optional<DataPoint>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<DataPoint>.bridgeJSLiftParameter())
+            __result.append(Optional<DataPoint>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
     }())
     for __bjs_elem_ret in ret {
-    __bjs_elem_ret.bridgeJSLowerReturn()
+    __bjs_elem_ret.bridgeJSStackPush()
     }
     _swift_js_push_i32(Int32(ret.count))
     #else
@@ -5337,7 +5337,7 @@ public func _bjs_roundTripOptionalDirectionArray() -> Void {
         var __result: [Optional<Direction>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<Direction>.bridgeJSLiftParameter())
+            __result.append(Optional<Direction>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -5345,7 +5345,7 @@ public func _bjs_roundTripOptionalDirectionArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -5364,7 +5364,7 @@ public func _bjs_roundTripOptionalStatusArray() -> Void {
         var __result: [Optional<Status>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<Status>.bridgeJSLiftParameter())
+            __result.append(Optional<Status>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -5372,7 +5372,7 @@ public func _bjs_roundTripOptionalStatusArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -5387,7 +5387,7 @@ public func _bjs_roundTripOptionalStatusArray() -> Void {
 public func _bjs_roundTripOptionalIntArrayType() -> Void {
     #if arch(wasm32)
     let ret = roundTripOptionalIntArrayType(_: Optional<[Int]>.bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5398,7 +5398,7 @@ public func _bjs_roundTripOptionalIntArrayType() -> Void {
 public func _bjs_roundTripOptionalStringArrayType() -> Void {
     #if arch(wasm32)
     let ret = roundTripOptionalStringArrayType(_: Optional<[String]>.bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5409,7 +5409,7 @@ public func _bjs_roundTripOptionalStringArrayType() -> Void {
 public func _bjs_roundTripOptionalGreeterArrayType() -> Void {
     #if arch(wasm32)
     let ret = roundTripOptionalGreeterArrayType(_: Optional<[Greeter]>.bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5419,8 +5419,8 @@ public func _bjs_roundTripOptionalGreeterArrayType() -> Void {
 @_cdecl("bjs_roundTripNestedIntArray")
 public func _bjs_roundTripNestedIntArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedIntArray(_: [[Int]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripNestedIntArray(_: [[Int]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5430,8 +5430,8 @@ public func _bjs_roundTripNestedIntArray() -> Void {
 @_cdecl("bjs_roundTripNestedStringArray")
 public func _bjs_roundTripNestedStringArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedStringArray(_: [[String]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripNestedStringArray(_: [[String]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5441,8 +5441,8 @@ public func _bjs_roundTripNestedStringArray() -> Void {
 @_cdecl("bjs_roundTripNestedDoubleArray")
 public func _bjs_roundTripNestedDoubleArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedDoubleArray(_: [[Double]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripNestedDoubleArray(_: [[Double]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5452,8 +5452,8 @@ public func _bjs_roundTripNestedDoubleArray() -> Void {
 @_cdecl("bjs_roundTripNestedBoolArray")
 public func _bjs_roundTripNestedBoolArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedBoolArray(_: [[Bool]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripNestedBoolArray(_: [[Bool]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5463,8 +5463,8 @@ public func _bjs_roundTripNestedBoolArray() -> Void {
 @_cdecl("bjs_roundTripNestedDataPointArray")
 public func _bjs_roundTripNestedDataPointArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedDataPointArray(_: [[DataPoint]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripNestedDataPointArray(_: [[DataPoint]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5474,8 +5474,8 @@ public func _bjs_roundTripNestedDataPointArray() -> Void {
 @_cdecl("bjs_roundTripNestedDirectionArray")
 public func _bjs_roundTripNestedDirectionArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedDirectionArray(_: [[Direction]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripNestedDirectionArray(_: [[Direction]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5485,8 +5485,8 @@ public func _bjs_roundTripNestedDirectionArray() -> Void {
 @_cdecl("bjs_roundTripNestedGreeterArray")
 public func _bjs_roundTripNestedGreeterArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripNestedGreeterArray(_: [[Greeter]].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripNestedGreeterArray(_: [[Greeter]].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5496,8 +5496,8 @@ public func _bjs_roundTripNestedGreeterArray() -> Void {
 @_cdecl("bjs_roundTripUnsafeRawPointerArray")
 public func _bjs_roundTripUnsafeRawPointerArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripUnsafeRawPointerArray(_: [UnsafeRawPointer].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripUnsafeRawPointerArray(_: [UnsafeRawPointer].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5507,8 +5507,8 @@ public func _bjs_roundTripUnsafeRawPointerArray() -> Void {
 @_cdecl("bjs_roundTripUnsafeMutableRawPointerArray")
 public func _bjs_roundTripUnsafeMutableRawPointerArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripUnsafeMutableRawPointerArray(_: [UnsafeMutableRawPointer].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripUnsafeMutableRawPointerArray(_: [UnsafeMutableRawPointer].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5518,8 +5518,8 @@ public func _bjs_roundTripUnsafeMutableRawPointerArray() -> Void {
 @_cdecl("bjs_roundTripOpaquePointerArray")
 public func _bjs_roundTripOpaquePointerArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripOpaquePointerArray(_: [OpaquePointer].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripOpaquePointerArray(_: [OpaquePointer].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5529,8 +5529,8 @@ public func _bjs_roundTripOpaquePointerArray() -> Void {
 @_cdecl("bjs_roundTripUnsafePointerArray")
 public func _bjs_roundTripUnsafePointerArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripUnsafePointerArray(_: [UnsafePointer<UInt8>].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripUnsafePointerArray(_: [UnsafePointer<UInt8>].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5540,8 +5540,8 @@ public func _bjs_roundTripUnsafePointerArray() -> Void {
 @_cdecl("bjs_roundTripUnsafeMutablePointerArray")
 public func _bjs_roundTripUnsafeMutablePointerArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripUnsafeMutablePointerArray(_: [UnsafeMutablePointer<UInt8>].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripUnsafeMutablePointerArray(_: [UnsafeMutablePointer<UInt8>].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5551,7 +5551,7 @@ public func _bjs_roundTripUnsafeMutablePointerArray() -> Void {
 @_cdecl("bjs_consumeDataProcessorArrayType")
 public func _bjs_consumeDataProcessorArrayType() -> Int32 {
     #if arch(wasm32)
-    let ret = consumeDataProcessorArrayType(_: [AnyDataProcessor].bridgeJSLiftParameter())
+    let ret = consumeDataProcessorArrayType(_: [AnyDataProcessor].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -5562,8 +5562,8 @@ public func _bjs_consumeDataProcessorArrayType() -> Int32 {
 @_cdecl("bjs_roundTripDataProcessorArrayType")
 public func _bjs_roundTripDataProcessorArrayType() -> Void {
     #if arch(wasm32)
-    let ret = roundTripDataProcessorArrayType(_: [AnyDataProcessor].bridgeJSLiftParameter())
-    ret.map { $0 as! AnyDataProcessor }.bridgeJSLowerReturn()
+    let ret = roundTripDataProcessorArrayType(_: [AnyDataProcessor].bridgeJSStackPop())
+    ret.map { $0 as! AnyDataProcessor }.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5573,8 +5573,8 @@ public func _bjs_roundTripDataProcessorArrayType() -> Void {
 @_cdecl("bjs_roundTripJSObjectArray")
 public func _bjs_roundTripJSObjectArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripJSObjectArray(_: [JSObject].bridgeJSLiftParameter())
-    ret.bridgeJSLowerReturn()
+    let ret = roundTripJSObjectArray(_: [JSObject].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5589,7 +5589,7 @@ public func _bjs_roundTripOptionalJSObjectArray() -> Void {
         var __result: [Optional<JSObject>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<JSObject>.bridgeJSLiftParameter())
+            __result.append(Optional<JSObject>.bridgeJSStackPop())
         }
         __result.reverse()
         return __result
@@ -5597,7 +5597,7 @@ public func _bjs_roundTripOptionalJSObjectArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -5611,8 +5611,8 @@ public func _bjs_roundTripOptionalJSObjectArray() -> Void {
 @_cdecl("bjs_roundTripFooArray")
 public func _bjs_roundTripFooArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripFooArray(_: [JSObject].bridgeJSLiftParameter().map { Foo(unsafelyWrapping: $0) })
-    ret.map { $0.jsObject }.bridgeJSLowerReturn()
+    let ret = roundTripFooArray(_: [JSObject].bridgeJSStackPop().map { Foo(unsafelyWrapping: $0) })
+    ret.map { $0.jsObject }.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -5627,7 +5627,7 @@ public func _bjs_roundTripOptionalFooArray() -> Void {
         var __result: [Optional<Foo>] = []
         __result.reserveCapacity(__count)
         for _ in 0..<__count {
-            __result.append(Optional<JSObject>.bridgeJSLiftParameter().map { Foo(unsafelyWrapping: $0) })
+            __result.append(Optional<JSObject>.bridgeJSStackPop().map { Foo(unsafelyWrapping: $0) })
         }
         __result.reverse()
         return __result
@@ -5635,7 +5635,7 @@ public func _bjs_roundTripOptionalFooArray() -> Void {
     for __bjs_elem_ret in ret {
     let __bjs_isSome_ret_elem = __bjs_elem_ret != nil
     if let __bjs_unwrapped_ret_elem = __bjs_elem_ret {
-    __bjs_unwrapped_ret_elem.jsObject.bridgeJSLowerStackReturn()
+    __bjs_unwrapped_ret_elem.jsObject.bridgeJSStackPush()
     }
     _swift_js_push_i32(__bjs_isSome_ret_elem ? 1 : 0)
     }
@@ -6148,7 +6148,7 @@ public func _bjs_roundTripArrayMembers() -> Void {
 @_cdecl("bjs_arrayMembersSum")
 public func _bjs_arrayMembersSum() -> Int32 {
     #if arch(wasm32)
-    let _tmp_values = [Int].bridgeJSLiftParameter()
+    let _tmp_values = [Int].bridgeJSStackPop()
     let _tmp_value = ArrayMembers.bridgeJSLiftParameter()
     let ret = arrayMembersSum(_: _tmp_value, _: _tmp_values)
     return ret.bridgeJSLowerReturn()
@@ -6161,7 +6161,7 @@ public func _bjs_arrayMembersSum() -> Int32 {
 @_cdecl("bjs_arrayMembersFirst")
 public func _bjs_arrayMembersFirst() -> Void {
     #if arch(wasm32)
-    let _tmp_values = [String].bridgeJSLiftParameter()
+    let _tmp_values = [String].bridgeJSStackPop()
     let _tmp_value = ArrayMembers.bridgeJSLiftParameter()
     let ret = arrayMembersFirst(_: _tmp_value, _: _tmp_values)
     return ret.bridgeJSLowerReturn()


### PR DESCRIPTION
To make push/pop operations agnostic to import/export contexts, rename the following methods:
- `bridgeJSLiftParameter()` -> `bridgeJSStackPop()`
- `bridgeJSLowerStackReturn()` -> `bridgeJSStackPush()`

---
<p><a href="https://cursor.com/background-agent?bcId=bc-fa9fdfeb-6900-4292-9a3e-347dba91a045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fa9fdfeb-6900-4292-9a3e-347dba91a045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad, cross-cutting rename across generated bridging code and runtime intrinsics; risk is primarily ABI/stack order mismatches or missed call sites causing runtime interop failures on wasm.
> 
> **Overview**
> **Renames the Stack ABI bridging API** to make stack operations import/export agnostic: `bridgeJSLiftParameter()` (no-arg stack lift) becomes `bridgeJSStackPop()`, and `bridgeJSLowerStackReturn()` becomes `bridgeJSStackPush()`.
> 
> This updates JavaScriptKit’s `BridgeJSIntrinsics.swift` protocols/default implementations (including `Optional`, arrays/dictionaries, structs, enums, `JSValue`, and heap objects), the BridgeJS code generator (`ExportSwift`’s `StackCodegen` and struct codegen), and regenerates affected snapshots/benchmark generated Swift glue to use the new method names throughout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98099d61a6743144e3dca7646d849f5c2b261ce8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->