### PR TITLE
BridgeJS: Take ownership of source Uint8Array id in `swift_js_init_memory`

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -298,6 +298,9 @@ public struct BridgeJSLink {
                         "const source = \(JSGlueVariableScope.reservedSwift).\(JSGlueVariableScope.reservedMemory).getObject(sourceId);"
                     )
                     printer.write(
+                        "\(JSGlueVariableScope.reservedSwift).\(JSGlueVariableScope.reservedMemory).release(sourceId);"
+                    )
+                    printer.write(
                         "const bytes = new Uint8Array(\(JSGlueVariableScope.reservedMemory).buffer, bytesPtr);"
                     )
                     printer.write("bytes.set(source);")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
@@ -71,6 +71,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -317,9 +318,6 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        arrayCleanups.push(() => {
-                            swift.memory.release(id);
-                        });
                     }
                     i32Stack.push(ret.length);
                 } catch (error) {
@@ -411,9 +409,6 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        arrayCleanups.push(() => {
-                            swift.memory.release(id);
-                        });
                     }
                     i32Stack.push(values.length);
                     instance.exports.bjs_processStringArray();
@@ -539,7 +534,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_findFirstPoint(matchingId, matchingBytes.length);
                     const structValue = structHelpers.Point.lift();
                     for (const cleanup of arrayCleanups) { cleanup(); }
-                    swift.memory.release(matchingId);
                     return structValue;
                 },
                 processUnsafeRawPointerArray: function bjs_processUnsafeRawPointerArray(values) {
@@ -632,7 +626,6 @@ export async function createInstantiator(options, swift) {
                             const id = swift.memory.retain(bytes);
                             i32Stack.push(bytes.length);
                             i32Stack.push(id);
-                            arrayCleanups.push(() => { swift.memory.release(id); });
                         } else {
                             i32Stack.push(0);
                             i32Stack.push(0);
@@ -817,9 +810,6 @@ export async function createInstantiator(options, swift) {
                             const id = swift.memory.retain(bytes);
                             i32Stack.push(bytes.length);
                             i32Stack.push(id);
-                            arrayCleanups1.push(() => {
-                                swift.memory.release(id);
-                            });
                         }
                         i32Stack.push(elem.length);
                         arrayCleanups.push(() => {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
@@ -43,6 +43,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -225,7 +226,6 @@ export async function createInstantiator(options, swift) {
                     const ret = instance.exports.bjs_asyncRoundTripString(vId, vBytes.length);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
-                    swift.memory.release(vId);
                     return ret1;
                 },
                 asyncRoundTripBool: function bjs_asyncRoundTripBool(v) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
@@ -44,10 +44,7 @@ export async function createInstantiator(options, swift) {
                 i32Stack.push(id);
                 i32Stack.push((value.value | 0));
                 i32Stack.push(value.enabled ? 1 : 0);
-                const cleanup = () => {
-                    swift.memory.release(id);
-                };
-                return { cleanup };
+                return { cleanup: undefined };
             },
             lift: () => {
                 const bool = i32Stack.pop() !== 0;
@@ -96,6 +93,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -325,7 +323,6 @@ export async function createInstantiator(options, swift) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
                     const ret = instance.exports.bjs_DefaultGreeter_init(nameId, nameBytes.length);
-                    swift.memory.release(nameId);
                     return DefaultGreeter.__construct(ret);
                 }
                 get name() {
@@ -338,7 +335,6 @@ export async function createInstantiator(options, swift) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
                     instance.exports.bjs_DefaultGreeter_name_set(this.pointer, valueId, valueBytes.length);
-                    swift.memory.release(valueId);
                 }
             }
             class EmptyGreeter extends SwiftHeapObject {
@@ -366,10 +362,6 @@ export async function createInstantiator(options, swift) {
                         tagId = swift.memory.retain(tagBytes);
                     }
                     const ret = instance.exports.bjs_ConstructorDefaults_init(nameId, nameBytes.length, count, enabled, status, +isSome, isSome ? tagId : 0, isSome ? tagBytes.length : 0);
-                    swift.memory.release(nameId);
-                    if (tagId != undefined) {
-                        swift.memory.release(tagId);
-                    }
                     return ConstructorDefaults.__construct(ret);
                 }
                 get name() {
@@ -382,7 +374,6 @@ export async function createInstantiator(options, swift) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
                     instance.exports.bjs_ConstructorDefaults_name_set(this.pointer, valueId, valueBytes.length);
-                    swift.memory.release(valueId);
                 }
                 get count() {
                     const ret = instance.exports.bjs_ConstructorDefaults_count_get(this.pointer);
@@ -419,9 +410,6 @@ export async function createInstantiator(options, swift) {
                         valueId = swift.memory.retain(valueBytes);
                     }
                     instance.exports.bjs_ConstructorDefaults_tag_set(this.pointer, +isSome, isSome ? valueId : 0, isSome ? valueBytes.length : 0);
-                    if (valueId != undefined) {
-                        swift.memory.release(valueId);
-                    }
                 }
             }
             const ConfigHelpers = __bjs_createConfigHelpers()();
@@ -440,7 +428,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_testStringDefault(messageId, messageBytes.length);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
-                    swift.memory.release(messageId);
                     return ret;
                 },
                 testNegativeIntDefault: function bjs_testNegativeIntDefault(value = -42) {
@@ -469,9 +456,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_testOptionalDefault(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (nameId != undefined) {
-                        swift.memory.release(nameId);
-                    }
                     return optResult;
                 },
                 testOptionalStringDefault: function bjs_testOptionalStringDefault(greeting = "Hi") {
@@ -484,9 +468,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_testOptionalStringDefault(+isSome, isSome ? greetingId : 0, isSome ? greetingBytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (greetingId != undefined) {
-                        swift.memory.release(greetingId);
-                    }
                     return optResult;
                 },
                 testMultipleDefaults: function bjs_testMultipleDefaults(title = "Default Title", count = 10, enabled = false) {
@@ -495,7 +476,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_testMultipleDefaults(titleId, titleBytes.length, count, enabled);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
-                    swift.memory.release(titleId);
                     return ret;
                 },
                 testEnumDefault: function bjs_testEnumDefault(status = StatusValues.Active) {
@@ -572,9 +552,6 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        arrayCleanups.push(() => {
-                            swift.memory.release(id);
-                        });
                     }
                     i32Stack.push(names.length);
                     instance.exports.bjs_testStringArrayDefault();
@@ -650,7 +627,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_testMixedWithArrayDefault(nameId, nameBytes.length, enabled);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
-                    swift.memory.release(nameId);
                     for (const cleanup of arrayCleanups) { cleanup(); }
                     return ret;
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -222,9 +223,6 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        arrayCleanups.push(() => {
-                            swift.memory.release(id);
-                        });
                         f64Stack.push(value);
                     }
                     i32Stack.push(entries.length);
@@ -280,9 +278,6 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        arrayCleanups.push(() => {
-                            swift.memory.release(id);
-                        });
                         i32Stack.push((value | 0));
                     }
                     i32Stack.push(entries.length);
@@ -309,16 +304,10 @@ export async function createInstantiator(options, swift) {
                             const id = swift.memory.retain(bytes);
                             i32Stack.push(bytes.length);
                             i32Stack.push(id);
-                            arrayCleanups.push(() => {
-                                swift.memory.release(id);
-                            });
                             const bytes1 = textEncoder.encode(value);
                             const id1 = swift.memory.retain(bytes1);
                             i32Stack.push(bytes1.length);
                             i32Stack.push(id1);
-                            arrayCleanups.push(() => {
-                                swift.memory.release(id1);
-                            });
                         }
                         i32Stack.push(entries.length);
                         valuesCleanups.push(() => { for (const cleanup of arrayCleanups) { cleanup(); } });
@@ -351,9 +340,6 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        arrayCleanups.push(() => {
-                            swift.memory.release(id);
-                        });
                         const arrayCleanups1 = [];
                         for (const elem of value) {
                             i32Stack.push((elem | 0));
@@ -390,9 +376,6 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        arrayCleanups.push(() => {
-                            swift.memory.release(id);
-                        });
                         ptrStack.push(value.pointer);
                     }
                     i32Stack.push(entries.length);
@@ -417,9 +400,6 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        arrayCleanups.push(() => {
-                            swift.memory.release(id);
-                        });
                         const isSome = value != null ? 1 : 0;
                         if (isSome) {
                             ptrStack.push(value.pointer);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
@@ -134,9 +134,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: APIResultValues.Tag.Success, cleanup };
                     }
                     case APIResultValues.Tag.Failure: {
@@ -205,9 +203,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: ComplexResultValues.Tag.Success, cleanup };
                     }
                     case ComplexResultValues.Tag.Error: {
@@ -216,9 +212,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: ComplexResultValues.Tag.Error, cleanup };
                     }
                     case ComplexResultValues.Tag.Status: {
@@ -228,9 +222,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(id);
                         i32Stack.push((value.param1 | 0));
                         i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: ComplexResultValues.Tag.Status, cleanup };
                     }
                     case ComplexResultValues.Tag.Coordinates: {
@@ -259,11 +251,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push((value.param2 | 0));
                         i32Stack.push(value.param1 ? 1 : 0);
                         i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                            swift.memory.release(id1);
-                            swift.memory.release(id2);
-                        };
+                        const cleanup = undefined;
                         return { caseId: ComplexResultValues.Tag.Comprehensive, cleanup };
                     }
                     case ComplexResultValues.Tag.Info: {
@@ -325,9 +313,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: ResultValues.Tag.Success, cleanup };
                     }
                     case ResultValues.Tag.Failure: {
@@ -336,9 +322,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: ResultValues.Tag.Failure, cleanup };
                     }
                     case ResultValues.Tag.Status: {
@@ -348,9 +332,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(id);
                         i32Stack.push((value.param1 | 0));
                         i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: ResultValues.Tag.Status, cleanup };
                     }
                     default: throw new Error("Unknown ResultValues tag: " + String(enumTag));
@@ -389,9 +371,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: NetworkingResultValues.Tag.Success, cleanup };
                     }
                     case NetworkingResultValues.Tag.Failure: {
@@ -400,9 +380,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: NetworkingResultValues.Tag.Failure, cleanup };
                     }
                     default: throw new Error("Unknown NetworkingResultValues tag: " + String(enumTag));
@@ -443,11 +421,7 @@ export async function createInstantiator(options, swift) {
                             i32Stack.push(0);
                         }
                         i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = () => {
-                            if(id) {
-                                swift.memory.release(id);
-                            }
-                        };
+                        const cleanup = undefined;
                         return { caseId: APIOptionalResultValues.Tag.Success, cleanup };
                     }
                     case APIOptionalResultValues.Tag.Failure: {
@@ -479,11 +453,7 @@ export async function createInstantiator(options, swift) {
                         const isSome2 = value.param0 != null;
                         i32Stack.push(isSome2 ? (value.param0 ? 1 : 0) : 0);
                         i32Stack.push(isSome2 ? 1 : 0);
-                        const cleanup = () => {
-                            if(id) {
-                                swift.memory.release(id);
-                            }
-                        };
+                        const cleanup = undefined;
                         return { caseId: APIOptionalResultValues.Tag.Status, cleanup };
                     }
                     default: throw new Error("Unknown APIOptionalResultValues tag: " + String(enumTag));
@@ -889,6 +859,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
@@ -67,6 +67,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
@@ -87,6 +87,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
@@ -68,6 +68,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
@@ -119,6 +119,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -306,7 +307,6 @@ export async function createInstantiator(options, swift) {
                     const themeBytes = textEncoder.encode(theme);
                     const themeId = swift.memory.retain(themeBytes);
                     instance.exports.bjs_setTheme(themeId, themeBytes.length);
-                    swift.memory.release(themeId);
                 },
                 getTheme: function bjs_getTheme() {
                     instance.exports.bjs_getTheme();
@@ -324,16 +324,12 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_roundTripOptionalTheme(+isSome, isSome ? inputId : 0, isSome ? inputBytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (inputId != undefined) {
-                        swift.memory.release(inputId);
-                    }
                     return optResult;
                 },
                 setTSTheme: function bjs_setTSTheme(theme) {
                     const themeBytes = textEncoder.encode(theme);
                     const themeId = swift.memory.retain(themeBytes);
                     instance.exports.bjs_setTSTheme(themeId, themeBytes.length);
-                    swift.memory.release(themeId);
                 },
                 getTSTheme: function bjs_getTSTheme() {
                     instance.exports.bjs_getTSTheme();
@@ -351,16 +347,12 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_roundTripOptionalTSTheme(+isSome, isSome ? inputId : 0, isSome ? inputBytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (inputId != undefined) {
-                        swift.memory.release(inputId);
-                    }
                     return optResult;
                 },
                 setFeatureFlag: function bjs_setFeatureFlag(flag) {
                     const flagBytes = textEncoder.encode(flag);
                     const flagId = swift.memory.retain(flagBytes);
                     instance.exports.bjs_setFeatureFlag(flagId, flagBytes.length);
-                    swift.memory.release(flagId);
                 },
                 getFeatureFlag: function bjs_getFeatureFlag() {
                     instance.exports.bjs_getFeatureFlag();
@@ -378,9 +370,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_roundTripOptionalFeatureFlag(+isSome, isSome ? inputId : 0, isSome ? inputBytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (inputId != undefined) {
-                        swift.memory.release(inputId);
-                    }
                     return optResult;
                 },
                 setHttpStatus: function bjs_setHttpStatus(status) {
@@ -513,7 +502,6 @@ export async function createInstantiator(options, swift) {
                     const themeBytes = textEncoder.encode(theme);
                     const themeId = swift.memory.retain(themeBytes);
                     const ret = instance.exports.bjs_processTheme(themeId, themeBytes.length);
-                    swift.memory.release(themeId);
                     return ret;
                 },
                 convertPriority: function bjs_convertPriority(status) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
@@ -43,6 +43,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
@@ -94,6 +94,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
@@ -133,6 +133,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
@@ -43,6 +43,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
@@ -43,6 +43,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
@@ -43,6 +43,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
@@ -43,6 +43,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -250,7 +251,6 @@ export async function createInstantiator(options, swift) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
                     const ret = instance.exports.bjs_Greeter_init(nameId, nameBytes.length);
-                    swift.memory.release(nameId);
                     return Greeter.__construct(ret);
                 }
                 greet() {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
@@ -43,6 +43,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -250,7 +251,6 @@ export async function createInstantiator(options, swift) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
                     const ret = instance.exports.bjs_Greeter_init(nameId, nameBytes.length);
-                    swift.memory.release(nameId);
                     return Greeter.__construct(ret);
                 }
                 greet() {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -506,9 +507,6 @@ export async function createInstantiator(options, swift) {
                         nameId = swift.memory.retain(nameBytes);
                     }
                     const ret = instance.exports.bjs_Greeter_init(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
-                    if (nameId != undefined) {
-                        swift.memory.release(nameId);
-                    }
                     return Greeter.__construct(ret);
                 }
                 greet() {
@@ -525,9 +523,6 @@ export async function createInstantiator(options, swift) {
                         nameId = swift.memory.retain(nameBytes);
                     }
                     instance.exports.bjs_Greeter_changeName(this.pointer, +isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
-                    if (nameId != undefined) {
-                        swift.memory.release(nameId);
-                    }
                 }
                 get name() {
                     instance.exports.bjs_Greeter_name_get(this.pointer);
@@ -543,9 +538,6 @@ export async function createInstantiator(options, swift) {
                         valueId = swift.memory.retain(valueBytes);
                     }
                     instance.exports.bjs_Greeter_name_set(this.pointer, +isSome, isSome ? valueId : 0, isSome ? valueBytes.length : 0);
-                    if (valueId != undefined) {
-                        swift.memory.release(valueId);
-                    }
                 }
             }
             class OptionalPropertyHolder extends SwiftHeapObject {
@@ -571,9 +563,6 @@ export async function createInstantiator(options, swift) {
                         valueId = swift.memory.retain(valueBytes);
                     }
                     instance.exports.bjs_OptionalPropertyHolder_optionalName_set(this.pointer, +isSome, isSome ? valueId : 0, isSome ? valueBytes.length : 0);
-                    if (valueId != undefined) {
-                        swift.memory.release(valueId);
-                    }
                 }
                 get optionalAge() {
                     instance.exports.bjs_OptionalPropertyHolder_optionalAge_get(this.pointer);
@@ -626,9 +615,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_roundTripString(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (nameId != undefined) {
-                        swift.memory.release(nameId);
-                    }
                     return optResult;
                 },
                 roundTripInt: function bjs_roundTripInt(value) {
@@ -669,9 +655,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_roundTripSyntax(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (nameId != undefined) {
-                        swift.memory.release(nameId);
-                    }
                     return optResult;
                 },
                 roundTripMixSyntax: function bjs_roundTripMixSyntax(name) {
@@ -684,9 +667,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_roundTripMixSyntax(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (nameId != undefined) {
-                        swift.memory.release(nameId);
-                    }
                     return optResult;
                 },
                 roundTripSwiftSyntax: function bjs_roundTripSwiftSyntax(name) {
@@ -699,9 +679,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_roundTripSwiftSyntax(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (nameId != undefined) {
-                        swift.memory.release(nameId);
-                    }
                     return optResult;
                 },
                 roundTripMixedSwiftSyntax: function bjs_roundTripMixedSwiftSyntax(name) {
@@ -714,9 +691,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_roundTripMixedSwiftSyntax(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (nameId != undefined) {
-                        swift.memory.release(nameId);
-                    }
                     return optResult;
                 },
                 roundTripWithSpaces: function bjs_roundTripWithSpaces(value) {
@@ -743,9 +717,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_roundTripOptionalAlias(+isSome, isSome ? nameId : 0, isSome ? nameBytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (nameId != undefined) {
-                        swift.memory.release(nameId);
-                    }
                     return optResult;
                 },
                 testMixedOptionals: function bjs_testMixedOptionals(firstName, lastName, age, active) {
@@ -765,12 +736,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_testMixedOptionals(+isSome, isSome ? firstNameId : 0, isSome ? firstNameBytes.length : 0, +isSome1, isSome1 ? lastNameId : 0, isSome1 ? lastNameBytes.length : 0, +isSome2, isSome2 ? age : 0, active);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (firstNameId != undefined) {
-                        swift.memory.release(firstNameId);
-                    }
-                    if (lastNameId != undefined) {
-                        swift.memory.release(lastNameId);
-                    }
                     return optResult;
                 },
             };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
@@ -43,6 +43,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -242,7 +243,6 @@ export async function createInstantiator(options, swift) {
                     const stringValueBytes = textEncoder.encode(stringValue);
                     const stringValueId = swift.memory.retain(stringValueBytes);
                     const ret = instance.exports.bjs_PropertyHolder_init(intValue, floatValue, doubleValue, boolValue, stringValueId, stringValueBytes.length, swift.memory.retain(jsObject));
-                    swift.memory.release(stringValueId);
                     return PropertyHolder.__construct(ret);
                 }
                 getAllValues() {
@@ -289,7 +289,6 @@ export async function createInstantiator(options, swift) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
                     instance.exports.bjs_PropertyHolder_stringValue_set(this.pointer, valueId, valueBytes.length);
-                    swift.memory.release(valueId);
                 }
                 get readonlyInt() {
                     const ret = instance.exports.bjs_PropertyHolder_readonlyInt_get(this.pointer);
@@ -339,7 +338,6 @@ export async function createInstantiator(options, swift) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
                     instance.exports.bjs_PropertyHolder_lazyValue_set(this.pointer, valueId, valueBytes.length);
-                    swift.memory.release(valueId);
                 }
                 get computedReadonly() {
                     const ret = instance.exports.bjs_PropertyHolder_computedReadonly_get(this.pointer);
@@ -355,7 +353,6 @@ export async function createInstantiator(options, swift) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
                     instance.exports.bjs_PropertyHolder_computedReadWrite_set(this.pointer, valueId, valueBytes.length);
-                    swift.memory.release(valueId);
                 }
                 get observedProperty() {
                     const ret = instance.exports.bjs_PropertyHolder_observedProperty_get(this.pointer);
@@ -371,7 +368,6 @@ export async function createInstantiator(options, swift) {
                     const stringValueBytes = textEncoder.encode(stringValue);
                     const stringValueId = swift.memory.retain(stringValueBytes);
                     const ret = instance.exports.bjs_createPropertyHolder(intValue, floatValue, doubleValue, boolValue, stringValueId, stringValueBytes.length, swift.memory.retain(jsObject));
-                    swift.memory.release(stringValueId);
                     return PropertyHolder.__construct(ret);
                 },
                 testPropertyHolder: function bjs_testPropertyHolder(holder) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
@@ -63,9 +63,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: ResultValues.Tag.Success, cleanup };
                     }
                     case ResultValues.Tag.Failure: {
@@ -106,6 +104,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -632,7 +631,6 @@ export async function createInstantiator(options, swift) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
                     instance.exports.bjs_MyViewController_updateValue(this.pointer, valueId, valueBytes.length);
-                    swift.memory.release(valueId);
                 }
                 updateCount(count) {
                     const ret = instance.exports.bjs_MyViewController_updateCount(this.pointer, count);
@@ -644,8 +642,6 @@ export async function createInstantiator(options, swift) {
                     const suffixBytes = textEncoder.encode(suffix);
                     const suffixId = swift.memory.retain(suffixBytes);
                     instance.exports.bjs_MyViewController_updateLabel(this.pointer, prefixId, prefixBytes.length, suffixId, suffixBytes.length);
-                    swift.memory.release(prefixId);
-                    swift.memory.release(suffixId);
                 }
                 checkEvenCount() {
                     const ret = instance.exports.bjs_MyViewController_checkEvenCount(this.pointer);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
@@ -50,9 +50,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: APIResultValues.Tag.Success, cleanup };
                     }
                     case APIResultValues.Tag.Failure: {
@@ -93,6 +91,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -341,7 +340,6 @@ export async function createInstantiator(options, swift) {
                             instance.exports.bjs_Utils_String_static_uppercase(textId, textBytes.length);
                             const ret = tmpRetString;
                             tmpRetString = undefined;
-                            swift.memory.release(textId);
                             return ret;
                         },
                     },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
@@ -50,9 +50,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: APIResultValues.Tag.Success, cleanup };
                     }
                     case APIResultValues.Tag.Failure: {
@@ -93,6 +91,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -335,7 +334,6 @@ export async function createInstantiator(options, swift) {
                             instance.exports.bjs_Utils_String_static_uppercase(textId, textBytes.length);
                             const ret = tmpRetString;
                             tmpRetString = undefined;
-                            swift.memory.release(textId);
                             return ret;
                         },
                     },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
@@ -48,6 +48,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -279,7 +280,6 @@ export async function createInstantiator(options, swift) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
                     instance.exports.bjs_PropertyClass_static_classVariable_set(valueId, valueBytes.length);
-                    swift.memory.release(valueId);
                 }
                 static get computedProperty() {
                     instance.exports.bjs_PropertyClass_static_computedProperty_get();
@@ -291,7 +291,6 @@ export async function createInstantiator(options, swift) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
                     instance.exports.bjs_PropertyClass_static_computedProperty_set(valueId, valueBytes.length);
-                    swift.memory.release(valueId);
                 }
                 static get readOnlyComputed() {
                     const ret = instance.exports.bjs_PropertyClass_static_readOnlyComputed_get();
@@ -311,9 +310,6 @@ export async function createInstantiator(options, swift) {
                         valueId = swift.memory.retain(valueBytes);
                     }
                     instance.exports.bjs_PropertyClass_static_optionalProperty_set(+isSome, isSome ? valueId : 0, isSome ? valueBytes.length : 0);
-                    if (valueId != undefined) {
-                        swift.memory.release(valueId);
-                    }
                 }
             }
             if (typeof globalThis.PropertyNamespace === 'undefined') {
@@ -336,7 +332,6 @@ export async function createInstantiator(options, swift) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
                         instance.exports.bjs_PropertyEnum_static_enumProperty_set(valueId, valueBytes.length);
-                        swift.memory.release(valueId);
                     },
                     get enumConstant() {
                         const ret = instance.exports.bjs_PropertyEnum_static_enumConstant_get();
@@ -352,7 +347,6 @@ export async function createInstantiator(options, swift) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
                         instance.exports.bjs_PropertyEnum_static_computedEnum_set(valueId, valueBytes.length);
-                        swift.memory.release(valueId);
                     }
                 },
                 PropertyNamespace: {
@@ -366,7 +360,6 @@ export async function createInstantiator(options, swift) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
                         instance.exports.bjs_PropertyNamespace_static_namespaceProperty_set(valueId, valueBytes.length);
-                        swift.memory.release(valueId);
                     },
                     get namespaceConstant() {
                         instance.exports.bjs_PropertyNamespace_static_namespaceConstant_get();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
@@ -48,6 +48,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -279,7 +280,6 @@ export async function createInstantiator(options, swift) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
                     instance.exports.bjs_PropertyClass_static_classVariable_set(valueId, valueBytes.length);
-                    swift.memory.release(valueId);
                 }
                 static get computedProperty() {
                     instance.exports.bjs_PropertyClass_static_computedProperty_get();
@@ -291,7 +291,6 @@ export async function createInstantiator(options, swift) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
                     instance.exports.bjs_PropertyClass_static_computedProperty_set(valueId, valueBytes.length);
-                    swift.memory.release(valueId);
                 }
                 static get readOnlyComputed() {
                     const ret = instance.exports.bjs_PropertyClass_static_readOnlyComputed_get();
@@ -311,9 +310,6 @@ export async function createInstantiator(options, swift) {
                         valueId = swift.memory.retain(valueBytes);
                     }
                     instance.exports.bjs_PropertyClass_static_optionalProperty_set(+isSome, isSome ? valueId : 0, isSome ? valueBytes.length : 0);
-                    if (valueId != undefined) {
-                        swift.memory.release(valueId);
-                    }
                 }
             }
             const exports = {
@@ -330,7 +326,6 @@ export async function createInstantiator(options, swift) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
                         instance.exports.bjs_PropertyEnum_static_enumProperty_set(valueId, valueBytes.length);
-                        swift.memory.release(valueId);
                     },
                     get enumConstant() {
                         const ret = instance.exports.bjs_PropertyEnum_static_enumConstant_get();
@@ -346,7 +341,6 @@ export async function createInstantiator(options, swift) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
                         instance.exports.bjs_PropertyEnum_static_computedEnum_set(valueId, valueBytes.length);
-                        swift.memory.release(valueId);
                     }
                 },
                 PropertyNamespace: {
@@ -360,7 +354,6 @@ export async function createInstantiator(options, swift) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
                         instance.exports.bjs_PropertyNamespace_static_namespaceProperty_set(valueId, valueBytes.length);
-                        swift.memory.release(valueId);
                     },
                     get namespaceConstant() {
                         instance.exports.bjs_PropertyNamespace_static_namespaceConstant_get();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -231,7 +232,6 @@ export async function createInstantiator(options, swift) {
                     const aBytes = textEncoder.encode(a);
                     const aId = swift.memory.retain(aBytes);
                     instance.exports.bjs_checkString(aId, aBytes.length);
-                    swift.memory.release(aId);
                 },
                 roundtripString: function bjs_roundtripString(a) {
                     const aBytes = textEncoder.encode(a);
@@ -239,7 +239,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.bjs_roundtripString(aId, aBytes.length);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
-                    swift.memory.release(aId);
                     return ret;
                 },
             };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -270,7 +271,6 @@ export async function createInstantiator(options, swift) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
                     const ret = instance.exports.bjs_Greeter_init(nameId, nameBytes.length);
-                    swift.memory.release(nameId);
                     return Greeter.__construct(ret);
                 }
                 greet() {
@@ -283,7 +283,6 @@ export async function createInstantiator(options, swift) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
                     instance.exports.bjs_Greeter_changeName(this.pointer, nameId, nameBytes.length);
-                    swift.memory.release(nameId);
                 }
                 get name() {
                     instance.exports.bjs_Greeter_name_get(this.pointer);
@@ -295,7 +294,6 @@ export async function createInstantiator(options, swift) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
                     instance.exports.bjs_Greeter_name_set(this.pointer, valueId, valueBytes.length);
-                    swift.memory.release(valueId);
                 }
             }
             class PublicGreeter extends SwiftHeapObject {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -94,9 +94,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = () => {
-                            swift.memory.release(id);
-                        };
+                        const cleanup = undefined;
                         return { caseId: APIResultValues.Tag.Success, cleanup };
                     }
                     case APIResultValues.Tag.Failure: {
@@ -169,6 +167,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -366,7 +365,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.invoke_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO(boxPtr, param0Id, param0Bytes.length);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
-                    swift.memory.release(param0Id);
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -469,7 +467,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.invoke_swift_closure_TestModule_10TestModuleSS_SS(boxPtr, param0Id, param0Bytes.length);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
-                    swift.memory.release(param0Id);
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -628,9 +625,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.invoke_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO(boxPtr, +isSome, isSome ? param0Id : 0, isSome ? param0Bytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (param0Id != undefined) {
-                        swift.memory.release(param0Id);
-                    }
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -772,9 +766,6 @@ export async function createInstantiator(options, swift) {
                     instance.exports.invoke_swift_closure_TestModule_10TestModuleSqSS_SqSS(boxPtr, +isSome, isSome ? param0Id : 0, isSome ? param0Bytes.length : 0);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
-                    if (param0Id != undefined) {
-                        swift.memory.release(param0Id);
-                    }
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -941,7 +932,6 @@ export async function createInstantiator(options, swift) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
                     const ret = instance.exports.bjs_Person_init(nameId, nameBytes.length);
-                    swift.memory.release(nameId);
                     return Person.__construct(ret);
                 }
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
@@ -69,6 +69,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
@@ -57,10 +57,7 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(0);
                 }
                 i32Stack.push(isSome1 ? 1 : 0);
-                const cleanup = () => {
-                    swift.memory.release(id);
-                };
-                return { cleanup };
+                return { cleanup: undefined };
             },
             lift: () => {
                 const isSome = i32Stack.pop();
@@ -104,11 +101,7 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(0);
                 }
                 i32Stack.push(isSome ? 1 : 0);
-                const cleanup = () => {
-                    swift.memory.release(id);
-                    swift.memory.release(id1);
-                };
-                return { cleanup };
+                return { cleanup: undefined };
             },
             lift: () => {
                 const isSome = i32Stack.pop();
@@ -147,9 +140,7 @@ export async function createInstantiator(options, swift) {
                 }
                 i32Stack.push(isSome ? 1 : 0);
                 const cleanup = () => {
-                    swift.memory.release(id);
                     if (structResult.cleanup) { structResult.cleanup(); }
-                    if(id1 !== undefined) { swift.memory.release(id1); }
                 };
                 return { cleanup };
             },
@@ -287,6 +278,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }
@@ -563,7 +555,6 @@ export async function createInstantiator(options, swift) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
                     const ret = instance.exports.bjs_Greeter_init(nameId, nameBytes.length);
-                    swift.memory.release(nameId);
                     return Greeter.__construct(ret);
                 }
                 greet() {
@@ -582,7 +573,6 @@ export async function createInstantiator(options, swift) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
                     instance.exports.bjs_Greeter_name_set(this.pointer, valueId, valueBytes.length);
-                    swift.memory.release(valueId);
                 }
             }
             const DataPointHelpers = __bjs_createDataPointHelpers()();
@@ -631,7 +621,6 @@ export async function createInstantiator(options, swift) {
                         const isSome1 = optFlag != null;
                         instance.exports.bjs_DataPoint_init(x, y, labelId, labelBytes.length, +isSome, isSome ? optCount : 0, +isSome1, isSome1 ? optFlag : 0);
                         const structValue = structHelpers.DataPoint.lift();
-                        swift.memory.release(labelId);
                         return structValue;
                     },
                 },
@@ -650,7 +639,6 @@ export async function createInstantiator(options, swift) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
                         instance.exports.bjs_ConfigStruct_static_defaultConfig_set(valueId, valueBytes.length);
-                        swift.memory.release(valueId);
                     },
                     get timeout() {
                         const ret = instance.exports.bjs_ConfigStruct_static_timeout_get();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
@@ -58,6 +58,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
@@ -43,6 +43,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
@@ -63,6 +63,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
@@ -44,6 +44,7 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
                 const bytes = new Uint8Array(memory.buffer, bytesPtr);
                 bytes.set(source);
             }

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -716,6 +716,12 @@ private func _swift_js_init_memory_extern(_ sourceId: Int32, _ ptr: UnsafeMutabl
 }
 #endif
 
+/// Initializes WebAssembly memory with a Uint8Array referenced by `sourceId` at `ptr`.
+/// Note that the ownership of the source Uint8Array id is taken by the callee, so callers
+/// must not release the source Uint8Array id by themselves.
+///
+/// - Parameter sourceId: The object ID of the source Uint8Array.
+/// - Parameter ptr: The pointer to the WebAssembly memory to initialize.
 @_spi(BridgeJS) @inline(never) public func _swift_js_init_memory(_ sourceId: Int32, _ ptr: UnsafeMutablePointer<UInt8>)
 {
     _swift_js_init_memory_extern(sourceId, ptr)


### PR DESCRIPTION
This allows us to insert cleanup code for String parameter passing for JS -> Swift.

Verified no noticeable performance difference for `String` passing from JS to Swift.

```console
Benchmarks (yt/remove-cleanups $=)$ node run.js --baseline=.build/baseline.json --filter "StringRoundtrip/takeString"
Starting benchmark suite with 10 runs per test...
Will compare with baseline: .build/baseline.json

Overall Progress:
Benchmark Runs: [██████████████████████████████] 10/10


==============================
      BENCHMARK SUMMARY
==============================

┌─────────┬──────────────────────────────┬──────────┬──────────┬──────────┬─────────────┬────────┬─────────┐
│ (index) │ Test                         │ Avg (ms) │ Min (ms) │ Max (ms) │ StdDev (ms) │ CV (%) │ Samples │
├─────────┼──────────────────────────────┼──────────┼──────────┼──────────┼─────────────┼────────┼─────────┤
│ 0       │ 'StringRoundtrip/takeString' │ '27.40'  │ '26.53'  │ '29.47'  │ '0.83'      │ '3.03' │ 10      │
└─────────┴──────────────────────────────┴──────────┴──────────┴──────────┴─────────────┴────────┴─────────┘

==============================
   COMPARISON WITH BASELINE
==============================

Test                       | Status   | Baseline (ms)   | Current (ms)    | Change          | Change (%)
--------------------------------------------------------------------------------------------------------
StringRoundtrip/takeString | NEUTRAL  | 27.55           | 27.40           | -0.15 ms        | -0.54%
```