### PR TITLE
BridgeJS: Skip writing output files when content is unchanged

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSTool/BridgeJSTool.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSTool/BridgeJSTool.swift
@@ -225,7 +225,7 @@ import BridgeJSUtilities
                         withIntermediateDirectories: true,
                         attributes: nil
                     )
-                    try outputSwift.write(to: outputSwiftURL, atomically: true, encoding: .utf8)
+                    try writeIfChanged(outputSwift, to: outputSwiftURL)
                 }
             }
 
@@ -240,7 +240,7 @@ import BridgeJSUtilities
                 let encoder = JSONEncoder()
                 encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
                 let skeletonData = try encoder.encode(skeleton)
-                try skeletonData.write(to: outputSkeletonURL)
+                try writeIfChanged(skeletonData, to: outputSkeletonURL)
             }
 
             if skeleton.exported != nil || skeleton.imported != nil {
@@ -280,6 +280,18 @@ private func printStderr(_ message: String) {
 
 private func hasBridgeJSSkipComment(_ content: String) -> Bool {
     BridgeJSGeneratedFile.hasSkipComment(content)
+}
+
+private func writeIfChanged(_ content: String, to url: URL) throws {
+    let existing = try? String(contentsOf: url, encoding: .utf8)
+    guard existing != content else { return }
+    try content.write(to: url, atomically: true, encoding: .utf8)
+}
+
+private func writeIfChanged(_ data: Data, to url: URL) throws {
+    let existing = try? Data(contentsOf: url)
+    guard existing != data else { return }
+    try data.write(to: url)
 }
 
 private func combineGeneratedSwift(_ pieces: [String]) -> String {


### PR DESCRIPTION
## Overview 

BridgeJSTool writes `BridgeJS.swift` and `BridgeJS.json` on every invocation, even when the content hasn't changed. The atomic write creates a new temp file each time, which updates the mtime and makes SPM think the output changed. This triggers a recompile of `BridgeJS.swift` and a relink on every build, even with zero source changes.

## Reproducing

While testing cross-plugin builds after #638, we noticed `Compiling Khasm BridgeJS.swift` and `Linking KhasmWasm.wasm` in every no-op build. Traced it to the unconditional `.write(to:atomically:)` calls in `BridgeJSTool` - the content was identical but the file got a new timestamp every time.

To reproduce with any BridgeJS project:

```bash
swift package js --product MyProduct    # first build
swift package js --product MyProduct    # immediate rebuild, no changes
# BridgeJS.swift recompiles, binary relinks
```

## Fix

Compare content before writing. If the existing file has identical content, skip the write.

```swift
private func writeIfChanged(_ content: String, to url: URL) throws {
    let existing = try? String(contentsOf: url, encoding: .utf8)
    guard existing != content else { return }
    try content.write(to: url, atomically: true, encoding: .utf8)
}
```

Applied to both `BridgeJS.swift` and `BridgeJS.json`. The `--always-write` flag still works - it controls whether the file gets created at all (even when empty), just doesn't force a rewrite when content matches.

## Question

Was the unconditional write intentional? Wondering if there's an edge case I'm not seeing, if so, lets just close this one 🙏🏻 