### PR TITLE
BridgeJS: Fix `@JSClass` on public/package access level struct

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSMacros/JSMacroSupport.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSMacros/JSMacroSupport.swift
@@ -14,6 +14,10 @@ enum JSMacroMessage: String, DiagnosticMessage {
     case setterRequiresThrows = "@JSSetter function must declare throws(JSException)."
     case jsFunctionRequiresThrows = "@JSFunction throws must be declared as throws(JSException)."
     case requiresJSClass = "JavaScript members must be declared inside a @JSClass struct."
+    case jsClassRequiresAtLeastInternal =
+        "@JSClass does not support private/fileprivate access level. Use internal, package, or public."
+    case jsClassMemberRequiresAtLeastInternal =
+        "@JSClass requires jsObject and init(unsafelyWrapping:) to be at least internal."
 
     var message: String { rawValue }
     var diagnosticID: MessageID { MessageID(domain: "JavaScriptKitMacros", id: rawValue) }

--- a/Plugins/BridgeJS/Tests/BridgeJSMacrosTests/JSClassMacroTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSMacrosTests/JSClassMacroTests.swift
@@ -370,4 +370,102 @@ import BridgeJSMacros
             indentationWidth: indentationWidth
         )
     }
+
+    @Test func publicStructSynthesizesPublicMembers() {
+        TestSupport.assertMacroExpansion(
+            """
+            @JSClass
+            public struct MyClass {
+            }
+            """,
+            expandedSource: """
+                public struct MyClass {
+
+                    public let jsObject: JSObject
+
+                    public init(unsafelyWrapping jsObject: JSObject) {
+                        self.jsObject = jsObject
+                    }
+                }
+
+                extension MyClass: _JSBridgedClass {
+                }
+                """,
+            macroSpecs: macroSpecs,
+            indentationWidth: indentationWidth
+        )
+    }
+
+    @Test func packageStructSynthesizesPackageMembers() {
+        TestSupport.assertMacroExpansion(
+            """
+            @JSClass
+            package struct MyClass {
+            }
+            """,
+            expandedSource: """
+                package struct MyClass {
+
+                    package let jsObject: JSObject
+
+                    package init(unsafelyWrapping jsObject: JSObject) {
+                        self.jsObject = jsObject
+                    }
+                }
+
+                extension MyClass: _JSBridgedClass {
+                }
+                """,
+            macroSpecs: macroSpecs,
+            indentationWidth: indentationWidth
+        )
+    }
+
+    @Test func privateStructIsRejected() {
+        TestSupport.assertMacroExpansion(
+            """
+            @JSClass
+            private struct MyClass {
+            }
+            """,
+            expandedSource: """
+                private struct MyClass {
+                }
+                """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message:
+                        "@JSClass does not support private/fileprivate access level. Use internal, package, or public.",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macroSpecs: macroSpecs,
+            indentationWidth: indentationWidth
+        )
+    }
+
+    @Test func fileprivateStructIsRejected() {
+        TestSupport.assertMacroExpansion(
+            """
+            @JSClass
+            fileprivate struct MyClass {
+            }
+            """,
+            expandedSource: """
+                fileprivate struct MyClass {
+                }
+                """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message:
+                        "@JSClass does not support private/fileprivate access level. Use internal, package, or public.",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macroSpecs: macroSpecs,
+            indentationWidth: indentationWidth
+        )
+    }
 }

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -10157,6 +10157,137 @@ func _$jsTranslatePoint(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_MyJSClassInternal_init")
+fileprivate func bjs_MyJSClassInternal_init() -> Int32
+#else
+fileprivate func bjs_MyJSClassInternal_init() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$MyJSClassInternal_init() throws(JSException) -> JSObject {
+    let ret = bjs_MyJSClassInternal_init()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSObject.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_MyJSClassPublic_init")
+fileprivate func bjs_MyJSClassPublic_init() -> Int32
+#else
+fileprivate func bjs_MyJSClassPublic_init() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$MyJSClassPublic_init() throws(JSException) -> JSObject {
+    let ret = bjs_MyJSClassPublic_init()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSObject.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_MyJSClassPackage_init")
+fileprivate func bjs_MyJSClassPackage_init() -> Int32
+#else
+fileprivate func bjs_MyJSClassPackage_init() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$MyJSClassPackage_init() throws(JSException) -> JSObject {
+    let ret = bjs_MyJSClassPackage_init()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSObject.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsFunctionWithPackageAccess")
+fileprivate func bjs_jsFunctionWithPackageAccess() -> Void
+#else
+fileprivate func bjs_jsFunctionWithPackageAccess() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsFunctionWithPackageAccess() throws(JSException) -> Void {
+    bjs_jsFunctionWithPackageAccess()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsFunctionWithPublicAccess")
+fileprivate func bjs_jsFunctionWithPublicAccess() -> Void
+#else
+fileprivate func bjs_jsFunctionWithPublicAccess() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsFunctionWithPublicAccess() throws(JSException) -> Void {
+    bjs_jsFunctionWithPublicAccess()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsFunctionWithInternalAccess")
+fileprivate func bjs_jsFunctionWithInternalAccess() -> Void
+#else
+fileprivate func bjs_jsFunctionWithInternalAccess() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsFunctionWithInternalAccess() throws(JSException) -> Void {
+    bjs_jsFunctionWithInternalAccess()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsFunctionWithFilePrivateAccess")
+fileprivate func bjs_jsFunctionWithFilePrivateAccess() -> Void
+#else
+fileprivate func bjs_jsFunctionWithFilePrivateAccess() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsFunctionWithFilePrivateAccess() throws(JSException) -> Void {
+    bjs_jsFunctionWithFilePrivateAccess()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsFunctionWithPrivateAccess")
+fileprivate func bjs_jsFunctionWithPrivateAccess() -> Void
+#else
+fileprivate func bjs_jsFunctionWithPrivateAccess() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+
+func _$jsFunctionWithPrivateAccess() throws(JSException) -> Void {
+    bjs_jsFunctionWithPrivateAccess()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalSupportImports_jsRoundTripOptionalNumberNull_static")
 fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalNumberNull_static(_ valueIsSome: Int32, _ valueValue: Int32) -> Void
 #else

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -15300,6 +15300,138 @@
         ],
         "types" : [
           {
+            "constructor" : {
+              "parameters" : [
+
+              ]
+            },
+            "from" : "global",
+            "getters" : [
+
+            ],
+            "methods" : [
+
+            ],
+            "name" : "MyJSClassInternal",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+
+            ]
+          },
+          {
+            "constructor" : {
+              "parameters" : [
+
+              ]
+            },
+            "from" : "global",
+            "getters" : [
+
+            ],
+            "methods" : [
+
+            ],
+            "name" : "MyJSClassPublic",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+
+            ]
+          },
+          {
+            "constructor" : {
+              "parameters" : [
+
+              ]
+            },
+            "from" : "global",
+            "getters" : [
+
+            ],
+            "methods" : [
+
+            ],
+            "name" : "MyJSClassPackage",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+
+            ]
+          }
+        ]
+      },
+      {
+        "functions" : [
+          {
+            "name" : "jsFunctionWithPackageAccess",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "name" : "jsFunctionWithPublicAccess",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "name" : "jsFunctionWithInternalAccess",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "name" : "jsFunctionWithFilePrivateAccess",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "name" : "jsFunctionWithPrivateAccess",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          }
+        ],
+        "types" : [
+
+        ]
+      },
+      {
+        "functions" : [
+
+        ],
+        "types" : [
+          {
             "getters" : [
 
             ],

--- a/Tests/BridgeJSRuntimeTests/MacroCompileTests/JSClassCompileTests.swift
+++ b/Tests/BridgeJSRuntimeTests/MacroCompileTests/JSClassCompileTests.swift
@@ -1,0 +1,11 @@
+import JavaScriptKit
+
+@JSClass(from: .global) internal struct MyJSClassInternal {
+    @JSFunction init() throws(JSException)
+}
+@JSClass(from: .global) public struct MyJSClassPublic {
+    @JSFunction init() throws(JSException)
+}
+@JSClass(from: .global) package struct MyJSClassPackage {
+    @JSFunction init() throws(JSException)
+}

--- a/Tests/BridgeJSRuntimeTests/MacroCompileTests/JSFunctionCompileTests.swift
+++ b/Tests/BridgeJSRuntimeTests/MacroCompileTests/JSFunctionCompileTests.swift
@@ -1,0 +1,7 @@
+import JavaScriptKit
+
+@JSFunction package func jsFunctionWithPackageAccess() throws(JSException)
+@JSFunction public func jsFunctionWithPublicAccess() throws(JSException)
+@JSFunction internal func jsFunctionWithInternalAccess() throws(JSException)
+@JSFunction fileprivate func jsFunctionWithFilePrivateAccess() throws(JSException)
+@JSFunction private func jsFunctionWithPrivateAccess() throws(JSException)


### PR DESCRIPTION
Also cover more access levels in `@JSFunction` tests.