### PR TITLE
BridgeJS: Use indirect _exports lookup in wrap functions

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -1122,7 +1122,7 @@ public struct BridgeJSLink {
             for klass in classes.sorted(by: { $0.name < $1.name }) {
                 let wrapperFunctionName = "bjs_\(klass.name)_wrap"
                 wrapperLines.append("importObject[\"\(moduleName)\"][\"\(wrapperFunctionName)\"] = function(pointer) {")
-                wrapperLines.append("    const obj = \(klass.name).__construct(pointer);")
+                wrapperLines.append("    const obj = _exports['\(klass.name)'].__construct(pointer);")
                 wrapperLines.append("    return \(JSGlueVariableScope.reservedSwift).memory.retain(obj);")
                 wrapperLines.append("};")
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
@@ -239,7 +239,7 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_Item_wrap"] = function(pointer) {
-                const obj = Item.__construct(pointer);
+                const obj = _exports['Item'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
@@ -272,15 +272,15 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_ConstructorDefaults_wrap"] = function(pointer) {
-                const obj = ConstructorDefaults.__construct(pointer);
+                const obj = _exports['ConstructorDefaults'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_DefaultGreeter_wrap"] = function(pointer) {
-                const obj = DefaultGreeter.__construct(pointer);
+                const obj = _exports['DefaultGreeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_EmptyGreeter_wrap"] = function(pointer) {
-                const obj = EmptyGreeter.__construct(pointer);
+                const obj = _exports['EmptyGreeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
@@ -201,7 +201,7 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_Box_wrap"] = function(pointer) {
-                const obj = Box.__construct(pointer);
+                const obj = _exports['Box'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
@@ -1027,7 +1027,7 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_User_wrap"] = function(pointer) {
-                const obj = User.__construct(pointer);
+                const obj = _exports['User'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
@@ -244,15 +244,15 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_Converter_wrap"] = function(pointer) {
-                const obj = Converter.__construct(pointer);
+                const obj = _exports['Converter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_HTTPServer_wrap"] = function(pointer) {
-                const obj = HTTPServer.__construct(pointer);
+                const obj = _exports['HTTPServer'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_TestServer_wrap"] = function(pointer) {
-                const obj = TestServer.__construct(pointer);
+                const obj = _exports['TestServer'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
@@ -225,15 +225,15 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_Converter_wrap"] = function(pointer) {
-                const obj = Converter.__construct(pointer);
+                const obj = _exports['Converter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_HTTPServer_wrap"] = function(pointer) {
-                const obj = HTTPServer.__construct(pointer);
+                const obj = _exports['HTTPServer'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_TestServer_wrap"] = function(pointer) {
-                const obj = TestServer.__construct(pointer);
+                const obj = _exports['TestServer'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
@@ -290,7 +290,7 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_JSValueHolder_wrap"] = function(pointer) {
-                const obj = JSValueHolder.__construct(pointer);
+                const obj = _exports['JSValueHolder'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
@@ -200,7 +200,7 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_GlobalClass_wrap"] = function(pointer) {
-                const obj = GlobalClass.__construct(pointer);
+                const obj = _exports['GlobalClass'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
@@ -200,7 +200,7 @@ export async function createInstantiator(options, swift) {
                 importObject["GlobalModule"] = {};
             }
             importObject["GlobalModule"]["bjs_GlobalClass_wrap"] = function(pointer) {
-                const obj = GlobalClass.__construct(pointer);
+                const obj = _exports['GlobalClass'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             // Wrapper functions for module: PrivateModule
@@ -208,7 +208,7 @@ export async function createInstantiator(options, swift) {
                 importObject["PrivateModule"] = {};
             }
             importObject["PrivateModule"]["bjs_PrivateClass_wrap"] = function(pointer) {
-                const obj = PrivateClass.__construct(pointer);
+                const obj = _exports['PrivateClass'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
@@ -200,7 +200,7 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_PrivateClass_wrap"] = function(pointer) {
-                const obj = PrivateClass.__construct(pointer);
+                const obj = _exports['PrivateClass'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
@@ -200,15 +200,15 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_Converter_wrap"] = function(pointer) {
-                const obj = Converter.__construct(pointer);
+                const obj = _exports['Converter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
-                const obj = Greeter.__construct(pointer);
+                const obj = _exports['Greeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_UUID_wrap"] = function(pointer) {
-                const obj = UUID.__construct(pointer);
+                const obj = _exports['UUID'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
@@ -200,15 +200,15 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_Converter_wrap"] = function(pointer) {
-                const obj = Converter.__construct(pointer);
+                const obj = _exports['Converter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
-                const obj = Greeter.__construct(pointer);
+                const obj = _exports['Greeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_UUID_wrap"] = function(pointer) {
-                const obj = UUID.__construct(pointer);
+                const obj = _exports['UUID'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
@@ -201,11 +201,11 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
-                const obj = Greeter.__construct(pointer);
+                const obj = _exports['Greeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_OptionalPropertyHolder_wrap"] = function(pointer) {
-                const obj = OptionalPropertyHolder.__construct(pointer);
+                const obj = _exports['OptionalPropertyHolder'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
@@ -200,7 +200,7 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_PropertyHolder_wrap"] = function(pointer) {
-                const obj = PropertyHolder.__construct(pointer);
+                const obj = _exports['PropertyHolder'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
@@ -261,15 +261,15 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_DelegateManager_wrap"] = function(pointer) {
-                const obj = DelegateManager.__construct(pointer);
+                const obj = _exports['DelegateManager'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_Helper_wrap"] = function(pointer) {
-                const obj = Helper.__construct(pointer);
+                const obj = _exports['Helper'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_MyViewController_wrap"] = function(pointer) {
-                const obj = MyViewController.__construct(pointer);
+                const obj = _exports['MyViewController'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
@@ -248,7 +248,7 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_MathUtils_wrap"] = function(pointer) {
-                const obj = MathUtils.__construct(pointer);
+                const obj = _exports['MathUtils'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
@@ -248,7 +248,7 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_MathUtils_wrap"] = function(pointer) {
-                const obj = MathUtils.__construct(pointer);
+                const obj = _exports['MathUtils'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
@@ -205,7 +205,7 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_PropertyClass_wrap"] = function(pointer) {
-                const obj = PropertyClass.__construct(pointer);
+                const obj = _exports['PropertyClass'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
@@ -205,7 +205,7 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_PropertyClass_wrap"] = function(pointer) {
-                const obj = PropertyClass.__construct(pointer);
+                const obj = _exports['PropertyClass'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
@@ -201,15 +201,15 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
-                const obj = Greeter.__construct(pointer);
+                const obj = _exports['Greeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_PackageGreeter_wrap"] = function(pointer) {
-                const obj = PackageGreeter.__construct(pointer);
+                const obj = _exports['PackageGreeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_PublicGreeter_wrap"] = function(pointer) {
-                const obj = PublicGreeter.__construct(pointer);
+                const obj = _exports['PublicGreeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -885,11 +885,11 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_Person_wrap"] = function(pointer) {
-                const obj = Person.__construct(pointer);
+                const obj = _exports['Person'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
             importObject["TestModule"]["bjs_TestProcessor_wrap"] = function(pointer) {
-                const obj = TestProcessor.__construct(pointer);
+                const obj = _exports['TestProcessor'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
@@ -512,7 +512,7 @@ export async function createInstantiator(options, swift) {
                 importObject["TestModule"] = {};
             }
             importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
-                const obj = Greeter.__construct(pointer);
+                const obj = _exports['Greeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
         },


### PR DESCRIPTION
## Overview

The `bjs_*_wrap` functions generated in `addImports` reference class names directly:

```js
importObject["Module"]["bjs_Greeter_wrap"] = function(pointer) {
    const obj = Greeter.__construct(pointer);  // Greeter not defined in this scope
    return swift.memory.retain(obj);
};
```

These classes are defined later inside `createExports`, so `Greeter` isn't in scope when `addImports` runs. It works at runtime because the callback only executes after `createExports` has been called, but it's a static scope violation - any linter with `no-undef` enabled will flag it, and it's flagged by default in most ESLint configs. We hit this when linting vendored BridgeJS output downstream.

The codebase already handles this elsewhere. `JSGlueGen.swift` has a `hasDirectAccessToSwiftClass` flag that controls whether to use the class directly or go through `_exports['ClassName']`. The import-side functions in `addImports` don't have direct access, so they should use the indirect lookup - same as the other import-side references already do (e.g. `bjs_jsRoundTripGreeter` on the same snapshot file already uses `_exports['Greeter'].__construct()`).

Before (SwiftClass.js snapshot):
```js
// addImports scope - class not defined here
importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
    const obj = Greeter.__construct(pointer);
    ...
};

// also addImports scope - already uses _exports correctly
let ret = imports.jsRoundTripGreeter(_exports['Greeter'].__construct(greeter));
```

After:
```js
importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
    const obj = _exports['Greeter'].__construct(pointer);
    ...
};
```