### PR TITLE
PackageToJS: Replace @ts-ignore with @ts-expect-error in templates

### DIFF
--- a/Plugins/PackageToJS/Templates/instantiate.js
+++ b/Plugins/PackageToJS/Templates/instantiate.js
@@ -4,17 +4,17 @@ import { SwiftRuntime } from "./runtime.js"
 export const MODULE_PATH = "@PACKAGE_TO_JS_MODULE_PATH@";
 /* #if USE_SHARED_MEMORY */
 export const MEMORY_TYPE = {
-    // @ts-ignore
+    // @ts-expect-error Substituted by PackageToJS preprocessor
     initial: import.meta.PACKAGE_TO_JS_MEMORY_INITIAL,
-    // @ts-ignore
+    // @ts-expect-error Substituted by PackageToJS preprocessor
     maximum: import.meta.PACKAGE_TO_JS_MEMORY_MAXIMUM,
-    // @ts-ignore
+    // @ts-expect-error Substituted by PackageToJS preprocessor
     shared: import.meta.PACKAGE_TO_JS_MEMORY_SHARED,
 }
 /* #endif */
 
 /* #if HAS_BRIDGE */
-// @ts-ignore
+// @ts-expect-error Substituted by PackageToJS preprocessor
 import { createInstantiator } from "./bridge-js.js"
 /* #else */
 /**


### PR DESCRIPTION
## Overview

`instantiate.js` uses `// @ts-ignore` (4 instances) to suppress TypeScript errors on `import.meta.PACKAGE_TO_JS_*` properties and the conditional `bridge-js.js` import. These are inside `/* #if */` preprocessor blocks, so after preprocessing only some survive into the final output.

`@ts-expect-error` is stricter than `@ts-ignore` - it errors if the suppressed line doesn't actually produce a type error, which catches stale suppressions. `@ts-ignore` silently swallows everything, including suppressions that are no longer needed.

This also resolves `@typescript-eslint/ban-ts-comment` violations in the generated output. The rule bans bare `@ts-ignore` by default since `@ts-expect-error` is the safer alternative.

Line 163 already uses `@ts-expect-error` with a description - this makes the rest consistent.