### PR TITLE
BridgeJS: Add runtime tests for `@JS class` to JSObject conversion

### DIFF
--- a/Tests/BridgeJSRuntimeTests/SwiftClassSupportTests.swift
+++ b/Tests/BridgeJSRuntimeTests/SwiftClassSupportTests.swift
@@ -19,4 +19,10 @@ final class SwiftClassSupportTests: XCTestCase {
         let greeter2 = try SwiftClassSupportImports.jsRoundTripOptionalGreeter(Greeter(name: "Hello"))
         XCTAssertEqual(greeter2?.name, "Hello")
     }
+
+    func testSwiftClassToJSObject() throws {
+        let greeter = Greeter(name: "BridgeJS")
+        let jsGreeter = try XCTUnwrap(greeter.jsValue.object)
+        XCTAssertEqual(jsGreeter["name"].string, "BridgeJS")
+    }
 }


### PR DESCRIPTION
Cover https://github.com/swiftwasm/JavaScriptKit/pull/642