### PR TITLE
Add AI coding agent config files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,19 @@ Plugins/BridgeJS/Sources/TS2Swift/JavaScript/package-lock.json
 Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/**/*.actual
 bridge-js.config.local.json
 _site/
+
+# AI coding agent config files
+AGENTS.md
+CLAUDE.md
+GEMINI.md
+.claude/
+.opencode/
+.cursor/
+.cursorrules
+.codex/
+.aider*
+.cline/
+.clinerules
+.windsurf/
+.windsurfrules
+.codeiumignore


### PR DESCRIPTION
## Overview

Adds common AI coding agent configuration files and directories to `.gitignore`. This lets contributors drop tool-specific config (like `AGENTS.md` from [JavaScriptKit-dev-skills](https://github.com/swiftwasm/JavaScriptKit-dev-skills), or `.cursor/rules/`) into their worktree without them showing up as untracked files.

Covers: Claude Code, OpenCode, Cursor, GitHub Copilot, Windsurf/Codeium, Aider, Cline, Codex.