### PR TITLE
Runtime: Fix lint issues in compiled output

### DIFF
--- a/Plugins/PackageToJS/Templates/runtime.mjs
+++ b/Plugins/PackageToJS/Templates/runtime.mjs
@@ -30,6 +30,7 @@ const decode = (kind, payload1, payload2, objectSpace) => {
                 case 1:
                     return true;
             }
+        // falls through
         case 2 /* Kind.Number */:
             return payload2;
         case 1 /* Kind.String */:
@@ -555,7 +556,7 @@ class SwiftRuntime {
             swjs_call_function: (ref, argv, argc, payload1_ptr, payload2_ptr) => {
                 const memory = this.memory;
                 const func = memory.getObject(ref);
-                let result = undefined;
+                let result;
                 try {
                     const args = decodeArray(argv, argc, this.getDataView(), memory);
                     result = func(...args);
@@ -590,9 +591,8 @@ class SwiftRuntime {
                 const memory = this.memory;
                 const obj = memory.getObject(obj_ref);
                 const func = memory.getObject(func_ref);
-                let result = undefined;
                 const args = decodeArray(argv, argc, this.getDataView(), memory);
-                result = func.apply(obj, args);
+                const result = func.apply(obj, args);
                 return writeAndReturnKindBits(result, payload1_ptr, payload2_ptr, false, this.getDataView(), this.memory);
             },
             swjs_call_new: (ref, argv, argc) => {
@@ -744,9 +744,10 @@ class SwiftRuntime {
                             broker.onReceivingResponse(message);
                             break;
                         }
-                        default:
+                        default: {
                             const unknownMessage = message;
                             throw new Error(`Unknown message type: ${unknownMessage}`);
+                        }
                     }
                 });
             },
@@ -773,9 +774,10 @@ class SwiftRuntime {
                             broker.onReceivingResponse(message);
                             break;
                         }
-                        default:
+                        default: {
                             const unknownMessage = message;
                             throw new Error(`Unknown message type: ${unknownMessage}`);
+                        }
                     }
                 });
             },

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -430,7 +430,7 @@ export class SwiftRuntime {
             ) => {
                 const memory = this.memory;
                 const func = memory.getObject(ref);
-                let result = undefined;
+                let result: any;
                 try {
                     const args = JSValue.decodeArray(
                         argv,
@@ -534,14 +534,13 @@ export class SwiftRuntime {
                 const memory = this.memory;
                 const obj = memory.getObject(obj_ref);
                 const func = memory.getObject(func_ref);
-                let result = undefined;
                 const args = JSValue.decodeArray(
                     argv,
                     argc,
                     this.getDataView(),
                     memory,
                 );
-                result = func.apply(obj, args);
+                const result = func.apply(obj, args);
                 return JSValue.writeAndReturnKindBits(
                     result,
                     payload1_ptr,
@@ -799,11 +798,12 @@ export class SwiftRuntime {
                             broker.onReceivingResponse(message);
                             break;
                         }
-                        default:
+                        default: {
                             const unknownMessage: never = message;
                             throw new Error(
                                 `Unknown message type: ${unknownMessage}`,
                             );
+                        }
                     }
                 });
             },
@@ -838,11 +838,12 @@ export class SwiftRuntime {
                             broker.onReceivingResponse(message);
                             break;
                         }
-                        default:
+                        default: {
                             const unknownMessage: never = message;
                             throw new Error(
                                 `Unknown message type: ${unknownMessage}`,
                             );
+                        }
                     }
                 });
             },

--- a/Runtime/src/js-value.ts
+++ b/Runtime/src/js-value.ts
@@ -31,6 +31,7 @@ export const decode = (
                 case 1:
                     return true;
             }
+        // falls through
         case Kind.Number:
             return payload2;
 


### PR DESCRIPTION
## Overview

This is a proposal - totally fine to reject and close if these aren't worth maintaining.

The compiled `runtime.mjs` has 5 issues that trip rules from `@eslint/js` recommended config (`no-fallthrough`, `no-useless-assignment`, `no-case-declarations`). All three have been in ESLint's recommended set since v9+ (the first two since v0.x/v1.x, `no-useless-assignment` since v9). These are in the TypeScript source and compile through to the rollup output unchanged.

**1. `no-fallthrough` in `js-value.ts`**

The Boolean case in `decode()` has a nested switch that doesn't cover all values, then falls through to the Number case. This is intentional (an invalid boolean payload gets treated as a number), but there's no annotation marking it so.

```ts
case Kind.Boolean:
    switch (payload1) {
        case 0: return false;
        case 1: return true;
    }
// falls through
case Kind.Number:
```

**2. `no-useless-assignment` in `index.ts` (2 instances)**

`swjs_call_function` and `swjs_call_function_with_this_no_catch` initialize `let result = undefined` then immediately reassign. In `swjs_call_function`, the init is never read because the catch returns early. In the no-catch variant, it's a straight reassign on the next statement.

```ts
// before
let result = undefined;
result = func.apply(obj, args);

// after
const result = func.apply(obj, args);
```

**3. `no-case-declarations` in `index.ts` (2 instances)**

The two `listenMessage` callbacks have `const` declarations in unbraced `default:` cases. Wrapping with `{}` scopes the declaration to the case block.

```ts
// before
default:
    const unknownMessage: never = message;

// after
default: {
    const unknownMessage: never = message;
}
```