### PR TITLE
TS2Swift: emit static properties as static members

### DIFF
--- a/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/__snapshots__/ts2swift.test.js.snap
+++ b/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/__snapshots__/ts2swift.test.js.snap
@@ -338,6 +338,22 @@ exports[`ts2swift > snapshots Swift output for RecordDictionary.d.ts > RecordDic
 "
 `;
 
+exports[`ts2swift > snapshots Swift output for StaticProperty.d.ts > StaticProperty 1`] = `
+"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// \`swift package bridge-js\`.
+
+@_spi(BridgeJS) import JavaScriptKit
+
+@JSClass struct Library {
+    @JSGetter static var version: String
+    @JSSetter static func setVersion(_ value: String) throws(JSException)
+}
+"
+`;
+
 exports[`ts2swift > snapshots Swift output for StringEnum.d.ts > StringEnum 1`] = `
 "// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.

--- a/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/fixtures/StaticProperty.d.ts
+++ b/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/fixtures/StaticProperty.d.ts
@@ -1,0 +1,3 @@
+export class Library {
+    static version: string;
+}


### PR DESCRIPTION
## Overview
- Render TS `static` properties as `static` Swift getters/setters so constructor/global members aren't emitted as instance accessors.
- Add `StaticProperty.d.ts` fixture and refresh snapshots to cover static field emission.
- Note: current JSGetter/JSSetter macros reject static members; this aligns TS2Swift output but will need the macro side to permit static properties.

## Testing
- npm -C Plugins/BridgeJS/Sources/TS2Swift/JavaScript/ test -- --update
