### PR TITLE
NFC: BridgeJS: Remove dead cleanup infrastructure

### DIFF
--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -132,10 +132,7 @@ extension SimpleStruct: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_SimpleStruct(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_SimpleStruct(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -148,9 +145,9 @@ extension SimpleStruct: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_SimpleStruct")
-fileprivate func _bjs_struct_lower_SimpleStruct(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_SimpleStruct(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_SimpleStruct(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_SimpleStruct(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -179,10 +176,7 @@ extension Address: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -195,9 +189,9 @@ extension Address: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Address")
-fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -232,10 +226,7 @@ extension Person: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Person(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Person(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -248,9 +239,9 @@ extension Person: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Person")
-fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -285,10 +276,7 @@ extension ComplexStruct: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_ComplexStruct(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_ComplexStruct(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -301,9 +289,9 @@ extension ComplexStruct: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ComplexStruct")
-fileprivate func _bjs_struct_lower_ComplexStruct(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_ComplexStruct(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ComplexStruct(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_ComplexStruct(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -330,10 +318,7 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -346,9 +331,9 @@ extension Point: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.swift
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.swift
@@ -24,10 +24,7 @@ extension PlayBridgeJSOutput: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_PlayBridgeJSOutput(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_PlayBridgeJSOutput(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -40,9 +37,9 @@ extension PlayBridgeJSOutput: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PlayBridgeJSOutput")
-fileprivate func _bjs_struct_lower_PlayBridgeJSOutput(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_PlayBridgeJSOutput(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PlayBridgeJSOutput(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_PlayBridgeJSOutput(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -77,10 +74,7 @@ extension PlayBridgeJSDiagnostic: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_PlayBridgeJSDiagnostic(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_PlayBridgeJSDiagnostic(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -93,9 +87,9 @@ extension PlayBridgeJSDiagnostic: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PlayBridgeJSDiagnostic")
-fileprivate func _bjs_struct_lower_PlayBridgeJSDiagnostic(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_PlayBridgeJSDiagnostic(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PlayBridgeJSDiagnostic(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_PlayBridgeJSDiagnostic(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -122,10 +116,7 @@ extension PlayBridgeJSResult: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_PlayBridgeJSResult(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_PlayBridgeJSResult(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -138,9 +129,9 @@ extension PlayBridgeJSResult: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PlayBridgeJSResult")
-fileprivate func _bjs_struct_lower_PlayBridgeJSResult(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_PlayBridgeJSResult(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PlayBridgeJSResult(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_PlayBridgeJSResult(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -1243,10 +1243,7 @@ struct StructCodegen {
             printer.write(
                 multilineString: """
                     \(accessControl)init(unsafelyCopying jsObject: JSObject) {
-                        let __bjs_cleanupId = \(lowerFunctionName)(jsObject.bridgeJSLowerParameter())
-                        defer {
-                            _swift_js_struct_cleanup(__bjs_cleanupId)
-                        }
+                        \(lowerFunctionName)(jsObject.bridgeJSLowerParameter())
                         self = Self.bridgeJSStackPop()
                     }
                     """
@@ -1274,7 +1271,7 @@ struct StructCodegen {
             functionName: lowerFunctionName,
             signature: SwiftSignatureBuilder.buildABIFunctionSignature(
                 abiParameters: [("objectId", .i32)],
-                returnType: .i32
+                returnType: nil
             )
         )
         let liftExternDeclPrinter = CodeFragmentPrinter()

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
@@ -57,10 +57,7 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -73,9 +70,9 @@ extension Point: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.swift
@@ -52,10 +52,7 @@ extension Config: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Config(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Config(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -68,9 +65,9 @@ extension Config: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Config")
-fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -95,10 +92,7 @@ extension MathOperations: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_MathOperations(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_MathOperations(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -111,9 +105,9 @@ extension MathOperations: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_MathOperations")
-fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
@@ -413,10 +413,7 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -429,9 +426,9 @@ extension Point: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.swift
@@ -15,10 +15,7 @@ extension FooContainer: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_FooContainer(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_FooContainer(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -31,9 +28,9 @@ extension FooContainer: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_FooContainer")
-fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.swift
@@ -28,10 +28,7 @@ extension DataPoint: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_DataPoint(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_DataPoint(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -44,9 +41,9 @@ extension DataPoint: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_DataPoint")
-fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -90,10 +87,7 @@ extension Address: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -106,9 +100,9 @@ extension Address: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Address")
-fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -143,10 +137,7 @@ extension Person: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Person(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Person(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -159,9 +150,9 @@ extension Person: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Person")
-fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -188,10 +179,7 @@ extension Session: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Session(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Session(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -204,9 +192,9 @@ extension Session: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Session")
-fileprivate func _bjs_struct_lower_Session(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Session(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Session(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Session(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -239,10 +227,7 @@ extension Measurement: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Measurement(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Measurement(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -255,9 +240,9 @@ extension Measurement: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Measurement")
-fileprivate func _bjs_struct_lower_Measurement(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Measurement(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Measurement(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Measurement(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -280,10 +265,7 @@ extension ConfigStruct: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_ConfigStruct(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_ConfigStruct(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -296,9 +278,9 @@ extension ConfigStruct: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ConfigStruct")
-fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -404,10 +386,7 @@ extension Container: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Container(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Container(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -420,9 +399,9 @@ extension Container: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Container")
-fileprivate func _bjs_struct_lower_Container(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Container(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Container(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Container(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
@@ -11,10 +11,7 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -27,9 +24,9 @@ extension Point: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/UnsafePointer.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/UnsafePointer.swift
@@ -17,10 +17,7 @@ extension PointerFields: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_PointerFields(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_PointerFields(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -33,9 +30,9 @@ extension PointerFields: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PointerFields")
-fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -93,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -215,7 +204,6 @@ export async function createInstantiator(options, swift) {
                         dictResult[string] = f64;
                     }
                     let ret = imports.importMirrorDictionary(dictResult);
-                    const arrayCleanups = [];
                     const entries = Object.entries(ret);
                     for (const entry of entries) {
                         const [key, value] = entry;
@@ -280,7 +268,6 @@ export async function createInstantiator(options, swift) {
             const exports = {
                 Box,
                 mirrorDictionary: function bjs_mirrorDictionary(values) {
-                    const arrayCleanups = [];
                     const entries = Object.entries(values);
                     for (const entry of entries) {
                         const [key, value] = entry;
@@ -299,14 +286,11 @@ export async function createInstantiator(options, swift) {
                         const string = strStack.pop();
                         dictResult[string] = int;
                     }
-                    for (const cleanup of arrayCleanups) { cleanup(); }
                     return dictResult;
                 },
                 optionalDictionary: function bjs_optionalDictionary(values) {
                     const isSome = values != null;
-                    const valuesCleanups = [];
                     if (isSome) {
-                        const arrayCleanups = [];
                         const entries = Object.entries(values);
                         for (const entry of entries) {
                             const [key, value] = entry;
@@ -320,7 +304,6 @@ export async function createInstantiator(options, swift) {
                             i32Stack.push(id1);
                         }
                         i32Stack.push(entries.length);
-                        valuesCleanups.push(() => { for (const cleanup of arrayCleanups) { cleanup(); } });
                     }
                     i32Stack.push(+isSome);
                     instance.exports.bjs_optionalDictionary();
@@ -338,11 +321,9 @@ export async function createInstantiator(options, swift) {
                     } else {
                         optResult = null;
                     }
-                    for (const cleanup of valuesCleanups) { cleanup(); }
                     return optResult;
                 },
                 nestedDictionary: function bjs_nestedDictionary(values) {
-                    const arrayCleanups = [];
                     const entries = Object.entries(values);
                     for (const entry of entries) {
                         const [key, value] = entry;
@@ -350,14 +331,10 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const arrayCleanups1 = [];
                         for (const elem of value) {
                             i32Stack.push((elem | 0));
                         }
                         i32Stack.push(value.length);
-                        arrayCleanups.push(() => {
-                            for (const cleanup of arrayCleanups1) { cleanup(); }
-                        });
                     }
                     i32Stack.push(entries.length);
                     instance.exports.bjs_nestedDictionary();
@@ -374,11 +351,9 @@ export async function createInstantiator(options, swift) {
                         const string = strStack.pop();
                         dictResult[string] = arrayResult;
                     }
-                    for (const cleanup of arrayCleanups) { cleanup(); }
                     return dictResult;
                 },
                 boxDictionary: function bjs_boxDictionary(boxes) {
-                    const arrayCleanups = [];
                     const entries = Object.entries(boxes);
                     for (const entry of entries) {
                         const [key, value] = entry;
@@ -398,11 +373,9 @@ export async function createInstantiator(options, swift) {
                         const string = strStack.pop();
                         dictResult[string] = obj;
                     }
-                    for (const cleanup of arrayCleanups) { cleanup(); }
                     return dictResult;
                 },
                 optionalBoxDictionary: function bjs_optionalBoxDictionary(boxes) {
-                    const arrayCleanups = [];
                     const entries = Object.entries(boxes);
                     for (const entry of entries) {
                         const [key, value] = entry;
@@ -435,7 +408,6 @@ export async function createInstantiator(options, swift) {
                         const string = strStack.pop();
                         dictResult[string] = optValue;
                     }
-                    for (const cleanup of arrayCleanups) { cleanup(); }
                     return dictResult;
                 },
             };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
@@ -104,7 +104,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -115,7 +114,6 @@ export async function createInstantiator(options, swift) {
             lower: (value) => {
                 f64Stack.push(value.x);
                 f64Stack.push(value.y);
-                return { cleanup: undefined };
             },
             lift: () => {
                 const f64 = f64Stack.pop();
@@ -134,32 +132,26 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Success, cleanup };
+                        return APIResultValues.Tag.Success;
                     }
                     case APIResultValues.Tag.Failure: {
                         i32Stack.push((value.param0 | 0));
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Failure, cleanup };
+                        return APIResultValues.Tag.Failure;
                     }
                     case APIResultValues.Tag.Flag: {
                         i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Flag, cleanup };
+                        return APIResultValues.Tag.Flag;
                     }
                     case APIResultValues.Tag.Rate: {
                         f32Stack.push(Math.fround(value.param0));
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Rate, cleanup };
+                        return APIResultValues.Tag.Rate;
                     }
                     case APIResultValues.Tag.Precise: {
                         f64Stack.push(value.param0);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Precise, cleanup };
+                        return APIResultValues.Tag.Precise;
                     }
                     case APIResultValues.Tag.Info: {
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Info, cleanup };
+                        return APIResultValues.Tag.Info;
                     }
                     default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
                 }
@@ -203,8 +195,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: ComplexResultValues.Tag.Success, cleanup };
+                        return ComplexResultValues.Tag.Success;
                     }
                     case ComplexResultValues.Tag.Error: {
                         i32Stack.push((value.param1 | 0));
@@ -212,8 +203,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: ComplexResultValues.Tag.Error, cleanup };
+                        return ComplexResultValues.Tag.Error;
                     }
                     case ComplexResultValues.Tag.Status: {
                         const bytes = textEncoder.encode(value.param2);
@@ -222,15 +212,13 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(id);
                         i32Stack.push((value.param1 | 0));
                         i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: ComplexResultValues.Tag.Status, cleanup };
+                        return ComplexResultValues.Tag.Status;
                     }
                     case ComplexResultValues.Tag.Coordinates: {
                         f64Stack.push(value.param2);
                         f64Stack.push(value.param1);
                         f64Stack.push(value.param0);
-                        const cleanup = undefined;
-                        return { caseId: ComplexResultValues.Tag.Coordinates, cleanup };
+                        return ComplexResultValues.Tag.Coordinates;
                     }
                     case ComplexResultValues.Tag.Comprehensive: {
                         const bytes = textEncoder.encode(value.param8);
@@ -251,12 +239,10 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push((value.param2 | 0));
                         i32Stack.push(value.param1 ? 1 : 0);
                         i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: ComplexResultValues.Tag.Comprehensive, cleanup };
+                        return ComplexResultValues.Tag.Comprehensive;
                     }
                     case ComplexResultValues.Tag.Info: {
-                        const cleanup = undefined;
-                        return { caseId: ComplexResultValues.Tag.Info, cleanup };
+                        return ComplexResultValues.Tag.Info;
                     }
                     default: throw new Error("Unknown ComplexResultValues tag: " + String(enumTag));
                 }
@@ -313,8 +299,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: ResultValues.Tag.Success, cleanup };
+                        return ResultValues.Tag.Success;
                     }
                     case ResultValues.Tag.Failure: {
                         i32Stack.push((value.param1 | 0));
@@ -322,8 +307,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: ResultValues.Tag.Failure, cleanup };
+                        return ResultValues.Tag.Failure;
                     }
                     case ResultValues.Tag.Status: {
                         const bytes = textEncoder.encode(value.param2);
@@ -332,8 +316,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(id);
                         i32Stack.push((value.param1 | 0));
                         i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: ResultValues.Tag.Status, cleanup };
+                        return ResultValues.Tag.Status;
                     }
                     default: throw new Error("Unknown ResultValues tag: " + String(enumTag));
                 }
@@ -371,8 +354,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: NetworkingResultValues.Tag.Success, cleanup };
+                        return NetworkingResultValues.Tag.Success;
                     }
                     case NetworkingResultValues.Tag.Failure: {
                         i32Stack.push((value.param1 | 0));
@@ -380,8 +362,7 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: NetworkingResultValues.Tag.Failure, cleanup };
+                        return NetworkingResultValues.Tag.Failure;
                     }
                     default: throw new Error("Unknown NetworkingResultValues tag: " + String(enumTag));
                 }
@@ -421,8 +402,7 @@ export async function createInstantiator(options, swift) {
                             i32Stack.push(0);
                         }
                         i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: APIOptionalResultValues.Tag.Success, cleanup };
+                        return APIOptionalResultValues.Tag.Success;
                     }
                     case APIOptionalResultValues.Tag.Failure: {
                         const isSome = value.param1 != null;
@@ -431,8 +411,7 @@ export async function createInstantiator(options, swift) {
                         const isSome1 = value.param0 != null;
                         i32Stack.push(isSome1 ? (value.param0 | 0) : 0);
                         i32Stack.push(isSome1 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: APIOptionalResultValues.Tag.Failure, cleanup };
+                        return APIOptionalResultValues.Tag.Failure;
                     }
                     case APIOptionalResultValues.Tag.Status: {
                         const isSome = value.param2 != null;
@@ -453,8 +432,7 @@ export async function createInstantiator(options, swift) {
                         const isSome2 = value.param0 != null;
                         i32Stack.push(isSome2 ? (value.param0 ? 1 : 0) : 0);
                         i32Stack.push(isSome2 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: APIOptionalResultValues.Tag.Status, cleanup };
+                        return APIOptionalResultValues.Tag.Status;
                     }
                     default: throw new Error("Unknown APIOptionalResultValues tag: " + String(enumTag));
                 }
@@ -531,31 +509,26 @@ export async function createInstantiator(options, swift) {
                 switch (enumTag) {
                     case TypedPayloadResultValues.Tag.Precision: {
                         f32Stack.push(Math.fround(value.param0));
-                        const cleanup = undefined;
-                        return { caseId: TypedPayloadResultValues.Tag.Precision, cleanup };
+                        return TypedPayloadResultValues.Tag.Precision;
                     }
                     case TypedPayloadResultValues.Tag.Direction: {
                         i32Stack.push((value.param0 | 0));
-                        const cleanup = undefined;
-                        return { caseId: TypedPayloadResultValues.Tag.Direction, cleanup };
+                        return TypedPayloadResultValues.Tag.Direction;
                     }
                     case TypedPayloadResultValues.Tag.OptPrecision: {
                         const isSome = value.param0 != null;
                         f32Stack.push(isSome ? Math.fround(value.param0) : 0.0);
                         i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: TypedPayloadResultValues.Tag.OptPrecision, cleanup };
+                        return TypedPayloadResultValues.Tag.OptPrecision;
                     }
                     case TypedPayloadResultValues.Tag.OptDirection: {
                         const isSome = value.param0 != null;
                         i32Stack.push(isSome ? (value.param0 | 0) : 0);
                         i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: TypedPayloadResultValues.Tag.OptDirection, cleanup };
+                        return TypedPayloadResultValues.Tag.OptDirection;
                     }
                     case TypedPayloadResultValues.Tag.Empty: {
-                        const cleanup = undefined;
-                        return { caseId: TypedPayloadResultValues.Tag.Empty, cleanup };
+                        return TypedPayloadResultValues.Tag.Empty;
                     }
                     default: throw new Error("Unknown TypedPayloadResultValues tag: " + String(enumTag));
                 }
@@ -605,45 +578,32 @@ export async function createInstantiator(options, swift) {
                 const enumTag = value.tag;
                 switch (enumTag) {
                     case AllTypesResultValues.Tag.StructPayload: {
-                        const { cleanup: structCleanup } = structHelpers.Point.lower(value.param0);
-                        const cleanup = () => {
-                            if (structCleanup) { structCleanup(); }
-                        };
-                        return { caseId: AllTypesResultValues.Tag.StructPayload, cleanup };
+                        structHelpers.Point.lower(value.param0);
+                        return AllTypesResultValues.Tag.StructPayload;
                     }
                     case AllTypesResultValues.Tag.ClassPayload: {
                         ptrStack.push(value.param0.pointer);
-                        const cleanup = undefined;
-                        return { caseId: AllTypesResultValues.Tag.ClassPayload, cleanup };
+                        return AllTypesResultValues.Tag.ClassPayload;
                     }
                     case AllTypesResultValues.Tag.JsObjectPayload: {
                         const objId = swift.memory.retain(value.param0);
                         i32Stack.push(objId);
-                        const cleanup = undefined;
-                        return { caseId: AllTypesResultValues.Tag.JsObjectPayload, cleanup };
+                        return AllTypesResultValues.Tag.JsObjectPayload;
                     }
                     case AllTypesResultValues.Tag.NestedEnum: {
-                        const { caseId: caseId, cleanup: enumCleanup } = enumHelpers.APIResult.lower(value.param0);
+                        const caseId = enumHelpers.APIResult.lower(value.param0);
                         i32Stack.push(caseId);
-                        const cleanup = () => {
-                            if (enumCleanup) { enumCleanup(); }
-                        };
-                        return { caseId: AllTypesResultValues.Tag.NestedEnum, cleanup };
+                        return AllTypesResultValues.Tag.NestedEnum;
                     }
                     case AllTypesResultValues.Tag.ArrayPayload: {
-                        const arrayCleanups = [];
                         for (const elem of value.param0) {
                             i32Stack.push((elem | 0));
                         }
                         i32Stack.push(value.param0.length);
-                        const cleanup = () => {
-                            for (const cleanup of arrayCleanups) { cleanup(); }
-                        };
-                        return { caseId: AllTypesResultValues.Tag.ArrayPayload, cleanup };
+                        return AllTypesResultValues.Tag.ArrayPayload;
                     }
                     case AllTypesResultValues.Tag.Empty: {
-                        const cleanup = undefined;
-                        return { caseId: AllTypesResultValues.Tag.Empty, cleanup };
+                        return AllTypesResultValues.Tag.Empty;
                     }
                     default: throw new Error("Unknown AllTypesResultValues tag: " + String(enumTag));
                 }
@@ -693,16 +653,11 @@ export async function createInstantiator(options, swift) {
                 switch (enumTag) {
                     case OptionalAllTypesResultValues.Tag.OptStruct: {
                         const isSome = value.param0 != null;
-                        let nestedCleanup;
                         if (isSome) {
-                            const structResult = structHelpers.Point.lower(value.param0);
-                            nestedCleanup = structResult.cleanup;
+                            structHelpers.Point.lower(value.param0);
                         }
                         i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = () => {
-                            if (nestedCleanup) { nestedCleanup(); }
-                        };
-                        return { caseId: OptionalAllTypesResultValues.Tag.OptStruct, cleanup };
+                        return OptionalAllTypesResultValues.Tag.OptStruct;
                     }
                     case OptionalAllTypesResultValues.Tag.OptClass: {
                         const isSome = value.param0 != null;
@@ -712,8 +667,7 @@ export async function createInstantiator(options, swift) {
                             ptrStack.push(0);
                         }
                         i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: OptionalAllTypesResultValues.Tag.OptClass, cleanup };
+                        return OptionalAllTypesResultValues.Tag.OptClass;
                     }
                     case OptionalAllTypesResultValues.Tag.OptJSObject: {
                         const isSome = value.param0 != null;
@@ -726,48 +680,33 @@ export async function createInstantiator(options, swift) {
                             i32Stack.push(0);
                         }
                         i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: OptionalAllTypesResultValues.Tag.OptJSObject, cleanup };
+                        return OptionalAllTypesResultValues.Tag.OptJSObject;
                     }
                     case OptionalAllTypesResultValues.Tag.OptNestedEnum: {
                         const isSome = value.param0 != null;
-                        let enumCaseId, enumCleanup;
+                        let enumCaseId;
                         if (isSome) {
-                            const enumResult = enumHelpers.APIResult.lower(value.param0);
-                            enumCaseId = enumResult.caseId;
-                            enumCleanup = enumResult.cleanup;
+                            enumCaseId = enumHelpers.APIResult.lower(value.param0);
                             i32Stack.push(enumCaseId);
                         } else {
                             i32Stack.push(0);
                         }
                         i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = () => {
-                            if (enumCleanup) { enumCleanup(); }
-                        };
-                        return { caseId: OptionalAllTypesResultValues.Tag.OptNestedEnum, cleanup };
+                        return OptionalAllTypesResultValues.Tag.OptNestedEnum;
                     }
                     case OptionalAllTypesResultValues.Tag.OptArray: {
                         const isSome = value.param0 != null;
-                        let arrCleanup;
                         if (isSome) {
-                            const arrayCleanups = [];
                             for (const elem of value.param0) {
                                 i32Stack.push((elem | 0));
                             }
                             i32Stack.push(value.param0.length);
-                            arrCleanup = () => {
-                                for (const cleanup of arrayCleanups) { cleanup(); }
-                            };
                         }
                         i32Stack.push(isSome ? 1 : 0);
-                        const cleanup = () => {
-                            if (arrCleanup) { arrCleanup(); }
-                        };
-                        return { caseId: OptionalAllTypesResultValues.Tag.OptArray, cleanup };
+                        return OptionalAllTypesResultValues.Tag.OptArray;
                     }
                     case OptionalAllTypesResultValues.Tag.Empty: {
-                        const cleanup = undefined;
-                        return { caseId: OptionalAllTypesResultValues.Tag.Empty, cleanup };
+                        return OptionalAllTypesResultValues.Tag.Empty;
                     }
                     default: throw new Error("Unknown OptionalAllTypesResultValues tag: " + String(enumTag));
                 }
@@ -910,22 +849,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
             }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
-            }
             bjs["swift_js_struct_lower_Point"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Point.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Point.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Point"] = function() {
                 const value = structHelpers.Point.lift();
@@ -1107,9 +1032,8 @@ export async function createInstantiator(options, swift) {
             const exports = {
                 User,
                 handle: function bjs_handle(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.APIResult.lower(result);
+                    const resultCaseId = enumHelpers.APIResult.lower(result);
                     instance.exports.bjs_handle(resultCaseId);
-                    if (resultCleanup) { resultCleanup(); }
                 },
                 getResult: function bjs_getResult() {
                     instance.exports.bjs_getResult();
@@ -1117,19 +1041,16 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 },
                 roundtripAPIResult: function bjs_roundtripAPIResult(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.APIResult.lower(result);
+                    const resultCaseId = enumHelpers.APIResult.lower(result);
                     instance.exports.bjs_roundtripAPIResult(resultCaseId);
                     const ret = enumHelpers.APIResult.lift(i32Stack.pop());
-                    if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
                 roundTripOptionalAPIResult: function bjs_roundTripOptionalAPIResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let resultCaseId;
                     if (isSome) {
-                        const enumResult = enumHelpers.APIResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
+                        resultCaseId = enumHelpers.APIResult.lower(result);
                     }
                     instance.exports.bjs_roundTripOptionalAPIResult(+isSome, isSome ? resultCaseId : 0);
                     const tag = i32Stack.pop();
@@ -1140,13 +1061,11 @@ export async function createInstantiator(options, swift) {
                     } else {
                         optResult = enumHelpers.APIResult.lift(tag);
                     }
-                    if (resultCleanup) { resultCleanup(); }
                     return optResult;
                 },
                 handleComplex: function bjs_handleComplex(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.ComplexResult.lower(result);
+                    const resultCaseId = enumHelpers.ComplexResult.lower(result);
                     instance.exports.bjs_handleComplex(resultCaseId);
-                    if (resultCleanup) { resultCleanup(); }
                 },
                 getComplexResult: function bjs_getComplexResult() {
                     instance.exports.bjs_getComplexResult();
@@ -1154,19 +1073,16 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 },
                 roundtripComplexResult: function bjs_roundtripComplexResult(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.ComplexResult.lower(result);
+                    const resultCaseId = enumHelpers.ComplexResult.lower(result);
                     instance.exports.bjs_roundtripComplexResult(resultCaseId);
                     const ret = enumHelpers.ComplexResult.lift(i32Stack.pop());
-                    if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
                 roundTripOptionalComplexResult: function bjs_roundTripOptionalComplexResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let resultCaseId;
                     if (isSome) {
-                        const enumResult = enumHelpers.ComplexResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
+                        resultCaseId = enumHelpers.ComplexResult.lower(result);
                     }
                     instance.exports.bjs_roundTripOptionalComplexResult(+isSome, isSome ? resultCaseId : 0);
                     const tag = i32Stack.pop();
@@ -1177,16 +1093,13 @@ export async function createInstantiator(options, swift) {
                     } else {
                         optResult = enumHelpers.ComplexResult.lift(tag);
                     }
-                    if (resultCleanup) { resultCleanup(); }
                     return optResult;
                 },
                 roundTripOptionalUtilitiesResult: function bjs_roundTripOptionalUtilitiesResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let resultCaseId;
                     if (isSome) {
-                        const enumResult = enumHelpers.Result.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
+                        resultCaseId = enumHelpers.Result.lower(result);
                     }
                     instance.exports.bjs_roundTripOptionalUtilitiesResult(+isSome, isSome ? resultCaseId : 0);
                     const tag = i32Stack.pop();
@@ -1197,16 +1110,13 @@ export async function createInstantiator(options, swift) {
                     } else {
                         optResult = enumHelpers.Result.lift(tag);
                     }
-                    if (resultCleanup) { resultCleanup(); }
                     return optResult;
                 },
                 roundTripOptionalNetworkingResult: function bjs_roundTripOptionalNetworkingResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let resultCaseId;
                     if (isSome) {
-                        const enumResult = enumHelpers.NetworkingResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
+                        resultCaseId = enumHelpers.NetworkingResult.lower(result);
                     }
                     instance.exports.bjs_roundTripOptionalNetworkingResult(+isSome, isSome ? resultCaseId : 0);
                     const tag = i32Stack.pop();
@@ -1217,16 +1127,13 @@ export async function createInstantiator(options, swift) {
                     } else {
                         optResult = enumHelpers.NetworkingResult.lift(tag);
                     }
-                    if (resultCleanup) { resultCleanup(); }
                     return optResult;
                 },
                 roundTripOptionalAPIOptionalResult: function bjs_roundTripOptionalAPIOptionalResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let resultCaseId;
                     if (isSome) {
-                        const enumResult = enumHelpers.APIOptionalResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
+                        resultCaseId = enumHelpers.APIOptionalResult.lower(result);
                     }
                     instance.exports.bjs_roundTripOptionalAPIOptionalResult(+isSome, isSome ? resultCaseId : 0);
                     const tag = i32Stack.pop();
@@ -1237,23 +1144,18 @@ export async function createInstantiator(options, swift) {
                     } else {
                         optResult = enumHelpers.APIOptionalResult.lift(tag);
                     }
-                    if (resultCleanup) { resultCleanup(); }
                     return optResult;
                 },
                 compareAPIResults: function bjs_compareAPIResults(result1, result2) {
                     const isSome = result1 != null;
-                    let result1CaseId, result1Cleanup;
+                    let result1CaseId;
                     if (isSome) {
-                        const enumResult = enumHelpers.APIOptionalResult.lower(result1);
-                        result1CaseId = enumResult.caseId;
-                        result1Cleanup = enumResult.cleanup;
+                        result1CaseId = enumHelpers.APIOptionalResult.lower(result1);
                     }
                     const isSome1 = result2 != null;
-                    let result2CaseId, result2Cleanup;
+                    let result2CaseId;
                     if (isSome1) {
-                        const enumResult1 = enumHelpers.APIOptionalResult.lower(result2);
-                        result2CaseId = enumResult1.caseId;
-                        result2Cleanup = enumResult1.cleanup;
+                        result2CaseId = enumHelpers.APIOptionalResult.lower(result2);
                     }
                     instance.exports.bjs_compareAPIResults(+isSome, isSome ? result1CaseId : 0, +isSome1, isSome1 ? result2CaseId : 0);
                     const tag = i32Stack.pop();
@@ -1264,24 +1166,19 @@ export async function createInstantiator(options, swift) {
                     } else {
                         optResult = enumHelpers.APIOptionalResult.lift(tag);
                     }
-                    if (result1Cleanup) { result1Cleanup(); }
-                    if (result2Cleanup) { result2Cleanup(); }
                     return optResult;
                 },
                 roundTripTypedPayloadResult: function bjs_roundTripTypedPayloadResult(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.TypedPayloadResult.lower(result);
+                    const resultCaseId = enumHelpers.TypedPayloadResult.lower(result);
                     instance.exports.bjs_roundTripTypedPayloadResult(resultCaseId);
                     const ret = enumHelpers.TypedPayloadResult.lift(i32Stack.pop());
-                    if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
                 roundTripOptionalTypedPayloadResult: function bjs_roundTripOptionalTypedPayloadResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let resultCaseId;
                     if (isSome) {
-                        const enumResult = enumHelpers.TypedPayloadResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
+                        resultCaseId = enumHelpers.TypedPayloadResult.lower(result);
                     }
                     instance.exports.bjs_roundTripOptionalTypedPayloadResult(+isSome, isSome ? resultCaseId : 0);
                     const tag = i32Stack.pop();
@@ -1292,23 +1189,19 @@ export async function createInstantiator(options, swift) {
                     } else {
                         optResult = enumHelpers.TypedPayloadResult.lift(tag);
                     }
-                    if (resultCleanup) { resultCleanup(); }
                     return optResult;
                 },
                 roundTripAllTypesResult: function bjs_roundTripAllTypesResult(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.AllTypesResult.lower(result);
+                    const resultCaseId = enumHelpers.AllTypesResult.lower(result);
                     instance.exports.bjs_roundTripAllTypesResult(resultCaseId);
                     const ret = enumHelpers.AllTypesResult.lift(i32Stack.pop());
-                    if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
                 roundTripOptionalAllTypesResult: function bjs_roundTripOptionalAllTypesResult(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let resultCaseId;
                     if (isSome) {
-                        const enumResult = enumHelpers.AllTypesResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
+                        resultCaseId = enumHelpers.AllTypesResult.lower(result);
                     }
                     instance.exports.bjs_roundTripOptionalAllTypesResult(+isSome, isSome ? resultCaseId : 0);
                     const tag = i32Stack.pop();
@@ -1319,23 +1212,19 @@ export async function createInstantiator(options, swift) {
                     } else {
                         optResult = enumHelpers.AllTypesResult.lift(tag);
                     }
-                    if (resultCleanup) { resultCleanup(); }
                     return optResult;
                 },
                 roundTripOptionalPayloadResult: function bjs_roundTripOptionalPayloadResult(result) {
-                    const { caseId: resultCaseId, cleanup: resultCleanup } = enumHelpers.OptionalAllTypesResult.lower(result);
+                    const resultCaseId = enumHelpers.OptionalAllTypesResult.lower(result);
                     instance.exports.bjs_roundTripOptionalPayloadResult(resultCaseId);
                     const ret = enumHelpers.OptionalAllTypesResult.lift(i32Stack.pop());
-                    if (resultCleanup) { resultCleanup(); }
                     return ret;
                 },
                 roundTripOptionalPayloadResultOpt: function bjs_roundTripOptionalPayloadResultOpt(result) {
                     const isSome = result != null;
-                    let resultCaseId, resultCleanup;
+                    let resultCaseId;
                     if (isSome) {
-                        const enumResult = enumHelpers.OptionalAllTypesResult.lower(result);
-                        resultCaseId = enumResult.caseId;
-                        resultCleanup = enumResult.cleanup;
+                        resultCaseId = enumHelpers.OptionalAllTypesResult.lower(result);
                     }
                     instance.exports.bjs_roundTripOptionalPayloadResultOpt(+isSome, isSome ? resultCaseId : 0);
                     const tag = i32Stack.pop();
@@ -1346,7 +1235,6 @@ export async function createInstantiator(options, swift) {
                     } else {
                         optResult = enumHelpers.OptionalAllTypesResult.lift(tag);
                     }
-                    if (resultCleanup) { resultCleanup(); }
                     return optResult;
                 },
                 APIResult: APIResultValues,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
@@ -47,7 +47,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -117,16 +116,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
@@ -67,7 +67,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -137,16 +136,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
@@ -48,7 +48,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -118,16 +117,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
@@ -98,7 +98,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -169,16 +168,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -93,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -207,7 +196,6 @@ export async function createInstantiator(options, swift) {
                     }
                     arrayResult.reverse();
                     let ret = imports.roundtrip(arrayResult);
-                    const arrayCleanups = [];
                     for (const elem of ret) {
                         i32Stack.push((elem | 0));
                     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -93,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -93,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -93,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -93,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -93,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -93,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
@@ -34,7 +34,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -50,13 +49,11 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Success, cleanup };
+                        return APIResultValues.Tag.Success;
                     }
                     case APIResultValues.Tag.Failure: {
                         i32Stack.push((value.param0 | 0));
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Failure, cleanup };
+                        return APIResultValues.Tag.Failure;
                     }
                     default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
                 }
@@ -141,16 +138,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -335,10 +322,9 @@ export async function createInstantiator(options, swift) {
                 APIResult: {
                     ...APIResultValues,
                     roundtrip: function(value) {
-                        const { caseId: valueCaseId, cleanup: valueCleanup } = enumHelpers.APIResult.lower(value);
+                        const valueCaseId = enumHelpers.APIResult.lower(value);
                         instance.exports.bjs_APIResult_static_roundtrip(valueCaseId);
                         const ret = enumHelpers.APIResult.lift(i32Stack.pop());
-                        if (valueCleanup) { valueCleanup(); }
                         return ret;
                     }
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
@@ -28,7 +28,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,16 +97,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
@@ -28,7 +28,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,16 +97,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -53,7 +53,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,32 +93,26 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Success, cleanup };
+                        return APIResultValues.Tag.Success;
                     }
                     case APIResultValues.Tag.Failure: {
                         i32Stack.push((value.param0 | 0));
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Failure, cleanup };
+                        return APIResultValues.Tag.Failure;
                     }
                     case APIResultValues.Tag.Flag: {
                         i32Stack.push(value.param0 ? 1 : 0);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Flag, cleanup };
+                        return APIResultValues.Tag.Flag;
                     }
                     case APIResultValues.Tag.Rate: {
                         f32Stack.push(Math.fround(value.param0));
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Rate, cleanup };
+                        return APIResultValues.Tag.Rate;
                     }
                     case APIResultValues.Tag.Precise: {
                         f64Stack.push(value.param0);
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Precise, cleanup };
+                        return APIResultValues.Tag.Precise;
                     }
                     case APIResultValues.Tag.Info: {
-                        const cleanup = undefined;
-                        return { caseId: APIResultValues.Tag.Info, cleanup };
+                        return APIResultValues.Tag.Info;
                     }
                     default: throw new Error("Unknown APIResultValues tag: " + String(enumTag));
                 }
@@ -217,16 +210,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -403,7 +386,7 @@ export async function createInstantiator(options, swift) {
                     const callback = swift.memory.getObject(callbackId);
                     const enumValue = enumHelpers.APIResult.lift(param0);
                     let ret = callback(enumValue);
-                    const { caseId: caseId, cleanup: cleanup } = enumHelpers.APIResult.lower(ret);
+                    const caseId = enumHelpers.APIResult.lower(ret);
                     return caseId;
                 } catch (error) {
                     setException(error);
@@ -411,10 +394,9 @@ export async function createInstantiator(options, swift) {
             }
             bjs["make_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO"] = function(boxPtr, file, line) {
                 const lower_closure_TestModule_10TestModule9APIResultO_9APIResultO = function(param0) {
-                    const { caseId: param0CaseId, cleanup: param0Cleanup } = enumHelpers.APIResult.lower(param0);
+                    const param0CaseId = enumHelpers.APIResult.lower(param0);
                     instance.exports.invoke_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO(boxPtr, param0CaseId);
                     const ret = enumHelpers.APIResult.lift(i32Stack.pop());
-                    if (param0Cleanup) { param0Cleanup(); }
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -672,7 +654,7 @@ export async function createInstantiator(options, swift) {
                     let ret = callback(param0IsSome ? enumValue : null);
                     const isSome = ret != null;
                     if (isSome) {
-                        const { caseId: caseId, cleanup: cleanup } = enumHelpers.APIResult.lower(ret);
+                        const caseId = enumHelpers.APIResult.lower(ret);
                         return caseId;
                     } else {
                         return -1;
@@ -684,11 +666,9 @@ export async function createInstantiator(options, swift) {
             bjs["make_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO"] = function(boxPtr, file, line) {
                 const lower_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO = function(param0) {
                     const isSome = param0 != null;
-                    let param0CaseId, param0Cleanup;
+                    let param0CaseId;
                     if (isSome) {
-                        const enumResult = enumHelpers.APIResult.lower(param0);
-                        param0CaseId = enumResult.caseId;
-                        param0Cleanup = enumResult.cleanup;
+                        param0CaseId = enumHelpers.APIResult.lower(param0);
                     }
                     instance.exports.invoke_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO(boxPtr, +isSome, isSome ? param0CaseId : 0);
                     const tag = i32Stack.pop();
@@ -699,7 +679,6 @@ export async function createInstantiator(options, swift) {
                     } else {
                         optResult = enumHelpers.APIResult.lift(tag);
                     }
-                    if (param0Cleanup) { param0Cleanup(); }
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -119,16 +118,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
@@ -28,7 +28,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -57,7 +56,6 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(0);
                 }
                 i32Stack.push(isSome1 ? 1 : 0);
-                return { cleanup: undefined };
             },
             lift: () => {
                 const isSome = i32Stack.pop();
@@ -101,7 +99,6 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(0);
                 }
                 i32Stack.push(isSome ? 1 : 0);
-                return { cleanup: undefined };
             },
             lift: () => {
                 const isSome = i32Stack.pop();
@@ -126,7 +123,7 @@ export async function createInstantiator(options, swift) {
                 i32Stack.push(bytes.length);
                 i32Stack.push(id);
                 i32Stack.push((value.age | 0));
-                const structResult = structHelpers.Address.lower(value.address);
+                structHelpers.Address.lower(value.address);
                 const isSome = value.email != null;
                 let id1;
                 if (isSome) {
@@ -139,10 +136,6 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(0);
                 }
                 i32Stack.push(isSome ? 1 : 0);
-                const cleanup = () => {
-                    if (structResult.cleanup) { structResult.cleanup(); }
-                };
-                return { cleanup };
             },
             lift: () => {
                 const isSome = i32Stack.pop();
@@ -165,7 +158,6 @@ export async function createInstantiator(options, swift) {
             lower: (value) => {
                 i32Stack.push((value.id | 0));
                 ptrStack.push(value.owner.pointer);
-                return { cleanup: undefined };
             },
             lift: () => {
                 const ptr = ptrStack.pop();
@@ -187,7 +179,6 @@ export async function createInstantiator(options, swift) {
                     f32Stack.push(0.0);
                 }
                 i32Stack.push(isSome ? 1 : 0);
-                return { cleanup: undefined };
             },
             lift: () => {
                 const isSome = i32Stack.pop();
@@ -207,7 +198,6 @@ export async function createInstantiator(options, swift) {
     const __bjs_createConfigStructHelpers = () => {
         return () => ({
             lower: (value) => {
-                return { cleanup: undefined };
             },
             lift: () => {
                 return {  };
@@ -234,7 +224,6 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(0);
                 }
                 i32Stack.push(isSome ? 1 : 0);
-                return { cleanup: undefined };
             },
             lift: () => {
                 const isSome = i32Stack.pop();
@@ -329,88 +318,50 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
             }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
-            }
             bjs["swift_js_struct_lower_DataPoint"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.DataPoint.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.DataPoint.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_DataPoint"] = function() {
                 const value = structHelpers.DataPoint.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Address"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Address.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Address.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Address"] = function() {
                 const value = structHelpers.Address.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Person"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Person.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Person.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Person"] = function() {
                 const value = structHelpers.Person.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Session"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Session.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Session.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Session"] = function() {
                 const value = structHelpers.Session.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Measurement"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Measurement.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Measurement.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Measurement"] = function() {
                 const value = structHelpers.Measurement.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_ConfigStruct"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.ConfigStruct.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.ConfigStruct.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_ConfigStruct"] = function() {
                 const value = structHelpers.ConfigStruct.lift();
                 return swift.memory.retain(value);
             }
             bjs["swift_js_struct_lower_Container"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Container.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Container.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Container"] = function() {
                 const value = structHelpers.Container.lift();
@@ -609,17 +560,15 @@ export async function createInstantiator(options, swift) {
             const exports = {
                 Greeter,
                 roundtrip: function bjs_roundtrip(session) {
-                    const { cleanup: cleanup } = structHelpers.Person.lower(session);
+                    structHelpers.Person.lower(session);
                     instance.exports.bjs_roundtrip();
                     const structValue = structHelpers.Person.lift();
-                    if (cleanup) { cleanup(); }
                     return structValue;
                 },
                 roundtripContainer: function bjs_roundtripContainer(container) {
-                    const { cleanup: cleanup } = structHelpers.Container.lower(container);
+                    structHelpers.Container.lower(container);
                     instance.exports.bjs_roundtripContainer();
                     const structValue = structHelpers.Container.lift();
-                    if (cleanup) { cleanup(); }
                     return structValue;
                 },
                 Precision: PrecisionValues,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -34,7 +33,6 @@ export async function createInstantiator(options, swift) {
             lower: (value) => {
                 i32Stack.push((value.x | 0));
                 i32Stack.push((value.y | 0));
-                return { cleanup: undefined };
             },
             lift: () => {
                 const int = i32Stack.pop();
@@ -109,22 +107,8 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
             }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
-            }
             bjs["swift_js_struct_lower_Point"] = function(objectId) {
-                const { cleanup: cleanup } = structHelpers.Point.lower(swift.memory.getObject(objectId));
-                if (cleanup) {
-                    return tmpStructCleanups.push(cleanup);
-                }
-                return 0;
+                structHelpers.Point.lower(swift.memory.getObject(objectId));
             }
             bjs["swift_js_struct_lift_Point"] = function() {
                 const value = structHelpers.Point.lift();

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -93,16 +92,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
@@ -23,7 +23,6 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
-    let tmpStructCleanups = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -94,16 +93,6 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_pointer"] = function() {
                 return ptrStack.pop();
-            }
-            bjs["swift_js_struct_cleanup"] = function(cleanupId) {
-                if (cleanupId === 0) { return; }
-                const index = (cleanupId | 0) - 1;
-                const cleanup = tmpStructCleanups[index];
-                tmpStructCleanups[index] = null;
-                if (cleanup) { cleanup(); }
-                while (tmpStructCleanups.length > 0 && tmpStructCleanups[tmpStructCleanups.length - 1] == null) {
-                    tmpStructCleanups.pop();
-                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/PackageToJS/Templates/instantiate.js
+++ b/Plugins/PackageToJS/Templates/instantiate.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { SwiftRuntime } from "./runtime.js"
+import { SwiftRuntime } from "./runtime.js";
 
 export const MODULE_PATH = "@PACKAGE_TO_JS_MODULE_PATH@";
 /* #if USE_SHARED_MEMORY */
@@ -10,12 +10,12 @@ export const MEMORY_TYPE = {
     maximum: import.meta.PACKAGE_TO_JS_MEMORY_MAXIMUM,
     // @ts-expect-error Substituted by PackageToJS preprocessor
     shared: import.meta.PACKAGE_TO_JS_MEMORY_SHARED,
-}
+};
 /* #endif */
 
 /* #if HAS_BRIDGE */
 // @ts-expect-error Substituted by PackageToJS preprocessor
-import { createInstantiator } from "./bridge-js.js"
+import { createInstantiator } from "./bridge-js.js";
 /* #else */
 /**
  * @param {import('./instantiate.d').InstantiateOptions} options
@@ -30,7 +30,9 @@ async function createInstantiator(options, swift) {
         addImports: (importObject, importsContext) => {
             // Provide a default implementation for BridgeJS functions that are not
             // used at runtime without BridgeJS but required to instantiate the module.
-            const unexpectedBjsCall = () => { throw new Error("Unexpected call to BridgeJS function") }
+            const unexpectedBjsCall = () => {
+                throw new Error("Unexpected call to BridgeJS function");
+            };
             importObject["bjs"] = {
                 swift_js_return_string: unexpectedBjsCall,
                 swift_js_init_memory: unexpectedBjsCall,
@@ -63,9 +65,8 @@ async function createInstantiator(options, swift) {
                 swift_js_get_optional_heap_object_pointer: unexpectedBjsCall,
                 swift_js_push_pointer: unexpectedBjsCall,
                 swift_js_pop_pointer: unexpectedBjsCall,
-                swift_js_struct_cleanup: unexpectedBjsCall,
                 swift_js_closure_unregister: unexpectedBjsCall,
-            }
+            };
         },
         /** @param {WebAssembly.Instance} instance */
         setInstance: (instance) => {},
@@ -73,67 +74,65 @@ async function createInstantiator(options, swift) {
         createExports: (instance) => {
             return {};
         },
-    }
+    };
 }
 /* #endif */
 
 /** @type {import('./instantiate.d').instantiate} */
-export async function instantiate(
-    options
-) {
+export async function instantiate(options) {
     const result = await _instantiate(options);
-/* #if IS_WASI */
+    /* #if IS_WASI */
     options.wasi.initialize(result.instance);
-/* #endif */
+    /* #endif */
     result.swift.main();
     return result;
 }
 
 /** @type {import('./instantiate.d').instantiateForThread} */
-export async function instantiateForThread(
-    tid, startArg, options
-) {
+export async function instantiateForThread(tid, startArg, options) {
     const result = await _instantiate(options);
-/* #if IS_WASI */
+    /* #if IS_WASI */
     options.wasi.setInstance(result.instance);
-/* #endif */
-    result.swift.startThread(tid, startArg)
+    /* #endif */
+    result.swift.startThread(tid, startArg);
     return result;
 }
 
 /** @type {import('./instantiate.d').instantiate} */
-async function _instantiate(
-    options
-) {
+async function _instantiate(options) {
     const _WebAssembly = options.WebAssembly || WebAssembly;
     const moduleSource = options.module;
-/* #if IS_WASI */
+    /* #if IS_WASI */
     const { wasi } = options;
-/* #endif */
+    /* #endif */
     const swift = new SwiftRuntime({
-/* #if USE_SHARED_MEMORY */
+        /* #if USE_SHARED_MEMORY */
         sharedMemory: true,
         threadChannel: options.threadChannel,
-/* #endif */
+        /* #endif */
     });
     const instantiator = await createInstantiator(options, swift);
 
     /** @type {WebAssembly.Imports} */
     const importObject = {
         javascript_kit: swift.wasmImports,
-/* #if IS_WASI */
+        /* #if IS_WASI */
         wasi_snapshot_preview1: wasi.wasiImport,
-/* #if USE_SHARED_MEMORY */
+        /* #if USE_SHARED_MEMORY */
         env: {
             memory: options.memory,
         },
         wasi: {
             "thread-spawn": (startArg) => {
-                return options.threadChannel.spawnThread(module, options.memory, startArg);
-            }
-        }
-/* #endif */
-/* #endif */
+                return options.threadChannel.spawnThread(
+                    module,
+                    options.memory,
+                    startArg,
+                );
+            },
+        },
+        /* #endif */
+        /* #endif */
     };
     const importsContext = {
         getInstance: () => instance,
@@ -149,9 +148,15 @@ async function _instantiate(
     if (moduleSource instanceof _WebAssembly.Module) {
         module = moduleSource;
         instance = await _WebAssembly.instantiate(module, importObject);
-    } else if (typeof Response === "function" && (moduleSource instanceof Response || moduleSource instanceof Promise)) {
+    } else if (
+        typeof Response === "function" &&
+        (moduleSource instanceof Response || moduleSource instanceof Promise)
+    ) {
         if (typeof _WebAssembly.instantiateStreaming === "function") {
-            const result = await _WebAssembly.instantiateStreaming(moduleSource, importObject);
+            const result = await _WebAssembly.instantiateStreaming(
+                moduleSource,
+                importObject,
+            );
             module = result.module;
             instance = result.instance;
         } else {
@@ -164,7 +169,8 @@ async function _instantiate(
         module = await _WebAssembly.compile(moduleSource);
         instance = await _WebAssembly.instantiate(module, importObject);
     }
-    instance = options.instrumentInstance?.(instance, { _swift: swift }) ?? instance;
+    instance =
+        options.instrumentInstance?.(instance, { _swift: swift }) ?? instance;
 
     swift.setInstance(instance);
     instantiator.setInstance(instance);
@@ -174,5 +180,5 @@ async function _instantiate(
         instance,
         swift,
         exports,
-    }
+    };
 }

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -818,21 +818,6 @@ private func _swift_js_pop_f64_extern() -> Float64 {
     _swift_js_pop_f64_extern()
 }
 
-// MARK: Struct bridging helpers (JS-side lowering/raising)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_cleanup")
-private func _swift_js_struct_cleanup_extern(_ cleanupId: Int32)
-#else
-private func _swift_js_struct_cleanup_extern(_ cleanupId: Int32) {
-    _onlyAvailableOnWasm()
-}
-#endif
-
-@_spi(BridgeJS) @inline(never) public func _swift_js_struct_cleanup(_ cleanupId: Int32) {
-    _swift_js_struct_cleanup_extern(cleanupId)
-}
-
 // MARK: Wasm externs used by type lowering/lifting
 
 #if arch(wasm32)

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -2720,10 +2720,7 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -2736,9 +2733,9 @@ extension Point: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2771,10 +2768,7 @@ extension PointerFields: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_PointerFields(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_PointerFields(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -2787,9 +2781,9 @@ extension PointerFields: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PointerFields")
-fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2841,10 +2835,7 @@ extension DataPoint: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_DataPoint(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_DataPoint(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -2857,9 +2848,9 @@ extension DataPoint: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_DataPoint")
-fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2897,10 +2888,7 @@ extension PublicPoint: _BridgedSwiftStruct {
     }
 
     public init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_PublicPoint(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_PublicPoint(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -2913,9 +2901,9 @@ extension PublicPoint: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PublicPoint")
-fileprivate func _bjs_struct_lower_PublicPoint(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_PublicPoint(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PublicPoint(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_PublicPoint(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -2959,10 +2947,7 @@ extension Address: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -2975,9 +2960,9 @@ extension Address: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Address")
-fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3014,10 +2999,7 @@ extension Contact: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Contact(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Contact(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3030,9 +3012,9 @@ extension Contact: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Contact")
-fileprivate func _bjs_struct_lower_Contact(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Contact(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Contact(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Contact(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3071,10 +3053,7 @@ extension Config: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_Config(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_Config(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3087,9 +3066,9 @@ extension Config: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Config")
-fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3120,10 +3099,7 @@ extension SessionData: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_SessionData(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_SessionData(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3136,9 +3112,9 @@ extension SessionData: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_SessionData")
-fileprivate func _bjs_struct_lower_SessionData(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_SessionData(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_SessionData(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_SessionData(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3177,10 +3153,7 @@ extension ValidationReport: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_ValidationReport(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_ValidationReport(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3193,9 +3166,9 @@ extension ValidationReport: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ValidationReport")
-fileprivate func _bjs_struct_lower_ValidationReport(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_ValidationReport(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ValidationReport(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_ValidationReport(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3246,10 +3219,7 @@ extension AdvancedConfig: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_AdvancedConfig(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_AdvancedConfig(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3262,9 +3232,9 @@ extension AdvancedConfig: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_AdvancedConfig")
-fileprivate func _bjs_struct_lower_AdvancedConfig(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_AdvancedConfig(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_AdvancedConfig(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_AdvancedConfig(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3303,10 +3273,7 @@ extension MeasurementConfig: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_MeasurementConfig(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_MeasurementConfig(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3319,9 +3286,9 @@ extension MeasurementConfig: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_MeasurementConfig")
-fileprivate func _bjs_struct_lower_MeasurementConfig(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_MeasurementConfig(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_MeasurementConfig(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_MeasurementConfig(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3346,10 +3313,7 @@ extension MathOperations: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_MathOperations(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_MathOperations(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3362,9 +3326,9 @@ extension MathOperations: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_MathOperations")
-fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3439,10 +3403,7 @@ extension CopyableCart: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_CopyableCart(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_CopyableCart(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3455,9 +3416,9 @@ extension CopyableCart: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_CopyableCart")
-fileprivate func _bjs_struct_lower_CopyableCart(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_CopyableCart(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_CopyableCart(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_CopyableCart(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3495,10 +3456,7 @@ extension CopyableCartItem: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_CopyableCartItem(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_CopyableCartItem(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3511,9 +3469,9 @@ extension CopyableCartItem: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_CopyableCartItem")
-fileprivate func _bjs_struct_lower_CopyableCartItem(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_CopyableCartItem(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_CopyableCartItem(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_CopyableCartItem(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3542,10 +3500,7 @@ extension CopyableNestedCart: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_CopyableNestedCart(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_CopyableNestedCart(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3558,9 +3513,9 @@ extension CopyableNestedCart: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_CopyableNestedCart")
-fileprivate func _bjs_struct_lower_CopyableNestedCart(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_CopyableNestedCart(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_CopyableNestedCart(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_CopyableNestedCart(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3598,10 +3553,7 @@ extension ConfigStruct: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_ConfigStruct(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_ConfigStruct(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3614,9 +3566,9 @@ extension ConfigStruct: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ConfigStruct")
-fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3711,10 +3663,7 @@ extension JSObjectContainer: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_JSObjectContainer(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_JSObjectContainer(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3727,9 +3676,9 @@ extension JSObjectContainer: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_JSObjectContainer")
-fileprivate func _bjs_struct_lower_JSObjectContainer(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_JSObjectContainer(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_JSObjectContainer(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_JSObjectContainer(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3760,10 +3709,7 @@ extension FooContainer: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_FooContainer(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_FooContainer(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3776,9 +3722,9 @@ extension FooContainer: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_FooContainer")
-fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
@@ -3805,10 +3751,7 @@ extension ArrayMembers: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        let __bjs_cleanupId = _bjs_struct_lower_ArrayMembers(jsObject.bridgeJSLowerParameter())
-        defer {
-            _swift_js_struct_cleanup(__bjs_cleanupId)
-        }
+        _bjs_struct_lower_ArrayMembers(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
@@ -3821,9 +3764,9 @@ extension ArrayMembers: _BridgedSwiftStruct {
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ArrayMembers")
-fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Int32
+fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Int32 {
+fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif


### PR DESCRIPTION
## Overview

As discussed recently, we're not going with the type descriptor approach from #622. Instead, splitting the improvements into targeted PRs, as #622 even after the cleanup is a bit too much, as most likely we don't want to include all changes (even after the cleanup), so this approach should work better.
This is the first one - removing cleanup infrastructure that became dead code after #635 and #636.

## What changed

After #635 (string lower no longer needs cleanup) and #636 (fixed JSObject? double-release in struct lowering), no type produces cleanup code at runtime. This PR removes all of it:

- `cleanupCode` printer field from `IntrinsicJSFragment.PrintCodeContext`
- `tmpStructCleanups` array and `swift_js_struct_cleanup` BJS handler from generated JS
- `_swift_js_struct_cleanup` extern and wrapper from `BridgeJSIntrinsics.swift`
- `swift_js_struct_cleanup` stub from `instantiate.js`
- Struct helper `lower()` no longer returns `{ cleanup }` - just pushes fields to stacks
- Enum helper `lower()` returns caseId directly instead of `{ caseId, cleanup }`
- Struct/enum helper factory collapse: `() => { return () => ({...}); }` simplified to `() => ({...})`; call-site `()()` becomes `()`
- `init(unsafelyCopying:)` no longer calls struct cleanup; lower extern returns `Void` instead of `Int32`
- `strStack.push(textDecoder.decode(bytes))` inlined (removed intermediate variable)
