### PR TITLE
relax swift-syntax version constraint to allow 603

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,8 @@ jobs:
             swift-syntax-version: "601.0.0"
           - image: "swift:6.2"
             swift-syntax-version: "602.0.0"
+          - image: "swift:6.3"
+            swift-syntax-version: "603.0.0"
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.entry.image }}

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
     ],
     traits: [tracingTrait],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"603.0.0")
+        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"604.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION

Packages are updating to 603 and this can fail the dependency solver.