### PR TITLE
BridgeJS: Emit static methods and properties on namespaced class entries

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -433,7 +433,11 @@ public class ExportSwift {
             switch self {
             case .enumStatic(let enumDef):
                 return property.callName(prefix: enumDef.swiftCallName)
-            case .classStatic, .classInstance:
+            case .classStatic(let klass):
+                // property.callName() would use staticContext (the ABI name) as prefix;
+                // use swiftCallName directly so the emitted expression is valid Swift.
+                return "\(klass.swiftCallName).\(property.name)"
+            case .classInstance:
                 return property.callName()
             case .structStatic(let structDef):
                 return property.callName(prefix: structDef.swiftCallName)

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -901,6 +901,19 @@ public struct BridgeJSLink {
                                 "new\(self.renderTSSignature(parameters: constructor.parameters, returnType: .swiftHeapObject(klass.name), effects: constructor.effects));"
                             )
                         }
+                        // Static methods and static properties belong on the namespace
+                        // entry alongside the constructor (same shape that
+                        // `renderExportedClass` produces for non-namespaced classes via
+                        // `dtsExportEntryPrinter`).
+                        for method in klass.methods where method.effects.isStatic {
+                            printer.write(
+                                "\(method.name)\(self.renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
+                            )
+                        }
+                        for property in klass.properties where property.isStatic {
+                            let readonly = property.isReadonly ? "readonly " : ""
+                            printer.write("\(readonly)\(property.name): \(property.type.tsType);")
+                        }
                     }
                     printer.write("}")
                     return printer.lines

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -130,6 +130,7 @@ public struct BridgeJSLink {
         var classLines: [String] = []
         var dtsExportLines: [String] = []
         var dtsClassLines: [String] = []
+        var namespacedClassDtsExportEntries: [String: [String]] = [:]
         var topLevelTypeLines: [String] = []
         var topLevelDtsTypeLines: [String] = []
         var importObjectBuilders: [ImportObjectBuilder] = []
@@ -161,13 +162,14 @@ public struct BridgeJSLink {
             for klass in skeleton.classes {
                 let (jsType, dtsType, dtsExportEntry) = try renderExportedClass(klass)
                 data.classLines.append(contentsOf: jsType)
+                data.dtsClassLines.append(contentsOf: dtsType)
 
                 if klass.namespace == nil {
                     data.exportsLines.append("\(klass.name),")
                     data.dtsExportLines.append(contentsOf: dtsExportEntry)
+                } else {
+                    data.namespacedClassDtsExportEntries[klass.name] = dtsExportEntry
                 }
-
-                data.dtsClassLines.append(contentsOf: dtsType)
             }
 
             // Process enums - collect top-level definitions and export entries
@@ -796,7 +798,7 @@ public struct BridgeJSLink {
         return printer.lines
     }
 
-    private func generateTypeScript(data: LinkData) throws -> String {
+    private func generateTypeScript(data: LinkData) -> String {
         let header = """
             // NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
             // DO NOT EDIT.
@@ -884,11 +886,10 @@ public struct BridgeJSLink {
         printer.write(lines: generateImportedTypeDefinitions())
 
         // Exports type
-        let hierarchicalExportLines = try namespaceBuilder.buildHierarchicalExportsType(
+        let hierarchicalExportLines = namespaceBuilder.buildHierarchicalExportsType(
             exportedSkeletons: exportedSkeletons,
             renderClassEntry: { klass in
-                let (_, _, dtsExportEntry) = try self.renderExportedClass(klass)
-                return dtsExportEntry
+                data.namespacedClassDtsExportEntries[klass.name] ?? []
             },
             renderFunctionSignature: { function in
                 "\(function.name)\(self.renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
@@ -1095,7 +1096,7 @@ public struct BridgeJSLink {
         }
         let data = try collectLinkData()
         let outputJs = try generateJavaScript(data: data)
-        let outputDts = try generateTypeScript(data: data)
+        let outputDts = generateTypeScript(data: data)
         return (outputJs, outputDts)
     }
 
@@ -2647,16 +2648,16 @@ extension BridgeJSLink {
 
         fileprivate func buildHierarchicalExportsType(
             exportedSkeletons: [ExportedSkeleton],
-            renderClassEntry: (ExportedClass) throws -> [String],
+            renderClassEntry: (ExportedClass) -> [String],
             renderFunctionSignature: (ExportedFunction) -> String
-        ) throws -> [String] {
+        ) -> [String] {
             let printer = CodeFragmentPrinter()
             let rootNode = NamespaceNode(name: "")
 
             buildExportsTree(rootNode: rootNode, exportedSkeletons: exportedSkeletons)
 
             for (_, node) in rootNode.children {
-                try populateTypeScriptExportLines(
+                populateTypeScriptExportLines(
                     node: node,
                     renderClassEntry: renderClassEntry,
                     renderFunctionSignature: renderFunctionSignature
@@ -2670,16 +2671,16 @@ extension BridgeJSLink {
 
         private func populateTypeScriptExportLines(
             node: NamespaceNode,
-            renderClassEntry: (ExportedClass) throws -> [String],
+            renderClassEntry: (ExportedClass) -> [String],
             renderFunctionSignature: (ExportedFunction) -> String
-        ) throws {
+        ) {
             for function in node.content.functions {
                 let signature = renderFunctionSignature(function)
                 node.content.functionDtsLines.append((function.name, [signature]))
             }
 
             for klass in node.content.classes {
-                let entry = try renderClassEntry(klass)
+                let entry = renderClassEntry(klass)
                 node.content.classDtsLines.append((klass.name, entry))
             }
 
@@ -2688,7 +2689,7 @@ extension BridgeJSLink {
             }
 
             for (_, childNode) in node.children {
-                try populateTypeScriptExportLines(
+                populateTypeScriptExportLines(
                     node: childNode,
                     renderClassEntry: renderClassEntry,
                     renderFunctionSignature: renderFunctionSignature

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -796,7 +796,7 @@ public struct BridgeJSLink {
         return printer.lines
     }
 
-    private func generateTypeScript(data: LinkData) -> String {
+    private func generateTypeScript(data: LinkData) throws -> String {
         let header = """
             // NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
             // DO NOT EDIT.
@@ -884,45 +884,22 @@ public struct BridgeJSLink {
         printer.write(lines: generateImportedTypeDefinitions())
 
         // Exports type
+        let hierarchicalExportLines = try namespaceBuilder.buildHierarchicalExportsType(
+            exportedSkeletons: exportedSkeletons,
+            renderClassEntry: { klass in
+                let (_, _, dtsExportEntry) = try self.renderExportedClass(klass)
+                return dtsExportEntry
+            },
+            renderFunctionSignature: { function in
+                "\(function.name)\(self.renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
+            }
+        )
         printer.write("export type Exports = {")
         printer.indent {
             // Add non-namespaced items
             printer.write(lines: data.dtsExportLines)
-
             // Add hierarchical namespaced items
-            let hierarchicalLines = namespaceBuilder.buildHierarchicalExportsType(
-                exportedSkeletons: exportedSkeletons,
-                renderClassEntry: { klass in
-                    let printer = CodeFragmentPrinter()
-                    printer.write("\(klass.name): {")
-                    printer.indent {
-                        if let constructor = klass.constructor {
-                            printer.write(
-                                "new\(self.renderTSSignature(parameters: constructor.parameters, returnType: .swiftHeapObject(klass.name), effects: constructor.effects));"
-                            )
-                        }
-                        // Static methods and static properties belong on the namespace
-                        // entry alongside the constructor (same shape that
-                        // `renderExportedClass` produces for non-namespaced classes via
-                        // `dtsExportEntryPrinter`).
-                        for method in klass.methods where method.effects.isStatic {
-                            printer.write(
-                                "\(method.name)\(self.renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
-                            )
-                        }
-                        for property in klass.properties where property.isStatic {
-                            let readonly = property.isReadonly ? "readonly " : ""
-                            printer.write("\(readonly)\(property.name): \(property.type.tsType);")
-                        }
-                    }
-                    printer.write("}")
-                    return printer.lines
-                },
-                renderFunctionSignature: { function in
-                    "\(function.name)\(self.renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
-                }
-            )
-            printer.write(lines: hierarchicalLines)
+            printer.write(lines: hierarchicalExportLines)
         }
         printer.write("}")
 
@@ -1118,7 +1095,7 @@ public struct BridgeJSLink {
         }
         let data = try collectLinkData()
         let outputJs = try generateJavaScript(data: data)
-        let outputDts = generateTypeScript(data: data)
+        let outputDts = try generateTypeScript(data: data)
         return (outputJs, outputDts)
     }
 
@@ -2670,16 +2647,16 @@ extension BridgeJSLink {
 
         fileprivate func buildHierarchicalExportsType(
             exportedSkeletons: [ExportedSkeleton],
-            renderClassEntry: (ExportedClass) -> [String],
+            renderClassEntry: (ExportedClass) throws -> [String],
             renderFunctionSignature: (ExportedFunction) -> String
-        ) -> [String] {
+        ) throws -> [String] {
             let printer = CodeFragmentPrinter()
             let rootNode = NamespaceNode(name: "")
 
             buildExportsTree(rootNode: rootNode, exportedSkeletons: exportedSkeletons)
 
             for (_, node) in rootNode.children {
-                populateTypeScriptExportLines(
+                try populateTypeScriptExportLines(
                     node: node,
                     renderClassEntry: renderClassEntry,
                     renderFunctionSignature: renderFunctionSignature
@@ -2693,16 +2670,16 @@ extension BridgeJSLink {
 
         private func populateTypeScriptExportLines(
             node: NamespaceNode,
-            renderClassEntry: (ExportedClass) -> [String],
+            renderClassEntry: (ExportedClass) throws -> [String],
             renderFunctionSignature: (ExportedFunction) -> String
-        ) {
+        ) throws {
             for function in node.content.functions {
                 let signature = renderFunctionSignature(function)
                 node.content.functionDtsLines.append((function.name, [signature]))
             }
 
             for klass in node.content.classes {
-                let entry = renderClassEntry(klass)
+                let entry = try renderClassEntry(klass)
                 node.content.classDtsLines.append((klass.name, entry))
             }
 
@@ -2711,7 +2688,7 @@ extension BridgeJSLink {
             }
 
             for (_, childNode) in node.children {
-                populateTypeScriptExportLines(
+                try populateTypeScriptExportLines(
                     node: childNode,
                     renderClassEntry: renderClassEntry,
                     renderFunctionSignature: renderFunctionSignature

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Namespaces.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Namespaces.swift
@@ -16,6 +16,17 @@
     func changeName(name: String) {
         self.name = name
     }
+
+    // Static methods and properties on a namespaced class must land on the
+    // class's namespace entry (alongside `new`), not on the instance
+    // interface and not silently dropped. Regression test for the
+    // `@JS(namespace:)` + `@JS static func` bug where the hierarchical
+    // exports builder only emitted the constructor.
+    @JS static func makeDefault() -> Greeter {
+        return Greeter(name: "World")
+    }
+
+    @JS static var defaultGreeting: String { "Hello, world!" }
 }
 
 @JS(namespace: "Utils.Converters") class Converter {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.Global.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.Global.json
@@ -38,6 +38,28 @@
 
               }
             }
+          },
+          {
+            "abiName" : "bjs___Swift_Foundation_Greeter_static_makeDefault",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "makeDefault",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "swiftHeapObject" : {
+                "_0" : "Greeter"
+              }
+            },
+            "staticContext" : {
+              "className" : {
+                "_0" : "__Swift_Foundation_Greeter"
+              }
+            }
           }
         ],
         "name" : "Greeter",
@@ -46,7 +68,21 @@
           "Foundation"
         ],
         "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : true,
+            "name" : "defaultGreeting",
+            "staticContext" : {
+              "className" : {
+                "_0" : "__Swift_Foundation_Greeter"
+              }
+            },
+            "type" : {
+              "string" : {
 
+              }
+            }
+          }
         ],
         "swiftCallName" : "Greeter"
       },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.Global.swift
@@ -42,6 +42,28 @@ public func _bjs___Swift_Foundation_Greeter_greet(_ _self: UnsafeMutableRawPoint
     #endif
 }
 
+@_expose(wasm, "bjs___Swift_Foundation_Greeter_static_makeDefault")
+@_cdecl("bjs___Swift_Foundation_Greeter_static_makeDefault")
+public func _bjs___Swift_Foundation_Greeter_static_makeDefault() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = Greeter.makeDefault()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs___Swift_Foundation_Greeter_static_defaultGreeting_get")
+@_cdecl("bjs___Swift_Foundation_Greeter_static_defaultGreeting_get")
+public func _bjs___Swift_Foundation_Greeter_static_defaultGreeting_get() -> Void {
+    #if arch(wasm32)
+    let ret = __Swift_Foundation_Greeter.defaultGreeting
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs___Swift_Foundation_Greeter_deinit")
 @_cdecl("bjs___Swift_Foundation_Greeter_deinit")
 public func _bjs___Swift_Foundation_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.Global.swift
@@ -57,7 +57,7 @@ public func _bjs___Swift_Foundation_Greeter_static_makeDefault() -> UnsafeMutabl
 @_cdecl("bjs___Swift_Foundation_Greeter_static_defaultGreeting_get")
 public func _bjs___Swift_Foundation_Greeter_static_defaultGreeting_get() -> Void {
     #if arch(wasm32)
-    let ret = __Swift_Foundation_Greeter.defaultGreeting
+    let ret = Greeter.defaultGreeting
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.json
@@ -38,6 +38,28 @@
 
               }
             }
+          },
+          {
+            "abiName" : "bjs___Swift_Foundation_Greeter_static_makeDefault",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "makeDefault",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "swiftHeapObject" : {
+                "_0" : "Greeter"
+              }
+            },
+            "staticContext" : {
+              "className" : {
+                "_0" : "__Swift_Foundation_Greeter"
+              }
+            }
           }
         ],
         "name" : "Greeter",
@@ -46,7 +68,21 @@
           "Foundation"
         ],
         "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : true,
+            "name" : "defaultGreeting",
+            "staticContext" : {
+              "className" : {
+                "_0" : "__Swift_Foundation_Greeter"
+              }
+            },
+            "type" : {
+              "string" : {
 
+              }
+            }
+          }
         ],
         "swiftCallName" : "Greeter"
       },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.swift
@@ -42,6 +42,28 @@ public func _bjs___Swift_Foundation_Greeter_greet(_ _self: UnsafeMutableRawPoint
     #endif
 }
 
+@_expose(wasm, "bjs___Swift_Foundation_Greeter_static_makeDefault")
+@_cdecl("bjs___Swift_Foundation_Greeter_static_makeDefault")
+public func _bjs___Swift_Foundation_Greeter_static_makeDefault() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = Greeter.makeDefault()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs___Swift_Foundation_Greeter_static_defaultGreeting_get")
+@_cdecl("bjs___Swift_Foundation_Greeter_static_defaultGreeting_get")
+public func _bjs___Swift_Foundation_Greeter_static_defaultGreeting_get() -> Void {
+    #if arch(wasm32)
+    let ret = __Swift_Foundation_Greeter.defaultGreeting
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs___Swift_Foundation_Greeter_deinit")
 @_cdecl("bjs___Swift_Foundation_Greeter_deinit")
 public func _bjs___Swift_Foundation_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.swift
@@ -57,7 +57,7 @@ public func _bjs___Swift_Foundation_Greeter_static_makeDefault() -> UnsafeMutabl
 @_cdecl("bjs___Swift_Foundation_Greeter_static_defaultGreeting_get")
 public func _bjs___Swift_Foundation_Greeter_static_defaultGreeting_get() -> Void {
     #if arch(wasm32)
-    let ret = __Swift_Foundation_Greeter.defaultGreeting
+    let ret = Greeter.defaultGreeting
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.d.ts
@@ -34,6 +34,7 @@ declare global {
             class Greeter {
                 constructor(name: string);
                 greet(): string;
+                makeDefault(): Greeter;
                 release(): void;
             }
             class UUID {
@@ -87,6 +88,8 @@ export type Exports = {
         Foundation: {
             Greeter: {
                 new(name: string): Greeter;
+                makeDefault(): Greeter;
+                readonly defaultGreeting: string;
             }
             UUID: {
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
@@ -268,6 +268,16 @@ export async function createInstantiator(options, swift) {
                     tmpRetString = undefined;
                     return ret;
                 }
+                static makeDefault() {
+                    const ret = instance.exports.bjs___Swift_Foundation_Greeter_static_makeDefault();
+                    return Greeter.__construct(ret);
+                }
+                static get defaultGreeting() {
+                    instance.exports.bjs___Swift_Foundation_Greeter_static_defaultGreeting_get();
+                    const ret = tmpRetString;
+                    tmpRetString = undefined;
+                    return ret;
+                }
             }
             class Converter extends SwiftHeapObject {
                 static __construct(ptr) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.d.ts
@@ -47,6 +47,8 @@ export type Exports = {
         Foundation: {
             Greeter: {
                 new(name: string): Greeter;
+                makeDefault(): Greeter;
+                readonly defaultGreeting: string;
             }
             UUID: {
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
@@ -268,6 +268,16 @@ export async function createInstantiator(options, swift) {
                     tmpRetString = undefined;
                     return ret;
                 }
+                static makeDefault() {
+                    const ret = instance.exports.bjs___Swift_Foundation_Greeter_static_makeDefault();
+                    return Greeter.__construct(ret);
+                }
+                static get defaultGreeting() {
+                    instance.exports.bjs___Swift_Foundation_Greeter_static_defaultGreeting_get();
+                    const ret = tmpRetString;
+                    tmpRetString = undefined;
+                    return ret;
+                }
             }
             class Converter extends SwiftHeapObject {
                 static __construct(ptr) {

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -433,6 +433,12 @@ class UUID {
     @JS func uuidString() -> String {
         return value
     }
+
+    @JS static func fromValue(_ value: String) -> UUID {
+        return UUID(value: value)
+    }
+
+    @JS static var placeholder: String { "00000000-0000-0000-0000-000000000000" }
 }
 
 @JS func createUUID(value: String) -> UUID {

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -8617,7 +8617,7 @@ public func _bjs___Swift_Foundation_UUID_static_fromValue(_ valueBytes: Int32, _
 @_cdecl("bjs___Swift_Foundation_UUID_static_placeholder_get")
 public func _bjs___Swift_Foundation_UUID_static_placeholder_get() -> Void {
     #if arch(wasm32)
-    let ret = __Swift_Foundation_UUID.placeholder
+    let ret = UUID.placeholder
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -8602,6 +8602,28 @@ public func _bjs___Swift_Foundation_UUID_uuidString(_ _self: UnsafeMutableRawPoi
     #endif
 }
 
+@_expose(wasm, "bjs___Swift_Foundation_UUID_static_fromValue")
+@_cdecl("bjs___Swift_Foundation_UUID_static_fromValue")
+public func _bjs___Swift_Foundation_UUID_static_fromValue(_ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = UUID.fromValue(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs___Swift_Foundation_UUID_static_placeholder_get")
+@_cdecl("bjs___Swift_Foundation_UUID_static_placeholder_get")
+public func _bjs___Swift_Foundation_UUID_static_placeholder_get() -> Void {
+    #if arch(wasm32)
+    let ret = __Swift_Foundation_UUID.placeholder
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs___Swift_Foundation_UUID_deinit")
 @_cdecl("bjs___Swift_Foundation_UUID_deinit")
 public func _bjs___Swift_Foundation_UUID_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -1108,6 +1108,36 @@
 
               }
             }
+          },
+          {
+            "abiName" : "bjs___Swift_Foundation_UUID_static_fromValue",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "fromValue",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "swiftHeapObject" : {
+                "_0" : "UUID"
+              }
+            },
+            "staticContext" : {
+              "className" : {
+                "_0" : "__Swift_Foundation_UUID"
+              }
+            }
           }
         ],
         "name" : "UUID",
@@ -1116,7 +1146,21 @@
           "Foundation"
         ],
         "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : true,
+            "name" : "placeholder",
+            "staticContext" : {
+              "className" : {
+                "_0" : "__Swift_Foundation_UUID"
+              }
+            },
+            "type" : {
+              "string" : {
 
+              }
+            }
+          }
         ],
         "swiftCallName" : "UUID"
       },

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -624,8 +624,6 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     roundTrippedUUID.release();
     uuid.release();
 
-    // Static method and property on a namespaced class (@JS(namespace:) + @JS static).
-    // These must be callable via the namespace path, not as instance members.
     const uuidFromStatic = exports.__Swift.Foundation.UUID.fromValue("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
     assert.equal(uuidFromStatic.uuidString(), "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
     uuidFromStatic.release();

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -624,6 +624,13 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
     roundTrippedUUID.release();
     uuid.release();
 
+    // Static method and property on a namespaced class (@JS(namespace:) + @JS static).
+    // These must be callable via the namespace path, not as instance members.
+    const uuidFromStatic = exports.__Swift.Foundation.UUID.fromValue("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    assert.equal(uuidFromStatic.uuidString(), "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    uuidFromStatic.release();
+    assert.equal(exports.__Swift.Foundation.UUID.placeholder, "00000000-0000-0000-0000-000000000000");
+
     const createdServer = exports.createHTTPServer();
     createdServer.call(exports.Networking.API.Method.Get);
     createdServer.release();


### PR DESCRIPTION
## Overview

`@JS(namespace: …)` classes silently drop their `@JS static func` and `@JS static var` declarations from the generated `bridge-js.d.ts`. The JS runtime is unaffected (the class definition still has the static members and the namespace tree references it by symbol), but TypeScript consumers see an incomplete type and cannot call static factories through `typeof MyNamespace.MyClass` without a hand-written augmentation.

```typescript
// Before: static members are missing from the namespace entry
__Swift: {
    Foundation: {
        Greeter: {
            new(name: string): Greeter;
        }
    },
},

// After
__Swift: {
    Foundation: {
        Greeter: {
            new(name: string): Greeter;
            makeDefault(): Greeter;
            readonly defaultGreeting: string;
        }
    },
},
```

## Root cause

`BridgeJSLink.generateTypeScript` writes the `export type Exports` block using two different paths for classes:

1. **Non-namespaced classes** (`renderExportedClass` in `BridgeJSLink.swift`): builds `dtsExportEntry` by iterating `klass.methods.filter(\.effects.isStatic)` and the static subset of `klass.properties`. The produced entry is appended to `data.dtsExportLines` and includes constructor + static methods + static properties.
2. **Namespaced classes** (inline `renderClassEntry` closure inside `generateTypeScript`, passed to `NamespaceBuilder.buildHierarchicalExportsType`): only emitted the constructor. Static methods and static properties were completely ignored.

Because `renderExportedClass` is still called for every class (to produce the JS class body), the JS side has `static makeDefault()` etc. as expected, and the `createExports` namespace tree references the class symbol by name. That's why runtime calls to `exports.__Swift.Foundation.Greeter.makeDefault()` work even with a missing static declaration in `.d.ts`.

## Fix

Mirror the non-namespaced path inside the `renderClassEntry` closure so namespaced classes emit their statics alongside `new(...)`:

```swift
for method in klass.methods where method.effects.isStatic {
    printer.write(
        "\(method.name)\(self.renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
    )
}
for property in klass.properties where property.isStatic {
    let readonly = property.isReadonly ? "readonly " : ""
    printer.write("\(readonly)\(property.name): \(property.type.tsType);")
}
```

13 lines added to `BridgeJSLink.swift`, no other source changes.

## Regression coverage

**Snapshot tests (`Plugins/BridgeJS/Tests/`):**
`Namespaces.swift` already had two namespaced classes but none exercised static methods or properties. Extended `__Swift.Foundation.Greeter` with a static factory and a static readonly property. The `Namespaces.swift` and `Namespaces.Global.swift` snapshot sets now cover the fixed output across both the codegen and the linker test suites.

**E2E test (`Tests/BridgeJSRuntimeTests/`, `Tests/prelude.mjs`):**
Extended the existing `@JS(namespace: "__Swift.Foundation") class UUID` with `@JS static func fromValue(_:) -> UUID` and `@JS static var placeholder: String`, then added assertions in `prelude.mjs` that call both via `exports.__Swift.Foundation.UUID.fromValue(...)` and `exports.__Swift.Foundation.UUID.placeholder`. This proves the generated JavaScript routes calls to the correct static thunks at runtime, not just that the `.d.ts` types are well-formed.

## Follow-up: path consolidation

With the fix in place, the inline `renderClassEntry` closure became a duplicate of what `renderExportedClass` already returns as `dtsExportEntry`. A follow-up commit replaces the closure with a direct `renderExportedClass` call, discarding the JS and instance-interface outputs and keeping only `dtsExportEntry`. This makes both paths share a single source of truth and threads `throws` through `buildHierarchicalExportsType`, `populateTypeScriptExportLines`, and `generateTypeScript`.

## Verification

- `swift test --package-path ./Plugins/BridgeJS --disable-experimental-prebuilts` — 105/105 pass on the default swift-syntax (600.0.1).
- `BRIDGEJS_OVERRIDE_SWIFT_SYNTAX_VERSION=602.0.0 swift test --package-path ./Plugins/BridgeJS --disable-experimental-prebuilts` — 106/106 pass.
- `./Utilities/format.swift` — no additional diffs.
- `./Utilities/bridge-js-generate.sh` — AoT bindings updated for the new UUID static method and property added to the e2e test.
