### PR TITLE
BridgeJS: fix code generation for public enums

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -966,7 +966,7 @@ struct EnumCodegen {
             )
             printer.nextLine()
 
-            printer.write("private init?(bridgeJSRawValue: Int32) {")
+            printer.write("@_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {")
             printer.indent {
                 printer.write("switch bridgeJSRawValue {")
                 for (index, enumCase) in enumDef.cases.enumerated() {
@@ -984,7 +984,7 @@ struct EnumCodegen {
             printer.write("}")
             printer.nextLine()
 
-            printer.write("private var bridgeJSRawValue: Int32 {")
+            printer.write("@_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {")
             printer.indent {
                 printer.write("switch self {")
                 for (index, enumCase) in enumDef.cases.enumerated() {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
@@ -12,7 +12,7 @@ extension Direction: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .north
@@ -27,7 +27,7 @@ extension Direction: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .north:
             return 0

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.swift
@@ -12,7 +12,7 @@ extension Status: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .active
@@ -25,7 +25,7 @@ extension Status: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .active:
             return 0

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
@@ -203,7 +203,7 @@ extension CardinalDirection: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .north
@@ -218,7 +218,7 @@ extension CardinalDirection: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .north:
             return 0

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCase.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCase.swift
@@ -12,7 +12,7 @@ extension Direction: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .north
@@ -27,7 +27,7 @@ extension Direction: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .north:
             return 0
@@ -55,7 +55,7 @@ extension Status: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .loading
@@ -68,7 +68,7 @@ extension Status: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .loading:
             return 0
@@ -94,7 +94,7 @@ extension TSDirection: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .north
@@ -109,7 +109,7 @@ extension TSDirection: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .north:
             return 0
@@ -137,7 +137,7 @@ extension PublicStatus: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .success
@@ -146,7 +146,7 @@ extension PublicStatus: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .success:
             return 0

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.Global.swift
@@ -12,7 +12,7 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .get
@@ -27,7 +27,7 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .get:
             return 0
@@ -61,7 +61,7 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .get
@@ -72,7 +72,7 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .get:
             return 0

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.swift
@@ -12,7 +12,7 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .get
@@ -27,7 +27,7 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .get:
             return 0
@@ -61,7 +61,7 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .get
@@ -72,7 +72,7 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .get:
             return 0

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
@@ -633,7 +633,7 @@ extension Direction: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .north
@@ -648,7 +648,7 @@ extension Direction: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .north:
             return 0

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.Global.swift
@@ -12,7 +12,7 @@ extension Calculator: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .scientific
@@ -23,7 +23,7 @@ extension Calculator: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .scientific:
             return 0

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.swift
@@ -12,7 +12,7 @@ extension Calculator: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .scientific
@@ -23,7 +23,7 @@ extension Calculator: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .scientific:
             return 0

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.Global.swift
@@ -12,7 +12,7 @@ extension PropertyEnum: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .value1
@@ -23,7 +23,7 @@ extension PropertyEnum: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .value1:
             return 0

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.swift
@@ -12,7 +12,7 @@ extension PropertyEnum: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .value1
@@ -23,7 +23,7 @@ extension PropertyEnum: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .value1:
             return 0

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
@@ -1280,7 +1280,7 @@ extension Direction: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .north
@@ -1295,7 +1295,7 @@ extension Direction: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .north:
             return 0

--- a/Tests/BridgeJSGlobalTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSGlobalTests/Generated/BridgeJS.swift
@@ -21,7 +21,7 @@ extension GlobalNetworking.API.CallMethod: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .get
@@ -36,7 +36,7 @@ extension GlobalNetworking.API.CallMethod: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .get:
             return 0
@@ -70,7 +70,7 @@ extension Internal.SupportedServerMethod: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .get
@@ -81,7 +81,7 @@ extension Internal.SupportedServerMethod: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .get:
             return 0

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -207,7 +207,7 @@ extension Greeter {
 
 // MARK: - Enum Tests
 
-@JS enum Direction {
+@JS public enum Direction {
     case north
     case south
     case east

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -3868,7 +3868,7 @@ extension Direction: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .north
@@ -3883,7 +3883,7 @@ extension Direction: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .north:
             return 0
@@ -3911,7 +3911,7 @@ extension Status: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .loading
@@ -3924,7 +3924,7 @@ extension Status: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .loading:
             return 0
@@ -3968,7 +3968,7 @@ extension TSDirection: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .north
@@ -3983,7 +3983,7 @@ extension TSDirection: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .north:
             return 0
@@ -4036,7 +4036,7 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .get
@@ -4051,7 +4051,7 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .get:
             return 0
@@ -4085,7 +4085,7 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .get
@@ -4096,7 +4096,7 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .get:
             return 0
@@ -4369,7 +4369,7 @@ extension StaticCalculator: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .scientific
@@ -4380,7 +4380,7 @@ extension StaticCalculator: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .scientific:
             return 0
@@ -4470,7 +4470,7 @@ extension StaticPropertyEnum: _BridgedSwiftCaseEnum {
         return bridgeJSLowerParameter()
     }
 
-    private init?(bridgeJSRawValue: Int32) {
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
         switch bridgeJSRawValue {
         case 0:
             self = .option1
@@ -4481,7 +4481,7 @@ extension StaticPropertyEnum: _BridgedSwiftCaseEnum {
         }
     }
 
-    private var bridgeJSRawValue: Int32 {
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
         switch self {
         case .option1:
             return 0

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -7235,6 +7235,7 @@
           }
         ],
         "emitStyle" : "const",
+        "explicitAccessControl" : "public",
         "name" : "Direction",
         "staticMethods" : [
 


### PR DESCRIPTION
Currently, the generated code for a `public enum` will fail to compile since it is not possible to reference a `private` initialiser/property from a `@_transparent` function.