### PR TITLE
JavaScriptKit: import Android module for non-Wasm Android targets

### DIFF
--- a/Sources/JavaScriptKit/ThreadLocal.swift
+++ b/Sources/JavaScriptKit/ThreadLocal.swift
@@ -4,6 +4,8 @@ import wasi_pthread
 #endif
 #elseif canImport(Darwin)
 import Darwin
+#elseif canImport(Android)
+import Android
 #elseif canImport(Glibc)
 import Glibc
 #else


### PR DESCRIPTION
## Summary

Adds a `canImport(Android)` branch to `ThreadLocal.swift`'s platform-import conditional so JavaScriptKit compiles for the Swift 6.3 Android SDK.

## Problem

Building any JavaScriptKit consumer for an Android triple via the official [Swift SDK for Android](https://www.swift.org/documentation/articles/swift-sdk-for-android-getting-started.html) (`swift-6.3.1-RELEASE_android`) currently fails in `Sources/JavaScriptKit/ThreadLocal.swift`:

```
error: cannot find 'pthread_key_create' in scope
    pthread_key_create(&key, nil)
    ^
error: cannot find 'pthread_key_t' in scope
    var key = pthread_key_t()
              ^
error: 'nil' requires a contextual type
```

Android uses Bionic, which Swift exposes as the `Android` module — not `Glibc`. The existing conditional therefore falls through to `#error("Unsupported platform")` on Android triples.

### Reproduction

```bash
swift sdk install https://download.swift.org/swift-6.3.1-release/android-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_android.artifactbundle.tar.gz \
    --checksum 8193a4e96538635131a154736c8896fba0e5a1c30e065524f00ed78719bac35a

# From any package that depends on JavaScriptKit:
swift build --swift-sdk swift-6.3.1-RELEASE_android
```

## Fix

Insert a `canImport(Android)` branch between the Darwin and Glibc branches, matching the pattern used in Foundation (`swift-corelibs-foundation`) and swift-corelibs-libdispatch for the same pthread imports:

```swift
#elseif canImport(Darwin)
import Darwin
#elseif canImport(Android)
import Android
#elseif canImport(Glibc)
import Glibc
```

`ThreadLocal.swift` is the only file under `Sources/JavaScriptKit/` that has this conditional-import shape; all other Swift sources either are Wasm-gated already or don't reference libc. No behavior change on Wasm, Darwin, or Glibc targets — only the previously-unreachable Android branch is newly covered.

## Test plan

- [x] `swift build --swift-sdk swift-6.3.1-RELEASE_android` succeeds through the Swift-compile phase for a consumer package that uses `@JS` (tested on `x86_64-unknown-linux-android30`). Without the patch: fails with the errors above. With the patch: compiles cleanly.
- [x] `swift package --swift-sdk swift-6.3.1-RELEASE_wasm js` still produces byte-identical Wasm output for the same consumer (no Wasm regression).
- [ ] Darwin / Glibc builds — unchanged by the patch; existing CI covers these paths.

## Context

Part of enabling Swift-on-Android via the Swift 6.3 Android SDK + upcoming `@c` attribute for ABI-stable C exports from `@JS` classes. Downstream work (separate from this PR) consumes `JavaScriptKit` on Android through the Android `.so` + JSI path on React Native; that work is blocked only by this one import conditional.