### PR TITLE
Adopt Foundation Essentials in compat target

### DIFF
--- a/Sources/JavaScriptFoundationCompat/Data+JSValue.swift
+++ b/Sources/JavaScriptFoundationCompat/Data+JSValue.swift
@@ -1,4 +1,8 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import JavaScriptKit
 
 /// Data <-> Uint8Array conversion. The conversion is lossless and copies the bytes at most once per conversion


### PR DESCRIPTION
As per [The adoption of `import FoundationEssentials` throughout the package ecosystem](https://forums.swift.org/t/the-adoption-of-import-foundationessentials-throughout-the-package-ecosystem/84112), this PR prefers to import `FoundationEssentials` when available which helps with binary sizes in non-Darwin platforms.