### PR TITLE
BridgeJS: Add swift-format-ignore-file to generated Swift sources

### DIFF
--- a/Benchmarks/Sources/Generated/BridgeJS.Macros.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.Macros.swift
@@ -1,3 +1,4 @@
+// swift-format-ignore-file
 // NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //

--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -1,4 +1,5 @@
 // bridge-js: skip
+// swift-format-ignore-file
 // NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //

--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.Macros.swift
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.Macros.swift
@@ -1,3 +1,4 @@
+// swift-format-ignore-file
 // NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //

--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.swift
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.swift
@@ -1,4 +1,5 @@
 // bridge-js: skip
+// swift-format-ignore-file
 // NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //

--- a/Plugins/BridgeJS/Sources/BridgeJSUtilities/Utilities.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSUtilities/Utilities.swift
@@ -17,6 +17,7 @@ public enum BridgeJSGeneratedFile {
         // The generated Swift file itself should not be processed by BridgeJS again.
         """
         \(skipLine)
+        // swift-format-ignore-file
         // NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
         // DO NOT EDIT.
         //

--- a/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/src/cli.js
+++ b/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/src/cli.js
@@ -149,6 +149,7 @@ export function run(filePaths, options) {
     }
 
     const prelude = [
+        "// swift-format-ignore-file",
         "// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,",
         "// DO NOT EDIT.",
         "//",

--- a/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/__snapshots__/ts2swift.test.js.snap
+++ b/Plugins/BridgeJS/Sources/TS2Swift/JavaScript/test/__snapshots__/ts2swift.test.js.snap
@@ -1,7 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ts2swift > snapshots Swift output for ArrayParameter.d.ts > ArrayParameter 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -24,7 +25,8 @@ exports[`ts2swift > snapshots Swift output for ArrayParameter.d.ts > ArrayParame
 `;
 
 exports[`ts2swift > snapshots Swift output for Async.d.ts > Async 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -49,7 +51,8 @@ exports[`ts2swift > snapshots Swift output for Async.d.ts > Async 1`] = `
 `;
 
 exports[`ts2swift > snapshots Swift output for CallableConst.d.ts > CallableConst 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -65,7 +68,8 @@ exports[`ts2swift > snapshots Swift output for CallableConst.d.ts > CallableCons
 `;
 
 exports[`ts2swift > snapshots Swift output for Documentation.d.ts > Documentation 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -122,7 +126,8 @@ exports[`ts2swift > snapshots Swift output for Documentation.d.ts > Documentatio
 `;
 
 exports[`ts2swift > snapshots Swift output for ExportAssignment.d.ts > ExportAssignment 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -135,7 +140,8 @@ exports[`ts2swift > snapshots Swift output for ExportAssignment.d.ts > ExportAss
 `;
 
 exports[`ts2swift > snapshots Swift output for Interface.d.ts > Interface 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -153,7 +159,8 @@ exports[`ts2swift > snapshots Swift output for Interface.d.ts > Interface 1`] = 
 `;
 
 exports[`ts2swift > snapshots Swift output for InvalidPropertyNames.d.ts > InvalidPropertyNames 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -201,7 +208,8 @@ exports[`ts2swift > snapshots Swift output for InvalidPropertyNames.d.ts > Inval
 `;
 
 exports[`ts2swift > snapshots Swift output for MultipleImportedTypes.d.ts > MultipleImportedTypes 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -238,7 +246,8 @@ exports[`ts2swift > snapshots Swift output for MultipleImportedTypes.d.ts > Mult
 `;
 
 exports[`ts2swift > snapshots Swift output for ObjectLikeTypes.d.ts > ObjectLikeTypes 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -251,7 +260,8 @@ exports[`ts2swift > snapshots Swift output for ObjectLikeTypes.d.ts > ObjectLike
 `;
 
 exports[`ts2swift > snapshots Swift output for OptionalNullUndefined.d.ts > OptionalNullUndefined 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -292,7 +302,8 @@ exports[`ts2swift > snapshots Swift output for OptionalNullUndefined.d.ts > Opti
 `;
 
 exports[`ts2swift > snapshots Swift output for PrimitiveParameters.d.ts > PrimitiveParameters 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -305,7 +316,8 @@ exports[`ts2swift > snapshots Swift output for PrimitiveParameters.d.ts > Primit
 `;
 
 exports[`ts2swift > snapshots Swift output for PrimitiveReturn.d.ts > PrimitiveReturn 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -320,7 +332,8 @@ exports[`ts2swift > snapshots Swift output for PrimitiveReturn.d.ts > PrimitiveR
 `;
 
 exports[`ts2swift > snapshots Swift output for ReExportFrom.d.ts > ReExportFrom 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -338,7 +351,8 @@ exports[`ts2swift > snapshots Swift output for ReExportFrom.d.ts > ReExportFrom 
 `;
 
 exports[`ts2swift > snapshots Swift output for RecordDictionary.d.ts > RecordDictionary 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -368,7 +382,8 @@ exports[`ts2swift > snapshots Swift output for RecordDictionary.d.ts > RecordDic
 `;
 
 exports[`ts2swift > snapshots Swift output for StaticProperty.d.ts > StaticProperty 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -384,7 +399,8 @@ exports[`ts2swift > snapshots Swift output for StaticProperty.d.ts > StaticPrope
 `;
 
 exports[`ts2swift > snapshots Swift output for StringEnum.d.ts > StringEnum 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -405,7 +421,8 @@ extension FeatureFlag: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {}
 `;
 
 exports[`ts2swift > snapshots Swift output for StringLiteralUnion.d.ts > StringLiteralUnion 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -426,7 +443,8 @@ extension Direction: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {}
 `;
 
 exports[`ts2swift > snapshots Swift output for StringParameter.d.ts > StringParameter 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -441,7 +459,8 @@ exports[`ts2swift > snapshots Swift output for StringParameter.d.ts > StringPara
 `;
 
 exports[`ts2swift > snapshots Swift output for StringReturn.d.ts > StringReturn 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -454,7 +473,8 @@ exports[`ts2swift > snapshots Swift output for StringReturn.d.ts > StringReturn 
 `;
 
 exports[`ts2swift > snapshots Swift output for TS2SkeletonLike.d.ts > TS2SkeletonLike 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -480,7 +500,8 @@ exports[`ts2swift > snapshots Swift output for TS2SkeletonLike.d.ts > TS2Skeleto
 `;
 
 exports[`ts2swift > snapshots Swift output for TypeAlias.d.ts > TypeAlias 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -493,7 +514,8 @@ exports[`ts2swift > snapshots Swift output for TypeAlias.d.ts > TypeAlias 1`] = 
 `;
 
 exports[`ts2swift > snapshots Swift output for TypeAliasObject.d.ts > TypeAliasObject 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -512,7 +534,8 @@ exports[`ts2swift > snapshots Swift output for TypeAliasObject.d.ts > TypeAliasO
 `;
 
 exports[`ts2swift > snapshots Swift output for TypeScriptClass.d.ts > TypeScriptClass 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -533,7 +556,8 @@ exports[`ts2swift > snapshots Swift output for TypeScriptClass.d.ts > TypeScript
 `;
 
 exports[`ts2swift > snapshots Swift output for VoidParameterVoidReturn.d.ts > VoidParameterVoidReturn 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run
@@ -546,7 +570,8 @@ exports[`ts2swift > snapshots Swift output for VoidParameterVoidReturn.d.ts > Vo
 `;
 
 exports[`ts2swift > snapshots Swift output for WebIDLDOMDocs.d.ts > WebIDLDOMDocs 1`] = `
-"// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+"// swift-format-ignore-file
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //
 // To update this file, just rebuild your project or run

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftTypedClosureAccess.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftTypedClosureAccess.json
@@ -281,5 +281,8 @@
       }
     ]
   },
-  "moduleName" : "TestModule"
+  "moduleName" : "TestModule",
+  "usedExternalModules" : [
+
+  ]
 }

--- a/Tests/BridgeJSGlobalTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSGlobalTests/Generated/BridgeJS.swift
@@ -1,4 +1,5 @@
 // bridge-js: skip
+// swift-format-ignore-file
 // NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //

--- a/Tests/BridgeJSIdentityTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSIdentityTests/Generated/BridgeJS.swift
@@ -1,4 +1,5 @@
 // bridge-js: skip
+// swift-format-ignore-file
 // NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.Macros.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.Macros.swift
@@ -1,3 +1,4 @@
+// swift-format-ignore-file
 // NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -1,4 +1,5 @@
 // bridge-js: skip
+// swift-format-ignore-file
 // NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
 // DO NOT EDIT.
 //


### PR DESCRIPTION
## Overview

Adds `// swift-format-ignore-file` to the header of all BridgeJS-generated Swift files (`BridgeJS.swift` and `BridgeJS.Macros.swift`), so that `swift format lint` skips them automatically.

Fixes #708.

Users who run `swift format lint` on their projects currently get violations on generated files. Since these files are regenerated by `swift package bridge-js`, manually adding the comment is not viable — it gets overwritten. Configuring swift-format to exclude specific directories is also surprisingly difficult.

This is standard practice for Swift code generators (protobuf-swift, grpc-swift, SwiftGen all do the same).

**1. `Utilities.swift`** — added `// swift-format-ignore-file` to `BridgeJSGeneratedFile.swiftHeader`, after the `// bridge-js: skip` marker (which must remain on line 1).

**2. `cli.js`** — added `// swift-format-ignore-file` as the first line of the TS2Swift `prelude` template.