### PR TITLE
BridgeJS: Diagnose struct initializer parameter order mismatch

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -1843,9 +1843,44 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
     }
 
     override func visitPost(_ node: StructDeclSyntax) {
-        if case .structBody(_, _) = stateStack.current {
+        if case .structBody(_, let structKey) = stateStack.current {
             stateStack.pop()
+            validateStructInitOrder(node: node, structKey: structKey)
         }
+    }
+
+    private func validateStructInitOrder(node: StructDeclSyntax, structKey: String) {
+        guard let exportedStruct = exportedStructByName[structKey],
+            let constructor = exportedStruct.constructor
+        else {
+            // No explicit @JS init — synthesized memberwise init is assumed,
+            // which always matches declaration order.
+            return
+        }
+
+        let instanceProps = exportedStruct.properties.filter { !$0.isStatic }
+        let expectedLabels = instanceProps.map(\.name)
+        let actualLabels = constructor.parameters.compactMap(\.label)
+
+        guard expectedLabels != actualLabels else { return }
+
+        // Find the @JS init node so we can point the diagnostic at it.
+        let initNode: (any SyntaxProtocol) =
+            node.memberBlock.members
+            .compactMap { $0.decl.as(InitializerDeclSyntax.self) }
+            .first(where: { $0.attributes.hasJSAttribute() })
+            ?? node
+
+        let expectedOrder = expectedLabels.joined(separator: ", ")
+        let actualOrder = actualLabels.joined(separator: ", ")
+
+        diagnose(
+            node: initNode,
+            message:
+                "@JS struct initializer parameters must match stored properties in declaration order. Expected (\(expectedOrder)), got (\(actualOrder))",
+            hint:
+                "Reorder the initializer parameters to match the property declaration order, or remove the @JS init to use the synthesized memberwise initializer"
+        )
     }
 
     private func visitProtocolMethod(

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
@@ -3,6 +3,7 @@ import SwiftSyntax
 import Testing
 
 @testable import BridgeJSCore
+@testable import BridgeJSSkeleton
 
 @Suite struct DiagnosticsTests {
     /// Returns the first parameter's type node from a function in the source (the first `@JS func`-like decl), for pinpointing diagnostics.
@@ -221,6 +222,76 @@ import Testing
                     var x: Double
                     var y: Double
                 }
+            }
+            """
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "test.swift")
+        let skeleton = try swiftAPI.finalize()
+        #expect(skeleton.exported != nil)
+    }
+
+    // MARK: - Struct init order validation
+
+    @Test
+    func structInitMismatchedOrderProducesDiagnostic() throws {
+        let source = """
+            @JS struct Animal {
+                var size: Double
+                var age: Int
+
+                @JS init(age: Int, size: Double) {
+                    self.age = age
+                    self.size = size
+                }
+            }
+            """
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "test.swift")
+        #expect(throws: BridgeJSCoreDiagnosticError.self) {
+            _ = try swiftAPI.finalize()
+        }
+    }
+
+    @Test
+    func structInitMatchingOrderSucceeds() throws {
+        let source = """
+            @JS struct Point {
+                var x: Double
+                var y: Double
+
+                @JS init(x: Double, y: Double) {
+                    self.x = x
+                    self.y = y
+                }
+            }
+            """
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "test.swift")
+        let skeleton = try swiftAPI.finalize()
+        #expect(skeleton.exported != nil)
+    }
+
+    @Test
+    func structWithoutExplicitInitSucceeds() throws {
+        let source = """
+            @JS struct Point {
+                var x: Double
+                var y: Double
             }
             """
         let swiftAPI = SwiftToSkeleton(


### PR DESCRIPTION
## Overview

Fixes #718. Adds a diagnostic when a `@JS` struct's explicit `@JS init` has parameters in a different order than the struct's stored property declarations.

The stack ABI pushes/pops struct fields in declaration order, so `bridgeJSStackPop()` always reconstructs the struct using property declaration order. If the user writes an init with a different parameter order, the generated code fails to compile with a confusing Swift error. This change catches the mismatch at codegen time with a clear message.

**Example diagnostic:**

```
test.swift:5:5: error: @JS struct initializer parameters must match stored properties in declaration order. Expected (size, age), got (age, size)
  5 |     @JS init(age: Int, size: Double) {
    |     `- error: ...
```

**What changed:**

- `SwiftToSkeleton.visitPost(_: StructDeclSyntax)` now validates that when an explicit `@JS init` exists, its parameter labels match the struct's property names in declaration order.
- If no `@JS init` is declared, the synthesized memberwise init is assumed (always correct).
- Three new tests: mismatched order produces diagnostic, matching order succeeds, no explicit init succeeds.