### PR TITLE
BridgeJS: Fix optionals build error with Embedded Swift

### DIFF
--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -182,13 +182,13 @@ extension _BridgedSwiftStackType {
 
 /// Types that bridge with the same (isSome, value) ABI as Optional.
 /// Used by JSUndefinedOr so all bridge methods delegate to Optional<Wrapped>.
-@_spi(BridgeJS) public protocol _BridgedAsOptional {
+public protocol _BridgedAsOptional {
     associatedtype Wrapped
     var asOptional: Wrapped? { get }
     init(optional: Wrapped?)
 }
 
-@_spi(BridgeJS) extension Optional: _BridgedAsOptional {
+extension Optional: _BridgedAsOptional {
     public var asOptional: Wrapped? { self }
     public init(optional: Wrapped?) { self = optional }
 }

--- a/Sources/JavaScriptKit/JSUndefinedOr.swift
+++ b/Sources/JavaScriptKit/JSUndefinedOr.swift
@@ -53,4 +53,4 @@ extension JSUndefinedOr: ConvertibleToJSValue where Wrapped: ConvertibleToJSValu
 
 // MARK: - BridgeJS (via _BridgedAsOptional in BridgeJSIntrinsics)
 
-@_spi(BridgeJS) extension JSUndefinedOr: _BridgedAsOptional {}
+extension JSUndefinedOr: _BridgedAsOptional {}


### PR DESCRIPTION
## Overview

Fixes #689 - BridgeJS-generated code using optionals fails to compile when targeting Embedded Swift with `cannot use conformance of 'Optional<Wrapped>' to '_BridgedAsOptional' here; the conformance is declared as SPI`.

The root cause is that `@_spi(BridgeJS)` on the `_BridgedAsOptional` protocol declaration and its `Optional` conformance makes the entire conformance invisible in Embedded Swift, even when the consumer uses `@_spi(BridgeJS) import JavaScriptKit`. This appears to be an Embedded Swift compiler limitation where SPI-gated retroactive conformances on stdlib types are not resolved.

**The fix** removes `@_spi(BridgeJS)` from three places:

1. The `_BridgedAsOptional` protocol declaration
2. The `Optional: _BridgedAsOptional` conformance
3. The `JSUndefinedOr: _BridgedAsOptional` conformance

The underscore-prefixed protocol name already signals internal API, and all methods on protocol extensions remain `@_spi(BridgeJS)`-gated, so there is no meaningful change to the public API surface.

**Verified locally:**

- Builds for embedded wasm (`swift-6.3-RELEASE_wasm-embedded`) - previously failed
- Builds for regular wasm (`swift-6.3-RELEASE_wasm`) - no regression
- Embedded example still builds
- BridgeJS codegen tests pass
- Runtime tests pass (`make unittest`)