### PR TITLE
BridgeJS: Support nested @JS types inside structs and classes

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -504,6 +504,14 @@ public final class SwiftToSkeleton {
                 enumDecl.attributes.hasJSAttribute()
             {
                 swiftPath.insert(enumDecl.name.text, at: 0)
+            } else if let structDecl = parent.as(StructDeclSyntax.self),
+                structDecl.attributes.hasJSAttribute()
+            {
+                swiftPath.insert(structDecl.name.text, at: 0)
+            } else if let classDecl = parent.as(ClassDeclSyntax.self),
+                classDecl.attributes.hasJSAttribute()
+            {
+                swiftPath.insert(classDecl.name.text, at: 0)
             }
             currentNode = parent.parent
         }
@@ -648,6 +656,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
     var state: State {
         return stateStack.current
     }
+
     let parent: SwiftToSkeleton
 
     init(parent: SwiftToSkeleton) {
@@ -1453,6 +1462,10 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         guard namespaceResult.isValid else {
             return .skipChildren
         }
+        let effectiveNamespace = effectiveNamespace(
+            resolvedNamespace: namespaceResult.namespace,
+            parentTypeNamespace: computeParentTypeNamespace(for: node)
+        )
         let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: node, itemName: name)
         let explicitAccessControl = computeExplicitAtLeastInternalAccessControl(
             for: node,
@@ -1466,10 +1479,10 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             constructor: nil,
             methods: [],
             properties: [],
-            namespace: namespaceResult.namespace,
+            namespace: effectiveNamespace,
             identityMode: classIdentityMode
         )
-        let uniqueKey = makeKey(name: name, namespace: namespaceResult.namespace)
+        let uniqueKey = makeKey(name: name, namespace: effectiveNamespace)
 
         stateStack.push(state: .classBody(name: name, key: uniqueKey))
         exportedClassByName[uniqueKey] = exportedClass
@@ -1558,6 +1571,10 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         guard namespaceResult.isValid else {
             return .skipChildren
         }
+        let effectiveNamespace = effectiveNamespace(
+            resolvedNamespace: namespaceResult.namespace,
+            parentTypeNamespace: computeParentTypeNamespace(for: node)
+        )
         let emitStyle = extractEnumStyle(from: jsAttribute) ?? .const
         let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: node, itemName: name)
         let explicitAccessControl = computeExplicitAtLeastInternalAccessControl(
@@ -1566,7 +1583,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         )
 
         let tsFullPath: String
-        if let namespace = namespaceResult.namespace, !namespace.isEmpty {
+        if let namespace = effectiveNamespace, !namespace.isEmpty {
             tsFullPath = namespace.joined(separator: ".") + "." + name
         } else {
             tsFullPath = name
@@ -1580,13 +1597,13 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             explicitAccessControl: explicitAccessControl,
             cases: [],  // Will be populated in visit(EnumCaseDeclSyntax)
             rawType: SwiftEnumRawType(rawType),
-            namespace: namespaceResult.namespace,
+            namespace: effectiveNamespace,
             emitStyle: emitStyle,
             staticMethods: [],
             staticProperties: []
         )
 
-        let enumUniqueKey = makeKey(name: name, namespace: namespaceResult.namespace)
+        let enumUniqueKey = makeKey(name: name, namespace: effectiveNamespace)
         exportedEnumByName[enumUniqueKey] = exportedEnum
         exportedEnumNames.append(enumUniqueKey)
 
@@ -1685,18 +1702,22 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         guard namespaceResult.isValid else {
             return .skipChildren
         }
+        let effectiveNamespace = effectiveNamespace(
+            resolvedNamespace: namespaceResult.namespace,
+            parentTypeNamespace: computeParentTypeNamespace(for: node)
+        )
         _ = computeExplicitAtLeastInternalAccessControl(
             for: node,
             message: "Protocol visibility must be at least internal"
         )
 
-        let protocolUniqueKey = makeKey(name: name, namespace: namespaceResult.namespace)
+        let protocolUniqueKey = makeKey(name: name, namespace: effectiveNamespace)
 
         exportedProtocolByName[protocolUniqueKey] = ExportedProtocol(
             name: name,
             methods: [],
             properties: [],
-            namespace: namespaceResult.namespace
+            namespace: effectiveNamespace
         )
 
         stateStack.push(state: .protocolBody(name: name, key: protocolUniqueKey))
@@ -1707,7 +1728,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
                 if let exportedFunction = visitProtocolMethod(
                     node: funcDecl,
                     protocolName: name,
-                    namespace: namespaceResult.namespace
+                    namespace: effectiveNamespace
                 ) {
                     methods.append(exportedFunction)
                 }
@@ -1720,7 +1741,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             name: name,
             methods: methods,
             properties: exportedProtocolByName[protocolUniqueKey]?.properties ?? [],
-            namespace: namespaceResult.namespace
+            namespace: effectiveNamespace
         )
 
         exportedProtocolByName[protocolUniqueKey] = exportedProtocol
@@ -1742,6 +1763,10 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         guard namespaceResult.isValid else {
             return .skipChildren
         }
+        let effectiveNamespace = effectiveNamespace(
+            resolvedNamespace: namespaceResult.namespace,
+            parentTypeNamespace: computeParentTypeNamespace(for: node)
+        )
         let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: node, itemName: name)
         let explicitAccessControl = computeExplicitAtLeastInternalAccessControl(
             for: node,
@@ -1791,7 +1816,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
                         type: fieldType,
                         isReadonly: true,
                         isStatic: false,
-                        namespace: namespaceResult.namespace,
+                        namespace: effectiveNamespace,
                         staticContext: nil
                     )
                     properties.append(property)
@@ -1799,14 +1824,14 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             }
         }
 
-        let structUniqueKey = makeKey(name: name, namespace: namespaceResult.namespace)
+        let structUniqueKey = makeKey(name: name, namespace: effectiveNamespace)
         let exportedStruct = ExportedStruct(
             name: name,
             swiftCallName: swiftCallName,
             explicitAccessControl: explicitAccessControl,
             properties: properties,
             methods: [],
-            namespace: namespaceResult.namespace
+            namespace: effectiveNamespace
         )
 
         exportedStructByName[structUniqueKey] = exportedStruct
@@ -2033,6 +2058,34 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         }
 
         return namespace.isEmpty ? nil : namespace
+    }
+
+    private func computeParentTypeNamespace(for node: some SyntaxProtocol) -> [String]? {
+        var path: [String] = []
+        var currentNode: Syntax? = node.parent
+
+        while let parent = currentNode {
+            if let structDecl = parent.as(StructDeclSyntax.self),
+                structDecl.attributes.hasJSAttribute()
+            {
+                path.insert(structDecl.name.text, at: 0)
+            } else if let classDecl = parent.as(ClassDeclSyntax.self),
+                classDecl.attributes.hasJSAttribute()
+            {
+                path.insert(classDecl.name.text, at: 0)
+            }
+            currentNode = parent.parent
+        }
+
+        return path.isEmpty ? nil : path
+    }
+
+    private func effectiveNamespace(
+        resolvedNamespace: [String]?,
+        parentTypeNamespace: [String]?
+    ) -> [String]? {
+        let combined = (parentTypeNamespace ?? []) + (resolvedNamespace ?? [])
+        return combined.isEmpty ? nil : combined
     }
 
     /// Requires the node to have at least internal access control.

--- a/Plugins/BridgeJS/Tests/BridgeJSMacrosTests/JSClassMacroTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSMacrosTests/JSClassMacroTests.swift
@@ -445,6 +445,64 @@ import BridgeJSMacros
         )
     }
 
+    @Test func nestedJSClassStruct() {
+        let combinedSpecs: [String: MacroSpec] = [
+            "JSClass": MacroSpec(type: JSClassMacro.self, conformances: ["_JSBridgedClass"]),
+            "JSGetter": MacroSpec(type: JSGetterMacro.self),
+        ]
+        TestSupport.assertMacroExpansion(
+            """
+            @JSClass
+            struct User {
+                @JSGetter
+                var stats: Stats
+
+                @JSClass
+                struct Stats {
+                    @JSGetter
+                    var health: Int
+                }
+            }
+            """,
+            expandedSource: """
+                struct User {
+                    var stats: Stats {
+                        get throws(JSException) {
+                            return try _$User_stats_get(self.jsObject)
+                        }
+                    }
+                    struct Stats {
+                        var health: Int {
+                            get throws(JSException) {
+                                return try _$Stats_health_get(self.jsObject)
+                            }
+                        }
+
+                        let jsObject: JSObject
+
+                        init(unsafelyWrapping jsObject: JSObject) {
+                            self.jsObject = jsObject
+                        }
+                    }
+
+                    let jsObject: JSObject
+
+                    init(unsafelyWrapping jsObject: JSObject) {
+                        self.jsObject = jsObject
+                    }
+                }
+
+                extension User.Stats: _JSBridgedClass {
+                }
+
+                extension User: _JSBridgedClass {
+                }
+                """,
+            macroSpecs: combinedSpecs,
+            indentationWidth: indentationWidth
+        )
+    }
+
     @Test func fileprivateStructIsRejected() {
         TestSupport.assertMacroExpansion(
             """

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
@@ -165,6 +165,75 @@ import Testing
         #expect(description.contains("<stdin>:2:"))
     }
 
+    // MARK: - Nested type validation
+
+    @Test
+    func nestedStructInsideClassSucceeds() throws {
+        let source = """
+            @JS class User {
+                @JS struct Stats {
+                    var health: Int
+                }
+            }
+            """
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "test.swift")
+        let skeleton = try swiftAPI.finalize()
+        #expect(skeleton.exported != nil)
+        let structs = skeleton.exported?.structs ?? []
+        #expect(structs.count == 1)
+        #expect(structs.first?.swiftCallName == "User.Stats")
+    }
+
+    @Test
+    func nestedClassInsideStructSucceeds() throws {
+        let source = """
+            @JS struct Container {
+                var value: Int
+                @JS class Inner {
+                }
+            }
+            """
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "test.swift")
+        let skeleton = try swiftAPI.finalize()
+        #expect(skeleton.exported != nil)
+        let classes = skeleton.exported?.classes ?? []
+        #expect(classes.count == 1)
+        #expect(classes.first?.swiftCallName == "Container.Inner")
+    }
+
+    @Test
+    func structInsideEnumNamespaceSucceeds() throws {
+        let source = """
+            @JS enum API {
+                @JS struct Point {
+                    var x: Double
+                    var y: Double
+                }
+            }
+            """
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "test.swift")
+        let skeleton = try swiftAPI.finalize()
+        #expect(skeleton.exported != nil)
+    }
+
     @Test
     func omitsNextLineWhenErrorIsOnLastLine() throws {
         let source = """

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/NestedType.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/NestedType.swift
@@ -1,0 +1,10 @@
+@JS class User {
+    @JS func getName() -> String {
+        return "test"
+    }
+
+    @JS struct Stats {
+        var health: Int
+        var score: Double
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/NestedType.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/NestedType.json
@@ -1,0 +1,89 @@
+{
+  "exported" : {
+    "classes" : [
+      {
+        "methods" : [
+          {
+            "abiName" : "bjs_User_getName",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "getName",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "name" : "User",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "User"
+      }
+    ],
+    "enums" : [
+
+    ],
+    "exposeToGlobal" : false,
+    "functions" : [
+
+    ],
+    "protocols" : [
+
+    ],
+    "structs" : [
+      {
+        "methods" : [
+
+        ],
+        "name" : "Stats",
+        "namespace" : [
+          "User"
+        ],
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "health",
+            "namespace" : [
+              "User"
+            ],
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "score",
+            "namespace" : [
+              "User"
+            ],
+            "type" : {
+              "double" : {
+
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "User.Stats"
+      }
+    ]
+  },
+  "moduleName" : "TestModule",
+  "usedExternalModules" : [
+
+  ]
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/NestedType.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/NestedType.swift
@@ -1,0 +1,89 @@
+extension User.Stats: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> User.Stats {
+        let score = Double.bridgeJSStackPop()
+        let health = Int.bridgeJSStackPop()
+        return User.Stats(health: health, score: score)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.health.bridgeJSStackPush()
+        self.score.bridgeJSStackPush()
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_User_Stats(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_User_Stats()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_User_Stats")
+fileprivate func _bjs_struct_lower_User_Stats_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_User_Stats_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_User_Stats(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_User_Stats_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_User_Stats")
+fileprivate func _bjs_struct_lift_User_Stats_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_User_Stats_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_User_Stats() -> Int32 {
+    return _bjs_struct_lift_User_Stats_extern()
+}
+
+@_expose(wasm, "bjs_User_getName")
+@_cdecl("bjs_User_getName")
+public func _bjs_User_getName(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = User.bridgeJSLiftParameter(_self).getName()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_User_deinit")
+@_cdecl("bjs_User_deinit")
+public func _bjs_User_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<User>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension User: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_User_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_User_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_User_wrap")
+fileprivate func _bjs_User_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_User_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_User_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_User_wrap_extern(pointer)
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/NestedType.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/NestedType.d.ts
@@ -1,0 +1,33 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export interface Stats {
+    health: number;
+    score: number;
+}
+/// Represents a Swift heap object like a class instance or an actor instance.
+export interface SwiftHeapObject {
+    /// Release the heap object.
+    ///
+    /// Note: Calling this method will release the heap object and it will no longer be accessible.
+    release(): void;
+}
+export interface User extends SwiftHeapObject {
+    getName(): string;
+}
+export type Exports = {
+    User: {
+    }
+}
+export type Imports = {
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/NestedType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/NestedType.js
@@ -1,0 +1,304 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    let decodeString;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let strStack = [];
+    let i32Stack = [];
+    let i64Stack = [];
+    let f32Stack = [];
+    let f64Stack = [];
+    let ptrStack = [];
+    const enumHelpers = {};
+    const structHelpers = {};
+
+    let _exports = null;
+    let bjs = null;
+    const __bjs_createStatsHelpers = () => ({
+        lower: (value) => {
+            i32Stack.push((value.health | 0));
+            f64Stack.push(value.score);
+        },
+        lift: () => {
+            const f64 = f64Stack.pop();
+            const int = i32Stack.pop();
+            return { health: int, score: f64 };
+        }
+    });
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            bjs = {};
+            importObject["bjs"] = bjs;
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                tmpRetString = decodeString(ptr, len);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                return swift.memory.retain(decodeString(ptr, len));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr, len);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_i32"] = function(v) {
+                i32Stack.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                f32Stack.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                f64Stack.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const value = decodeString(ptr, len);
+                strStack.push(value);
+            }
+            bjs["swift_js_pop_i32"] = function() {
+                return i32Stack.pop();
+            }
+            bjs["swift_js_pop_f32"] = function() {
+                return f32Stack.pop();
+            }
+            bjs["swift_js_pop_f64"] = function() {
+                return f64Stack.pop();
+            }
+            bjs["swift_js_push_pointer"] = function(pointer) {
+                ptrStack.push(pointer);
+            }
+            bjs["swift_js_pop_pointer"] = function() {
+                return ptrStack.pop();
+            }
+            bjs["swift_js_push_i64"] = function(v) {
+                i64Stack.push(v);
+            }
+            bjs["swift_js_pop_i64"] = function() {
+                return i64Stack.pop();
+            }
+            bjs["swift_js_struct_lower_User_Stats"] = function(objectId) {
+                structHelpers.Stats.lower(swift.memory.getObject(objectId));
+            }
+            bjs["swift_js_struct_lift_User_Stats"] = function() {
+                const value = structHelpers.Stats.lift();
+                return swift.memory.retain(value);
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = decodeString(ptr, len);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            bjs["swift_js_get_optional_int_presence"] = function() {
+                return tmpRetOptionalInt != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_int_value"] = function() {
+                const value = tmpRetOptionalInt;
+                tmpRetOptionalInt = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_string"] = function() {
+                const str = tmpRetString;
+                tmpRetString = undefined;
+                if (str == null) {
+                    return -1;
+                } else {
+                    const bytes = textEncoder.encode(str);
+                    tmpRetBytes = bytes;
+                    return bytes.length;
+                }
+            }
+            bjs["swift_js_get_optional_float_presence"] = function() {
+                return tmpRetOptionalFloat != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_float_value"] = function() {
+                const value = tmpRetOptionalFloat;
+                tmpRetOptionalFloat = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_double_presence"] = function() {
+                return tmpRetOptionalDouble != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_double_value"] = function() {
+                const value = tmpRetOptionalDouble;
+                tmpRetOptionalDouble = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_heap_object_pointer"] = function() {
+                const pointer = tmpRetOptionalHeapObject;
+                tmpRetOptionalHeapObject = undefined;
+                return pointer || 0;
+            }
+            bjs["swift_js_closure_unregister"] = function(funcRef) {}
+            // Wrapper functions for module: TestModule
+            if (!importObject["TestModule"]) {
+                importObject["TestModule"] = {};
+            }
+            importObject["TestModule"]["bjs_User_wrap"] = function(pointer) {
+                const obj = _exports['User'].__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            decodeString = (ptr, len) => { const bytes = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0); return textDecoder.decode(bytes); }
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            const swiftHeapObjectFinalizationRegistry = (typeof FinalizationRegistry === "undefined") ? { register: () => {}, unregister: () => {} } : new FinalizationRegistry((state) => {
+                if (state.hasReleased) {
+                    return;
+                }
+                state.hasReleased = true;
+                state.identityMap?.delete(state.pointer);
+                state.deinit(state.pointer);
+            });
+
+            /// Represents a Swift heap object like a class instance or an actor instance.
+            class SwiftHeapObject {
+                static __wrap(pointer, deinit, prototype, identityCache) {
+                    const makeFresh = (identityMap) => {
+                        const obj = Object.create(prototype);
+                        const state = { pointer, deinit, hasReleased: false, identityMap };
+                        obj.pointer = pointer;
+                        obj.__swiftHeapObjectState = state;
+                        swiftHeapObjectFinalizationRegistry.register(obj, state, state);
+                        if (identityMap) {
+                            identityMap.set(pointer, new WeakRef(obj));
+                        }
+                        return obj;
+                    };
+
+                    if (!identityCache) {
+                        return makeFresh(null);
+                    }
+
+                    const cached = identityCache.get(pointer)?.deref();
+                    if (cached && !cached.__swiftHeapObjectState.hasReleased) {
+                        deinit(pointer);
+                        return cached;
+                    }
+                    if (identityCache.has(pointer)) {
+                        identityCache.delete(pointer);
+                    }
+
+                    return makeFresh(identityCache);
+                }
+
+                release() {
+                    const state = this.__swiftHeapObjectState;
+                    if (state.hasReleased) {
+                        return;
+                    }
+                    state.hasReleased = true;
+                    swiftHeapObjectFinalizationRegistry.unregister(state);
+                    state.identityMap?.delete(state.pointer);
+                    state.deinit(state.pointer);
+                }
+            }
+            class User extends SwiftHeapObject {
+                static __construct(ptr) {
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_User_deinit, User.prototype, null);
+                }
+
+                getName() {
+                    instance.exports.bjs_User_getName(this.pointer);
+                    const ret = tmpRetString;
+                    tmpRetString = undefined;
+                    return ret;
+                }
+            }
+            const StatsHelpers = __bjs_createStatsHelpers();
+            structHelpers.Stats = StatsHelpers;
+
+            const exports = {
+                User,
+            };
+            _exports = exports;
+            return exports;
+        },
+    }
+}


### PR DESCRIPTION
## Overview

Fixes #667. `@JS` structs and classes nested inside other `@JS` structs or classes now generate correct Swift code with fully qualified type names and unique ABI symbols.

The import side (`@JSClass`/`@JSGetter` macros) already handles nested types correctly — the Swift compiler provides the fully qualified type for extension generation. The bug was on the **export side** (`@JS` attribute), where the codegen pipeline produced broken code for nested types.

Previously, a nested type like `User.Stats` would generate code referencing bare `Stats` — wrong Swift name, wrong ABI symbols, and potential collisions with top-level types of the same name.

```swift
@JS class User {
    @JS func getName() -> String { "test" }
    @JS struct Stats {
        var health: Int
        var score: Double
    }
}
```

Before:
```swift
extension Stats: _BridgedSwiftStruct { ... }         // wrong
@_cdecl("bjs_Stats_init") ...                         // collision risk
```

After:
```swift
extension User.Stats: _BridgedSwiftStruct { ... }     // correct
@_cdecl("bjs_User_Stats_init") ...                     // unique
```

**1. `computeSwiftCallName`** — now walks parent `StructDeclSyntax` and `ClassDeclSyntax` in addition to `EnumDeclSyntax`, producing `"User.Stats"` instead of `"Stats"`.

**2. `computeParentTypeNamespace` + `effectiveNamespace`** — computes the parent struct/class path and merges it with the resolved enum namespace for ABI name uniqueness.

**3. Struct/class visitors** — use effective namespace when creating `ExportedStruct` / `ExportedClass`, keeping keys and ABI names collision-free.

Existing enum namespace nesting continues to work unchanged.

**Tests:**
- New `NestedType.swift` export-side test fixture with codegen + link snapshots
- New `nestedJSClassStruct` macro test confirming the import side already works
- Existing nested type diagnostic tests updated to assert success