### PR TITLE
BridgeJS: Move optional JSObject to stack ABI, enabling Optional<@JSClass>

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -128,7 +128,9 @@ public struct ImportTS {
             self.returnType = returnType
             self.context = context
             let liftingInfo = try returnType.liftingReturnInfo(context: context)
-            if effects.isAsync || returnType == .void || returnType.usesSideChannelForOptionalReturn() {
+            if effects.isAsync || returnType == .void || returnType.usesSideChannelForOptionalReturn()
+                || liftingInfo.valueToLift == nil
+            {
                 abiReturnType = nil
             } else {
                 abiReturnType = liftingInfo.valueToLift
@@ -1032,6 +1034,10 @@ extension BridgeType {
         case .namespaceEnum:
             throw BridgeJSCoreError("Namespace enums cannot be used as return values")
         case .nullable(let wrappedType, _):
+            // jsObject uses stack ABI for optionals — returns void, value goes through stacks
+            if case .jsObject = wrappedType {
+                return LiftingReturnInfo(valueToLift: nil)
+            }
             let wrappedInfo = try wrappedType.liftingReturnInfo(context: context)
             return LiftingReturnInfo(valueToLift: wrappedInfo.valueToLift)
         case .array, .dictionary:

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -2648,7 +2648,7 @@ private extension BridgeType {
         case .string:
             return .sideChannelReturn(.storage)
         case .jsObject:
-            return .sideChannelReturn(.retainedObject)
+            return .stackABI
         case .jsValue:
             return .inlineFlag
         case .swiftHeapObject:
@@ -2685,7 +2685,7 @@ private extension BridgeType {
 
     var nilSentinel: NilSentinel {
         switch self {
-        case .jsObject, .swiftProtocol:
+        case .swiftProtocol:
             return .i32(0)
         case .swiftHeapObject:
             return .pointer

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -1655,7 +1655,7 @@ extension BridgeType {
         }
 
         switch wrappedType {
-        case .string, .integer, .float, .double, .jsObject, .swiftProtocol:
+        case .string, .integer, .float, .double, .swiftProtocol:
             return true
         case .rawValueEnum(_, let rawType):
             switch rawType {
@@ -1666,7 +1666,7 @@ extension BridgeType {
             default:
                 return false
             }
-        case .bool, .caseEnum, .swiftHeapObject, .associatedValueEnum:
+        case .bool, .caseEnum, .swiftHeapObject, .associatedValueEnum, .jsObject:
             return false
         default:
             return false

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Optionals.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Optionals.swift
@@ -155,4 +155,10 @@ func testMixedOptionals(firstName: String?, lastName: String?, age: Int?, active
     @JSSetter func setIntOrUndefined(_ value: JSUndefinedOr<Int>) throws(JSException)
     @JSFunction func roundTripIntOrNull(value: Int?) throws(JSException) -> Int?
     @JSFunction func roundTripIntOrUndefined(value: JSUndefinedOr<Int>) throws(JSException) -> JSUndefinedOr<Int>
+
+    @JSGetter var childOrNull: WithOptionalJSClass?
+    @JSSetter func setChildOrNull(_ value: WithOptionalJSClass?) throws(JSException)
+    @JSFunction func roundTripChildOrNull(
+        value: WithOptionalJSClass?
+    ) throws(JSException) -> WithOptionalJSClass?
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.json
@@ -1158,6 +1158,20 @@
                     "_1" : "undefined"
                   }
                 }
+              },
+              {
+                "accessLevel" : "internal",
+                "name" : "childOrNull",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "jsObject" : {
+                        "_0" : "WithOptionalJSClass"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
               }
             ],
             "methods" : [
@@ -1444,6 +1458,40 @@
                     "_1" : "undefined"
                   }
                 }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "roundTripChildOrNull",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "nullable" : {
+                        "_0" : {
+                          "jsObject" : {
+                            "_0" : "WithOptionalJSClass"
+                          }
+                        },
+                        "_1" : "null"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "nullable" : {
+                    "_0" : {
+                      "jsObject" : {
+                        "_0" : "WithOptionalJSClass"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
               }
             ],
             "name" : "WithOptionalJSClass",
@@ -1571,6 +1619,21 @@
                       }
                     },
                     "_1" : "undefined"
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "functionName" : "childOrNull_set",
+                "name" : "childOrNull",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "jsObject" : {
+                        "_0" : "WithOptionalJSClass"
+                      }
+                    },
+                    "_1" : "null"
                   }
                 }
               }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.swift
@@ -527,6 +527,18 @@ fileprivate func bjs_WithOptionalJSClass_intOrUndefined_get_extern(_ self: Int32
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_WithOptionalJSClass_childOrNull_get")
+fileprivate func bjs_WithOptionalJSClass_childOrNull_get_extern(_ self: Int32) -> Void
+#else
+fileprivate func bjs_WithOptionalJSClass_childOrNull_get_extern(_ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_WithOptionalJSClass_childOrNull_get(_ self: Int32) -> Void {
+    return bjs_WithOptionalJSClass_childOrNull_get_extern(self)
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "TestModule", name: "bjs_WithOptionalJSClass_stringOrNull_set")
 fileprivate func bjs_WithOptionalJSClass_stringOrNull_set_extern(_ self: Int32, _ newValueIsSome: Int32, _ newValueBytes: Int32, _ newValueLength: Int32) -> Void
 #else
@@ -620,6 +632,18 @@ fileprivate func bjs_WithOptionalJSClass_intOrUndefined_set_extern(_ self: Int32
 #endif
 @inline(never) fileprivate func bjs_WithOptionalJSClass_intOrUndefined_set(_ self: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void {
     return bjs_WithOptionalJSClass_intOrUndefined_set_extern(self, newValueIsSome, newValueValue)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_WithOptionalJSClass_childOrNull_set")
+fileprivate func bjs_WithOptionalJSClass_childOrNull_set_extern(_ self: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void
+#else
+fileprivate func bjs_WithOptionalJSClass_childOrNull_set_extern(_ self: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_WithOptionalJSClass_childOrNull_set(_ self: Int32, _ newValueIsSome: Int32, _ newValueValue: Int32) -> Void {
+    return bjs_WithOptionalJSClass_childOrNull_set_extern(self, newValueIsSome, newValueValue)
 }
 
 #if arch(wasm32)
@@ -718,6 +742,18 @@ fileprivate func bjs_WithOptionalJSClass_roundTripIntOrUndefined_extern(_ self: 
     return bjs_WithOptionalJSClass_roundTripIntOrUndefined_extern(self, valueIsSome, valueValue)
 }
 
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_WithOptionalJSClass_roundTripChildOrNull")
+fileprivate func bjs_WithOptionalJSClass_roundTripChildOrNull_extern(_ self: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+#else
+fileprivate func bjs_WithOptionalJSClass_roundTripChildOrNull_extern(_ self: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_WithOptionalJSClass_roundTripChildOrNull(_ self: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    return bjs_WithOptionalJSClass_roundTripChildOrNull_extern(self, valueIsSome, valueValue)
+}
+
 func _$WithOptionalJSClass_init(_ valueOrNull: Optional<String>, _ valueOrUndefined: JSUndefinedOr<String>) throws(JSException) -> JSObject {
     let ret0 = valueOrNull.bridgeJSWithLoweredParameter { (valueOrNullIsSome, valueOrNullBytes, valueOrNullLength) in
         let ret1 = valueOrUndefined.bridgeJSWithLoweredParameter { (valueOrUndefinedIsSome, valueOrUndefinedBytes, valueOrUndefinedLength) in
@@ -805,6 +841,15 @@ func _$WithOptionalJSClass_intOrUndefined_get(_ self: JSObject) throws(JSExcepti
     return JSUndefinedOr<Int>.bridgeJSLiftReturnFromSideChannel()
 }
 
+func _$WithOptionalJSClass_childOrNull_get(_ self: JSObject) throws(JSException) -> Optional<WithOptionalJSClass> {
+    let selfValue = self.bridgeJSLowerParameter()
+    bjs_WithOptionalJSClass_childOrNull_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<WithOptionalJSClass>.bridgeJSLiftReturn()
+}
+
 func _$WithOptionalJSClass_stringOrNull_set(_ self: JSObject, _ newValue: Optional<String>) throws(JSException) -> Void {
     let selfValue = self.bridgeJSLowerParameter()
     newValue.bridgeJSWithLoweredParameter { (newValueIsSome, newValueBytes, newValueLength) in
@@ -874,6 +919,15 @@ func _$WithOptionalJSClass_intOrUndefined_set(_ self: JSObject, _ newValue: JSUn
     let selfValue = self.bridgeJSLowerParameter()
     let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_intOrUndefined_set(selfValue, newValueIsSome, newValueValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+func _$WithOptionalJSClass_childOrNull_set(_ self: JSObject, _ newValue: Optional<WithOptionalJSClass>) throws(JSException) -> Void {
+    let selfValue = self.bridgeJSLowerParameter()
+    let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+    bjs_WithOptionalJSClass_childOrNull_set(selfValue, newValueIsSome, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
     }
@@ -959,4 +1013,14 @@ func _$WithOptionalJSClass_roundTripIntOrUndefined(_ self: JSObject, _ value: JS
         throw error
     }
     return JSUndefinedOr<Int>.bridgeJSLiftReturnFromSideChannel()
+}
+
+func _$WithOptionalJSClass_roundTripChildOrNull(_ self: JSObject, _ value: Optional<WithOptionalJSClass>) throws(JSException) -> Optional<WithOptionalJSClass> {
+    let selfValue = self.bridgeJSLowerParameter()
+    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    bjs_WithOptionalJSClass_roundTripChildOrNull(selfValue, valueIsSome, valueValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<WithOptionalJSClass>.bridgeJSLiftReturn()
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.d.ts
@@ -30,6 +30,7 @@ export interface WithOptionalJSClass {
     roundTripBoolOrUndefined(value: boolean | undefined): boolean | undefined;
     roundTripIntOrNull(value: number | null): number | null;
     roundTripIntOrUndefined(value: number | undefined): number | undefined;
+    roundTripChildOrNull(value: WithOptionalJSClass | null): WithOptionalJSClass | null;
     stringOrNull: string | null;
     stringOrUndefined: string | undefined;
     doubleOrNull: number | null;
@@ -38,6 +39,7 @@ export interface WithOptionalJSClass {
     boolOrUndefined: boolean | undefined;
     intOrNull: number | null;
     intOrUndefined: number | undefined;
+    childOrNull: WithOptionalJSClass | null;
 }
 export type Exports = {
     Greeter: {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
@@ -296,6 +296,19 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
+            TestModule["bjs_WithOptionalJSClass_childOrNull_get"] = function bjs_WithOptionalJSClass_childOrNull_get(self) {
+                try {
+                    let ret = swift.memory.getObject(self).childOrNull;
+                    const isSome = ret != null;
+                    if (isSome) {
+                        const objId = swift.memory.retain(ret);
+                        i32Stack.push(objId);
+                    }
+                    i32Stack.push(isSome ? 1 : 0);
+                } catch (error) {
+                    setException(error);
+                }
+            }
             TestModule["bjs_WithOptionalJSClass_stringOrNull_set"] = function bjs_WithOptionalJSClass_stringOrNull_set(self, newValueIsSome, newValueBytes, newValueCount) {
                 try {
                     let optResult;
@@ -362,6 +375,22 @@ export async function createInstantiator(options, swift) {
             TestModule["bjs_WithOptionalJSClass_intOrUndefined_set"] = function bjs_WithOptionalJSClass_intOrUndefined_set(self, newValueIsSome, newValueWrappedValue) {
                 try {
                     swift.memory.getObject(self).intOrUndefined = newValueIsSome ? newValueWrappedValue : undefined;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_WithOptionalJSClass_childOrNull_set"] = function bjs_WithOptionalJSClass_childOrNull_set(self, newValue) {
+                try {
+                    let optResult;
+                    if (newValue) {
+                        const objId = i32Stack.pop();
+                        const obj = swift.memory.getObject(objId);
+                        swift.memory.release(objId);
+                        optResult = obj;
+                    } else {
+                        optResult = null;
+                    }
+                    swift.memory.getObject(self).childOrNull = optResult;
                 } catch (error) {
                     setException(error);
                 }
@@ -448,6 +477,28 @@ export async function createInstantiator(options, swift) {
                     let ret = swift.memory.getObject(self).roundTripIntOrUndefined(valueIsSome ? valueWrappedValue : undefined);
                     const isSome = ret !== undefined;
                     bjs["swift_js_return_optional_int"](isSome ? 1 : 0, isSome ? (ret | 0) : 0);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_WithOptionalJSClass_roundTripChildOrNull"] = function bjs_WithOptionalJSClass_roundTripChildOrNull(self, value) {
+                try {
+                    let optResult;
+                    if (value) {
+                        const objId = i32Stack.pop();
+                        const obj = swift.memory.getObject(objId);
+                        swift.memory.release(objId);
+                        optResult = obj;
+                    } else {
+                        optResult = null;
+                    }
+                    let ret = swift.memory.getObject(self).roundTripChildOrNull(optResult);
+                    const isSome = ret != null;
+                    if (isSome) {
+                        const objId1 = swift.memory.retain(ret);
+                        i32Stack.push(objId1);
+                    }
+                    i32Stack.push(isSome ? 1 : 0);
                 } catch (error) {
                     setException(error);
                 }

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -1693,11 +1693,7 @@ extension _BridgedAsOptional where Wrapped == JSObject {
     }
 
     @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Void {
-        asOptional._bridgeJSLowerReturn(
-            noneValue: 0,
-            lowerWrapped: { $0.bridgeJSLowerReturn() },
-            write: _swift_js_return_optional_object
-        )
+        Wrapped.bridgeJSStackPushAsOptional(asOptional)
     }
 }
 


### PR DESCRIPTION
## Overview

Fixes #666. Moves `Optional<JSObject>` (and by extension `Optional<@JSClass>`) from the side-channel ABI to the stack ABI, enabling optional custom types on both import and export sides.

Previously, `@JSFunction func foo() -> Foo?` where `Foo` is a `@JSClass` struct would fail because the side-channel path for `JSObject` optionals lacked a `bridgeJSLiftReturnFromSideChannel` implementation. Rather than adding another per-type side-channel intrinsic, this switches `jsObject` optionals to the stack ABI — the same convention already used by structs, arrays, and dictionaries.

```swift
@JSClass struct Foo {
    @JSGetter var id: String
}
@JSFunction func foo() throws(JSException) -> Foo?  // now works
```

**What changed:**

**1. `JSGlueGen.swift`** — `optionalConvention` for `.jsObject`: changed from `.sideChannelReturn(.retainedObject)` to `.stackABI`. Removed `jsObject` from `nilSentinel` (stack ABI uses the isSome flag instead).

**2. `BridgeJSSkeleton.swift`** — `usesSideChannelForOptionalReturn()`: moved `.jsObject` from the `true` branch to `false`.

**3. `ImportTS.swift`** — `liftingReturnInfo` for `.nullable`: when the wrapped type no longer uses side-channel, returns `valueToLift: nil` so the extern returns void (values go through typed stacks).

**4. `BridgeJSIntrinsics.swift`** — `Optional<JSObject>.bridgeJSLowerReturn()`: changed from calling `_swift_js_return_optional_object` (global side-channel) to `Wrapped.bridgeJSStackPushAsOptional` (stack ABI). JSObject already conforms to `_BridgedSwiftStackType`, and `_JSBridgedClass` inherits from it, so `Optional<Foo>` gets stack-based lifting/lowering for free through the protocol chain.

**Tests:** Added `childOrNull` getter/setter/roundTrip for `WithOptionalJSClass?` to the `Optionals` test fixture, covering the import-side `@JSClass` optional pattern from the original issue.