### PR TITLE
BridgeJS: Fix closures with struct return

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -1441,8 +1441,6 @@ public struct BridgeJSLink {
                 }
             }
             return type.tsType
-        case .swiftStruct(let name):
-            return name.components(separatedBy: ".").last ?? name
         case .nullable(let wrapped, let kind):
             let base = resolveTypeScriptType(wrapped, exportedSkeletons: exportedSkeletons)
             return "\(base) | \(kind.absenceLiteral)"
@@ -3612,7 +3610,7 @@ extension BridgeType {
         case .associatedValueEnum(let name):
             return "\(name)Tag"
         case .swiftStruct(let name):
-            return "\(name)Tag"
+            return name.components(separatedBy: ".").last ?? name
         case .namespaceEnum(let name):
             return name
         case .swiftProtocol(let name):

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/SwiftClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/SwiftClosure.swift
@@ -8,9 +8,20 @@ import JavaScriptKit
     }
 }
 
+@JS public struct Animal {
+    public let type: String
+
+    @JS public init(type: String) {
+        self.type = type
+    }
+}
+
 @JS class TestProcessor {
     @JS init(transform: @escaping (String) -> String) {}
 }
+
+@JS func roundtripAnimal(_ animalClosure: (Animal) -> Animal) -> (Animal) -> Animal
+@JS func roundtripOptionalAnimal(_ animalClosure: (Animal?) -> Animal?) -> (Animal?) -> Animal?
 
 @JS func roundtripString(_ stringClosure: (String) -> String) -> (String) -> String
 @JS func roundtripInt(_ intClosure: (Int) -> Int) -> (Int) -> Int

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.json
@@ -285,6 +285,152 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
+        "abiName" : "bjs_roundtripAnimal",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundtripAnimal",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "animalClosure",
+            "type" : {
+              "closure" : {
+                "_0" : {
+                  "isAsync" : false,
+                  "isThrows" : false,
+                  "mangleName" : "10TestModule6AnimalV_6AnimalV",
+                  "moduleName" : "TestModule",
+                  "parameters" : [
+                    {
+                      "swiftStruct" : {
+                        "_0" : "Animal"
+                      }
+                    }
+                  ],
+                  "returnType" : {
+                    "swiftStruct" : {
+                      "_0" : "Animal"
+                    }
+                  },
+                  "sendingParameters" : false
+                },
+                "useJSTypedClosure" : false
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : false,
+              "isThrows" : false,
+              "mangleName" : "10TestModule6AnimalV_6AnimalV",
+              "moduleName" : "TestModule",
+              "parameters" : [
+                {
+                  "swiftStruct" : {
+                    "_0" : "Animal"
+                  }
+                }
+              ],
+              "returnType" : {
+                "swiftStruct" : {
+                  "_0" : "Animal"
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : false
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundtripOptionalAnimal",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundtripOptionalAnimal",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "animalClosure",
+            "type" : {
+              "closure" : {
+                "_0" : {
+                  "isAsync" : false,
+                  "isThrows" : false,
+                  "mangleName" : "10TestModuleSq6AnimalV_Sq6AnimalV",
+                  "moduleName" : "TestModule",
+                  "parameters" : [
+                    {
+                      "nullable" : {
+                        "_0" : {
+                          "swiftStruct" : {
+                            "_0" : "Animal"
+                          }
+                        },
+                        "_1" : "null"
+                      }
+                    }
+                  ],
+                  "returnType" : {
+                    "nullable" : {
+                      "_0" : {
+                        "swiftStruct" : {
+                          "_0" : "Animal"
+                        }
+                      },
+                      "_1" : "null"
+                    }
+                  },
+                  "sendingParameters" : false
+                },
+                "useJSTypedClosure" : false
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : false,
+              "isThrows" : false,
+              "mangleName" : "10TestModuleSq6AnimalV_Sq6AnimalV",
+              "moduleName" : "TestModule",
+              "parameters" : [
+                {
+                  "nullable" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "Animal"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              ],
+              "returnType" : {
+                "nullable" : {
+                  "_0" : {
+                    "swiftStruct" : {
+                      "_0" : "Animal"
+                    }
+                  },
+                  "_1" : "null"
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : false
+          }
+        }
+      },
+      {
         "abiName" : "bjs_roundtripString",
         "effects" : {
           "isAsync" : false,
@@ -1872,7 +2018,45 @@
 
     ],
     "structs" : [
+      {
+        "constructor" : {
+          "abiName" : "bjs_Animal_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "type",
+              "name" : "type",
+              "type" : {
+                "string" : {
 
+                }
+              }
+            }
+          ]
+        },
+        "explicitAccessControl" : "public",
+        "methods" : [
+
+        ],
+        "name" : "Animal",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "type",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "Animal"
+      }
     ]
   },
   "moduleName" : "TestModule",

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
@@ -128,6 +128,69 @@ public func _invoke_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO(_ boxPt
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV")
+fileprivate func invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV_extern(_ callback: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV_extern(_ callback: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV(_ callback: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV_extern(callback)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV")
+fileprivate func make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModule6AnimalV_6AnimalV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Animal) -> Animal {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let _ = param0.bridgeJSLowerParameter()
+            invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV(callbackValue)
+            return Animal.bridgeJSLiftReturn()
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (Animal) -> Animal {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Animal) -> Animal) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV")
+@_cdecl("invoke_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV")
+public func _invoke_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV(_ boxPtr: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Animal) -> Animal>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Animal.bridgeJSLiftParameter())
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule6PersonC_6PersonC")
 fileprivate func invoke_js_callback_TestModule_10TestModule6PersonC_6PersonC_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
 #else
@@ -762,6 +825,69 @@ public func _invoke_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO(_ b
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV")
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(_ callback: Int32, _ param0: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(_ callback: Int32, _ param0: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(_ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV")
+fileprivate func make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModuleSq6AnimalV_Sq6AnimalV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<Animal>) -> Optional<Animal> {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0IsSome = param0.bridgeJSLowerParameter()
+            invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(callbackValue, param0IsSome)
+            return Optional<Animal>.bridgeJSLiftReturn()
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (Optional<Animal>) -> Optional<Animal> {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<Animal>) -> Optional<Animal>) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV")
+public func _invoke_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(_ boxPtr: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<Animal>) -> Optional<Animal>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<Animal>.bridgeJSLiftParameter())
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC")
 fileprivate func invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
 #else
@@ -1356,6 +1482,85 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
             return Int32(5)
         }
     }
+}
+
+extension Animal: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Animal {
+        let type = String.bridgeJSStackPop()
+        return Animal(type: type)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.type.bridgeJSStackPush()
+    }
+
+    public init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_Animal(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    public func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Animal()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Animal")
+fileprivate func _bjs_struct_lower_Animal_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_Animal_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_Animal(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_Animal_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Animal")
+fileprivate func _bjs_struct_lift_Animal_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_Animal_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_Animal() -> Int32 {
+    return _bjs_struct_lift_Animal_extern()
+}
+
+@_expose(wasm, "bjs_Animal_init")
+@_cdecl("bjs_Animal_init")
+public func _bjs_Animal_init(_ typeBytes: Int32, _ typeLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = Animal(type: String.bridgeJSLiftParameter(typeBytes, typeLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundtripAnimal")
+@_cdecl("bjs_roundtripAnimal")
+public func _bjs_roundtripAnimal(_ animalClosure: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = roundtripAnimal(_: _BJS_Closure_10TestModule6AnimalV_6AnimalV.bridgeJSLift(animalClosure))
+    return JSTypedClosure(ret).bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundtripOptionalAnimal")
+@_cdecl("bjs_roundtripOptionalAnimal")
+public func _bjs_roundtripOptionalAnimal(_ animalClosure: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = roundtripOptionalAnimal(_: _BJS_Closure_10TestModuleSq6AnimalV_Sq6AnimalV.bridgeJSLift(animalClosure))
+    return JSTypedClosure(ret).bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 @_expose(wasm, "bjs_roundtripString")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.d.ts
@@ -41,6 +41,9 @@ export const APIResultValues: {
 export type APIResultTag =
   { tag: typeof APIResultValues.Tag.Success; param0: string } | { tag: typeof APIResultValues.Tag.Failure; param0: number } | { tag: typeof APIResultValues.Tag.Flag; param0: boolean } | { tag: typeof APIResultValues.Tag.Rate; param0: number } | { tag: typeof APIResultValues.Tag.Precise; param0: number } | { tag: typeof APIResultValues.Tag.Info }
 
+export interface Animal {
+    type: string;
+}
 export type DirectionObject = typeof DirectionValues;
 
 export type ThemeObject = typeof ThemeValues;
@@ -67,6 +70,8 @@ export type Exports = {
     TestProcessor: {
         new(transform: (arg0: string) => string): TestProcessor;
     }
+    roundtripAnimal(animalClosure: (arg0: AnimalTag) => AnimalTag): (arg0: AnimalTag) => AnimalTag;
+    roundtripOptionalAnimal(animalClosure: (arg0: AnimalTag | null) => AnimalTag | null): (arg0: AnimalTag | null) => AnimalTag | null;
     roundtripString(stringClosure: (arg0: string) => string): (arg0: string) => string;
     roundtripInt(intClosure: (arg0: number) => number): (arg0: number) => number;
     roundtripBool(boolClosure: (arg0: boolean) => boolean): (arg0: boolean) => boolean;
@@ -92,6 +97,9 @@ export type Exports = {
     Theme: ThemeObject
     HttpStatus: HttpStatusObject
     APIResult: APIResultObject
+    Animal: {
+        init(type: string): Animal;
+    }
 }
 export type Imports = {
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.d.ts
@@ -70,8 +70,8 @@ export type Exports = {
     TestProcessor: {
         new(transform: (arg0: string) => string): TestProcessor;
     }
-    roundtripAnimal(animalClosure: (arg0: AnimalTag) => AnimalTag): (arg0: AnimalTag) => AnimalTag;
-    roundtripOptionalAnimal(animalClosure: (arg0: AnimalTag | null) => AnimalTag | null): (arg0: AnimalTag | null) => AnimalTag | null;
+    roundtripAnimal(animalClosure: (arg0: Animal) => Animal): (arg0: Animal) => Animal;
+    roundtripOptionalAnimal(animalClosure: (arg0: Animal | null) => Animal | null): (arg0: Animal | null) => Animal | null;
     roundtripString(stringClosure: (arg0: string) => string): (arg0: string) => string;
     roundtripInt(intClosure: (arg0: number) => number): (arg0: number) => number;
     roundtripBool(boolClosure: (arg0: boolean) => boolean): (arg0: boolean) => boolean;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -85,6 +85,18 @@ export async function createInstantiator(options, swift) {
         return swift.memory.retain(real);
     };
 
+    const __bjs_createAnimalHelpers = () => ({
+        lower: (value) => {
+            const bytes = textEncoder.encode(value.type);
+            const id = swift.memory.retain(bytes);
+            i32Stack.push(bytes.length);
+            i32Stack.push(id);
+        },
+        lift: () => {
+            const string = strStack.pop();
+            return { type: string };
+        }
+    });
     const __bjs_createAPIResultValuesHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
@@ -213,6 +225,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            bjs["swift_js_struct_lower_Animal"] = function(objectId) {
+                structHelpers.Animal.lower(swift.memory.getObject(objectId));
+            }
+            bjs["swift_js_struct_lift_Animal"] = function() {
+                const value = structHelpers.Animal.lift();
+                return swift.memory.retain(value);
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -358,6 +377,31 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule5ThemeO_5ThemeO);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV"] = function(callbackId) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    const structValue = structHelpers.Animal.lift();
+                    let ret = callback(structValue);
+                    structHelpers.Animal.lower(ret);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModule6AnimalV_6AnimalV = function(param0) {
+                    structHelpers.Animal.lower(param0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV(boxPtr);
+                    const structValue = structHelpers.Animal.lift();
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return structValue;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule6AnimalV_6AnimalV);
             }
             bjs["invoke_js_callback_TestModule_10TestModule6PersonC_6PersonC"] = function(callbackId, param0) {
                 try {
@@ -619,6 +663,46 @@ export async function createInstantiator(options, swift) {
                     return optResult;
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV"] = function(callbackId, param0) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    let optResult;
+                    if (param0) {
+                        const struct = structHelpers.Animal.lift();
+                        optResult = struct;
+                    } else {
+                        optResult = null;
+                    }
+                    let ret = callback(optResult);
+                    const isSome = ret != null;
+                    if (isSome) {
+                        structHelpers.Animal.lower(ret);
+                    }
+                    i32Stack.push(isSome ? 1 : 0);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV = function(param0) {
+                    const isSome = param0 != null;
+                    if (isSome) {
+                        structHelpers.Animal.lower(param0);
+                    }
+                    i32Stack.push(+isSome);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(boxPtr);
+                    const isSome1 = i32Stack.pop();
+                    const optResult = isSome1 ? structHelpers.Animal.lift() : null;
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return optResult;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV);
             }
             bjs["invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC"] = function(callbackId, param0IsSome, param0Pointer) {
                 try {
@@ -971,12 +1055,25 @@ export async function createInstantiator(options, swift) {
                     return TestProcessor.__construct(ret);
                 }
             }
+            const AnimalHelpers = __bjs_createAnimalHelpers();
+            structHelpers.Animal = AnimalHelpers;
+
             const APIResultHelpers = __bjs_createAPIResultValuesHelpers();
             enumHelpers.APIResult = APIResultHelpers;
 
             const exports = {
                 Person,
                 TestProcessor,
+                roundtripAnimal: function bjs_roundtripAnimal(animalClosure) {
+                    const callbackId = swift.memory.retain(animalClosure);
+                    const ret = instance.exports.bjs_roundtripAnimal(callbackId);
+                    return swift.memory.getObject(ret);
+                },
+                roundtripOptionalAnimal: function bjs_roundtripOptionalAnimal(animalClosure) {
+                    const callbackId = swift.memory.retain(animalClosure);
+                    const ret = instance.exports.bjs_roundtripOptionalAnimal(callbackId);
+                    return swift.memory.getObject(ret);
+                },
                 roundtripString: function bjs_roundtripString(stringClosure) {
                     const callbackId = swift.memory.retain(stringClosure);
                     const ret = instance.exports.bjs_roundtripString(callbackId);
@@ -1086,6 +1183,15 @@ export async function createInstantiator(options, swift) {
                 Theme: ThemeValues,
                 HttpStatus: HttpStatusValues,
                 APIResult: APIResultValues,
+                Animal: {
+                    init: function(type) {
+                        const typeBytes = textEncoder.encode(type);
+                        const typeId = swift.memory.retain(typeBytes);
+                        instance.exports.bjs_Animal_init(typeId, typeBytes.length);
+                        const structValue = structHelpers.Animal.lift();
+                        return structValue;
+                    },
+                },
             };
             _exports = exports;
             return exports;

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -847,6 +847,10 @@ extension _BridgedSwiftStruct {
         return Self(unsafelyCopying: jsObject)
     }
 
+    @_spi(BridgeJS) public static func bridgeJSLiftReturn() -> Self {
+        bridgeJSStackPop()
+    }
+
     @_spi(BridgeJS) public static func bridgeJSLiftParameter() -> Self {
         bridgeJSStackPop()
     }

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -1285,6 +1285,18 @@ enum GraphOperations {
         processor.increment(by: 7)
         return callback(processor) + " | " + callback(nil)
     }
+
+    @JS func processVector(_ callback: (Double) -> Vector2D) -> Double {
+        return callback(3.0).magnitude()
+    }
+
+    @JS func processOptionalVector(_ callback: (Double) -> Vector2D?) -> String {
+        let some = callback(2.0)
+        let none = callback(-1.0)
+        let someStr = some.map { "(\($0.dx),\($0.dy))" } ?? "nil"
+        let noneStr = none.map { "(\($0.dx),\($0.dy))" } ?? "nil"
+        return "\(someStr) | \(noneStr)"
+    }
 }
 
 class ExportAPITests: XCTestCase {

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -777,6 +777,69 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV_extern(_ callback: Int32, _ param0: Float64) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV_extern(_ callback: Int32, _ param0: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV(_ callback: Int32, _ param0: Float64) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsSd_8Vector2DV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Double) -> Vector2D {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0Value = param0.bridgeJSLowerParameter()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV(callbackValue, param0Value)
+            return Vector2D.bridgeJSLiftReturn()
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (Double) -> Vector2D {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Double) -> Vector2D) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV(_ boxPtr: UnsafeMutableRawPointer, _ param0: Float64) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Double) -> Vector2D>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Double.bridgeJSLiftParameter(param0))
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sd")
 fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sd_extern(_ callback: Int32, _ param0: Float64) -> Float64
 #else
@@ -832,6 +895,69 @@ extension JSTypedClosure where Signature == (Double) -> Double {
 public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sd(_ boxPtr: UnsafeMutableRawPointer, _ param0: Float64) -> Float64 {
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<(Double) -> Double>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Double.bridgeJSLiftParameter(param0))
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV_extern(_ callback: Int32, _ param0: Float64) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV_extern(_ callback: Int32, _ param0: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV(_ callback: Int32, _ param0: Float64) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsSd_Sq8Vector2DV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Double) -> Optional<Vector2D> {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0Value = param0.bridgeJSLowerParameter()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV(callbackValue, param0Value)
+            return Optional<Vector2D>.bridgeJSLiftReturn()
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (Double) -> Optional<Vector2D> {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Double) -> Optional<Vector2D>) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV(_ boxPtr: UnsafeMutableRawPointer, _ param0: Float64) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Double) -> Optional<Vector2D>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     let result = closure(Double.bridgeJSLiftParameter(param0))
     return result.bridgeJSLowerReturn()
     #else
@@ -10436,6 +10562,28 @@ public func _bjs_TextProcessor_roundtripDataProcessor(_ _self: UnsafeMutableRawP
 public func _bjs_TextProcessor_processOptionalDataProcessor(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
     let ret = TextProcessor.bridgeJSLiftParameter(_self).processOptionalDataProcessor(_: _BJS_Closure_20BridgeJSRuntimeTestsSq13DataProcessorP_SS.bridgeJSLift(callback))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_TextProcessor_processVector")
+@_cdecl("bjs_TextProcessor_processVector")
+public func _bjs_TextProcessor_processVector(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Float64 {
+    #if arch(wasm32)
+    let ret = TextProcessor.bridgeJSLiftParameter(_self).processVector(_: _BJS_Closure_20BridgeJSRuntimeTestsSd_8Vector2DV.bridgeJSLift(callback))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_TextProcessor_processOptionalVector")
+@_cdecl("bjs_TextProcessor_processOptionalVector")
+public func _bjs_TextProcessor_processOptionalVector(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = TextProcessor.bridgeJSLiftParameter(_self).processOptionalVector(_: _BJS_Closure_20BridgeJSRuntimeTestsSd_Sq8Vector2DV.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -4059,6 +4059,99 @@
 
               }
             }
+          },
+          {
+            "abiName" : "bjs_TextProcessor_processVector",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "processVector",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "callback",
+                "type" : {
+                  "closure" : {
+                    "_0" : {
+                      "isAsync" : false,
+                      "isThrows" : false,
+                      "mangleName" : "20BridgeJSRuntimeTestsSd_8Vector2DV",
+                      "moduleName" : "BridgeJSRuntimeTests",
+                      "parameters" : [
+                        {
+                          "double" : {
+
+                          }
+                        }
+                      ],
+                      "returnType" : {
+                        "swiftStruct" : {
+                          "_0" : "Vector2D"
+                        }
+                      },
+                      "sendingParameters" : false
+                    },
+                    "useJSTypedClosure" : false
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "double" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_TextProcessor_processOptionalVector",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "processOptionalVector",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "callback",
+                "type" : {
+                  "closure" : {
+                    "_0" : {
+                      "isAsync" : false,
+                      "isThrows" : false,
+                      "mangleName" : "20BridgeJSRuntimeTestsSd_Sq8Vector2DV",
+                      "moduleName" : "BridgeJSRuntimeTests",
+                      "parameters" : [
+                        {
+                          "double" : {
+
+                          }
+                        }
+                      ],
+                      "returnType" : {
+                        "nullable" : {
+                          "_0" : {
+                            "swiftStruct" : {
+                              "_0" : "Vector2D"
+                            }
+                          },
+                          "_1" : "null"
+                        }
+                      },
+                      "sendingParameters" : false
+                    },
+                    "useJSTypedClosure" : false
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
           }
         ],
         "name" : "TextProcessor",

--- a/Tests/BridgeJSRuntimeTests/JavaScript/ClosureSupportTests.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/ClosureSupportTests.mjs
@@ -355,6 +355,17 @@ export function runJsClosureSupportTests(exports) {
     });
     assert.equal(optDpResult, "DP: 7 | DP: null");
 
+    const vectorMagnitude = processor.processVector((value) => ({
+        dx: value,
+        dy: 4.0,
+    }));
+    assert.equal(vectorMagnitude, 5.0);
+
+    const optVectorResult = processor.processOptionalVector((value) =>
+        value > 0 ? { dx: value, dy: value * 2 } : null,
+    );
+    assert.equal(optVectorResult, "(2.0,4.0) | nil");
+
     processor.release();
 
     const intToInt = exports.ClosureSupportExports.makeIntToInt(10);


### PR DESCRIPTION
Currently, the following code will result in generated code that fails to compile.
```swift
@JS public struct Animal {
    public let type: String
}

@JS func roundtripAnimal(_ animalClosure: (Animal) -> Animal) -> (Animal) -> Animal
```

The generated code uses `bridgeJSLiftReturn` with no arguments, which doesn’t exist.

This fixes this by adding an overload for `bridgeJSLiftReturn` which uses the stack ABI.