### PR TITLE
fix: use `export type` for SwiftRuntimeThreadChannel re-export

### DIFF
--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -20,7 +20,7 @@ import {
 } from "./itc.js";
 import { decodeObjectRefs } from "./js-value.js";
 import { JSObjectSpace } from "./object-heap.js";
-export { SwiftRuntimeThreadChannel };
+export type { SwiftRuntimeThreadChannel };
 
 export type SwiftRuntimeOptions = {
     /**


### PR DESCRIPTION
Fixes https://github.com/swiftwasm/JavaScriptKit/issues/477

`SwiftRuntimeThreadChannel` is a TypeScript type alias, not a value. Re-exporting it with the value-style `export { ... }` causes esbuild and rolldown (which run in `isolatedModules` mode by default) to fail with:

```
Cannot re-export a type when 'isolatedModules' is enabled.
```

This breaks anyone trying to bundle JavaScriptKit with Vite or other esbuild/rolldown-based toolchains.

Changing to `export type { SwiftRuntimeThreadChannel }` makes the intent explicit and restores compatibility with esbuild/rolldown without affecting `tsc` or any runtime behaviour — a value-only consumer wouldn't be importing this anyway.

## Test plan

- [x] `tsc` still compiles cleanly.
- [x] Type-only consumers still resolve the import.
- [ ] Local verification with esbuild / rolldown is welcome from a maintainer with the toolchain set up.