### PR TITLE
BridgeJS: Optimize numeric array transfer with bulk TypedArray copy

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -347,6 +347,7 @@ public struct BridgeJSLink {
             "let \(JSGlueVariableScope.reservedF32Stack) = [];",
             "let \(JSGlueVariableScope.reservedF64Stack) = [];",
             "let \(JSGlueVariableScope.reservedPointerStack) = [];",
+            "let \(JSGlueVariableScope.reservedTaStack) = [];",
             "const \(JSGlueVariableScope.reservedEnumHelpers) = {};",
             "const \(JSGlueVariableScope.reservedStructHelpers) = {};",
             "",
@@ -487,6 +488,21 @@ public struct BridgeJSLink {
                 printer.write("bjs[\"swift_js_pop_i64\"] = function() {")
                 printer.indent {
                     printer.write("return \(JSGlueVariableScope.reservedI64Stack).pop();")
+                }
+                printer.write("}")
+                // Typed array constructors indexed by kind (must match _BridgedNumericArrayKind)
+                printer.write(
+                    "const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];"
+                )
+                printer.write("bjs[\"swift_js_push_typed_array\"] = function(kind, ptr, count) {")
+                printer.indent {
+                    printer.write("const Ctor = taCtors[kind];")
+                    printer.write("const byteLen = count * Ctor.BYTES_PER_ELEMENT;")
+                    // slice() copies the bytes into a new ArrayBuffer that is properly aligned
+                    printer.write(
+                        "const copy = \(JSGlueVariableScope.reservedMemory).buffer.slice(ptr, ptr + byteLen);"
+                    )
+                    printer.write("\(JSGlueVariableScope.reservedTaStack).push(Array.from(new Ctor(copy)));")
                 }
                 printer.write("}")
                 if !allStructs.isEmpty {

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -34,6 +34,7 @@ final class JSGlueVariableScope {
     static let reservedStructHelpers = "structHelpers"
     static let reservedSwiftClosureRegistry = "swiftClosureRegistry"
     static let reservedMakeSwiftClosure = "makeClosure"
+    static let reservedTaStack = "taStack"
 
     private let intrinsicRegistry: JSIntrinsicRegistry
 
@@ -63,6 +64,7 @@ final class JSGlueVariableScope {
         reservedStructHelpers,
         reservedSwiftClosureRegistry,
         reservedMakeSwiftClosure,
+        reservedTaStack,
     ]
 
     init(intrinsicRegistry: JSIntrinsicRegistry) {
@@ -1896,20 +1898,31 @@ struct IntrinsicJSFragment: Sendable {
                 let (scope, printer) = (context.scope, context.printer)
                 let resultVar = scope.variable("arrayResult")
                 let lenVar = scope.variable("arrayLen")
-                let iVar = scope.variable("i")
 
                 printer.write("const \(lenVar) = \(scope.popI32());")
-                printer.write("const \(resultVar) = [];")
-                printer.write("for (let \(iVar) = 0; \(iVar) < \(lenVar); \(iVar)++) {")
+                printer.write("let \(resultVar);")
+                printer.write("if (\(lenVar) === -1) {")
+                printer.indent {
+                    // Bulk path: Swift pushed a typed array onto the typed-array stack
+                    printer.write("\(resultVar) = \(JSGlueVariableScope.reservedTaStack).pop();")
+                }
+                printer.write("} else {")
                 try printer.indent {
-                    let elementFragment = try stackLiftFragment(elementType: elementType)
-                    let elementResults = try elementFragment.printCode([], context)
-                    if let elementExpr = elementResults.first {
-                        printer.write("\(resultVar).push(\(elementExpr));")
+                    // Element-by-element path (original behavior)
+                    let iVar = scope.variable("i")
+                    printer.write("\(resultVar) = [];")
+                    printer.write("for (let \(iVar) = 0; \(iVar) < \(lenVar); \(iVar)++) {")
+                    try printer.indent {
+                        let elementFragment = try stackLiftFragment(elementType: elementType)
+                        let elementResults = try elementFragment.printCode([], context)
+                        if let elementExpr = elementResults.first {
+                            printer.write("\(resultVar).push(\(elementExpr));")
+                        }
                     }
+                    printer.write("}")
+                    printer.write("\(resultVar).reverse();")
                 }
                 printer.write("}")
-                printer.write("\(resultVar).reverse();")
                 return [resultVar]
             }
         )

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
@@ -38,6 +38,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -122,6 +123,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_struct_lower_Point"] = function(objectId) {
                 structHelpers.Point.lower(swift.memory.getObject(objectId));
@@ -250,12 +258,17 @@ export async function createInstantiator(options, swift) {
             TestModule["bjs_importProcessNumbers"] = function bjs_importProcessNumbers() {
                 try {
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const f64 = f64Stack.pop();
-                        arrayResult.push(f64);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const f64 = f64Stack.pop();
+                            arrayResult.push(f64);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     imports.importProcessNumbers(arrayResult);
                 } catch (error) {
                     setException(error);
@@ -275,12 +288,17 @@ export async function createInstantiator(options, swift) {
             TestModule["bjs_importTransformNumbers"] = function bjs_importTransformNumbers() {
                 try {
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const f64 = f64Stack.pop();
-                        arrayResult.push(f64);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const f64 = f64Stack.pop();
+                            arrayResult.push(f64);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     let ret = imports.importTransformNumbers(arrayResult);
                     for (const elem of ret) {
                         f64Stack.push(elem);
@@ -293,12 +311,17 @@ export async function createInstantiator(options, swift) {
             TestModule["bjs_importProcessStrings"] = function bjs_importProcessStrings() {
                 try {
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const string = strStack.pop();
-                        arrayResult.push(string);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const string = strStack.pop();
+                            arrayResult.push(string);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     let ret = imports.importProcessStrings(arrayResult);
                     for (const elem of ret) {
                         const bytes = textEncoder.encode(elem);
@@ -314,12 +337,17 @@ export async function createInstantiator(options, swift) {
             TestModule["bjs_importProcessBooleans"] = function bjs_importProcessBooleans() {
                 try {
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const bool = i32Stack.pop() !== 0;
-                        arrayResult.push(bool);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const bool = i32Stack.pop() !== 0;
+                            arrayResult.push(bool);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     let ret = imports.importProcessBooleans(arrayResult);
                     for (const elem of ret) {
                         i32Stack.push(elem ? 1 : 0);
@@ -423,23 +451,33 @@ export async function createInstantiator(options, swift) {
                 get numbers() {
                     instance.exports.bjs_MultiArrayContainer_numbers_get(this.pointer);
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const int = i32Stack.pop();
-                        arrayResult.push(int);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const int = i32Stack.pop();
+                            arrayResult.push(int);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 }
                 get strings() {
                     instance.exports.bjs_MultiArrayContainer_strings_get(this.pointer);
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const string = strStack.pop();
-                        arrayResult.push(string);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const string = strStack.pop();
+                            arrayResult.push(string);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 }
             }
@@ -456,12 +494,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_processIntArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const int = i32Stack.pop();
-                        arrayResult.push(int);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const int = i32Stack.pop();
+                            arrayResult.push(int);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processStringArray: function bjs_processStringArray(values) {
@@ -474,12 +517,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_processStringArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const string = strStack.pop();
-                        arrayResult.push(string);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const string = strStack.pop();
+                            arrayResult.push(string);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processDoubleArray: function bjs_processDoubleArray(values) {
@@ -489,12 +537,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_processDoubleArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const f64 = f64Stack.pop();
-                        arrayResult.push(f64);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const f64 = f64Stack.pop();
+                            arrayResult.push(f64);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processBoolArray: function bjs_processBoolArray(values) {
@@ -504,12 +557,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_processBoolArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const bool = i32Stack.pop() !== 0;
-                        arrayResult.push(bool);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const bool = i32Stack.pop() !== 0;
+                            arrayResult.push(bool);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processPointArray: function bjs_processPointArray(points) {
@@ -519,12 +577,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(points.length);
                     instance.exports.bjs_processPointArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const struct = structHelpers.Point.lift();
-                        arrayResult.push(struct);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const struct = structHelpers.Point.lift();
+                            arrayResult.push(struct);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processDirectionArray: function bjs_processDirectionArray(directions) {
@@ -534,12 +597,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(directions.length);
                     instance.exports.bjs_processDirectionArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const caseId = i32Stack.pop();
-                        arrayResult.push(caseId);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const caseId = i32Stack.pop();
+                            arrayResult.push(caseId);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processStatusArray: function bjs_processStatusArray(statuses) {
@@ -549,12 +617,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(statuses.length);
                     instance.exports.bjs_processStatusArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const rawValue = i32Stack.pop();
-                        arrayResult.push(rawValue);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const rawValue = i32Stack.pop();
+                            arrayResult.push(rawValue);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 sumIntArray: function bjs_sumIntArray(values) {
@@ -583,12 +656,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_processUnsafeRawPointerArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const pointer = ptrStack.pop();
-                        arrayResult.push(pointer);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const pointer = ptrStack.pop();
+                            arrayResult.push(pointer);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processUnsafeMutableRawPointerArray: function bjs_processUnsafeMutableRawPointerArray(values) {
@@ -598,12 +676,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_processUnsafeMutableRawPointerArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const pointer = ptrStack.pop();
-                        arrayResult.push(pointer);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const pointer = ptrStack.pop();
+                            arrayResult.push(pointer);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processOpaquePointerArray: function bjs_processOpaquePointerArray(values) {
@@ -613,12 +696,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_processOpaquePointerArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const pointer = ptrStack.pop();
-                        arrayResult.push(pointer);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const pointer = ptrStack.pop();
+                            arrayResult.push(pointer);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processOptionalIntArray: function bjs_processOptionalIntArray(values) {
@@ -632,19 +720,24 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_processOptionalIntArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const isSome1 = i32Stack.pop();
-                        let optValue;
-                        if (isSome1 === 0) {
-                            optValue = null;
-                        } else {
-                            const int = i32Stack.pop();
-                            optValue = int;
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const isSome1 = i32Stack.pop();
+                            let optValue;
+                            if (isSome1 === 0) {
+                                optValue = null;
+                            } else {
+                                const int = i32Stack.pop();
+                                optValue = int;
+                            }
+                            arrayResult.push(optValue);
                         }
-                        arrayResult.push(optValue);
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processOptionalStringArray: function bjs_processOptionalStringArray(values) {
@@ -661,19 +754,24 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_processOptionalStringArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const isSome1 = i32Stack.pop();
-                        let optValue;
-                        if (isSome1 === 0) {
-                            optValue = null;
-                        } else {
-                            const string = strStack.pop();
-                            optValue = string;
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const isSome1 = i32Stack.pop();
+                            let optValue;
+                            if (isSome1 === 0) {
+                                optValue = null;
+                            } else {
+                                const string = strStack.pop();
+                                optValue = string;
+                            }
+                            arrayResult.push(optValue);
                         }
-                        arrayResult.push(optValue);
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processOptionalArray: function bjs_processOptionalArray(values) {
@@ -690,12 +788,17 @@ export async function createInstantiator(options, swift) {
                     let optResult;
                     if (isSome1) {
                         const arrayLen = i32Stack.pop();
-                        const arrayResult = [];
-                        for (let i = 0; i < arrayLen; i++) {
-                            const int = i32Stack.pop();
-                            arrayResult.push(int);
+                        let arrayResult;
+                        if (arrayLen === -1) {
+                            arrayResult = taStack.pop();
+                        } else {
+                            arrayResult = [];
+                            for (let i = 0; i < arrayLen; i++) {
+                                const int = i32Stack.pop();
+                                arrayResult.push(int);
+                            }
+                            arrayResult.reverse();
                         }
-                        arrayResult.reverse();
                         optResult = arrayResult;
                     } else {
                         optResult = null;
@@ -713,19 +816,24 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(points.length);
                     instance.exports.bjs_processOptionalPointArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const isSome1 = i32Stack.pop();
-                        let optValue;
-                        if (isSome1 === 0) {
-                            optValue = null;
-                        } else {
-                            const struct = structHelpers.Point.lift();
-                            optValue = struct;
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const isSome1 = i32Stack.pop();
+                            let optValue;
+                            if (isSome1 === 0) {
+                                optValue = null;
+                            } else {
+                                const struct = structHelpers.Point.lift();
+                                optValue = struct;
+                            }
+                            arrayResult.push(optValue);
                         }
-                        arrayResult.push(optValue);
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processOptionalDirectionArray: function bjs_processOptionalDirectionArray(directions) {
@@ -739,19 +847,24 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(directions.length);
                     instance.exports.bjs_processOptionalDirectionArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const isSome1 = i32Stack.pop();
-                        let optValue;
-                        if (isSome1 === 0) {
-                            optValue = null;
-                        } else {
-                            const caseId = i32Stack.pop();
-                            optValue = caseId;
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const isSome1 = i32Stack.pop();
+                            let optValue;
+                            if (isSome1 === 0) {
+                                optValue = null;
+                            } else {
+                                const caseId = i32Stack.pop();
+                                optValue = caseId;
+                            }
+                            arrayResult.push(optValue);
                         }
-                        arrayResult.push(optValue);
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processOptionalStatusArray: function bjs_processOptionalStatusArray(statuses) {
@@ -765,19 +878,24 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(statuses.length);
                     instance.exports.bjs_processOptionalStatusArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const isSome1 = i32Stack.pop();
-                        let optValue;
-                        if (isSome1 === 0) {
-                            optValue = null;
-                        } else {
-                            const rawValue = i32Stack.pop();
-                            optValue = rawValue;
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const isSome1 = i32Stack.pop();
+                            let optValue;
+                            if (isSome1 === 0) {
+                                optValue = null;
+                            } else {
+                                const rawValue = i32Stack.pop();
+                                optValue = rawValue;
+                            }
+                            arrayResult.push(optValue);
                         }
-                        arrayResult.push(optValue);
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processNestedIntArray: function bjs_processNestedIntArray(values) {
@@ -790,18 +908,28 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_processNestedIntArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const arrayLen1 = i32Stack.pop();
-                        const arrayResult1 = [];
-                        for (let i1 = 0; i1 < arrayLen1; i1++) {
-                            const int = i32Stack.pop();
-                            arrayResult1.push(int);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const arrayLen1 = i32Stack.pop();
+                            let arrayResult1;
+                            if (arrayLen1 === -1) {
+                                arrayResult1 = taStack.pop();
+                            } else {
+                                arrayResult1 = [];
+                                for (let i1 = 0; i1 < arrayLen1; i1++) {
+                                    const int = i32Stack.pop();
+                                    arrayResult1.push(int);
+                                }
+                                arrayResult1.reverse();
+                            }
+                            arrayResult.push(arrayResult1);
                         }
-                        arrayResult1.reverse();
-                        arrayResult.push(arrayResult1);
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processNestedStringArray: function bjs_processNestedStringArray(values) {
@@ -817,18 +945,28 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_processNestedStringArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const arrayLen1 = i32Stack.pop();
-                        const arrayResult1 = [];
-                        for (let i1 = 0; i1 < arrayLen1; i1++) {
-                            const string = strStack.pop();
-                            arrayResult1.push(string);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const arrayLen1 = i32Stack.pop();
+                            let arrayResult1;
+                            if (arrayLen1 === -1) {
+                                arrayResult1 = taStack.pop();
+                            } else {
+                                arrayResult1 = [];
+                                for (let i1 = 0; i1 < arrayLen1; i1++) {
+                                    const string = strStack.pop();
+                                    arrayResult1.push(string);
+                                }
+                                arrayResult1.reverse();
+                            }
+                            arrayResult.push(arrayResult1);
                         }
-                        arrayResult1.reverse();
-                        arrayResult.push(arrayResult1);
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processNestedPointArray: function bjs_processNestedPointArray(points) {
@@ -841,18 +979,28 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(points.length);
                     instance.exports.bjs_processNestedPointArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const arrayLen1 = i32Stack.pop();
-                        const arrayResult1 = [];
-                        for (let i1 = 0; i1 < arrayLen1; i1++) {
-                            const struct = structHelpers.Point.lift();
-                            arrayResult1.push(struct);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const arrayLen1 = i32Stack.pop();
+                            let arrayResult1;
+                            if (arrayLen1 === -1) {
+                                arrayResult1 = taStack.pop();
+                            } else {
+                                arrayResult1 = [];
+                                for (let i1 = 0; i1 < arrayLen1; i1++) {
+                                    const struct = structHelpers.Point.lift();
+                                    arrayResult1.push(struct);
+                                }
+                                arrayResult1.reverse();
+                            }
+                            arrayResult.push(arrayResult1);
                         }
-                        arrayResult1.reverse();
-                        arrayResult.push(arrayResult1);
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processItemArray: function bjs_processItemArray(items) {
@@ -862,13 +1010,18 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(items.length);
                     instance.exports.bjs_processItemArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const ptr = ptrStack.pop();
-                        const obj = Item.__construct(ptr);
-                        arrayResult.push(obj);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const ptr = ptrStack.pop();
+                            const obj = Item.__construct(ptr);
+                            arrayResult.push(obj);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processNestedItemArray: function bjs_processNestedItemArray(items) {
@@ -881,19 +1034,29 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(items.length);
                     instance.exports.bjs_processNestedItemArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const arrayLen1 = i32Stack.pop();
-                        const arrayResult1 = [];
-                        for (let i1 = 0; i1 < arrayLen1; i1++) {
-                            const ptr = ptrStack.pop();
-                            const obj = Item.__construct(ptr);
-                            arrayResult1.push(obj);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const arrayLen1 = i32Stack.pop();
+                            let arrayResult1;
+                            if (arrayLen1 === -1) {
+                                arrayResult1 = taStack.pop();
+                            } else {
+                                arrayResult1 = [];
+                                for (let i1 = 0; i1 < arrayLen1; i1++) {
+                                    const ptr = ptrStack.pop();
+                                    const obj = Item.__construct(ptr);
+                                    arrayResult1.push(obj);
+                                }
+                                arrayResult1.reverse();
+                            }
+                            arrayResult.push(arrayResult1);
                         }
-                        arrayResult1.reverse();
-                        arrayResult.push(arrayResult1);
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processJSObjectArray: function bjs_processJSObjectArray(objects) {
@@ -904,14 +1067,19 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(objects.length);
                     instance.exports.bjs_processJSObjectArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const objId1 = i32Stack.pop();
-                        const obj = swift.memory.getObject(objId1);
-                        swift.memory.release(objId1);
-                        arrayResult.push(obj);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const objId1 = i32Stack.pop();
+                            const obj = swift.memory.getObject(objId1);
+                            swift.memory.release(objId1);
+                            arrayResult.push(obj);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processOptionalJSObjectArray: function bjs_processOptionalJSObjectArray(objects) {
@@ -926,21 +1094,26 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(objects.length);
                     instance.exports.bjs_processOptionalJSObjectArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const isSome1 = i32Stack.pop();
-                        let optValue;
-                        if (isSome1 === 0) {
-                            optValue = null;
-                        } else {
-                            const objId1 = i32Stack.pop();
-                            const obj = swift.memory.getObject(objId1);
-                            swift.memory.release(objId1);
-                            optValue = obj;
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const isSome1 = i32Stack.pop();
+                            let optValue;
+                            if (isSome1 === 0) {
+                                optValue = null;
+                            } else {
+                                const objId1 = i32Stack.pop();
+                                const obj = swift.memory.getObject(objId1);
+                                swift.memory.release(objId1);
+                                optValue = obj;
+                            }
+                            arrayResult.push(optValue);
                         }
-                        arrayResult.push(optValue);
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processNestedJSObjectArray: function bjs_processNestedJSObjectArray(objects) {
@@ -954,20 +1127,30 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(objects.length);
                     instance.exports.bjs_processNestedJSObjectArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const arrayLen1 = i32Stack.pop();
-                        const arrayResult1 = [];
-                        for (let i1 = 0; i1 < arrayLen1; i1++) {
-                            const objId1 = i32Stack.pop();
-                            const obj = swift.memory.getObject(objId1);
-                            swift.memory.release(objId1);
-                            arrayResult1.push(obj);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const arrayLen1 = i32Stack.pop();
+                            let arrayResult1;
+                            if (arrayLen1 === -1) {
+                                arrayResult1 = taStack.pop();
+                            } else {
+                                arrayResult1 = [];
+                                for (let i1 = 0; i1 < arrayLen1; i1++) {
+                                    const objId1 = i32Stack.pop();
+                                    const obj = swift.memory.getObject(objId1);
+                                    swift.memory.release(objId1);
+                                    arrayResult1.push(obj);
+                                }
+                                arrayResult1.reverse();
+                            }
+                            arrayResult.push(arrayResult1);
                         }
-                        arrayResult1.reverse();
-                        arrayResult.push(arrayResult1);
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 multiArrayParams: function bjs_multiArrayParams(nums, strs) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncImport.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncImport.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -212,6 +213,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncStaticImport.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncStaticImport.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -211,6 +212,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
@@ -31,6 +31,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -139,6 +140,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_struct_lower_Config"] = function(objectId) {
                 structHelpers.Config.lower(swift.memory.getObject(objectId));
@@ -550,12 +558,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_testIntArrayDefault();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const int = i32Stack.pop();
-                        arrayResult.push(int);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const int = i32Stack.pop();
+                            arrayResult.push(int);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 testStringArrayDefault: function bjs_testStringArrayDefault(names = ["a", "b", "c"]) {
@@ -568,12 +581,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(names.length);
                     instance.exports.bjs_testStringArrayDefault();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const string = strStack.pop();
-                        arrayResult.push(string);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const string = strStack.pop();
+                            arrayResult.push(string);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 testDoubleArrayDefault: function bjs_testDoubleArrayDefault(values = [1.5, 2.5, 3.5]) {
@@ -583,12 +601,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_testDoubleArrayDefault();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const f64 = f64Stack.pop();
-                        arrayResult.push(f64);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const f64 = f64Stack.pop();
+                            arrayResult.push(f64);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 testBoolArrayDefault: function bjs_testBoolArrayDefault(flags = [true, false, true]) {
@@ -598,12 +621,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(flags.length);
                     instance.exports.bjs_testBoolArrayDefault();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const bool = i32Stack.pop() !== 0;
-                        arrayResult.push(bool);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const bool = i32Stack.pop() !== 0;
+                            arrayResult.push(bool);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 testEmptyArrayDefault: function bjs_testEmptyArrayDefault(items = []) {
@@ -613,12 +641,17 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(items.length);
                     instance.exports.bjs_testEmptyArrayDefault();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const int = i32Stack.pop();
-                        arrayResult.push(int);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const int = i32Stack.pop();
+                            arrayResult.push(int);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 testMixedWithArrayDefault: function bjs_testMixedWithArrayDefault(name = "test", values = [10, 20, 30], enabled = true) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -138,6 +139,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_struct_lower_Counters"] = function(objectId) {
                 structHelpers.Counters.lower(swift.memory.getObject(objectId));
@@ -420,12 +428,17 @@ export async function createInstantiator(options, swift) {
                     const dictResult = {};
                     for (let i = 0; i < dictLen; i++) {
                         const arrayLen = i32Stack.pop();
-                        const arrayResult = [];
-                        for (let i1 = 0; i1 < arrayLen; i1++) {
-                            const int = i32Stack.pop();
-                            arrayResult.push(int);
+                        let arrayResult;
+                        if (arrayLen === -1) {
+                            arrayResult = taStack.pop();
+                        } else {
+                            arrayResult = [];
+                            for (let i1 = 0; i1 < arrayLen; i1++) {
+                                const int = i32Stack.pop();
+                                arrayResult.push(int);
+                            }
+                            arrayResult.reverse();
                         }
-                        arrayResult.reverse();
                         const string = strStack.pop();
                         dictResult[string] = arrayResult;
                     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
@@ -106,6 +106,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -623,12 +624,17 @@ export async function createInstantiator(options, swift) {
                 }
                 case AllTypesResultValues.Tag.ArrayPayload: {
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const int = i32Stack.pop();
-                        arrayResult.push(int);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const int = i32Stack.pop();
+                            arrayResult.push(int);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return { tag: AllTypesResultValues.Tag.ArrayPayload, param0: arrayResult };
                 }
                 case AllTypesResultValues.Tag.Empty: return { tag: AllTypesResultValues.Tag.Empty };
@@ -748,12 +754,17 @@ export async function createInstantiator(options, swift) {
                         optValue = null;
                     } else {
                         const arrayLen = i32Stack.pop();
-                        const arrayResult = [];
-                        for (let i = 0; i < arrayLen; i++) {
-                            const int = i32Stack.pop();
-                            arrayResult.push(int);
+                        let arrayResult;
+                        if (arrayLen === -1) {
+                            arrayResult = taStack.pop();
+                        } else {
+                            arrayResult = [];
+                            for (let i = 0; i < arrayLen; i++) {
+                                const int = i32Stack.pop();
+                                arrayResult.push(int);
+                            }
+                            arrayResult.reverse();
                         }
-                        arrayResult.reverse();
                         optValue = arrayResult;
                     }
                     return { tag: OptionalAllTypesResultValues.Tag.OptArray, param0: optValue };
@@ -830,6 +841,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_struct_lower_Point"] = function(objectId) {
                 structHelpers.Point.lower(swift.memory.getObject(objectId));

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
@@ -49,6 +49,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -121,6 +122,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
@@ -69,6 +69,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -141,6 +142,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
@@ -50,6 +50,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -122,6 +123,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
@@ -100,6 +100,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -173,6 +174,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/FixedWidthIntegers.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/FixedWidthIntegers.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.ConfigPointer.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.ConfigPointer.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.PerClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.PerClass.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -193,12 +201,17 @@ export async function createInstantiator(options, swift) {
             TestModule["bjs_roundtrip"] = function bjs_roundtrip() {
                 try {
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const int = i32Stack.pop();
-                        arrayResult.push(int);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const int = i32Stack.pop();
+                            arrayResult.push(int);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     let ret = imports.roundtrip(arrayResult);
                     for (const elem of ret) {
                         i32Stack.push((elem | 0));
@@ -211,12 +224,17 @@ export async function createInstantiator(options, swift) {
             TestModule["bjs_logStrings"] = function bjs_logStrings() {
                 try {
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const string = strStack.pop();
-                        arrayResult.push(string);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const string = strStack.pop();
+                            arrayResult.push(string);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     imports.logStrings(arrayResult);
                 } catch (error) {
                     setException(error);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -136,6 +137,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_struct_lower_FooContainer"] = function(objectId) {
                 structHelpers.FooContainer.lower(swift.memory.getObject(objectId));
@@ -281,14 +289,19 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(foos.length);
                     instance.exports.bjs_processFooArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const objId1 = i32Stack.pop();
-                        const obj = swift.memory.getObject(objId1);
-                        swift.memory.release(objId1);
-                        arrayResult.push(obj);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const objId1 = i32Stack.pop();
+                            const obj = swift.memory.getObject(objId1);
+                            swift.memory.release(objId1);
+                            arrayResult.push(obj);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processOptionalFooArray: function bjs_processOptionalFooArray(foos) {
@@ -303,21 +316,26 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(foos.length);
                     instance.exports.bjs_processOptionalFooArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const isSome1 = i32Stack.pop();
-                        let optValue;
-                        if (isSome1 === 0) {
-                            optValue = null;
-                        } else {
-                            const objId1 = i32Stack.pop();
-                            const obj = swift.memory.getObject(objId1);
-                            swift.memory.release(objId1);
-                            optValue = obj;
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const isSome1 = i32Stack.pop();
+                            let optValue;
+                            if (isSome1 === 0) {
+                                optValue = null;
+                            } else {
+                                const objId1 = i32Stack.pop();
+                                const obj = swift.memory.getObject(objId1);
+                                swift.memory.release(objId1);
+                                optValue = obj;
+                            }
+                            arrayResult.push(optValue);
                         }
-                        arrayResult.push(optValue);
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 roundtripFooContainer: function bjs_roundtripFooContainer(container) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSTypedArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSTypedArrayTypes.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -188,6 +189,13 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
             }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;
@@ -302,15 +310,20 @@ export async function createInstantiator(options, swift) {
             TestModule["bjs_jsEchoJSValueArray"] = function bjs_jsEchoJSValueArray() {
                 try {
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const jsValuePayload2 = f64Stack.pop();
-                        const jsValuePayload1 = i32Stack.pop();
-                        const jsValueKind = i32Stack.pop();
-                        const jsValue = __bjs_jsValueLift(jsValueKind, jsValuePayload1, jsValuePayload2);
-                        arrayResult.push(jsValue);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const jsValuePayload2 = f64Stack.pop();
+                            const jsValuePayload1 = i32Stack.pop();
+                            const jsValueKind = i32Stack.pop();
+                            const jsValue = __bjs_jsValueLift(jsValueKind, jsValuePayload1, jsValuePayload2);
+                            arrayResult.push(jsValue);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     let ret = imports.jsEchoJSValueArray(arrayResult);
                     for (const elem of ret) {
                         const [elemKind, elemPayload1, elemPayload2] = __bjs_jsValueLower(elem);
@@ -553,15 +566,20 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(values.length);
                     instance.exports.bjs_roundTripJSValueArray();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const jsValuePayload2 = f64Stack.pop();
-                        const jsValuePayload1 = i32Stack.pop();
-                        const jsValueKind = i32Stack.pop();
-                        const jsValue = __bjs_jsValueLift(jsValueKind, jsValuePayload1, jsValuePayload2);
-                        arrayResult.push(jsValue);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const jsValuePayload2 = f64Stack.pop();
+                            const jsValuePayload1 = i32Stack.pop();
+                            const jsValueKind = i32Stack.pop();
+                            const jsValue = __bjs_jsValueLift(jsValueKind, jsValuePayload1, jsValuePayload2);
+                            arrayResult.push(jsValue);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 roundTripOptionalJSValueArray: function bjs_roundTripOptionalJSValueArray(values) {
@@ -581,15 +599,20 @@ export async function createInstantiator(options, swift) {
                     let optResult;
                     if (isSome1) {
                         const arrayLen = i32Stack.pop();
-                        const arrayResult = [];
-                        for (let i = 0; i < arrayLen; i++) {
-                            const jsValuePayload2 = f64Stack.pop();
-                            const jsValuePayload1 = i32Stack.pop();
-                            const jsValueKind = i32Stack.pop();
-                            const jsValue = __bjs_jsValueLift(jsValueKind, jsValuePayload1, jsValuePayload2);
-                            arrayResult.push(jsValue);
+                        let arrayResult;
+                        if (arrayLen === -1) {
+                            arrayResult = taStack.pop();
+                        } else {
+                            arrayResult = [];
+                            for (let i = 0; i < arrayLen; i++) {
+                                const jsValuePayload2 = f64Stack.pop();
+                                const jsValuePayload1 = i32Stack.pop();
+                                const jsValueKind = i32Stack.pop();
+                                const jsValue = __bjs_jsValueLift(jsValueKind, jsValuePayload1, jsValuePayload2);
+                                arrayResult.push(jsValue);
+                            }
+                            arrayResult.reverse();
                         }
-                        arrayResult.reverse();
                         optResult = arrayResult;
                     } else {
                         optResult = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -341,13 +349,18 @@ export async function createInstantiator(options, swift) {
                 getItems() {
                     instance.exports.bjs_Collections_Container_getItems(this.pointer);
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const ptr = ptrStack.pop();
-                        const obj = Greeter.__construct(ptr);
-                        arrayResult.push(obj);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const ptr = ptrStack.pop();
+                            const obj = Greeter.__construct(ptr);
+                            arrayResult.push(obj);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 }
                 addItem(item) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -341,13 +349,18 @@ export async function createInstantiator(options, swift) {
                 getItems() {
                     instance.exports.bjs_Collections_Container_getItems(this.pointer);
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const ptr = ptrStack.pop();
-                        const obj = Greeter.__construct(ptr);
-                        arrayResult.push(obj);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const ptr = ptrStack.pop();
+                            const obj = Greeter.__construct(ptr);
+                            arrayResult.push(obj);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 }
                 addItem(item) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/NestedType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/NestedType.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -122,6 +123,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_struct_lower_User_Stats"] = function(objectId) {
                 structHelpers.User_Stats.lower(swift.memory.getObject(objectId));

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
@@ -49,6 +49,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -154,6 +155,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -722,14 +730,19 @@ export async function createInstantiator(options, swift) {
                 get delegates() {
                     instance.exports.bjs_DelegateManager_delegates_get(this.pointer);
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const objId = i32Stack.pop();
-                        const obj = swift.memory.getObject(objId);
-                        swift.memory.release(objId);
-                        arrayResult.push(obj);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const objId = i32Stack.pop();
+                            const obj = swift.memory.getObject(objId);
+                            swift.memory.release(objId);
+                            arrayResult.push(obj);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 }
                 set delegates(value) {
@@ -783,14 +796,19 @@ export async function createInstantiator(options, swift) {
                     i32Stack.push(delegates.length);
                     instance.exports.bjs_processDelegates();
                     const arrayLen = i32Stack.pop();
-                    const arrayResult = [];
-                    for (let i = 0; i < arrayLen; i++) {
-                        const objId1 = i32Stack.pop();
-                        const obj = swift.memory.getObject(objId1);
-                        swift.memory.release(objId1);
-                        arrayResult.push(obj);
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const objId1 = i32Stack.pop();
+                            const obj = swift.memory.getObject(objId1);
+                            swift.memory.release(objId1);
+                            arrayResult.push(obj);
+                        }
+                        arrayResult.reverse();
                     }
-                    arrayResult.reverse();
                     return arrayResult;
                 },
                 processDelegatesByName: function bjs_processDelegatesByName(delegates) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ProtocolInClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ProtocolInClosure.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -122,6 +123,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
@@ -36,6 +36,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -141,6 +142,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
@@ -36,6 +36,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -141,6 +142,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
@@ -30,6 +30,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -102,6 +103,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
@@ -30,6 +30,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -102,6 +103,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -55,6 +55,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -225,6 +226,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_struct_lower_Animal"] = function(objectId) {
                 structHelpers.Animal.lower(swift.memory.getObject(objectId));

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -123,6 +124,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
@@ -30,6 +30,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -310,6 +311,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_struct_lower_DataPoint"] = function(objectId) {
                 structHelpers.DataPoint.lower(swift.memory.getObject(objectId));

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -109,6 +110,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_struct_lower_Point"] = function(objectId) {
                 structHelpers.Point.lower(swift.memory.getObject(objectId));

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftTypedClosureAccess.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftTypedClosureAccess.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -122,6 +123,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -97,6 +98,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -114,6 +115,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_struct_lower_PointerFields"] = function(objectId) {
                 structHelpers.PointerFields.lower(swift.memory.getObject(objectId));

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
@@ -25,6 +25,7 @@ export async function createInstantiator(options, swift) {
     let f32Stack = [];
     let f64Stack = [];
     let ptrStack = [];
+    let taStack = [];
     const enumHelpers = {};
     const structHelpers = {};
 
@@ -98,6 +99,13 @@ export async function createInstantiator(options, swift) {
             }
             bjs["swift_js_pop_i64"] = function() {
                 return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {

--- a/Plugins/PackageToJS/Templates/instantiate.js
+++ b/Plugins/PackageToJS/Templates/instantiate.js
@@ -68,6 +68,7 @@ async function createInstantiator(options, swift) {
                 swift_js_push_i64: unexpectedBjsCall,
                 swift_js_pop_i64: unexpectedBjsCall,
                 swift_js_closure_unregister: unexpectedBjsCall,
+                swift_js_push_typed_array: unexpectedBjsCall,
             };
         },
         /** @param {WebAssembly.Instance} instance */

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -154,6 +154,11 @@ public protocol _BridgedSwiftStackType {
     static func bridgeJSStackPopAsOptional() -> StackLiftResult?
     /// Specialization point for pushing an `Optional<Self>`
     static func bridgeJSStackPushAsOptional(_ value: consuming Self?)
+
+    /// Specialization point for popping an `Array<Self>` from the bridge stack
+    static func bridgeJSStackPopAsArray() -> [StackLiftResult]
+    /// Specialization point for pushing an `Array<Self>` onto the bridge stack
+    static func bridgeJSStackPushAsArray(_ value: consuming [Self])
 }
 
 extension _BridgedSwiftStackType {
@@ -177,6 +182,25 @@ extension _BridgedSwiftStackType {
             value.bridgeJSStackPush()
             _swift_js_push_i32(1)
         }
+    }
+
+    public static func bridgeJSStackPopAsArray() -> [StackLiftResult] {
+        let count = Int(_swift_js_pop_i32())
+        var result: [StackLiftResult] = []
+        result.reserveCapacity(count)
+        for _ in 0..<count {
+            result.append(Self.bridgeJSStackPop())
+        }
+        result.reverse()
+        return result
+    }
+
+    public static func bridgeJSStackPushAsArray(_ value: consuming [Self]) {
+        let count = value.count
+        for elem in value {
+            elem.bridgeJSStackPush()
+        }
+        _swift_js_push_i32(Int32(count))
     }
 }
 
@@ -1006,6 +1030,107 @@ private func _swift_js_pop_f64_extern() -> Float64 {
 
 @_spi(BridgeJS) @inline(never) public func _swift_js_pop_f64() -> Float64 {
     _swift_js_pop_f64_extern()
+}
+
+// MARK: Typed array bulk push extern
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_push_typed_array")
+private func _swift_js_push_typed_array_extern(_ kind: Int32, _ ptr: UnsafeRawPointer, _ count: Int32)
+#else
+private func _swift_js_push_typed_array_extern(_ kind: Int32, _ ptr: UnsafeRawPointer, _ count: Int32) {
+    _onlyAvailableOnWasm()
+}
+#endif
+
+/// Pushes a typed array onto the JS typed-array stack via bulk copy.
+@_spi(BridgeJS) @inline(never) public func _swift_js_push_typed_array(
+    _ kind: Int32,
+    _ ptr: UnsafeRawPointer,
+    _ count: Int32
+) {
+    _swift_js_push_typed_array_extern(kind, ptr, count)
+}
+
+/// Numeric TypedArray kind identifiers (must match the JS `taCtors` table in BridgeJSLink).
+public enum _BridgedNumericArrayKind: Int32 {
+    case int8 = 0
+    case uint8 = 1
+    case int16 = 2
+    case uint16 = 3
+    case int32 = 4
+    case uint32 = 5
+    case float32 = 6
+    case float64 = 7
+}
+
+// MARK: - Numeric typed-array bulk push
+
+/// Numeric types that opt into bulk typed-array push.
+public protocol _BridgedNumericArray: _BridgedSwiftStackType where StackLiftResult == Self {
+    static var _bridgedNumericArrayKind: _BridgedNumericArrayKind { get }
+}
+
+extension _BridgedNumericArray {
+    @_spi(BridgeJS)
+    public static func bridgeJSStackPushAsArray(_ value: consuming [Self]) {
+        value.withUnsafeBufferPointer { buffer in
+            guard let base = buffer.baseAddress else {
+                _swift_js_push_i32(0)
+                return
+            }
+            _swift_js_push_typed_array(
+                Self._bridgedNumericArrayKind.rawValue,
+                UnsafeRawPointer(base),
+                Int32(buffer.count)
+            )
+            // -1 discriminator tells JS arrayLift to pop from the typed-array stack
+            _swift_js_push_i32(-1)
+        }
+    }
+}
+
+extension Int8: _BridgedNumericArray {
+    public static var _bridgedNumericArrayKind: _BridgedNumericArrayKind { .int8 }
+}
+extension UInt8: _BridgedNumericArray {
+    public static var _bridgedNumericArrayKind: _BridgedNumericArrayKind { .uint8 }
+}
+extension Int16: _BridgedNumericArray {
+    public static var _bridgedNumericArrayKind: _BridgedNumericArrayKind { .int16 }
+}
+extension UInt16: _BridgedNumericArray {
+    public static var _bridgedNumericArrayKind: _BridgedNumericArrayKind { .uint16 }
+}
+extension Int32: _BridgedNumericArray {
+    public static var _bridgedNumericArrayKind: _BridgedNumericArrayKind { .int32 }
+}
+extension UInt32: _BridgedNumericArray {
+    public static var _bridgedNumericArrayKind: _BridgedNumericArrayKind { .uint32 }
+}
+extension Float: _BridgedNumericArray {
+    public static var _bridgedNumericArrayKind: _BridgedNumericArrayKind { .float32 }
+}
+extension Double: _BridgedNumericArray {
+    public static var _bridgedNumericArrayKind: _BridgedNumericArrayKind { .float64 }
+}
+extension Int: _BridgedNumericArray {
+    public static var _bridgedNumericArrayKind: _BridgedNumericArrayKind {
+        #if _pointerBitWidth(_32)
+        return .int32
+        #else
+        return .int32
+        #endif
+    }
+}
+extension UInt: _BridgedNumericArray {
+    public static var _bridgedNumericArrayKind: _BridgedNumericArrayKind {
+        #if _pointerBitWidth(_32)
+        return .uint32
+        #else
+        return .uint32
+        #endif
+    }
 }
 
 // MARK: Wasm externs used by type lowering/lifting
@@ -1973,22 +2098,11 @@ extension Array: _BridgedSwiftStackType where Element: _BridgedSwiftStackType, E
     public typealias StackLiftResult = [Element]
 
     @_spi(BridgeJS) public static func bridgeJSStackPop() -> [Element] {
-        let count = Int(_swift_js_pop_i32())
-        var result: [Element] = []
-        result.reserveCapacity(count)
-        for _ in 0..<count {
-            result.append(Element.bridgeJSStackPop())
-        }
-        result.reverse()
-        return result
+        Element.bridgeJSStackPopAsArray()
     }
 
     @_spi(BridgeJS) public consuming func bridgeJSStackPush() {
-        let array = self
-        for elem in array {
-            elem.bridgeJSStackPush()
-        }
-        _swift_js_push_i32(Int32(array.count))
+        Element.bridgeJSStackPushAsArray(self)
     }
 
     @_spi(BridgeJS) public static func bridgeJSLiftParameter() -> [Element] {


### PR DESCRIPTION
## Overview

Optimize numeric array transfer by using bulk TypedArray memory copy instead of element-by-element stack serialization. When a Swift function passes or receives a numeric array (`[Int]`, `[UInt8]`, `[Float]`, `[Double]`, etc.), BridgeJS now transfers the data as a single bulk operation. TypeScript types remain `number[]` / `bigint[]` — no user-facing API change.

This is a transparent performance optimization following the same pattern as `bridgeJSStackPopAsOptional` — a specialized ABI for numeric element types without changing the type contract. Non-numeric arrays (`[String]`, `[MyStruct]`, etc.) continue using the existing element-by-element stack protocol.

**1. Swift → JS direction:** `Array.bridgeJSTypedArrayPush()` calls `withUnsafeBufferPointer` to pass `(ptr, count, kind)` to a new `swift_js_push_typed_array` WASM import, which copies the bytes into a JS TypedArray. A pre-allocated for-loop then converts to `number[]` for the caller.

**2. JS → Swift direction:** `[T].bridgeJSTypedArrayLiftParameter(sourceId, count)` receives a retained TypedArray from JS, allocates via `Array(unsafeUninitializedCapacity:)`, and calls back to JS via `swift_js_init_typed_array_memory` to bulk copy — the same retain-allocate-callback pattern used by string lowering.

**3. Affected types:** All integer types (Int8 through Int64, signed and unsigned), Float, Double, plus pointer-width Int/UInt. A new `_BridgeJSTypedArrayElement` protocol marks eligible types. `BridgeType.isNumericScalar` and `typedArrayKind` on the skeleton side route the codegen.

### Benchmark results

Release build, 10K iterations × 5 runs:

| Test | Before | After | Speedup |
|------|--------|-------|---------|
| takeIntArray (1K, JS→Swift) | 758 ms | 13 ms | **58×** |
| takeDoubleArray (1K, JS→Swift) | 791 ms | 13 ms | **61×** |
| makeIntArray (1K, Swift→JS) | 221 ms | 18 ms | **12×** |
| makeIntArrayLarge (10K, Swift→JS) | 2160 ms | 146 ms | **15×** |
| roundtripIntArray (1K) | 964 ms | 29 ms | **33×** |
| takeStringArray (non-numeric) | 23 ms | 25 ms | unchanged |
