### PR TITLE
BridgeJS: Add JSTypedArray as a recognized BridgeJS type

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -42,6 +42,14 @@ public final class SwiftToSkeleton {
         self.typeDeclResolver.addSourceFile(
             """
             @JSClass struct JSPromise {}
+            @JSClass struct JSInt8Array {}
+            @JSClass struct JSUint8Array {}
+            @JSClass struct JSInt16Array {}
+            @JSClass struct JSUint16Array {}
+            @JSClass struct JSInt32Array {}
+            @JSClass struct JSUint32Array {}
+            @JSClass struct JSFloat32Array {}
+            @JSClass struct JSFloat64Array {}
             """
         )
     }
@@ -128,9 +136,33 @@ public final class SwiftToSkeleton {
         )
     }
 
+    private static let jsTypedArrayTypealiasNames: [String: String] = [
+        "Int8": "JSInt8Array",
+        "UInt8": "JSUint8Array",
+        "Int16": "JSInt16Array",
+        "UInt16": "JSUint16Array",
+        "Int32": "JSInt32Array",
+        "UInt32": "JSUint32Array",
+        "Float": "JSFloat32Array",
+        "Float32": "JSFloat32Array",
+        "Double": "JSFloat64Array",
+        "Float64": "JSFloat64Array",
+    ]
+
     func lookupType(for type: TypeSyntax, errors: inout [DiagnosticError]) -> BridgeType? {
         if let attributedType = type.as(AttributedTypeSyntax.self) {
             return lookupType(for: attributedType.baseType, errors: &errors)
+        }
+
+        // JSTypedArray<T>
+        if let identifierType = type.as(IdentifierTypeSyntax.self),
+            identifierType.name.text == "JSTypedArray",
+            let genericArgs = identifierType.genericArgumentClause?.arguments,
+            genericArgs.count == 1,
+            let elementName = genericArgs.first?.argument.as(IdentifierTypeSyntax.self)?.name.text,
+            let typealiasName = Self.jsTypedArrayTypealiasNames[elementName]
+        {
+            return .jsObject(typealiasName)
         }
 
         if let identifierType = type.as(IdentifierTypeSyntax.self),

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -3594,6 +3594,9 @@ extension BridgeType {
         case .bool:
             return "boolean"
         case .jsObject(let name):
+            if let name, let tsName = Self.jsTypedArrayTSNames[name] {
+                return tsName
+            }
             return name ?? "any"
         case .jsValue:
             return "any"
@@ -3630,6 +3633,18 @@ extension BridgeType {
             return "Record<string, \(valueType.tsType)>"
         }
     }
+
+    /// Maps JSTypedArray Swift typealias names to their JavaScript TypedArray constructor names.
+    private static let jsTypedArrayTSNames: [String: String] = [
+        "JSInt8Array": "Int8Array",
+        "JSUint8Array": "Uint8Array",
+        "JSInt16Array": "Int16Array",
+        "JSUint16Array": "Uint16Array",
+        "JSInt32Array": "Int32Array",
+        "JSUint32Array": "Uint32Array",
+        "JSFloat32Array": "Float32Array",
+        "JSFloat64Array": "Float64Array",
+    ]
 }
 
 extension WasmCoreType {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/JSTypedArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/JSTypedArrayTypes.swift
@@ -1,0 +1,19 @@
+import JavaScriptKit
+
+// Using typealiases
+@JS func processBytes(_ data: JSUint8Array) -> JSUint8Array {
+    return data
+}
+
+@JS func processFloats(_ data: JSFloat32Array) -> JSFloat32Array {
+    return data
+}
+
+// Using generic form directly
+@JS func processGenericDoubles(_ data: JSTypedArray<Double>) -> JSTypedArray<Double> {
+    return data
+}
+
+@JS func processGenericInts(_ data: JSTypedArray<Int32>) -> JSTypedArray<Int32> {
+    return data
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSTypedArrayTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSTypedArrayTypes.json
@@ -1,0 +1,123 @@
+{
+  "exported" : {
+    "classes" : [
+
+    ],
+    "enums" : [
+
+    ],
+    "exposeToGlobal" : false,
+    "functions" : [
+      {
+        "abiName" : "bjs_processBytes",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "processBytes",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "data",
+            "type" : {
+              "jsObject" : {
+                "_0" : "JSUint8Array"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "jsObject" : {
+            "_0" : "JSUint8Array"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_processFloats",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "processFloats",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "data",
+            "type" : {
+              "jsObject" : {
+                "_0" : "JSFloat32Array"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "jsObject" : {
+            "_0" : "JSFloat32Array"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_processGenericDoubles",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "processGenericDoubles",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "data",
+            "type" : {
+              "jsObject" : {
+                "_0" : "JSFloat64Array"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "jsObject" : {
+            "_0" : "JSFloat64Array"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_processGenericInts",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "processGenericInts",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "data",
+            "type" : {
+              "jsObject" : {
+                "_0" : "JSInt32Array"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "jsObject" : {
+            "_0" : "JSInt32Array"
+          }
+        }
+      }
+    ],
+    "protocols" : [
+
+    ],
+    "structs" : [
+
+    ]
+  },
+  "moduleName" : "TestModule",
+  "usedExternalModules" : [
+
+  ]
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSTypedArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSTypedArrayTypes.swift
@@ -1,0 +1,43 @@
+@_expose(wasm, "bjs_processBytes")
+@_cdecl("bjs_processBytes")
+public func _bjs_processBytes(_ data: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = processBytes(_: JSUint8Array.bridgeJSLiftParameter(data))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processFloats")
+@_cdecl("bjs_processFloats")
+public func _bjs_processFloats(_ data: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = processFloats(_: JSFloat32Array.bridgeJSLiftParameter(data))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processGenericDoubles")
+@_cdecl("bjs_processGenericDoubles")
+public func _bjs_processGenericDoubles(_ data: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = processGenericDoubles(_: JSFloat64Array.bridgeJSLiftParameter(data))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_processGenericInts")
+@_cdecl("bjs_processGenericInts")
+public func _bjs_processGenericInts(_ data: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = processGenericInts(_: JSInt32Array.bridgeJSLiftParameter(data))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSTypedArrayTypes.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSTypedArrayTypes.d.ts
@@ -1,0 +1,21 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export type Exports = {
+    processBytes(data: Uint8Array): Uint8Array;
+    processFloats(data: Float32Array): Float32Array;
+    processGenericDoubles(data: Float64Array): Float64Array;
+    processGenericInts(data: Int32Array): Int32Array;
+}
+export type Imports = {
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSTypedArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSTypedArrayTypes.js
@@ -1,0 +1,235 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    let decodeString;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let strStack = [];
+    let i32Stack = [];
+    let i64Stack = [];
+    let f32Stack = [];
+    let f64Stack = [];
+    let ptrStack = [];
+    const enumHelpers = {};
+    const structHelpers = {};
+
+    let _exports = null;
+    let bjs = null;
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            bjs = {};
+            importObject["bjs"] = bjs;
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                tmpRetString = decodeString(ptr, len);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                return swift.memory.retain(decodeString(ptr, len));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr, len);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_i32"] = function(v) {
+                i32Stack.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                f32Stack.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                f64Stack.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const value = decodeString(ptr, len);
+                strStack.push(value);
+            }
+            bjs["swift_js_pop_i32"] = function() {
+                return i32Stack.pop();
+            }
+            bjs["swift_js_pop_f32"] = function() {
+                return f32Stack.pop();
+            }
+            bjs["swift_js_pop_f64"] = function() {
+                return f64Stack.pop();
+            }
+            bjs["swift_js_push_pointer"] = function(pointer) {
+                ptrStack.push(pointer);
+            }
+            bjs["swift_js_pop_pointer"] = function() {
+                return ptrStack.pop();
+            }
+            bjs["swift_js_push_i64"] = function(v) {
+                i64Stack.push(v);
+            }
+            bjs["swift_js_pop_i64"] = function() {
+                return i64Stack.pop();
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = decodeString(ptr, len);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            bjs["swift_js_get_optional_int_presence"] = function() {
+                return tmpRetOptionalInt != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_int_value"] = function() {
+                const value = tmpRetOptionalInt;
+                tmpRetOptionalInt = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_string"] = function() {
+                const str = tmpRetString;
+                tmpRetString = undefined;
+                if (str == null) {
+                    return -1;
+                } else {
+                    const bytes = textEncoder.encode(str);
+                    tmpRetBytes = bytes;
+                    return bytes.length;
+                }
+            }
+            bjs["swift_js_get_optional_float_presence"] = function() {
+                return tmpRetOptionalFloat != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_float_value"] = function() {
+                const value = tmpRetOptionalFloat;
+                tmpRetOptionalFloat = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_double_presence"] = function() {
+                return tmpRetOptionalDouble != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_double_value"] = function() {
+                const value = tmpRetOptionalDouble;
+                tmpRetOptionalDouble = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_heap_object_pointer"] = function() {
+                const pointer = tmpRetOptionalHeapObject;
+                tmpRetOptionalHeapObject = undefined;
+                return pointer || 0;
+            }
+            bjs["swift_js_closure_unregister"] = function(funcRef) {}
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            decodeString = (ptr, len) => { const bytes = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0); return textDecoder.decode(bytes); }
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            const exports = {
+                processBytes: function bjs_processBytes(data) {
+                    const ret = instance.exports.bjs_processBytes(swift.memory.retain(data));
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                processFloats: function bjs_processFloats(data) {
+                    const ret = instance.exports.bjs_processFloats(swift.memory.retain(data));
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                processGenericDoubles: function bjs_processGenericDoubles(data) {
+                    const ret = instance.exports.bjs_processGenericDoubles(swift.memory.retain(data));
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                processGenericInts: function bjs_processGenericInts(data) {
+                    const ret = instance.exports.bjs_processGenericInts(swift.memory.retain(data));
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+            };
+            _exports = exports;
+            return exports;
+        },
+    }
+}

--- a/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
+++ b/Sources/JavaScriptKit/BasicObjects/JSTypedArray.swift
@@ -204,3 +204,12 @@ public enum JSUInt8Clamped: TypedArrayElement {
 }
 
 public typealias JSUInt8ClampedArray = JSTypedArray<JSUInt8Clamped>
+
+public typealias JSInt8Array = JSTypedArray<Int8>
+public typealias JSUint8Array = JSTypedArray<UInt8>
+public typealias JSInt16Array = JSTypedArray<Int16>
+public typealias JSUint16Array = JSTypedArray<UInt16>
+public typealias JSInt32Array = JSTypedArray<Int32>
+public typealias JSUint32Array = JSTypedArray<UInt32>
+public typealias JSFloat32Array = JSTypedArray<Float32>
+public typealias JSFloat64Array = JSTypedArray<Float64>

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Array.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Array.md
@@ -95,6 +95,42 @@ TypeScript definitions:
 - `[Int]?` becomes `number[] | null`
 - `[[Int]]` becomes `number[][]`
 
+## Using TypedArrays
+
+When you need the JavaScript API to use native TypedArray types (e.g., `Uint8Array` for `fetch` body, `Float32Array` for WebGPU), use ``JSTypedArray`` instead of a plain Swift array:
+
+```swift
+import JavaScriptKit
+
+@JS func processData(_ data: JSTypedArray<UInt8>) -> JSTypedArray<UInt8> {
+    return data
+}
+
+// Convenience typealiases also work:
+@JS func processFloats(_ data: JSFloat32Array) -> JSFloat32Array {
+    return data
+}
+```
+
+Generated TypeScript:
+
+```typescript
+export type Exports = {
+    processData(data: Uint8Array): Uint8Array;
+    processFloats(data: Float32Array): Float32Array;
+}
+```
+
+Unlike plain arrays which use copy semantics, `JSTypedArray` uses **reference semantics** — it wraps a JavaScript TypedArray object and passes it by reference (no data copying). This is ideal for large binary data or when interacting with JavaScript APIs that expect TypedArrays.
+
+| Swift | TypeScript |
+|:------|:-----------|
+| `JSTypedArray<UInt8>` / `JSUint8Array` | `Uint8Array` |
+| `JSTypedArray<Int8>` / `JSInt8Array` | `Int8Array` |
+| `JSTypedArray<Int32>` / `JSInt32Array` | `Int32Array` |
+| `JSTypedArray<Float>` / `JSFloat32Array` | `Float32Array` |
+| `JSTypedArray<Double>` / `JSFloat64Array` | `Float64Array` |
+
 ## How It Works
 
 Arrays use **copy semantics** when crossing the Swift/JavaScript boundary:

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Supported-Types.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Supported-Types.md
@@ -16,6 +16,20 @@ Swift types and their JavaScript/TypeScript equivalents at the BridgeJS boundary
 | ``JSUndefinedOr`` `<T>` | `undefined` or `T` | `T \| undefined` |
 | ``JSObject`` | object | `object` |
 | ``JSValue`` | any | `any` |
+| ``JSTypedArray`` `<T>` | TypedArray | `Uint8Array`, `Float32Array`, etc. |
+
+### TypedArray mapping
+
+When using `JSTypedArray<T>` (or convenience typealiases) in `@JS` signatures, the TypeScript type maps to the corresponding JavaScript TypedArray:
+
+| Swift | TypeScript |
+|:--|:--|
+| `JSTypedArray<UInt8>` / `JSUint8Array` | `Uint8Array` |
+| `JSTypedArray<Int32>` / `JSInt32Array` | `Int32Array` |
+| `JSTypedArray<Float>` / `JSFloat32Array` | `Float32Array` |
+| `JSTypedArray<Double>` / `JSFloat64Array` | `Float64Array` |
+
+See <doc:Exporting-Swift-Array> for usage details.
 
 ## See Also
 

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -4919,6 +4919,50 @@ public func _bjs_IntegerTypesSupportExports_static_roundTripUInt64(_ v: Int64) -
     #endif
 }
 
+@_expose(wasm, "bjs_JSTypedArrayExports_static_roundTripUint8Array")
+@_cdecl("bjs_JSTypedArrayExports_static_roundTripUint8Array")
+public func _bjs_JSTypedArrayExports_static_roundTripUint8Array(_ v: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSTypedArrayExports.roundTripUint8Array(_: JSUint8Array.bridgeJSLiftParameter(v))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_JSTypedArrayExports_static_roundTripFloat32Array")
+@_cdecl("bjs_JSTypedArrayExports_static_roundTripFloat32Array")
+public func _bjs_JSTypedArrayExports_static_roundTripFloat32Array(_ v: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSTypedArrayExports.roundTripFloat32Array(_: JSFloat32Array.bridgeJSLiftParameter(v))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_JSTypedArrayExports_static_roundTripFloat64Array")
+@_cdecl("bjs_JSTypedArrayExports_static_roundTripFloat64Array")
+public func _bjs_JSTypedArrayExports_static_roundTripFloat64Array(_ v: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSTypedArrayExports.roundTripFloat64Array(_: JSFloat64Array.bridgeJSLiftParameter(v))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_JSTypedArrayExports_static_roundTripInt32Array")
+@_cdecl("bjs_JSTypedArrayExports_static_roundTripInt32Array")
+public func _bjs_JSTypedArrayExports_static_roundTripInt32Array(_ v: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSTypedArrayExports.roundTripInt32Array(_: JSInt32Array.bridgeJSLiftParameter(v))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalString")
 @_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalString")
 public func _bjs_OptionalSupportExports_static_roundTripOptionalString(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Void {
@@ -13538,6 +13582,129 @@ func _$JSClassSupportImports_makeJSClassWithArrayMembers(_ numbers: [Int], _ lab
         throw error
     }
     return JSClassWithArrayMembers.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JSTypedArrayImports_jsCreateUint8Array_static")
+fileprivate func bjs_JSTypedArrayImports_jsCreateUint8Array_static_extern() -> Int32
+#else
+fileprivate func bjs_JSTypedArrayImports_jsCreateUint8Array_static_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_JSTypedArrayImports_jsCreateUint8Array_static() -> Int32 {
+    return bjs_JSTypedArrayImports_jsCreateUint8Array_static_extern()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JSTypedArrayImports_jsRoundTripUint8Array_static")
+fileprivate func bjs_JSTypedArrayImports_jsRoundTripUint8Array_static_extern(_ v: Int32) -> Int32
+#else
+fileprivate func bjs_JSTypedArrayImports_jsRoundTripUint8Array_static_extern(_ v: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_JSTypedArrayImports_jsRoundTripUint8Array_static(_ v: Int32) -> Int32 {
+    return bjs_JSTypedArrayImports_jsRoundTripUint8Array_static_extern(v)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JSTypedArrayImports_jsRoundTripFloat32Array_static")
+fileprivate func bjs_JSTypedArrayImports_jsRoundTripFloat32Array_static_extern(_ v: Int32) -> Int32
+#else
+fileprivate func bjs_JSTypedArrayImports_jsRoundTripFloat32Array_static_extern(_ v: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_JSTypedArrayImports_jsRoundTripFloat32Array_static(_ v: Int32) -> Int32 {
+    return bjs_JSTypedArrayImports_jsRoundTripFloat32Array_static_extern(v)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JSTypedArrayImports_jsRoundTripFloat64Array_static")
+fileprivate func bjs_JSTypedArrayImports_jsRoundTripFloat64Array_static_extern(_ v: Int32) -> Int32
+#else
+fileprivate func bjs_JSTypedArrayImports_jsRoundTripFloat64Array_static_extern(_ v: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_JSTypedArrayImports_jsRoundTripFloat64Array_static(_ v: Int32) -> Int32 {
+    return bjs_JSTypedArrayImports_jsRoundTripFloat64Array_static_extern(v)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JSTypedArrayImports_jsRoundTripInt32Array_static")
+fileprivate func bjs_JSTypedArrayImports_jsRoundTripInt32Array_static_extern(_ v: Int32) -> Int32
+#else
+fileprivate func bjs_JSTypedArrayImports_jsRoundTripInt32Array_static_extern(_ v: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_JSTypedArrayImports_jsRoundTripInt32Array_static(_ v: Int32) -> Int32 {
+    return bjs_JSTypedArrayImports_jsRoundTripInt32Array_static_extern(v)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JSTypedArrayImports_runJsTypedArrayTests_static")
+fileprivate func bjs_JSTypedArrayImports_runJsTypedArrayTests_static_extern() -> Void
+#else
+fileprivate func bjs_JSTypedArrayImports_runJsTypedArrayTests_static_extern() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_JSTypedArrayImports_runJsTypedArrayTests_static() -> Void {
+    return bjs_JSTypedArrayImports_runJsTypedArrayTests_static_extern()
+}
+
+func _$JSTypedArrayImports_jsCreateUint8Array() throws(JSException) -> JSUint8Array {
+    let ret = bjs_JSTypedArrayImports_jsCreateUint8Array_static()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSUint8Array.bridgeJSLiftReturn(ret)
+}
+
+func _$JSTypedArrayImports_jsRoundTripUint8Array(_ v: JSUint8Array) throws(JSException) -> JSUint8Array {
+    let vValue = v.bridgeJSLowerParameter()
+    let ret = bjs_JSTypedArrayImports_jsRoundTripUint8Array_static(vValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSUint8Array.bridgeJSLiftReturn(ret)
+}
+
+func _$JSTypedArrayImports_jsRoundTripFloat32Array(_ v: JSFloat32Array) throws(JSException) -> JSFloat32Array {
+    let vValue = v.bridgeJSLowerParameter()
+    let ret = bjs_JSTypedArrayImports_jsRoundTripFloat32Array_static(vValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSFloat32Array.bridgeJSLiftReturn(ret)
+}
+
+func _$JSTypedArrayImports_jsRoundTripFloat64Array(_ v: JSFloat64Array) throws(JSException) -> JSFloat64Array {
+    let vValue = v.bridgeJSLowerParameter()
+    let ret = bjs_JSTypedArrayImports_jsRoundTripFloat64Array_static(vValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSFloat64Array.bridgeJSLiftReturn(ret)
+}
+
+func _$JSTypedArrayImports_jsRoundTripInt32Array(_ v: JSInt32Array) throws(JSException) -> JSInt32Array {
+    let vValue = v.bridgeJSLowerParameter()
+    let ret = bjs_JSTypedArrayImports_jsRoundTripInt32Array_static(vValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSInt32Array.bridgeJSLiftReturn(ret)
+}
+
+func _$JSTypedArrayImports_runJsTypedArrayTests() throws(JSException) -> Void {
+    bjs_JSTypedArrayImports_runJsTypedArrayTests_static()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
 }
 
 #if arch(wasm32)

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -9569,6 +9569,152 @@
 
         ],
         "emitStyle" : "const",
+        "name" : "JSTypedArrayExports",
+        "staticMethods" : [
+          {
+            "abiName" : "bjs_JSTypedArrayExports_static_roundTripUint8Array",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "roundTripUint8Array",
+            "namespace" : [
+              "JSTypedArrayExports"
+            ],
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "v",
+                "type" : {
+                  "jsObject" : {
+                    "_0" : "JSUint8Array"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "jsObject" : {
+                "_0" : "JSUint8Array"
+              }
+            },
+            "staticContext" : {
+              "namespaceEnum" : {
+                "_0" : "JSTypedArrayExports"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_JSTypedArrayExports_static_roundTripFloat32Array",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "roundTripFloat32Array",
+            "namespace" : [
+              "JSTypedArrayExports"
+            ],
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "v",
+                "type" : {
+                  "jsObject" : {
+                    "_0" : "JSFloat32Array"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "jsObject" : {
+                "_0" : "JSFloat32Array"
+              }
+            },
+            "staticContext" : {
+              "namespaceEnum" : {
+                "_0" : "JSTypedArrayExports"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_JSTypedArrayExports_static_roundTripFloat64Array",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "roundTripFloat64Array",
+            "namespace" : [
+              "JSTypedArrayExports"
+            ],
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "v",
+                "type" : {
+                  "jsObject" : {
+                    "_0" : "JSFloat64Array"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "jsObject" : {
+                "_0" : "JSFloat64Array"
+              }
+            },
+            "staticContext" : {
+              "namespaceEnum" : {
+                "_0" : "JSTypedArrayExports"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_JSTypedArrayExports_static_roundTripInt32Array",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "roundTripInt32Array",
+            "namespace" : [
+              "JSTypedArrayExports"
+            ],
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "v",
+                "type" : {
+                  "jsObject" : {
+                    "_0" : "JSInt32Array"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "jsObject" : {
+                "_0" : "JSInt32Array"
+              }
+            },
+            "staticContext" : {
+              "namespaceEnum" : {
+                "_0" : "JSTypedArrayExports"
+              }
+            }
+          }
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "JSTypedArrayExports",
+        "tsFullPath" : "JSTypedArrayExports"
+      },
+      {
+        "cases" : [
+
+        ],
+        "emitStyle" : "const",
         "name" : "OptionalSupportExports",
         "staticMethods" : [
           {
@@ -20032,6 +20178,158 @@
                 "returnType" : {
                   "jsObject" : {
                     "_0" : "JSClassWithArrayMembers"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "functions" : [
+
+        ],
+        "types" : [
+          {
+            "accessLevel" : "internal",
+            "getters" : [
+
+            ],
+            "methods" : [
+
+            ],
+            "name" : "JSTypedArrayImports",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsCreateUint8Array",
+                "parameters" : [
+
+                ],
+                "returnType" : {
+                  "jsObject" : {
+                    "_0" : "JSUint8Array"
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsRoundTripUint8Array",
+                "parameters" : [
+                  {
+                    "name" : "v",
+                    "type" : {
+                      "jsObject" : {
+                        "_0" : "JSUint8Array"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "jsObject" : {
+                    "_0" : "JSUint8Array"
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsRoundTripFloat32Array",
+                "parameters" : [
+                  {
+                    "name" : "v",
+                    "type" : {
+                      "jsObject" : {
+                        "_0" : "JSFloat32Array"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "jsObject" : {
+                    "_0" : "JSFloat32Array"
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsRoundTripFloat64Array",
+                "parameters" : [
+                  {
+                    "name" : "v",
+                    "type" : {
+                      "jsObject" : {
+                        "_0" : "JSFloat64Array"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "jsObject" : {
+                    "_0" : "JSFloat64Array"
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsRoundTripInt32Array",
+                "parameters" : [
+                  {
+                    "name" : "v",
+                    "type" : {
+                      "jsObject" : {
+                        "_0" : "JSInt32Array"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "jsObject" : {
+                    "_0" : "JSInt32Array"
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "runJsTypedArrayTests",
+                "parameters" : [
+
+                ],
+                "returnType" : {
+                  "void" : {
+
                   }
                 }
               }

--- a/Tests/BridgeJSRuntimeTests/JSTypedArrayTests.swift
+++ b/Tests/BridgeJSRuntimeTests/JSTypedArrayTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import JavaScriptKit
+
+@JS enum JSTypedArrayExports {
+    @JS static func roundTripUint8Array(_ v: JSUint8Array) -> JSUint8Array { v }
+    @JS static func roundTripFloat32Array(_ v: JSFloat32Array) -> JSFloat32Array { v }
+    @JS static func roundTripFloat64Array(_ v: JSFloat64Array) -> JSFloat64Array { v }
+    @JS static func roundTripInt32Array(_ v: JSInt32Array) -> JSInt32Array { v }
+}
+
+@JSClass struct JSTypedArrayImports {
+    @JSFunction static func jsCreateUint8Array() throws(JSException) -> JSUint8Array
+    @JSFunction static func jsRoundTripUint8Array(_ v: JSUint8Array) throws(JSException) -> JSUint8Array
+    @JSFunction static func jsRoundTripFloat32Array(_ v: JSFloat32Array) throws(JSException) -> JSFloat32Array
+    @JSFunction static func jsRoundTripFloat64Array(_ v: JSFloat64Array) throws(JSException) -> JSFloat64Array
+    @JSFunction static func jsRoundTripInt32Array(_ v: JSInt32Array) throws(JSException) -> JSInt32Array
+    @JSFunction static func runJsTypedArrayTests() throws(JSException)
+}
+
+final class JSTypedArrayTests: XCTestCase {
+    func testRunJsTypedArrayTests() throws {
+        try JSTypedArrayImports.runJsTypedArrayTests()
+    }
+
+    func testRoundTripUint8Array() throws {
+        let arr = JSUint8Array([1, 2, 3, 255])
+        let result = try JSTypedArrayImports.jsRoundTripUint8Array(arr)
+        XCTAssertEqual(result.length, 4)
+    }
+
+    func testCreateUint8Array() throws {
+        let result = try JSTypedArrayImports.jsCreateUint8Array()
+        XCTAssertEqual(result.length, 3)
+    }
+
+    func testRoundTripFloat32Array() throws {
+        let arr = JSFloat32Array([1.0, 2.5, 3.0])
+        let result = try JSTypedArrayImports.jsRoundTripFloat32Array(arr)
+        XCTAssertEqual(result.length, 3)
+    }
+
+    func testRoundTripFloat64Array() throws {
+        let arr = JSFloat64Array([1.0, 2.5, 3.14159])
+        let result = try JSTypedArrayImports.jsRoundTripFloat64Array(arr)
+        XCTAssertEqual(result.length, 3)
+    }
+
+    func testRoundTripInt32Array() throws {
+        let arr = JSInt32Array([1, -2, 2_147_483_647])
+        let result = try JSTypedArrayImports.jsRoundTripInt32Array(arr)
+        XCTAssertEqual(result.length, 3)
+    }
+}

--- a/Tests/BridgeJSRuntimeTests/JavaScript/JSTypedArrayTests.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/JSTypedArrayTests.mjs
@@ -1,0 +1,77 @@
+// @ts-check
+
+import assert from 'node:assert';
+
+/**
+ * @returns {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Imports["JSTypedArrayImports"]}
+ */
+export function getImports(importsContext) {
+    return {
+        jsCreateUint8Array: function () {
+            return new Uint8Array([10, 20, 30]);
+        },
+        jsRoundTripUint8Array: function (arr) {
+            assert.ok(arr instanceof Uint8Array, 'Expected Uint8Array');
+            return arr;
+        },
+        jsRoundTripFloat32Array: function (arr) {
+            assert.ok(arr instanceof Float32Array, 'Expected Float32Array');
+            return arr;
+        },
+        jsRoundTripFloat64Array: function (arr) {
+            assert.ok(arr instanceof Float64Array, 'Expected Float64Array');
+            return arr;
+        },
+        jsRoundTripInt32Array: function (arr) {
+            assert.ok(arr instanceof Int32Array, 'Expected Int32Array');
+            return arr;
+        },
+        runJsTypedArrayTests: () => {
+            const exports = importsContext.getExports();
+            if (!exports) { throw new Error("No exports!?"); }
+            runJsTypedArrayTests(exports);
+        },
+    };
+}
+
+/**
+ * JSTypedArray bridging coverage for BridgeJS runtime tests.
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} rootExports
+ */
+export function runJsTypedArrayTests(rootExports) {
+    const exports = rootExports.JSTypedArrayExports;
+
+    // Uint8Array round-trip
+    const u8 = new Uint8Array([1, 2, 3, 255]);
+    const u8Result = exports.roundTripUint8Array(u8);
+    assert.ok(u8Result instanceof Uint8Array, 'Expected Uint8Array back from Swift');
+    assert.equal(u8Result.length, 4);
+    assert.deepEqual(Array.from(u8Result), [1, 2, 3, 255]);
+
+    // Float32Array round-trip
+    const f32 = new Float32Array([1.0, 2.5, 3.0]);
+    const f32Result = exports.roundTripFloat32Array(f32);
+    assert.ok(f32Result instanceof Float32Array, 'Expected Float32Array back from Swift');
+    assert.equal(f32Result.length, 3);
+    assert.deepEqual(Array.from(f32Result), [1.0, 2.5, 3.0]);
+
+    // Float64Array round-trip
+    const f64 = new Float64Array([1.0, 2.5, 3.14159]);
+    const f64Result = exports.roundTripFloat64Array(f64);
+    assert.ok(f64Result instanceof Float64Array, 'Expected Float64Array back from Swift');
+    assert.equal(f64Result.length, 3);
+    assert.deepEqual(Array.from(f64Result), [1.0, 2.5, 3.14159]);
+
+    // Int32Array round-trip
+    const i32 = new Int32Array([1, -2, 2147483647]);
+    const i32Result = exports.roundTripInt32Array(i32);
+    assert.ok(i32Result instanceof Int32Array, 'Expected Int32Array back from Swift');
+    assert.equal(i32Result.length, 3);
+    assert.deepEqual(Array.from(i32Result), [1, -2, 2147483647]);
+
+    // Empty typed array
+    const emptyU8 = new Uint8Array([]);
+    const emptyResult = exports.roundTripUint8Array(emptyU8);
+    assert.ok(emptyResult instanceof Uint8Array, 'Expected Uint8Array for empty array');
+    assert.equal(emptyResult.length, 0);
+}

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -14,6 +14,7 @@ import { getImports as getDefaultArgumentImports } from './BridgeJSRuntimeTests/
 import { getImports as getJSClassSupportImports, JSClassWithArrayMembers } from './BridgeJSRuntimeTests/JavaScript/JSClassSupportTests.mjs';
 import { getImports as getIntegerTypesSupportImports } from './BridgeJSRuntimeTests/JavaScript/IntegerTypesSupportTests.mjs';
 import { getImports as getAsyncImportImports, runAsyncWorksTests } from './BridgeJSRuntimeTests/JavaScript/AsyncImportTests.mjs';
+import { getImports as getJSTypedArrayImports } from './BridgeJSRuntimeTests/JavaScript/JSTypedArrayTests.mjs';
 import { getImports as getIdentityModeTestImports } from './BridgeJSIdentityTests/JavaScript/IdentityModeTests.mjs';
 
 /** @type {import('../.build/plugins/PackageToJS/outputs/PackageTests/test.d.ts').SetupOptionsFn} */
@@ -156,6 +157,7 @@ export async function setupOptions(options, context) {
                 DefaultArgumentImports: getDefaultArgumentImports(importsContext),
                 JSClassSupportImports: getJSClassSupportImports(importsContext),
                 IntegerTypesSupportImports: getIntegerTypesSupportImports(importsContext),
+                JSTypedArrayImports: getJSTypedArrayImports(importsContext),
                 IdentityModeTestImports: getIdentityModeTestImports(importsContext),
             };
         },


### PR DESCRIPTION
## Overview

Add `JSTypedArray<T>` and convenience typealiases (`JSUint8Array`, `JSFloat32Array`, etc.) as recognized BridgeJS types. Users can now use typed arrays directly in `@JS` function signatures to get native TypedArray types in the generated TypeScript declarations.

Both the generic form and typealiases work:

```swift
@JS func processData(_ data: JSTypedArray<UInt8>) -> JSTypedArray<UInt8> { ... }
@JS func processData(_ data: JSUint8Array) -> JSUint8Array { ... }  // equivalent
```

Generated TypeScript:
```typescript
processData(data: Uint8Array): Uint8Array;
```

Bridging is reference-based — passes the JSObject ID across the boundary with no data copying. The TypedArray lives on the JS heap. This follows the same pattern as `JSPromise`, which is already pre-seeded as a known BridgeJS type.

**1. `JSTypedArray.swift`** — 8 convenience typealiases: `JSInt8Array`, `JSUint8Array`, `JSInt16Array`, `JSUint16Array`, `JSInt32Array`, `JSUint32Array`, `JSFloat32Array`, `JSFloat64Array`.

**2. `SwiftToSkeleton.swift`** — Pre-seed typed array types in the type resolver (same as `JSPromise`). Recognize `JSTypedArray<T>` generic form via element name → typealias mapping.

**3. `BridgeJSLink.swift`** — Map Swift typealias names to JS TypedArray constructor names in `tsType` (e.g., `JSUint8Array` → `Uint8Array`).

**4. `TS2Swift/processor.js`** — Map TypeScript TypedArray types to Swift typealiases in the TS importer, preventing import of the full TypedArray API surface from TypeScript's stdlib.

**5. E2e tests** — `JSTypedArrayTests.swift` + `JSTypedArrayTests.mjs` with round-trip tests for Uint8Array, Float32Array, Float64Array, Int32Array from both Swift and JS sides.