### PR TITLE
BridgeJS: Export types using a separate JS representation

### DIFF
--- a/Benchmarks/Sources/Generated/JavaScript/BridgeJS.json
+++ b/Benchmarks/Sources/Generated/JavaScript/BridgeJS.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/JavaScript/BridgeJS.json
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/JavaScript/BridgeJS.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ClosureCodegen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ClosureCodegen.swift
@@ -153,7 +153,8 @@ public struct ClosureCodegen {
             let argNames = liftInfo.parameters.map { (argName, _) in
                 liftInfo.parameters.count > 1 ? "\(paramName)\(argName.capitalizedFirstLetter)" : paramName
             }
-            liftedParams.append("\(paramType.swiftType).bridgeJSLiftParameter(\(argNames.joined(separator: ", ")))")
+            let liftCall = "\(paramType.unaliased.swiftType).bridgeJSLiftParameter(\(argNames.joined(separator: ", ")))"
+            liftedParams.append(paramType.liftAliases(expression: liftCall))
         }
 
         let tryPrefix = signature.isThrows ? "try " : ""
@@ -197,7 +198,8 @@ public struct ClosureCodegen {
                     }
                     printer.write("}")
                 default:
-                    printer.write("return result.bridgeJSLowerReturn()")
+                    let lowered = signature.returnType.lowerAliases(expression: "result")
+                    printer.write("return \(lowered).bridgeJSLowerReturn()")
                 }
             }
         }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ClosureCodegen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ClosureCodegen.swift
@@ -153,8 +153,9 @@ public struct ClosureCodegen {
             let argNames = liftInfo.parameters.map { (argName, _) in
                 liftInfo.parameters.count > 1 ? "\(paramName)\(argName.capitalizedFirstLetter)" : paramName
             }
-            let liftCall = "\(paramType.unaliased.swiftType).bridgeJSLiftParameter(\(argNames.joined(separator: ", ")))"
-            liftedParams.append(paramType.liftAliases(expression: liftCall))
+            liftedParams.append(
+                "\(paramType.swiftType).bridgeJSLiftParameter(\(argNames.joined(separator: ", ")))"
+            )
         }
 
         let tryPrefix = signature.isThrows ? "try " : ""
@@ -198,8 +199,7 @@ public struct ClosureCodegen {
                     }
                     printer.write("}")
                 default:
-                    let lowered = signature.returnType.lowerAliases(expression: "result")
-                    printer.write("return \(lowered).bridgeJSLowerReturn()")
+                    printer.write("return result.bridgeJSLowerReturn()")
                 }
             }
         }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -227,15 +227,15 @@ public class ExportSwift {
                 } else {
                     optionalSwiftType = "JSUndefinedOr"
                 }
-                typeNameForIntrinsic = "\(optionalSwiftType)<\(wrappedType.swiftType)>"
-                liftingExpr = ExprSyntax(
-                    "\(raw: typeNameForIntrinsic).bridgeJSLiftParameter(\(raw: argumentsToLift.joined(separator: ", ")))"
-                )
+                typeNameForIntrinsic = "\(optionalSwiftType)<\(wrappedType.unaliased.swiftType)>"
+                let liftCall =
+                    "\(typeNameForIntrinsic).bridgeJSLiftParameter(\(argumentsToLift.joined(separator: ", ")))"
+                liftingExpr = "\(raw: param.type.liftAliases(expression: liftCall))"
             default:
-                typeNameForIntrinsic = param.type.swiftType
-                liftingExpr = ExprSyntax(
-                    "\(raw: typeNameForIntrinsic).bridgeJSLiftParameter(\(raw: argumentsToLift.joined(separator: ", ")))"
-                )
+                typeNameForIntrinsic = param.type.unaliased.swiftType
+                let liftCall =
+                    "\(typeNameForIntrinsic).bridgeJSLiftParameter(\(argumentsToLift.joined(separator: ", ")))"
+                liftingExpr = "\(raw: param.type.liftAliases(expression: liftCall))"
             }
 
             liftedParameterExprs.append(liftingExpr)
@@ -280,7 +280,8 @@ public class ExportSwift {
             }
 
             if effects.isAsync, returnType != .void {
-                return CodeBlockItemSyntax(item: .init(StmtSyntax("return \(raw: callExpr)")))
+                let lowered = returnType.lowerAliases(expression: callExpr.description)
+                return CodeBlockItemSyntax(item: .init(StmtSyntax("return \(raw: lowered)")))
             }
 
             if returnType == .void {
@@ -393,17 +394,18 @@ public class ExportSwift {
                 return
             }
 
+            let returnAccessor = returnType.lowerAliases(expression: "ret")
             switch returnType {
             case .closure(_, useJSTypedClosure: false):
                 append("return JSTypedClosure(ret).bridgeJSLowerReturn()")
             case .array, .nullable(.array, _):
                 let stackCodegen = StackCodegen()
-                for stmt in stackCodegen.lowerStatements(for: returnType, accessor: "ret", varPrefix: "ret") {
+                for stmt in stackCodegen.lowerStatements(for: returnType, accessor: returnAccessor, varPrefix: "ret") {
                     append(stmt)
                 }
             case .dictionary(.swiftProtocol):
                 let stackCodegen = StackCodegen()
-                for stmt in stackCodegen.lowerStatements(for: returnType, accessor: "ret", varPrefix: "ret") {
+                for stmt in stackCodegen.lowerStatements(for: returnType, accessor: returnAccessor, varPrefix: "ret") {
                     append(stmt)
                 }
             case .swiftProtocol:
@@ -419,7 +421,7 @@ public class ExportSwift {
                     """
                 )
             default:
-                append("return ret.bridgeJSLowerReturn()")
+                append("return \(raw: returnAccessor).bridgeJSLowerReturn()")
             }
         }
 
@@ -877,8 +879,8 @@ struct StackCodegen {
         switch type {
         case .string, .integer, .bool, .float, .double,
             .jsObject(nil), .jsValue, .swiftStruct, .swiftHeapObject, .unsafePointer,
-            .swiftProtocol, .caseEnum, .associatedValueEnum, .rawValueEnum, .array, .dictionary:
-            return "\(raw: type.swiftType).bridgeJSStackPop()"
+            .swiftProtocol, .caseEnum, .associatedValueEnum, .rawValueEnum, .array, .dictionary, .alias:
+            return "\(raw: type.liftAliases(expression: "\(type.unaliased.swiftType).bridgeJSStackPop()"))"
         case .jsObject(let className?):
             return "\(raw: className)(unsafelyWrapping: JSObject.bridgeJSStackPop())"
         case .nullable(let wrappedType, let kind):
@@ -895,8 +897,10 @@ struct StackCodegen {
         switch wrappedType {
         case .string, .integer, .bool, .float, .double, .jsObject(nil), .jsValue,
             .swiftStruct, .swiftHeapObject, .caseEnum, .associatedValueEnum, .rawValueEnum,
-            .array, .dictionary:
-            return "\(raw: typeName)<\(raw: wrappedType.swiftType)>.bridgeJSStackPop()"
+            .array, .dictionary, .alias:
+            let popCall = "\(typeName)<\(wrappedType.unaliased.swiftType)>.bridgeJSStackPop()"
+            let nullableType = BridgeType.nullable(wrappedType, kind)
+            return "\(raw: nullableType.liftAliases(expression: popCall))"
         case .jsObject(let className?):
             return "\(raw: typeName)<JSObject>.bridgeJSStackPop().map { \(raw: className)(unsafelyWrapping: $0) }"
         case .nullable, .void, .namespaceEnum, .closure, .unsafePointer, .swiftProtocol:
@@ -918,7 +922,7 @@ struct StackCodegen {
         switch type {
         case .string, .integer, .bool, .float, .double, .jsValue,
             .jsObject(nil), .swiftHeapObject, .unsafePointer, .closure,
-            .caseEnum, .rawValueEnum, .associatedValueEnum, .swiftStruct, .nullable:
+            .caseEnum, .rawValueEnum, .associatedValueEnum, .swiftStruct, .nullable, .alias:
             return ["\(raw: accessor).bridgeJSStackPush()"]
         case .jsObject(_?):
             return ["\(raw: accessor).jsObject.bridgeJSStackPush()"]
@@ -1204,9 +1208,10 @@ struct EnumCodegen {
     ) {
         for (index, associatedValue) in associatedValues.enumerated() {
             let paramName = associatedValue.label ?? "param\(index)"
+            let accessor = associatedValue.type.lowerAliases(expression: paramName)
             let statements = stackCodegen.lowerStatements(
                 for: associatedValue.type,
-                accessor: paramName,
+                accessor: accessor,
                 varPrefix: paramName
             )
             for statement in statements {
@@ -1339,7 +1344,7 @@ struct StructCodegen {
         let instanceProps = structDef.properties.filter { !$0.isStatic }
 
         for property in instanceProps {
-            let accessor = "self.\(property.name)"
+            let accessor = property.type.lowerAliases(expression: "self.\(property.name)")
             let statements = stackCodegen.lowerStatements(
                 for: property.type,
                 accessor: accessor,
@@ -1565,6 +1570,64 @@ extension UnsafePointerType {
 }
 
 extension BridgeType {
+    var unaliased: BridgeType {
+        switch self {
+        case .alias(_, let underlying): return underlying.unaliased
+        case .nullable(let wrapped, let kind): return .nullable(wrapped.unaliased, kind)
+        case .array(let element): return .array(element.unaliased)
+        case .dictionary(let value): return .dictionary(value.unaliased)
+        case .bool, .integer, .float, .double, .string, .jsValue, .jsObject,
+            .swiftHeapObject, .unsafePointer, .swiftProtocol, .void,
+            .caseEnum, .rawValueEnum, .associatedValueEnum, .swiftStruct,
+            .namespaceEnum, .closure:
+            return self
+        }
+    }
+
+    /// If this type contains an alias, convert the expression with a type of the alias to the underlying type.
+    func liftAliases(expression: String) -> String {
+        switch self {
+        case .alias(let name, _):
+            return "\(name).bridgeFromJS(\(expression))"
+        case .nullable(let wrapped, _):
+            let lifted = wrapped.liftAliases(expression: "$0")
+            return lifted == "$0" ? expression : "\(expression).map { \(lifted) }"
+        case .array(let element):
+            let lifted = element.liftAliases(expression: "$0")
+            return lifted == "$0" ? expression : "\(expression).map { \(lifted) }"
+        case .dictionary(let value):
+            let lifted = value.liftAliases(expression: "$0")
+            return lifted == "$0" ? expression : "\(expression).mapValues { \(lifted) }"
+        case .bool, .integer, .float, .double, .string, .jsValue, .jsObject,
+            .swiftHeapObject, .unsafePointer, .swiftProtocol, .void,
+            .caseEnum, .rawValueEnum, .associatedValueEnum, .swiftStruct,
+            .namespaceEnum, .closure:
+            return expression
+        }
+    }
+
+    /// Opposite of `liftAliases`: if this type contains an alias, convert the expression with a type of the underlying to the alias type.
+    func lowerAliases(expression: String) -> String {
+        switch self {
+        case .alias:
+            return "\(expression).bridgeToJS()"
+        case .nullable(let wrapped, _):
+            let lowered = wrapped.lowerAliases(expression: "$0")
+            return lowered == "$0" ? expression : "\(expression).map { \(lowered) }"
+        case .array(let element):
+            let lowered = element.lowerAliases(expression: "$0")
+            return lowered == "$0" ? expression : "\(expression).map { \(lowered) }"
+        case .dictionary(let value):
+            let lowered = value.lowerAliases(expression: "$0")
+            return lowered == "$0" ? expression : "\(expression).mapValues { \(lowered) }"
+        case .bool, .integer, .float, .double, .string, .jsValue, .jsObject,
+            .swiftHeapObject, .unsafePointer, .swiftProtocol, .void,
+            .caseEnum, .rawValueEnum, .associatedValueEnum, .swiftStruct,
+            .namespaceEnum, .closure:
+            return expression
+        }
+    }
+
     var swiftType: String {
         switch self {
         case .bool: return "Bool"
@@ -1593,6 +1656,7 @@ extension BridgeType {
             let effectsStr = (signature.isAsync ? " async" : "") + (signature.isThrows ? " throws" : "")
             let closureType = "(\(paramTypes))\(effectsStr) -> \(signature.returnType.swiftType)"
             return useJSTypedClosure ? "JSTypedClosure<\(closureType)>" : closureType
+        case .alias(let name, _): return name
         }
     }
 
@@ -1617,6 +1681,8 @@ extension BridgeType {
             return true
         case .nullable(let wrapped, _):
             return wrapped.isStackUsingParameter
+        case .alias(_, let underlying):
+            return underlying.isStackUsingParameter
         default:
             return false
         }
@@ -1675,6 +1741,8 @@ extension BridgeType {
             return LiftingIntrinsicInfo(parameters: [("callbackId", .i32)])
         case .array, .dictionary:
             return LiftingIntrinsicInfo(parameters: [])
+        case .alias(_, let underlying):
+            return try underlying.liftParameterInfo()
         }
     }
 
@@ -1726,6 +1794,8 @@ extension BridgeType {
             return .jsObject
         case .array, .dictionary:
             return .array
+        case .alias(_, let underlying):
+            return try underlying.loweringReturnInfo()
         }
     }
 }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -100,6 +100,15 @@ public class ExportSwift {
                 }
             }
         }
+
+        withSpan("Render Aliases") { [self] in
+            let aliasCodegen = AliasCodegen()
+            for alias in skeleton.aliases {
+                if let aliasExtension = aliasCodegen.renderAliasConformance(alias) {
+                    decls.append(aliasExtension)
+                }
+            }
+        }
         return withSpan("Format Export Glue") {
             return decls.map { $0.description }.joined(separator: "\n\n")
         }
@@ -227,15 +236,15 @@ public class ExportSwift {
                 } else {
                     optionalSwiftType = "JSUndefinedOr"
                 }
-                typeNameForIntrinsic = "\(optionalSwiftType)<\(wrappedType.unaliased.swiftType)>"
-                let liftCall =
-                    "\(typeNameForIntrinsic).bridgeJSLiftParameter(\(argumentsToLift.joined(separator: ", ")))"
-                liftingExpr = "\(raw: param.type.liftAliases(expression: liftCall))"
+                typeNameForIntrinsic = "\(optionalSwiftType)<\(wrappedType.swiftType)>"
+                liftingExpr = ExprSyntax(
+                    "\(raw: typeNameForIntrinsic).bridgeJSLiftParameter(\(raw: argumentsToLift.joined(separator: ", ")))"
+                )
             default:
-                typeNameForIntrinsic = param.type.unaliased.swiftType
-                let liftCall =
-                    "\(typeNameForIntrinsic).bridgeJSLiftParameter(\(argumentsToLift.joined(separator: ", ")))"
-                liftingExpr = "\(raw: param.type.liftAliases(expression: liftCall))"
+                typeNameForIntrinsic = param.type.swiftType
+                liftingExpr = ExprSyntax(
+                    "\(raw: typeNameForIntrinsic).bridgeJSLiftParameter(\(raw: argumentsToLift.joined(separator: ", ")))"
+                )
             }
 
             liftedParameterExprs.append(liftingExpr)
@@ -280,8 +289,7 @@ public class ExportSwift {
             }
 
             if effects.isAsync, returnType != .void {
-                let lowered = returnType.lowerAliases(expression: callExpr.description)
-                return CodeBlockItemSyntax(item: .init(StmtSyntax("return \(raw: lowered)")))
+                return CodeBlockItemSyntax(item: .init(StmtSyntax("return \(raw: callExpr)")))
             }
 
             if returnType == .void {
@@ -394,18 +402,17 @@ public class ExportSwift {
                 return
             }
 
-            let returnAccessor = returnType.lowerAliases(expression: "ret")
             switch returnType {
             case .closure(_, useJSTypedClosure: false):
                 append("return JSTypedClosure(ret).bridgeJSLowerReturn()")
             case .array, .nullable(.array, _):
                 let stackCodegen = StackCodegen()
-                for stmt in stackCodegen.lowerStatements(for: returnType, accessor: returnAccessor, varPrefix: "ret") {
+                for stmt in stackCodegen.lowerStatements(for: returnType, accessor: "ret", varPrefix: "ret") {
                     append(stmt)
                 }
             case .dictionary(.swiftProtocol):
                 let stackCodegen = StackCodegen()
-                for stmt in stackCodegen.lowerStatements(for: returnType, accessor: returnAccessor, varPrefix: "ret") {
+                for stmt in stackCodegen.lowerStatements(for: returnType, accessor: "ret", varPrefix: "ret") {
                     append(stmt)
                 }
             case .swiftProtocol:
@@ -421,7 +428,7 @@ public class ExportSwift {
                     """
                 )
             default:
-                append("return \(raw: returnAccessor).bridgeJSLowerReturn()")
+                append("return ret.bridgeJSLowerReturn()")
             }
         }
 
@@ -880,7 +887,7 @@ struct StackCodegen {
         case .string, .integer, .bool, .float, .double,
             .jsObject(nil), .jsValue, .swiftStruct, .swiftHeapObject, .unsafePointer,
             .swiftProtocol, .caseEnum, .associatedValueEnum, .rawValueEnum, .array, .dictionary, .alias:
-            return "\(raw: type.liftAliases(expression: "\(type.unaliased.swiftType).bridgeJSStackPop()"))"
+            return "\(raw: type.swiftType).bridgeJSStackPop()"
         case .jsObject(let className?):
             return "\(raw: className)(unsafelyWrapping: JSObject.bridgeJSStackPop())"
         case .nullable(let wrappedType, let kind):
@@ -898,9 +905,7 @@ struct StackCodegen {
         case .string, .integer, .bool, .float, .double, .jsObject(nil), .jsValue,
             .swiftStruct, .swiftHeapObject, .caseEnum, .associatedValueEnum, .rawValueEnum,
             .array, .dictionary, .alias:
-            let popCall = "\(typeName)<\(wrappedType.unaliased.swiftType)>.bridgeJSStackPop()"
-            let nullableType = BridgeType.nullable(wrappedType, kind)
-            return "\(raw: nullableType.liftAliases(expression: popCall))"
+            return "\(raw: typeName)<\(raw: wrappedType.swiftType)>.bridgeJSStackPop()"
         case .jsObject(let className?):
             return "\(raw: typeName)<JSObject>.bridgeJSStackPop().map { \(raw: className)(unsafelyWrapping: $0) }"
         case .nullable, .void, .namespaceEnum, .closure, .unsafePointer, .swiftProtocol:
@@ -1208,10 +1213,9 @@ struct EnumCodegen {
     ) {
         for (index, associatedValue) in associatedValues.enumerated() {
             let paramName = associatedValue.label ?? "param\(index)"
-            let accessor = associatedValue.type.lowerAliases(expression: paramName)
             let statements = stackCodegen.lowerStatements(
                 for: associatedValue.type,
-                accessor: accessor,
+                accessor: paramName,
                 varPrefix: paramName
             )
             for statement in statements {
@@ -1344,10 +1348,9 @@ struct StructCodegen {
         let instanceProps = structDef.properties.filter { !$0.isStatic }
 
         for property in instanceProps {
-            let accessor = property.type.lowerAliases(expression: "self.\(property.name)")
             let statements = stackCodegen.lowerStatements(
                 for: property.type,
-                accessor: accessor,
+                accessor: "self.\(property.name)",
                 varPrefix: property.name
             )
             for statement in statements {
@@ -1356,6 +1359,18 @@ struct StructCodegen {
         }
 
         return printer.lines
+    }
+}
+
+// MARK: - AliasCodegen
+
+struct AliasCodegen {
+    func renderAliasConformance(_ alias: ExportedAlias) -> DeclSyntax? {
+        guard let protocols = alias.underlying.aliasConformanceProtocols else {
+            return nil
+        }
+        let conformances = (["_BridgedSwiftAlias"] + protocols).joined(separator: ", ")
+        return "extension \(raw: alias.swiftCallName): \(raw: conformances) {}"
     }
 }
 
@@ -1570,61 +1585,20 @@ extension UnsafePointerType {
 }
 
 extension BridgeType {
-    var unaliased: BridgeType {
+    var aliasConformanceProtocols: [String]? {
         switch self {
-        case .alias(_, let underlying): return underlying.unaliased
-        case .nullable(let wrapped, let kind): return .nullable(wrapped.unaliased, kind)
-        case .array(let element): return .array(element.unaliased)
-        case .dictionary(let value): return .dictionary(value.unaliased)
-        case .bool, .integer, .float, .double, .string, .jsValue, .jsObject,
-            .swiftHeapObject, .unsafePointer, .swiftProtocol, .void,
-            .caseEnum, .rawValueEnum, .associatedValueEnum, .swiftStruct,
-            .namespaceEnum, .closure:
-            return self
-        }
-    }
-
-    /// If this type contains an alias, convert the expression with a type of the alias to the underlying type.
-    func liftAliases(expression: String) -> String {
-        switch self {
-        case .alias(let name, _):
-            return "\(name).bridgeFromJS(\(expression))"
-        case .nullable(let wrapped, _):
-            let lifted = wrapped.liftAliases(expression: "$0")
-            return lifted == "$0" ? expression : "\(expression).map { \(lifted) }"
-        case .array(let element):
-            let lifted = element.liftAliases(expression: "$0")
-            return lifted == "$0" ? expression : "\(expression).map { \(lifted) }"
-        case .dictionary(let value):
-            let lifted = value.liftAliases(expression: "$0")
-            return lifted == "$0" ? expression : "\(expression).mapValues { \(lifted) }"
-        case .bool, .integer, .float, .double, .string, .jsValue, .jsObject,
-            .swiftHeapObject, .unsafePointer, .swiftProtocol, .void,
-            .caseEnum, .rawValueEnum, .associatedValueEnum, .swiftStruct,
-            .namespaceEnum, .closure:
-            return expression
-        }
-    }
-
-    /// Opposite of `liftAliases`: if this type contains an alias, convert the expression with a type of the underlying to the alias type.
-    func lowerAliases(expression: String) -> String {
-        switch self {
-        case .alias:
-            return "\(expression).bridgeToJS()"
-        case .nullable(let wrapped, _):
-            let lowered = wrapped.lowerAliases(expression: "$0")
-            return lowered == "$0" ? expression : "\(expression).map { \(lowered) }"
-        case .array(let element):
-            let lowered = element.lowerAliases(expression: "$0")
-            return lowered == "$0" ? expression : "\(expression).map { \(lowered) }"
-        case .dictionary(let value):
-            let lowered = value.lowerAliases(expression: "$0")
-            return lowered == "$0" ? expression : "\(expression).mapValues { \(lowered) }"
-        case .bool, .integer, .float, .double, .string, .jsValue, .jsObject,
-            .swiftHeapObject, .unsafePointer, .swiftProtocol, .void,
-            .caseEnum, .rawValueEnum, .associatedValueEnum, .swiftStruct,
-            .namespaceEnum, .closure:
-            return expression
+        case .swiftHeapObject, .jsObject, .integer, .float, .double, .bool, .string, .jsValue:
+            return ["_BridgedSwiftStackType"]
+        case .swiftStruct:
+            return ["_BridgedSwiftStruct"]
+        case .caseEnum:
+            return ["_BridgedSwiftCaseEnum"]
+        case .associatedValueEnum:
+            return ["_BridgedSwiftAssociatedValueEnum"]
+        case .rawValueEnum, .void, .unsafePointer, .namespaceEnum,
+            .swiftProtocol, .closure, .nullable, .array, .dictionary, .alias:
+            // Not supported yet.
+            return nil
         }
     }
 

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExternalModuleIndex.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExternalModuleIndex.swift
@@ -63,6 +63,12 @@ public struct ExternalModuleIndex {
             for proto in exported.protocols {
                 register(dotPath: proto.name, bridgeType: .swiftProtocol(proto.name))
             }
+            for alias in exported.aliases {
+                register(
+                    dotPath: alias.swiftCallName,
+                    bridgeType: .alias(name: alias.swiftCallName, underlying: alias.underlying)
+                )
+            }
 
             entriesByModule[moduleName] = moduleEntries
         }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -958,7 +958,7 @@ extension BridgeType {
         case .array, .dictionary:
             return LoweringParameterInfo(loweredParameters: [])
         case .alias:
-            preconditionFailure()
+            preconditionFailure("`.alias` must be resolved by `.unaliased` before reaching loweringParameterInfo")
         }
     }
 
@@ -1032,7 +1032,7 @@ extension BridgeType {
         case .array, .dictionary:
             return LiftingReturnInfo(valueToLift: nil)
         case .alias:
-            preconditionFailure()
+            preconditionFailure("`.alias` must be resolved by `.unaliased` before reaching liftingReturnInfo")
         }
     }
 }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -172,8 +172,7 @@ public struct ImportTS {
             if loweringInfo.useBorrowing {
                 let returnVariableName = "ret\(borrowedArguments.count)"
                 let assign = needsReturnVariable ? "let \(returnVariableName) = " : ""
-                let loweredAlias = param.type.lowerAliases(expression: param.name)
-                body.write("\(assign)\(loweredAlias).bridgeJSWithLoweredParameter { \(pattern) in")
+                body.write("\(assign)\(param.name).bridgeJSWithLoweredParameter { \(pattern) in")
                 body.indent()
                 borrowedArguments.append(
                     BorrowedArgument(
@@ -204,8 +203,7 @@ public struct ImportTS {
                         "(\(raw: param.name) as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()"
                     )
                 } else {
-                    let loweredAlias = param.type.lowerAliases(expression: param.name)
-                    initializerExpr = ExprSyntax("\(raw: loweredAlias).bridgeJSLowerParameter()")
+                    initializerExpr = ExprSyntax("\(raw: param.name).bridgeJSLowerParameter()")
                 }
 
                 if loweringInfo.loweredParameters.isEmpty {
@@ -296,21 +294,18 @@ public struct ImportTS {
 
             if returnType.usesSideChannelForOptionalReturn() {
                 // Side channel returns: extern function returns Void, value is retrieved via side channel
-                let liftCall = "\(returnType.unaliased.swiftType).bridgeJSLiftReturnFromSideChannel()"
-                body.write("return \(returnType.liftAliases(expression: liftCall))")
+                body.write("return \(returnType.swiftType).bridgeJSLiftReturnFromSideChannel()")
             } else {
                 let liftExpr: String
                 switch returnType {
                 case .closure(let signature, _):
                     liftExpr = "_BJS_Closure_\(signature.mangleName).bridgeJSLift(ret)"
                 default:
-                    let liftCall: String
                     if liftingInfo.valueToLift != nil {
-                        liftCall = "\(returnType.unaliased.swiftType).bridgeJSLiftReturn(ret)"
+                        liftExpr = "\(returnType.swiftType).bridgeJSLiftReturn(ret)"
                     } else {
-                        liftCall = "\(returnType.unaliased.swiftType).bridgeJSLiftReturn()"
+                        liftExpr = "\(returnType.swiftType).bridgeJSLiftReturn()"
                     }
-                    liftExpr = returnType.liftAliases(expression: liftCall)
                 }
                 body.write("return \(liftExpr)")
             }
@@ -908,7 +903,7 @@ extension BridgeType {
     }
 
     func loweringParameterInfo(context: BridgeContext = .importTS) throws -> LoweringParameterInfo {
-        switch self {
+        switch self.unaliased {
         case .bool: return .bool
         case .integer(let t): return LoweringParameterInfo(loweredParameters: [("value", t.wasmCoreType)])
         case .float: return .float
@@ -962,8 +957,8 @@ extension BridgeType {
             return LoweringParameterInfo(loweredParameters: params, useBorrowing: wrappedInfo.useBorrowing)
         case .array, .dictionary:
             return LoweringParameterInfo(loweredParameters: [])
-        case .alias(_, let underlying):
-            return try underlying.loweringParameterInfo(context: context)
+        case .alias:
+            preconditionFailure()
         }
     }
 
@@ -983,7 +978,7 @@ extension BridgeType {
     func liftingReturnInfo(
         context: BridgeContext = .importTS
     ) throws -> LiftingReturnInfo {
-        switch self {
+        switch self.unaliased {
         case .bool: return .bool
         case .integer(let t): return LiftingReturnInfo(valueToLift: t.wasmCoreType)
         case .float: return .float
@@ -1026,7 +1021,7 @@ extension BridgeType {
         case .nullable(let wrappedType, _):
             // jsObject and `@JS struct` use the stack ABI for optionals — the thunk returns
             // void and the value (plus isSome discriminator) flows through the stacks.
-            if case .jsObject = wrappedType.unaliased {
+            if case .jsObject = wrappedType {
                 return LiftingReturnInfo(valueToLift: nil)
             }
             if case .swiftStruct = wrappedType, context == .importTS {
@@ -1036,8 +1031,8 @@ extension BridgeType {
             return LiftingReturnInfo(valueToLift: wrappedInfo.valueToLift)
         case .array, .dictionary:
             return LiftingReturnInfo(valueToLift: nil)
-        case .alias(_, let underlying):
-            return try underlying.liftingReturnInfo(context: context)
+        case .alias:
+            preconditionFailure()
         }
     }
 }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -172,7 +172,8 @@ public struct ImportTS {
             if loweringInfo.useBorrowing {
                 let returnVariableName = "ret\(borrowedArguments.count)"
                 let assign = needsReturnVariable ? "let \(returnVariableName) = " : ""
-                body.write("\(assign)\(param.name).bridgeJSWithLoweredParameter { \(pattern) in")
+                let loweredAlias = param.type.lowerAliases(expression: param.name)
+                body.write("\(assign)\(loweredAlias).bridgeJSWithLoweredParameter { \(pattern) in")
                 body.indent()
                 borrowedArguments.append(
                     BorrowedArgument(
@@ -203,7 +204,8 @@ public struct ImportTS {
                         "(\(raw: param.name) as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()"
                     )
                 } else {
-                    initializerExpr = ExprSyntax("\(raw: param.name).bridgeJSLowerParameter()")
+                    let loweredAlias = param.type.lowerAliases(expression: param.name)
+                    initializerExpr = ExprSyntax("\(raw: loweredAlias).bridgeJSLowerParameter()")
                 }
 
                 if loweringInfo.loweredParameters.isEmpty {
@@ -294,18 +296,21 @@ public struct ImportTS {
 
             if returnType.usesSideChannelForOptionalReturn() {
                 // Side channel returns: extern function returns Void, value is retrieved via side channel
-                body.write("return \(returnType.swiftType).bridgeJSLiftReturnFromSideChannel()")
+                let liftCall = "\(returnType.unaliased.swiftType).bridgeJSLiftReturnFromSideChannel()"
+                body.write("return \(returnType.liftAliases(expression: liftCall))")
             } else {
                 let liftExpr: String
                 switch returnType {
                 case .closure(let signature, _):
                     liftExpr = "_BJS_Closure_\(signature.mangleName).bridgeJSLift(ret)"
                 default:
+                    let liftCall: String
                     if liftingInfo.valueToLift != nil {
-                        liftExpr = "\(returnType.swiftType).bridgeJSLiftReturn(ret)"
+                        liftCall = "\(returnType.unaliased.swiftType).bridgeJSLiftReturn(ret)"
                     } else {
-                        liftExpr = "\(returnType.swiftType).bridgeJSLiftReturn()"
+                        liftCall = "\(returnType.unaliased.swiftType).bridgeJSLiftReturn()"
                     }
+                    liftExpr = returnType.liftAliases(expression: liftCall)
                 }
                 body.write("return \(liftExpr)")
             }
@@ -957,6 +962,8 @@ extension BridgeType {
             return LoweringParameterInfo(loweredParameters: params, useBorrowing: wrappedInfo.useBorrowing)
         case .array, .dictionary:
             return LoweringParameterInfo(loweredParameters: [])
+        case .alias(_, let underlying):
+            return try underlying.loweringParameterInfo(context: context)
         }
     }
 
@@ -1019,7 +1026,7 @@ extension BridgeType {
         case .nullable(let wrappedType, _):
             // jsObject and `@JS struct` use the stack ABI for optionals — the thunk returns
             // void and the value (plus isSome discriminator) flows through the stacks.
-            if case .jsObject = wrappedType {
+            if case .jsObject = wrappedType.unaliased {
                 return LiftingReturnInfo(valueToLift: nil)
             }
             if case .swiftStruct = wrappedType, context == .importTS {
@@ -1029,6 +1036,8 @@ extension BridgeType {
             return LiftingReturnInfo(valueToLift: wrappedInfo.valueToLift)
         case .array, .dictionary:
             return LiftingReturnInfo(valueToLift: nil)
+        case .alias(_, let underlying):
+            return try underlying.liftingReturnInfo(context: context)
         }
     }
 }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -399,6 +399,11 @@ public final class SwiftToSkeleton {
 
             if let enumDecl = typeDecl.as(EnumDeclSyntax.self) {
                 let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: enumDecl, itemName: enumDecl.name.text)
+                if let jsAttribute = enumDecl.attributes.firstJSAttribute,
+                    let aliasTarget = extractAliasTarget(from: jsAttribute)
+                {
+                    return aliasType(target: aliasTarget, swiftCallName: swiftCallName, errors: &errors)
+                }
                 let rawTypeString = enumDecl.inheritanceClause?.inheritedTypes.first { inheritedType in
                     let typeName = inheritedType.type.trimmedDescription
                     return ExportSwiftConstants.supportedRawTypes.contains(typeName)
@@ -439,6 +444,11 @@ public final class SwiftToSkeleton {
                 if structDecl.attributes.hasAttribute(name: "JSClass") {
                     return .jsObject(swiftCallName)
                 }
+                if let jsAttribute = structDecl.attributes.firstJSAttribute,
+                    let aliasTarget = extractAliasTarget(from: jsAttribute)
+                {
+                    return aliasType(target: aliasTarget, swiftCallName: swiftCallName, errors: &errors)
+                }
                 return .swiftStruct(swiftCallName)
             }
 
@@ -454,6 +464,13 @@ public final class SwiftToSkeleton {
             }
             if let actorDecl = typeDecl.as(ActorDeclSyntax.self), actorDecl.attributes.hasAttribute(name: "JSClass") {
                 return .jsObject(swiftCallName)
+            }
+
+            if let classDecl = typeDecl.as(ClassDeclSyntax.self),
+                let jsAttribute = classDecl.attributes.firstJSAttribute,
+                let aliasTarget = extractAliasTarget(from: jsAttribute)
+            {
+                return aliasType(target: aliasTarget, swiftCallName: swiftCallName, errors: &errors)
             }
 
             return .swiftHeapObject(swiftCallName)
@@ -515,6 +532,50 @@ public final class SwiftToSkeleton {
             )
             return nil
         }
+    }
+
+    fileprivate func extractAliasTarget(from jsAttribute: AttributeSyntax) -> TypeSyntax? {
+        guard
+            let arguments = jsAttribute.arguments?.as(LabeledExprListSyntax.self),
+            let asArg = arguments.first(where: { $0.label?.text == "as" }),
+            let memberAccess = asArg.expression.as(MemberAccessExprSyntax.self),
+            memberAccess.declName.baseName.text == "self",
+            let base = memberAccess.base
+        else {
+            return nil
+        }
+        return TypeSyntax(stringLiteral: base.trimmedDescription)
+    }
+
+    fileprivate func aliasType(
+        target aliasTarget: TypeSyntax,
+        swiftCallName: String,
+        errors: inout [DiagnosticError]
+    ) -> BridgeType? {
+        if let targetDecl = typeDeclResolver.resolve(aliasTarget),
+            let targetJSAttribute = targetDecl.attributes.firstJSAttribute,
+            extractAliasTarget(from: targetJSAttribute) != nil
+        {
+            errors.append(
+                DiagnosticError(
+                    node: aliasTarget,
+                    message: "`@JS(as:)` target must be a `@JS` type, not another `@JS(as:)` type",
+                    hint: "Use the underlying `@JS` type directly"
+                )
+            )
+            return nil
+        }
+        guard let targetType = lookupType(for: aliasTarget, errors: &errors) else { return nil }
+        if case .swiftProtocol = targetType {
+            errors.append(
+                DiagnosticError(
+                    node: aliasTarget,
+                    message: "`@JS(as:)` cannot target a `@JS protocol`"
+                )
+            )
+            return nil
+        }
+        return .alias(name: swiftCallName, underlying: targetType)
     }
 
     fileprivate static func parseUnsafePointerType(_ type: TypeSyntax) -> UnsafePointerType? {
@@ -650,6 +711,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
     /// The names of the exported structs, in the order they were written in the source file
     var exportedStructNames: [String] = []
     var exportedStructByName: [String: ExportedStruct] = [:]
+    var exportedAliases: [ExportedAlias] = []
     var errors: [DiagnosticError] = []
     /// Extensions collected during the walk, to be resolved after all files have been walked
     var deferredExtensions: [ExtensionDeclSyntax] = []
@@ -660,6 +722,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         result.enums.append(contentsOf: exportedEnumNames.map { exportedEnumByName[$0]! })
         result.structs.append(contentsOf: exportedStructNames.map { exportedStructByName[$0]! })
         result.protocols.append(contentsOf: exportedProtocolNames.map { exportedProtocolByName[$0]! })
+        result.aliases.append(contentsOf: exportedAliases)
     }
 
     /// Creates a unique key by combining name and namespace
@@ -1564,6 +1627,11 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             return .skipChildren
         }
 
+        if let aliasTarget = parent.extractAliasTarget(from: jsAttribute) {
+            recordAlias(node: node, aliasTarget: aliasTarget)
+            return .skipChildren
+        }
+
         let namespaceResult = resolveNamespace(from: jsAttribute, for: node, declarationType: "class")
         guard namespaceResult.isValid else {
             return .skipChildren
@@ -1662,8 +1730,35 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         return true
     }
 
+    private func recordAlias(
+        node: some SyntaxProtocol & NamedDeclSyntax,
+        aliasTarget: TypeSyntax
+    ) {
+        let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: node, itemName: node.name.text)
+        var lookupErrors: [DiagnosticError] = []
+        guard
+            let aliasBridgeType = parent.aliasType(
+                target: aliasTarget,
+                swiftCallName: swiftCallName,
+                errors: &lookupErrors
+            ),
+            case .alias(_, let underlying) = aliasBridgeType
+        else {
+            errors.append(contentsOf: lookupErrors)
+            return
+        }
+        exportedAliases.append(
+            ExportedAlias(swiftCallName: swiftCallName, underlying: underlying)
+        )
+    }
+
     override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
         guard let jsAttribute = node.attributes.firstJSAttribute else {
+            return .skipChildren
+        }
+
+        if let aliasTarget = parent.extractAliasTarget(from: jsAttribute) {
+            recordAlias(node: node, aliasTarget: aliasTarget)
             return .skipChildren
         }
 
@@ -1767,24 +1862,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             }
             for enumCase in exportedEnum.cases {
                 for associatedValue in enumCase.associatedValues {
-                    switch associatedValue.type {
-                    case .string, .integer, .float, .double, .bool, .caseEnum, .rawValueEnum,
-                        .swiftStruct, .swiftHeapObject, .jsObject, .associatedValueEnum, .array:
-                        break
-                    case .nullable(let wrappedType, _):
-                        switch wrappedType {
-                        case .string, .integer, .float, .double, .bool, .caseEnum, .rawValueEnum,
-                            .swiftStruct, .swiftHeapObject, .jsObject, .associatedValueEnum, .array:
-                            break
-                        default:
-                            diagnose(
-                                node: node,
-                                message: "Unsupported associated value type: \(associatedValue.type.swiftType)",
-                                hint:
-                                    "Only primitive types, enums, structs, classes, JSObject, arrays, and their optionals are supported in associated-value enums"
-                            )
-                        }
-                    default:
+                    if !associatedValue.type.isSupportedAsAssociatedValue() {
                         diagnose(
                             node: node,
                             message: "Unsupported associated value type: \(associatedValue.type.swiftType)",
@@ -1864,6 +1942,11 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
 
     override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
         guard let jsAttribute = node.attributes.firstJSAttribute else {
+            return .skipChildren
+        }
+
+        if let aliasTarget = parent.extractAliasTarget(from: jsAttribute) {
+            recordAlias(node: node, aliasTarget: aliasTarget)
             return .skipChildren
         }
 
@@ -2968,6 +3051,22 @@ private final class ImportSwiftMacrosAPICollector: SyntaxAnyVisitor {
             }
         }
         return fallback
+    }
+}
+
+extension BridgeType {
+    fileprivate func isSupportedAsAssociatedValue(allowNullable: Bool = true) -> Bool {
+        switch self {
+        case .string, .integer, .float, .double, .bool, .caseEnum, .rawValueEnum,
+            .swiftStruct, .swiftHeapObject, .jsObject, .associatedValueEnum, .array:
+            return true
+        case .alias(_, let underlying):
+            return underlying.isSupportedAsAssociatedValue(allowNullable: false)
+        case .nullable(let wrapped, _) where allowNullable:
+            return wrapped.isSupportedAsAssociatedValue(allowNullable: false)
+        default:
+            return false
+        }
     }
 }
 

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -1635,7 +1635,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         }
 
         if let aliasTarget = parent.extractAliasTarget(from: jsAttribute) {
-            recordAlias(node: node, aliasTarget: aliasTarget)
+            recordAlias(node: node, jsAttribute: jsAttribute, aliasTarget: aliasTarget)
             return .skipChildren
         }
 
@@ -1739,9 +1739,20 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
 
     private func recordAlias(
         node: some SyntaxProtocol & NamedDeclSyntax,
+        jsAttribute: AttributeSyntax,
         aliasTarget: TypeSyntax
     ) {
         let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: node, itemName: node.name.text)
+        if extractNamespace(from: jsAttribute) != nil {
+            errors.append(
+                DiagnosticError(
+                    node: node,
+                    message: "`namespace` is not supported on `@JS(as:)` types",
+                    hint: "Remove the `namespace:` argument; an alias adopts its target's representation"
+                )
+            )
+            return
+        }
         var lookupErrors: [DiagnosticError] = []
         guard
             let aliasBridgeType = parent.aliasType(
@@ -1774,7 +1785,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         }
 
         if let aliasTarget = parent.extractAliasTarget(from: jsAttribute) {
-            recordAlias(node: node, aliasTarget: aliasTarget)
+            recordAlias(node: node, jsAttribute: jsAttribute, aliasTarget: aliasTarget)
             return .skipChildren
         }
 
@@ -1962,7 +1973,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         }
 
         if let aliasTarget = parent.extractAliasTarget(from: jsAttribute) {
-            recordAlias(node: node, aliasTarget: aliasTarget)
+            recordAlias(node: node, jsAttribute: jsAttribute, aliasTarget: aliasTarget)
             return .skipChildren
         }
 

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -552,10 +552,7 @@ public final class SwiftToSkeleton {
         swiftCallName: String,
         errors: inout [DiagnosticError]
     ) -> BridgeType? {
-        if let targetDecl = typeDeclResolver.resolve(aliasTarget),
-            let targetJSAttribute = targetDecl.attributes.firstJSAttribute,
-            extractAliasTarget(from: targetJSAttribute) != nil
-        {
+        func diagnoseChainedAlias() -> BridgeType? {
             errors.append(
                 DiagnosticError(
                     node: aliasTarget,
@@ -565,7 +562,17 @@ public final class SwiftToSkeleton {
             )
             return nil
         }
+        if let targetDecl = typeDeclResolver.resolve(aliasTarget),
+            let targetJSAttribute = targetDecl.attributes.firstJSAttribute,
+            extractAliasTarget(from: targetJSAttribute) != nil
+        {
+            return diagnoseChainedAlias()
+        }
         guard let targetType = lookupType(for: aliasTarget, errors: &errors) else { return nil }
+        if case .alias = targetType {
+            // Alias declared in another module.
+            return diagnoseChainedAlias()
+        }
         if case .swiftProtocol = targetType {
             errors.append(
                 DiagnosticError(
@@ -1745,6 +1752,15 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             case .alias(_, let underlying) = aliasBridgeType
         else {
             errors.append(contentsOf: lookupErrors)
+            return
+        }
+        guard underlying.aliasConformanceProtocols != nil else {
+            errors.append(
+                DiagnosticError(
+                    node: aliasTarget,
+                    message: "Representation \(underlying.swiftType) is not supported"
+                )
+            )
             return
         }
         exportedAliases.append(

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -1550,6 +1550,8 @@ public struct BridgeJSLink {
                 }
             }
             return type.tsType
+        case .alias(_, let underlying):
+            return resolveTypeScriptType(underlying, exportedSkeletons: exportedSkeletons)
         case .nullable(let wrapped, let kind):
             let base = resolveTypeScriptType(wrapped, exportedSkeletons: exportedSkeletons)
             return "\(base) | \(kind.absenceLiteral)"
@@ -3960,6 +3962,8 @@ extension BridgeType {
             return "\(inner)[]"
         case .dictionary(let valueType):
             return "Record<string, \(valueType.tsType)>"
+        case .alias(_, let underlying):
+            return underlying.tsType
         }
     }
 

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -651,6 +651,9 @@ struct IntrinsicJSFragment: Sendable {
         kind: JSOptionalKind,
         context bridgeContext: BridgeContext = .importTS
     ) throws -> IntrinsicJSFragment {
+        if case .alias(_, let underlying) = wrappedType {
+            return try optionalLiftParameter(wrappedType: underlying, kind: kind, context: bridgeContext)
+        }
         if wrappedType.isSingleParamScalar {
             let coerce = wrappedType.liftCoerce
             return IntrinsicJSFragment(
@@ -739,6 +742,9 @@ struct IntrinsicJSFragment: Sendable {
         wrappedType: BridgeType,
         kind: JSOptionalKind
     ) throws -> IntrinsicJSFragment {
+        if case .alias(_, let underlying) = wrappedType {
+            return try optionalLowerParameter(wrappedType: underlying, kind: kind)
+        }
         if wrappedType.isSingleParamScalar {
             let wasmType = wrappedType.wasmParams[0].type
             let coerce = wrappedType.lowerCoerce
@@ -967,6 +973,9 @@ struct IntrinsicJSFragment: Sendable {
         wrappedType: BridgeType,
         kind: JSOptionalKind
     ) -> IntrinsicJSFragment {
+        if case .alias(_, let underlying) = wrappedType {
+            return optionalLiftReturn(wrappedType: underlying, kind: kind)
+        }
         if let scalarKind = wrappedType.optionalScalarKind {
             return optionalLiftReturnFromStorage(storage: scalarKind.storageName)
         }
@@ -1064,6 +1073,9 @@ struct IntrinsicJSFragment: Sendable {
     }
 
     static func optionalLowerReturn(wrappedType: BridgeType, kind: JSOptionalKind) throws -> IntrinsicJSFragment {
+        if case .alias(_, let underlying) = wrappedType {
+            return try optionalLowerReturn(wrappedType: underlying, kind: kind)
+        }
         switch wrappedType {
         case .void, .nullable, .namespaceEnum, .closure:
             throw BridgeJSLinkError(message: "Unsupported optional wrapped type for protocol export: \(wrappedType)")
@@ -1188,6 +1200,9 @@ struct IntrinsicJSFragment: Sendable {
     // MARK: - Protocol Support
 
     static func protocolPropertyOptionalToSideChannel(wrappedType: BridgeType) throws -> IntrinsicJSFragment {
+        if case .alias(_, let underlying) = wrappedType {
+            return try protocolPropertyOptionalToSideChannel(wrappedType: underlying)
+        }
         if let scalarKind = wrappedType.optionalScalarKind {
             let storage = scalarKind.storageName
             return IntrinsicJSFragment(
@@ -1323,6 +1338,8 @@ struct IntrinsicJSFragment: Sendable {
             return try arrayLower(elementType: elementType)
         case .dictionary(let valueType):
             return try dictionaryLower(valueType: valueType)
+        case .alias(_, let underlying):
+            return try lowerParameter(type: underlying)
         default:
             throw BridgeJSLinkError(message: "Unhandled type in lowerParameter: \(type)")
         }
@@ -1380,6 +1397,8 @@ struct IntrinsicJSFragment: Sendable {
             return try arrayLift(elementType: elementType)
         case .dictionary(let valueType):
             return try dictionaryLift(valueType: valueType)
+        case .alias(_, let underlying):
+            return try liftReturn(type: underlying)
         default:
             throw BridgeJSLinkError(message: "Unhandled type in liftReturn: \(type)")
         }
@@ -1470,6 +1489,8 @@ struct IntrinsicJSFragment: Sendable {
             return try arrayLift(elementType: elementType)
         case .dictionary(let valueType):
             return try dictionaryLift(valueType: valueType)
+        case .alias(_, let underlying):
+            return try liftParameter(type: underlying, context: context)
         default:
             throw BridgeJSLinkError(message: "Unhandled type in liftParameter: \(type)")
         }
@@ -1524,6 +1545,8 @@ struct IntrinsicJSFragment: Sendable {
             return try arrayLower(elementType: elementType)
         case .dictionary(let valueType):
             return try dictionaryLower(valueType: valueType)
+        case .alias(_, let underlying):
+            return try lowerReturn(type: underlying, context: context)
         default:
             throw BridgeJSLinkError(message: "Unhandled type in lowerReturn: \(type)")
         }
@@ -1941,6 +1964,9 @@ struct IntrinsicJSFragment: Sendable {
     }
 
     private static func stackLiftFragment(elementType: BridgeType) throws -> IntrinsicJSFragment {
+        if case .alias(_, let underlying) = elementType {
+            return try stackLiftFragment(elementType: underlying)
+        }
         if case .nullable(let wrappedType, let kind) = elementType {
             return try optionalElementRaiseFragment(wrappedType: wrappedType, kind: kind)
         }
@@ -2068,6 +2094,9 @@ struct IntrinsicJSFragment: Sendable {
     }
 
     private static func stackLowerFragment(elementType: BridgeType) throws -> IntrinsicJSFragment {
+        if case .alias(_, let underlying) = elementType {
+            return try stackLowerFragment(elementType: underlying)
+        }
         if case .nullable(let wrappedType, let kind) = elementType {
             return try optionalElementLowerFragment(wrappedType: wrappedType, kind: kind)
         }
@@ -2192,6 +2221,9 @@ struct IntrinsicJSFragment: Sendable {
         wrappedType: BridgeType,
         kind: JSOptionalKind
     ) throws -> IntrinsicJSFragment {
+        if case .alias(_, let underlying) = wrappedType {
+            return try optionalElementRaiseFragment(wrappedType: underlying, kind: kind)
+        }
         if case .associatedValueEnum(let fullName) = wrappedType {
             let base = fullName.components(separatedBy: ".").last ?? fullName
             let absenceLiteral = kind.absenceLiteral
@@ -2258,6 +2290,9 @@ struct IntrinsicJSFragment: Sendable {
         wrappedType: BridgeType,
         kind: JSOptionalKind
     ) throws -> IntrinsicJSFragment {
+        if case .alias(_, let underlying) = wrappedType {
+            return try optionalElementLowerFragment(wrappedType: underlying, kind: kind)
+        }
         if case .associatedValueEnum(let fullName) = wrappedType {
             let base = fullName.components(separatedBy: ".").last ?? fullName
             return IntrinsicJSFragment(
@@ -2680,6 +2715,8 @@ private extension BridgeType {
             return .stackABI
         case .nullable(let wrapped, _):
             return wrapped.optionalConvention
+        case .alias(_, let underlying):
+            return underlying.optionalConvention
         }
     }
 
@@ -2711,6 +2748,8 @@ private extension BridgeType {
             return .i32(-1)
         case .nullable(let wrapped, _):
             return wrapped.nilSentinel
+        case .alias(_, let underlying):
+            return underlying.nilSentinel
         default:
             return .none
         }
@@ -2776,6 +2815,8 @@ private extension BridgeType {
             return []
         case .nullable(let wrapped, _):
             return wrapped.wasmParams
+        case .alias(_, let underlying):
+            return underlying.wasmParams
         }
     }
 

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -651,9 +651,6 @@ struct IntrinsicJSFragment: Sendable {
         kind: JSOptionalKind,
         context bridgeContext: BridgeContext = .importTS
     ) throws -> IntrinsicJSFragment {
-        if case .alias(_, let underlying) = wrappedType {
-            return try optionalLiftParameter(wrappedType: underlying, kind: kind, context: bridgeContext)
-        }
         if wrappedType.isSingleParamScalar {
             let coerce = wrappedType.liftCoerce
             return IntrinsicJSFragment(
@@ -742,9 +739,6 @@ struct IntrinsicJSFragment: Sendable {
         wrappedType: BridgeType,
         kind: JSOptionalKind
     ) throws -> IntrinsicJSFragment {
-        if case .alias(_, let underlying) = wrappedType {
-            return try optionalLowerParameter(wrappedType: underlying, kind: kind)
-        }
         if wrappedType.isSingleParamScalar {
             let wasmType = wrappedType.wasmParams[0].type
             let coerce = wrappedType.lowerCoerce
@@ -973,9 +967,6 @@ struct IntrinsicJSFragment: Sendable {
         wrappedType: BridgeType,
         kind: JSOptionalKind
     ) -> IntrinsicJSFragment {
-        if case .alias(_, let underlying) = wrappedType {
-            return optionalLiftReturn(wrappedType: underlying, kind: kind)
-        }
         if let scalarKind = wrappedType.optionalScalarKind {
             return optionalLiftReturnFromStorage(storage: scalarKind.storageName)
         }
@@ -1073,9 +1064,6 @@ struct IntrinsicJSFragment: Sendable {
     }
 
     static func optionalLowerReturn(wrappedType: BridgeType, kind: JSOptionalKind) throws -> IntrinsicJSFragment {
-        if case .alias(_, let underlying) = wrappedType {
-            return try optionalLowerReturn(wrappedType: underlying, kind: kind)
-        }
         switch wrappedType {
         case .void, .nullable, .namespaceEnum, .closure:
             throw BridgeJSLinkError(message: "Unsupported optional wrapped type for protocol export: \(wrappedType)")
@@ -1200,9 +1188,7 @@ struct IntrinsicJSFragment: Sendable {
     // MARK: - Protocol Support
 
     static func protocolPropertyOptionalToSideChannel(wrappedType: BridgeType) throws -> IntrinsicJSFragment {
-        if case .alias(_, let underlying) = wrappedType {
-            return try protocolPropertyOptionalToSideChannel(wrappedType: underlying)
-        }
+        let wrappedType = wrappedType.unaliased
         if let scalarKind = wrappedType.optionalScalarKind {
             let storage = scalarKind.storageName
             return IntrinsicJSFragment(
@@ -1299,7 +1285,7 @@ struct IntrinsicJSFragment: Sendable {
 
     /// Returns a fragment that lowers a JS value to Wasm core values for parameters
     static func lowerParameter(type: BridgeType) throws -> IntrinsicJSFragment {
-        switch type {
+        switch type.unaliased {
         case .bool, .integer, .float, .double, .unsafePointer, .caseEnum:
             return .identity
         case .rawValueEnum(_, let rawType) where rawType != .string:
@@ -1338,8 +1324,6 @@ struct IntrinsicJSFragment: Sendable {
             return try arrayLower(elementType: elementType)
         case .dictionary(let valueType):
             return try dictionaryLower(valueType: valueType)
-        case .alias(_, let underlying):
-            return try lowerParameter(type: underlying)
         default:
             throw BridgeJSLinkError(message: "Unhandled type in lowerParameter: \(type)")
         }
@@ -1347,7 +1331,7 @@ struct IntrinsicJSFragment: Sendable {
 
     /// Returns a fragment that lifts a Wasm core value to a JS value for return values
     static func liftReturn(type: BridgeType) throws -> IntrinsicJSFragment {
-        switch type {
+        switch type.unaliased {
         case .bool, .rawValueEnum(_, .bool):
             return .boolLiftReturn
         case .integer(let t) where !t.is64Bit && !t.isSigned:
@@ -1397,8 +1381,6 @@ struct IntrinsicJSFragment: Sendable {
             return try arrayLift(elementType: elementType)
         case .dictionary(let valueType):
             return try dictionaryLift(valueType: valueType)
-        case .alias(_, let underlying):
-            return try liftReturn(type: underlying)
         default:
             throw BridgeJSLinkError(message: "Unhandled type in liftReturn: \(type)")
         }
@@ -1408,7 +1390,7 @@ struct IntrinsicJSFragment: Sendable {
 
     /// Returns a fragment that lifts Wasm core values to JS values for parameters
     static func liftParameter(type: BridgeType, context: BridgeContext = .importTS) throws -> IntrinsicJSFragment {
-        switch type {
+        switch type.unaliased {
         case .bool, .rawValueEnum(_, .bool):
             return .boolLiftParameter
         case .integer(let t) where !t.is64Bit && !t.isSigned:
@@ -1489,8 +1471,6 @@ struct IntrinsicJSFragment: Sendable {
             return try arrayLift(elementType: elementType)
         case .dictionary(let valueType):
             return try dictionaryLift(valueType: valueType)
-        case .alias(_, let underlying):
-            return try liftParameter(type: underlying, context: context)
         default:
             throw BridgeJSLinkError(message: "Unhandled type in liftParameter: \(type)")
         }
@@ -1498,7 +1478,7 @@ struct IntrinsicJSFragment: Sendable {
 
     /// Returns a fragment that lowers a JS value to Wasm core values for return values
     static func lowerReturn(type: BridgeType, context: BridgeContext = .importTS) throws -> IntrinsicJSFragment {
-        switch type {
+        switch type.unaliased {
         case .bool, .rawValueEnum(_, .bool):
             return .boolLowerReturn
         case .integer, .float, .double, .unsafePointer, .caseEnum:
@@ -1545,8 +1525,6 @@ struct IntrinsicJSFragment: Sendable {
             return try arrayLower(elementType: elementType)
         case .dictionary(let valueType):
             return try dictionaryLower(valueType: valueType)
-        case .alias(_, let underlying):
-            return try lowerReturn(type: underlying, context: context)
         default:
             throw BridgeJSLinkError(message: "Unhandled type in lowerReturn: \(type)")
         }
@@ -1782,6 +1760,7 @@ struct IntrinsicJSFragment: Sendable {
     }
 
     private static func associatedValuePushPayload(type: BridgeType) throws -> IntrinsicJSFragment {
+        let type = type.unaliased
         switch type {
         case .nullable(let wrappedType, let kind):
             return try optionalElementLowerFragment(wrappedType: wrappedType, kind: kind)
@@ -1791,6 +1770,7 @@ struct IntrinsicJSFragment: Sendable {
     }
 
     private static func associatedValuePopPayload(type: BridgeType) throws -> IntrinsicJSFragment {
+        let type = type.unaliased
         switch type {
         case .nullable(let wrappedType, let kind):
             return try optionalElementRaiseFragment(wrappedType: wrappedType, kind: kind)
@@ -1964,9 +1944,6 @@ struct IntrinsicJSFragment: Sendable {
     }
 
     private static func stackLiftFragment(elementType: BridgeType) throws -> IntrinsicJSFragment {
-        if case .alias(_, let underlying) = elementType {
-            return try stackLiftFragment(elementType: underlying)
-        }
         if case .nullable(let wrappedType, let kind) = elementType {
             return try optionalElementRaiseFragment(wrappedType: wrappedType, kind: kind)
         }
@@ -2094,9 +2071,6 @@ struct IntrinsicJSFragment: Sendable {
     }
 
     private static func stackLowerFragment(elementType: BridgeType) throws -> IntrinsicJSFragment {
-        if case .alias(_, let underlying) = elementType {
-            return try stackLowerFragment(elementType: underlying)
-        }
         if case .nullable(let wrappedType, let kind) = elementType {
             return try optionalElementLowerFragment(wrappedType: wrappedType, kind: kind)
         }
@@ -2221,9 +2195,6 @@ struct IntrinsicJSFragment: Sendable {
         wrappedType: BridgeType,
         kind: JSOptionalKind
     ) throws -> IntrinsicJSFragment {
-        if case .alias(_, let underlying) = wrappedType {
-            return try optionalElementRaiseFragment(wrappedType: underlying, kind: kind)
-        }
         if case .associatedValueEnum(let fullName) = wrappedType {
             let base = fullName.components(separatedBy: ".").last ?? fullName
             let absenceLiteral = kind.absenceLiteral
@@ -2290,9 +2261,6 @@ struct IntrinsicJSFragment: Sendable {
         wrappedType: BridgeType,
         kind: JSOptionalKind
     ) throws -> IntrinsicJSFragment {
-        if case .alias(_, let underlying) = wrappedType {
-            return try optionalElementLowerFragment(wrappedType: underlying, kind: kind)
-        }
         if case .associatedValueEnum(let fullName) = wrappedType {
             let base = fullName.components(separatedBy: ".").last ?? fullName
             return IntrinsicJSFragment(
@@ -2499,6 +2467,7 @@ struct IntrinsicJSFragment: Sendable {
         fieldName: String,
         allStructs: [ExportedStruct]
     ) throws -> IntrinsicJSFragment {
+        let type = type.unaliased
         switch type {
         case .jsValue:
             preconditionFailure("Struct field of JSValue is not supported yet")
@@ -2560,7 +2529,8 @@ struct IntrinsicJSFragment: Sendable {
         field: ExportedProperty,
         allStructs: [ExportedStruct]
     ) throws -> IntrinsicJSFragment {
-        switch field.type {
+        let fieldType = field.type.unaliased
+        switch fieldType {
         case .jsValue:
             preconditionFailure("Struct field of JSValue is not supported yet")
         case .nullable(let wrappedType, let kind):
@@ -2611,7 +2581,7 @@ struct IntrinsicJSFragment: Sendable {
                 }
             )
         default:
-            return try stackLiftFragment(elementType: field.type)
+            return try stackLiftFragment(elementType: fieldType)
         }
     }
 }
@@ -2715,8 +2685,8 @@ private extension BridgeType {
             return .stackABI
         case .nullable(let wrapped, _):
             return wrapped.optionalConvention
-        case .alias(_, let underlying):
-            return underlying.optionalConvention
+        case .alias:
+            preconditionFailure()
         }
     }
 
@@ -2748,8 +2718,6 @@ private extension BridgeType {
             return .i32(-1)
         case .nullable(let wrapped, _):
             return wrapped.nilSentinel
-        case .alias(_, let underlying):
-            return underlying.nilSentinel
         default:
             return .none
         }
@@ -2815,8 +2783,8 @@ private extension BridgeType {
             return []
         case .nullable(let wrapped, _):
             return wrapped.wasmParams
-        case .alias(_, let underlying):
-            return underlying.wasmParams
+        case .alias:
+            preconditionFailure()
         }
     }
 

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -2685,8 +2685,8 @@ private extension BridgeType {
             return .stackABI
         case .nullable(let wrapped, _):
             return wrapped.optionalConvention
-        case .alias:
-            preconditionFailure()
+        case .alias(_, let underlying):
+            return underlying.optionalConvention
         }
     }
 
@@ -2783,8 +2783,8 @@ private extension BridgeType {
             return []
         case .nullable(let wrapped, _):
             return wrapped.wasmParams
-        case .alias:
-            preconditionFailure()
+        case .alias(_, let underlying):
+            return underlying.wasmParams
         }
     }
 

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -1770,6 +1770,8 @@ extension BridgeType {
             // Dictionary mangling: "SD" prefix followed by value type (key is always String)
             return "SD\(valueType.mangleTypeName)"
         case .alias(let name, _):
+            // `name` is the namespace-qualified swiftCallName (unique), so the underlying
+            // representation isn't mangled in - aliases bridge via their JS type's ABI.
             return "Al\(name.count)\(name)"
         }
     }

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -1008,7 +1008,7 @@ public struct ExportedProperty: Codable, Equatable, Sendable {
     }
 }
 
-public struct ExportedAlias: Codable {
+public struct ExportedAlias: Codable, Equatable, Sendable {
     public let swiftCallName: String
     public let underlying: BridgeType
 
@@ -1623,6 +1623,20 @@ extension BridgeType {
             self = .unsafePointer(.init(kind: .opaquePointer))
         default:
             return nil
+        }
+    }
+
+    public var unaliased: BridgeType {
+        switch self {
+        case .alias(_, let underlying): return underlying.unaliased
+        case .nullable(let wrapped, let kind): return .nullable(wrapped.unaliased, kind)
+        case .array(let element): return .array(element.unaliased)
+        case .dictionary(let value): return .dictionary(value.unaliased)
+        case .bool, .integer, .float, .double, .string, .jsValue, .jsObject,
+            .swiftHeapObject, .unsafePointer, .swiftProtocol, .void,
+            .caseEnum, .rawValueEnum, .associatedValueEnum, .swiftStruct,
+            .namespaceEnum, .closure:
+            return self
         }
     }
 

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -274,6 +274,7 @@ public enum BridgeType: Codable, Equatable, Hashable, Sendable {
     case swiftProtocol(String)
     case swiftStruct(String)
     indirect case closure(ClosureSignature, useJSTypedClosure: Bool)
+    indirect case alias(name: String, underlying: BridgeType)
 }
 
 public enum WasmCoreType: String, Codable, Sendable {
@@ -1007,12 +1008,23 @@ public struct ExportedProperty: Codable, Equatable, Sendable {
     }
 }
 
+public struct ExportedAlias: Codable {
+    public let swiftCallName: String
+    public let underlying: BridgeType
+
+    public init(swiftCallName: String, underlying: BridgeType) {
+        self.swiftCallName = swiftCallName
+        self.underlying = underlying
+    }
+}
+
 public struct ExportedSkeleton: Codable {
     public var functions: [ExportedFunction]
     public var classes: [ExportedClass]
     public var enums: [ExportedEnum]
     public var structs: [ExportedStruct]
     public var protocols: [ExportedProtocol]
+    public var aliases: [ExportedAlias]
     /// Whether to expose exported APIs to the global namespace.
     ///
     /// When `true`, exported functions, classes, and namespaces are available
@@ -1032,6 +1044,7 @@ public struct ExportedSkeleton: Codable {
         enums: [ExportedEnum],
         structs: [ExportedStruct] = [],
         protocols: [ExportedProtocol] = [],
+        aliases: [ExportedAlias] = [],
         exposeToGlobal: Bool,
         identityMode: String? = nil
     ) {
@@ -1040,6 +1053,7 @@ public struct ExportedSkeleton: Codable {
         self.enums = enums
         self.structs = structs
         self.protocols = protocols
+        self.aliases = aliases
         self.exposeToGlobal = exposeToGlobal
         self.identityMode = identityMode
     }
@@ -1050,12 +1064,13 @@ public struct ExportedSkeleton: Codable {
         self.enums.append(contentsOf: other.enums)
         self.structs.append(contentsOf: other.structs)
         self.protocols.append(contentsOf: other.protocols)
+        self.aliases.append(contentsOf: other.aliases)
         assert(self.exposeToGlobal == other.exposeToGlobal)
         assert(self.identityMode == other.identityMode)
     }
 
     public var isEmpty: Bool {
-        functions.isEmpty && classes.isEmpty && enums.isEmpty && structs.isEmpty && protocols.isEmpty
+        functions.isEmpty && classes.isEmpty && enums.isEmpty && structs.isEmpty && protocols.isEmpty && aliases.isEmpty
     }
 
     /// Distinct `async` return types needing a `Promise_resolve_<mangled>` helper, deduplicated
@@ -1651,6 +1666,8 @@ extension BridgeType {
         case .dictionary:
             // Dictionaries use stack-based return with entry count (no direct WASM return type)
             return nil
+        case .alias(_, let underlying):
+            return underlying.abiReturnType
         }
     }
 
@@ -1738,6 +1755,8 @@ extension BridgeType {
         case .dictionary(let valueType):
             // Dictionary mangling: "SD" prefix followed by value type (key is always String)
             return "SD\(valueType.mangleTypeName)"
+        case .alias(let name, _):
+            return "Al\(name.count)\(name)"
         }
     }
 
@@ -1749,8 +1768,11 @@ extension BridgeType {
         guard case .nullable(let wrappedType, _) = self else {
             return false
         }
+        return wrappedType.requiresSideChannelForOptionalReturnIfWrapped
+    }
 
-        switch wrappedType {
+    private var requiresSideChannelForOptionalReturnIfWrapped: Bool {
+        switch self {
         case .string, .integer, .float, .double, .swiftProtocol:
             return true
         case .rawValueEnum(_, let rawType):
@@ -1764,6 +1786,8 @@ extension BridgeType {
             }
         case .bool, .caseEnum, .swiftHeapObject, .associatedValueEnum, .jsObject:
             return false
+        case .alias(_, let underlying):
+            return underlying.requiresSideChannelForOptionalReturnIfWrapped
         default:
             return false
         }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/CrossModuleResolutionTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/CrossModuleResolutionTests.swift
@@ -457,6 +457,36 @@ import Testing
         }
     }
 
+    @Test
+    func crossModuleChainedJSAsDiagnostic() throws {
+        let core = try buildDependencySkeleton(
+            moduleName: "Core",
+            source: """
+                @JS(as: Box.self) public struct Wrapped {
+                    public consuming func bridgeToJS() -> Box { fatalError() }
+                    public static func bridgeFromJS(_ value: consuming Box) -> Wrapped { fatalError() }
+                }
+                @JS public final class Box { @JS public init() {} }
+                """
+        )
+        do {
+            _ = try resolveApp(
+                source: """
+                    import Core
+                    @JS(as: Wrapped.self) public struct Doubly {
+                        public consuming func bridgeToJS() -> Wrapped { fatalError() }
+                        public static func bridgeFromJS(_ value: consuming Wrapped) -> Doubly { fatalError() }
+                    }
+                    """,
+                dependencies: [(moduleName: "Core", skeleton: core)]
+            )
+            Issue.record("Expected chained-alias diagnostic for cross-module `@JS(as:)` target")
+        } catch let error as BridgeJSCoreDiagnosticError {
+            let combinedMessages = error.diagnostics.map(\.diagnostic.message).joined(separator: "\n")
+            #expect(combinedMessages.contains("not another `@JS(as:)` type"))
+        }
+    }
+
     // MARK: - Utillites
 
     private func resolveApp(

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
@@ -427,6 +427,27 @@ import Testing
     }
 
     @Test
+    func jsAsWithNamespaceDiagnostic() throws {
+        let source = """
+            @JS final class Box { @JS init() {} }
+            @JS(as: Box.self, namespace: "Foo") struct Wrapped {
+                consuming func bridgeToJS() -> Box { fatalError() }
+                static func bridgeFromJS(_ value: consuming Box) -> Wrapped { fatalError() }
+            }
+            """
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "test.swift")
+        #expect(throws: BridgeJSCoreDiagnosticError.self) {
+            _ = try swiftAPI.finalize()
+        }
+    }
+
+    @Test
     func omitsNextLineWhenErrorIsOnLastLine() throws {
         let source = """
             preamble

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
@@ -355,6 +355,78 @@ import Testing
     }
 
     @Test
+    func chainedJSAsDiagnostic() throws {
+        let source = """
+            @JS(as: B.self) struct A {
+                consuming func bridgeToJS() -> B { fatalError() }
+                static func bridgeFromJS(_ value: consuming B) -> A { fatalError() }
+            }
+            @JS(as: C.self) struct B {
+                consuming func bridgeToJS() -> C { fatalError() }
+                static func bridgeFromJS(_ value: consuming C) -> B { fatalError() }
+            }
+            @JS class C { @JS init() {} }
+            """
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "test.swift")
+        #expect(throws: BridgeJSCoreDiagnosticError.self) {
+            _ = try swiftAPI.finalize()
+        }
+    }
+
+    @Test
+    func cyclicJSAsDiagnostic() throws {
+        let source = """
+            @JS(as: B.self) struct A {
+                consuming func bridgeToJS() -> B { fatalError() }
+                static func bridgeFromJS(_ value: consuming B) -> A { fatalError() }
+            }
+            @JS(as: A.self) struct B {
+                consuming func bridgeToJS() -> A { fatalError() }
+                static func bridgeFromJS(_ value: consuming A) -> B { fatalError() }
+            }
+            """
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "test.swift")
+        #expect(throws: BridgeJSCoreDiagnosticError.self) {
+            _ = try swiftAPI.finalize()
+        }
+    }
+
+    @Test
+    func jsAsProtocolTargetDiagnostic() throws {
+        let source = """
+            @JS protocol Audible {
+                func play()
+            }
+            @JS(as: Audible.self) struct AudibleTag {
+                consuming func bridgeToJS() -> any Audible { fatalError() }
+                static func bridgeFromJS(_ value: consuming any Audible) -> AudibleTag { fatalError() }
+            }
+            """
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "test.swift")
+        #expect(throws: BridgeJSCoreDiagnosticError.self) {
+            _ = try swiftAPI.finalize()
+        }
+    }
+
+    @Test
     func omitsNextLineWhenErrorIsOnLastLine() throws {
         let source = """
             preamble

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Alias.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Alias.swift
@@ -1,0 +1,121 @@
+@JS(as: PolygonReference.self) struct Polygon {
+    var vertices: [Double]
+
+    consuming func bridgeToJS() -> PolygonReference {
+        return PolygonReference(underlying: self)
+    }
+
+    static func bridgeFromJS(_ value: consuming PolygonReference) -> Polygon {
+        return value.underlying
+    }
+}
+
+@JS final class PolygonReference {
+    var underlying: Polygon
+
+    @JS init(underlying: Polygon) {
+        self.underlying = underlying
+    }
+
+    @JS func snapshot() -> Polygon
+    @JS func merge(_ other: Polygon) -> Polygon
+    @JS static func origin() -> Polygon
+}
+
+@JS(as: TagReference.self) struct Tag {
+    var name: String
+
+    consuming func bridgeToJS() -> TagReference {
+        return TagReference(underlying: self)
+    }
+
+    static func bridgeFromJS(_ value: consuming TagReference) -> Tag {
+        return value.underlying
+    }
+}
+
+@JS final class TagReference {
+    var underlying: Tag
+
+    @JS init(underlying: Tag) {
+        self.underlying = underlying
+    }
+}
+
+@JS func roundtripPolygon(_ polygon: Polygon) -> Polygon
+
+@JS func optionalPolygon(_ polygon: Polygon?) -> Polygon?
+
+@JS func polygonArray(_ polygons: [Polygon]) -> [Polygon]
+
+@JS func validatePolygon(_ polygon: Polygon) throws(JSException) -> Polygon
+
+@JS func makeTag(_ name: String) -> Tag
+
+@JS(as: String.self) struct Tagged {
+    var raw: String
+
+    consuming func bridgeToJS() -> String {
+        return raw
+    }
+
+    static func bridgeFromJS(_ value: consuming String) -> Tagged {
+        return Tagged(raw: value)
+    }
+}
+
+@JSFunction func acceptTagged(_ tagged: Tagged) throws(JSException) -> Void
+@JSFunction func acceptOptionalTagged(_ tagged: Tagged?) throws(JSException) -> Void
+@JSFunction func roundtripTagged(_ tagged: Tagged) throws(JSException) -> Tagged
+
+@JSClass class Surface {
+    @JSFunction init() throws(JSException)
+    @JSGetter var label: String
+}
+
+@JS(as: Surface.self) struct Canvas {
+    consuming func bridgeToJS() -> Surface {
+        fatalError("test stub")
+    }
+
+    static func bridgeFromJS(_ value: consuming Surface) -> Canvas {
+        return Canvas()
+    }
+}
+
+@JSFunction func produceOptionalCanvas() throws(JSException) -> Canvas?
+
+@JS enum InnerTag {
+    case payload(Int)
+    case empty
+}
+
+@JS(as: InnerTag.self) struct AliasedTag {
+    consuming func bridgeToJS() -> InnerTag {
+        return .empty
+    }
+
+    static func bridgeFromJS(_ value: consuming InnerTag) -> AliasedTag {
+        return AliasedTag()
+    }
+}
+
+@JS func roundtripTags(_ xs: [AliasedTag?]) -> [AliasedTag?]
+
+@JS(as: Int.self) struct UserId {
+    var rawValue: Int
+
+    consuming func bridgeToJS() -> Int {
+        return rawValue
+    }
+
+    static func bridgeFromJS(_ value: consuming Int) -> UserId {
+        return UserId(rawValue: value)
+    }
+}
+
+@JS protocol HasOptionalUserId {
+    var userId: UserId? { get }
+}
+
+@JS func describeUser(_ owner: HasOptionalUserId) -> HasOptionalUserId

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/AliasInClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/AliasInClosure.swift
@@ -1,0 +1,22 @@
+@JS(as: PolygonReference.self) struct Polygon {
+    var sides: Int
+
+    consuming func bridgeToJS() -> PolygonReference {
+        return PolygonReference(sides: sides)
+    }
+
+    static func bridgeFromJS(_ value: consuming PolygonReference) -> Polygon {
+        return Polygon(sides: value.sides)
+    }
+}
+
+@JS final class PolygonReference {
+    var sides: Int
+
+    @JS init(sides: Int) {
+        self.sides = sides
+    }
+}
+
+@JS func makePolygonFactory() -> () -> Polygon
+@JS func makePolygonInspector() -> (Polygon) -> Int

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/EnumAlias.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/EnumAlias.swift
@@ -1,0 +1,29 @@
+@JS(as: ColorBox.self) enum Color {
+    case red, green, blue
+
+    consuming func bridgeToJS() -> ColorBox {
+        switch self {
+        case .red: return ColorBox(name: "red")
+        case .green: return ColorBox(name: "green")
+        case .blue: return ColorBox(name: "blue")
+        }
+    }
+
+    static func bridgeFromJS(_ value: consuming ColorBox) -> Color {
+        switch value.name {
+        case "green": return .green
+        case "blue": return .blue
+        default: return .red
+        }
+    }
+}
+
+@JS final class ColorBox {
+    var name: String
+
+    @JS init(name: String) {
+        self.name = name
+    }
+}
+
+@JS func roundtripColor(_ color: Color) -> Color

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Alias.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Alias.json
@@ -1,0 +1,719 @@
+{
+  "exported" : {
+    "aliases" : [
+      {
+        "swiftCallName" : "Polygon",
+        "underlying" : {
+          "swiftHeapObject" : {
+            "_0" : "PolygonReference"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "Tag",
+        "underlying" : {
+          "swiftHeapObject" : {
+            "_0" : "TagReference"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "Tagged",
+        "underlying" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "swiftCallName" : "Canvas",
+        "underlying" : {
+          "jsObject" : {
+            "_0" : "Surface"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "AliasedTag",
+        "underlying" : {
+          "associatedValueEnum" : {
+            "_0" : "InnerTag"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "UserId",
+        "underlying" : {
+          "integer" : {
+            "_0" : {
+              "isSigned" : true,
+              "width" : "word"
+            }
+          }
+        }
+      }
+    ],
+    "classes" : [
+      {
+        "constructor" : {
+          "abiName" : "bjs_PolygonReference_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "underlying",
+              "name" : "underlying",
+              "type" : {
+                "alias" : {
+                  "name" : "Polygon",
+                  "underlying" : {
+                    "swiftHeapObject" : {
+                      "_0" : "PolygonReference"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+          {
+            "abiName" : "bjs_PolygonReference_snapshot",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "snapshot",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_PolygonReference_merge",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "merge",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "other",
+                "type" : {
+                  "alias" : {
+                    "name" : "Polygon",
+                    "underlying" : {
+                      "swiftHeapObject" : {
+                        "_0" : "PolygonReference"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_PolygonReference_static_origin",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "origin",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            },
+            "staticContext" : {
+              "className" : {
+                "_0" : "PolygonReference"
+              }
+            }
+          }
+        ],
+        "name" : "PolygonReference",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "PolygonReference"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_TagReference_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "underlying",
+              "name" : "underlying",
+              "type" : {
+                "alias" : {
+                  "name" : "Tag",
+                  "underlying" : {
+                    "swiftHeapObject" : {
+                      "_0" : "TagReference"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+
+        ],
+        "name" : "TagReference",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "TagReference"
+      }
+    ],
+    "enums" : [
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "name" : "payload"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "empty"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "InnerTag",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "InnerTag",
+        "tsFullPath" : "InnerTag"
+      }
+    ],
+    "exposeToGlobal" : false,
+    "functions" : [
+      {
+        "abiName" : "bjs_roundtripPolygon",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundtripPolygon",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "polygon",
+            "type" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Polygon",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "PolygonReference"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_optionalPolygon",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "optionalPolygon",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "polygon",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "alias" : {
+                    "name" : "Polygon",
+                    "underlying" : {
+                      "swiftHeapObject" : {
+                        "_0" : "PolygonReference"
+                      }
+                    }
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_polygonArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "polygonArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "polygons",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "alias" : {
+                    "name" : "Polygon",
+                    "underlying" : {
+                      "swiftHeapObject" : {
+                        "_0" : "PolygonReference"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_validatePolygon",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "validatePolygon",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "polygon",
+            "type" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Polygon",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "PolygonReference"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeTag",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeTag",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "name",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Tag",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "TagReference"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundtripTags",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundtripTags",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "xs",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "nullable" : {
+                    "_0" : {
+                      "alias" : {
+                        "name" : "AliasedTag",
+                        "underlying" : {
+                          "associatedValueEnum" : {
+                            "_0" : "InnerTag"
+                          }
+                        }
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "nullable" : {
+                "_0" : {
+                  "alias" : {
+                    "name" : "AliasedTag",
+                    "underlying" : {
+                      "associatedValueEnum" : {
+                        "_0" : "InnerTag"
+                      }
+                    }
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_describeUser",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "describeUser",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "owner",
+            "type" : {
+              "swiftProtocol" : {
+                "_0" : "HasOptionalUserId"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftProtocol" : {
+            "_0" : "HasOptionalUserId"
+          }
+        }
+      }
+    ],
+    "protocols" : [
+      {
+        "methods" : [
+
+        ],
+        "name" : "HasOptionalUserId",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "name" : "userId",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "alias" : {
+                    "name" : "UserId",
+                    "underlying" : {
+                      "integer" : {
+                        "_0" : {
+                          "isSigned" : true,
+                          "width" : "word"
+                        }
+                      }
+                    }
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "structs" : [
+
+    ]
+  },
+  "imported" : {
+    "children" : [
+      {
+        "functions" : [
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "acceptTagged",
+            "parameters" : [
+              {
+                "name" : "tagged",
+                "type" : {
+                  "alias" : {
+                    "name" : "Tagged",
+                    "underlying" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "acceptOptionalTagged",
+            "parameters" : [
+              {
+                "name" : "tagged",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "alias" : {
+                        "name" : "Tagged",
+                        "underlying" : {
+                          "string" : {
+
+                          }
+                        }
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "roundtripTagged",
+            "parameters" : [
+              {
+                "name" : "tagged",
+                "type" : {
+                  "alias" : {
+                    "name" : "Tagged",
+                    "underlying" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "alias" : {
+                "name" : "Tagged",
+                "underlying" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "produceOptionalCanvas",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "alias" : {
+                    "name" : "Canvas",
+                    "underlying" : {
+                      "jsObject" : {
+                        "_0" : "Surface"
+                      }
+                    }
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "types" : [
+          {
+            "accessLevel" : "internal",
+            "constructor" : {
+              "accessLevel" : "internal",
+              "parameters" : [
+
+              ]
+            },
+            "getters" : [
+              {
+                "accessLevel" : "internal",
+                "name" : "label",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "methods" : [
+
+            ],
+            "name" : "Surface",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "moduleName" : "TestModule",
+  "usedExternalModules" : [
+
+  ]
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Alias.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Alias.swift
@@ -1,0 +1,389 @@
+struct AnyHasOptionalUserId: HasOptionalUserId, _BridgedSwiftProtocolWrapper {
+    let jsObject: JSObject
+
+    var userId: Optional<UserId> {
+        get {
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
+            bjs_HasOptionalUserId_userId_get(jsObjectValue)
+            return Optional<Int>.bridgeJSLiftReturnFromSideChannel().map { UserId.bridgeFromJS($0) }
+        }
+    }
+
+    static func bridgeJSLiftParameter(_ value: Int32) -> Self {
+        return AnyHasOptionalUserId(jsObject: JSObject(id: UInt32(bitPattern: value)))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_HasOptionalUserId_userId_get")
+fileprivate func bjs_HasOptionalUserId_userId_get_extern(_ jsObject: Int32) -> Void
+#else
+fileprivate func bjs_HasOptionalUserId_userId_get_extern(_ jsObject: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_HasOptionalUserId_userId_get(_ jsObject: Int32) -> Void {
+    return bjs_HasOptionalUserId_userId_get_extern(jsObject)
+}
+
+extension InnerTag: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> InnerTag {
+        switch caseId {
+        case 0:
+            return .payload(Int.bridgeJSStackPop())
+        case 1:
+            return .empty
+        default:
+            fatalError("Unknown InnerTag case ID: \(caseId)")
+        }
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
+        switch self {
+        case .payload(let param0):
+            param0.bridgeJSStackPush()
+            return Int32(0)
+        case .empty:
+            return Int32(1)
+        }
+    }
+}
+
+@_expose(wasm, "bjs_roundtripPolygon")
+@_cdecl("bjs_roundtripPolygon")
+public func _bjs_roundtripPolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = roundtripPolygon(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_optionalPolygon")
+@_cdecl("bjs_optionalPolygon")
+public func _bjs_optionalPolygon(_ polygonIsSome: Int32, _ polygonValue: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = optionalPolygon(_: Optional<PolygonReference>.bridgeJSLiftParameter(polygonIsSome, polygonValue).map { Polygon.bridgeFromJS($0) })
+    return ret.map { $0.bridgeToJS() }.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_polygonArray")
+@_cdecl("bjs_polygonArray")
+public func _bjs_polygonArray() -> Void {
+    #if arch(wasm32)
+    let ret = polygonArray(_: [PolygonReference].bridgeJSStackPop().map { Polygon.bridgeFromJS($0) })
+    ret.map { $0.bridgeToJS() }.bridgeJSStackPush()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_validatePolygon")
+@_cdecl("bjs_validatePolygon")
+public func _bjs_validatePolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    do {
+        let ret = try validatePolygon(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
+        return ret.bridgeToJS().bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: String(describing: error))
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return UnsafeMutableRawPointer(bitPattern: -1).unsafelyUnwrapped
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeTag")
+@_cdecl("bjs_makeTag")
+public func _bjs_makeTag(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = makeTag(_: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundtripTags")
+@_cdecl("bjs_roundtripTags")
+public func _bjs_roundtripTags() -> Void {
+    #if arch(wasm32)
+    let ret = roundtripTags(_: [Optional<InnerTag>].bridgeJSStackPop().map { $0.map { AliasedTag.bridgeFromJS($0) } })
+    ret.map { $0.map { $0.bridgeToJS() } }.bridgeJSStackPush()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_describeUser")
+@_cdecl("bjs_describeUser")
+public func _bjs_describeUser(_ owner: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = describeUser(_: AnyHasOptionalUserId.bridgeJSLiftParameter(owner)) as! _BridgedSwiftProtocolExportable
+    return ret.bridgeJSLowerAsProtocolReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_init")
+@_cdecl("bjs_PolygonReference_init")
+public func _bjs_PolygonReference_init(_ underlying: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = PolygonReference(underlying: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(underlying)))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_snapshot")
+@_cdecl("bjs_PolygonReference_snapshot")
+public func _bjs_PolygonReference_snapshot(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = PolygonReference.bridgeJSLiftParameter(_self).snapshot()
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_merge")
+@_cdecl("bjs_PolygonReference_merge")
+public func _bjs_PolygonReference_merge(_ _self: UnsafeMutableRawPointer, _ other: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = PolygonReference.bridgeJSLiftParameter(_self).merge(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(other)))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_static_origin")
+@_cdecl("bjs_PolygonReference_static_origin")
+public func _bjs_PolygonReference_static_origin() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = PolygonReference.origin()
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_deinit")
+@_cdecl("bjs_PolygonReference_deinit")
+public func _bjs_PolygonReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<PolygonReference>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension PolygonReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_PolygonReference_wrap")
+fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_PolygonReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_PolygonReference_wrap_extern(pointer)
+}
+
+@_expose(wasm, "bjs_TagReference_init")
+@_cdecl("bjs_TagReference_init")
+public func _bjs_TagReference_init(_ underlying: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = TagReference(underlying: Tag.bridgeFromJS(TagReference.bridgeJSLiftParameter(underlying)))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_TagReference_deinit")
+@_cdecl("bjs_TagReference_deinit")
+public func _bjs_TagReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<TagReference>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension TagReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TagReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_TagReference_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_TagReference_wrap")
+fileprivate func _bjs_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_TagReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TagReference_wrap_extern(pointer)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_acceptTagged")
+fileprivate func bjs_acceptTagged_extern(_ taggedBytes: Int32, _ taggedLength: Int32) -> Void
+#else
+fileprivate func bjs_acceptTagged_extern(_ taggedBytes: Int32, _ taggedLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_acceptTagged(_ taggedBytes: Int32, _ taggedLength: Int32) -> Void {
+    return bjs_acceptTagged_extern(taggedBytes, taggedLength)
+}
+
+func _$acceptTagged(_ tagged: Tagged) throws(JSException) -> Void {
+    tagged.bridgeToJS().bridgeJSWithLoweredParameter { (taggedBytes, taggedLength) in
+        bjs_acceptTagged(taggedBytes, taggedLength)
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_acceptOptionalTagged")
+fileprivate func bjs_acceptOptionalTagged_extern(_ taggedIsSome: Int32, _ taggedBytes: Int32, _ taggedLength: Int32) -> Void
+#else
+fileprivate func bjs_acceptOptionalTagged_extern(_ taggedIsSome: Int32, _ taggedBytes: Int32, _ taggedLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_acceptOptionalTagged(_ taggedIsSome: Int32, _ taggedBytes: Int32, _ taggedLength: Int32) -> Void {
+    return bjs_acceptOptionalTagged_extern(taggedIsSome, taggedBytes, taggedLength)
+}
+
+func _$acceptOptionalTagged(_ tagged: Optional<Tagged>) throws(JSException) -> Void {
+    tagged.map {
+        $0.bridgeToJS()
+    } .bridgeJSWithLoweredParameter { (taggedIsSome, taggedBytes, taggedLength) in
+        bjs_acceptOptionalTagged(taggedIsSome, taggedBytes, taggedLength)
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_roundtripTagged")
+fileprivate func bjs_roundtripTagged_extern(_ taggedBytes: Int32, _ taggedLength: Int32) -> Int32
+#else
+fileprivate func bjs_roundtripTagged_extern(_ taggedBytes: Int32, _ taggedLength: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_roundtripTagged(_ taggedBytes: Int32, _ taggedLength: Int32) -> Int32 {
+    return bjs_roundtripTagged_extern(taggedBytes, taggedLength)
+}
+
+func _$roundtripTagged(_ tagged: Tagged) throws(JSException) -> Tagged {
+    let ret0 = tagged.bridgeToJS().bridgeJSWithLoweredParameter { (taggedBytes, taggedLength) in
+        let ret = bjs_roundtripTagged(taggedBytes, taggedLength)
+        return ret
+    }
+    let ret = ret0
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Tagged.bridgeFromJS(String.bridgeJSLiftReturn(ret))
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_produceOptionalCanvas")
+fileprivate func bjs_produceOptionalCanvas_extern() -> Void
+#else
+fileprivate func bjs_produceOptionalCanvas_extern() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_produceOptionalCanvas() -> Void {
+    return bjs_produceOptionalCanvas_extern()
+}
+
+func _$produceOptionalCanvas() throws(JSException) -> Optional<Canvas> {
+    bjs_produceOptionalCanvas()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<Surface>.bridgeJSLiftReturn().map {
+        Canvas.bridgeFromJS($0)
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_Surface_init")
+fileprivate func bjs_Surface_init_extern() -> Int32
+#else
+fileprivate func bjs_Surface_init_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Surface_init() -> Int32 {
+    return bjs_Surface_init_extern()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_Surface_label_get")
+fileprivate func bjs_Surface_label_get_extern(_ self: Int32) -> Int32
+#else
+fileprivate func bjs_Surface_label_get_extern(_ self: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Surface_label_get(_ self: Int32) -> Int32 {
+    return bjs_Surface_label_get_extern(self)
+}
+
+func _$Surface_init() throws(JSException) -> JSObject {
+    let ret = bjs_Surface_init()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSObject.bridgeJSLiftReturn(ret)
+}
+
+func _$Surface_label_get(_ self: JSObject) throws(JSException) -> String {
+    let selfValue = self.bridgeJSLowerParameter()
+    let ret = bjs_Surface_label_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return String.bridgeJSLiftReturn(ret)
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Alias.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Alias.swift
@@ -5,7 +5,7 @@ struct AnyHasOptionalUserId: HasOptionalUserId, _BridgedSwiftProtocolWrapper {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_HasOptionalUserId_userId_get(jsObjectValue)
-            return Optional<Int>.bridgeJSLiftReturnFromSideChannel().map { UserId.bridgeFromJS($0) }
+            return Optional<UserId>.bridgeJSLiftReturnFromSideChannel()
         }
     }
 
@@ -53,8 +53,8 @@ extension InnerTag: _BridgedSwiftAssociatedValueEnum {
 @_cdecl("bjs_roundtripPolygon")
 public func _bjs_roundtripPolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = roundtripPolygon(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    let ret = roundtripPolygon(_: Polygon.bridgeJSLiftParameter(polygon))
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -64,8 +64,8 @@ public func _bjs_roundtripPolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeM
 @_cdecl("bjs_optionalPolygon")
 public func _bjs_optionalPolygon(_ polygonIsSome: Int32, _ polygonValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = optionalPolygon(_: Optional<PolygonReference>.bridgeJSLiftParameter(polygonIsSome, polygonValue).map { Polygon.bridgeFromJS($0) })
-    return ret.map { $0.bridgeToJS() }.bridgeJSLowerReturn()
+    let ret = optionalPolygon(_: Optional<Polygon>.bridgeJSLiftParameter(polygonIsSome, polygonValue))
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -75,8 +75,8 @@ public func _bjs_optionalPolygon(_ polygonIsSome: Int32, _ polygonValue: UnsafeM
 @_cdecl("bjs_polygonArray")
 public func _bjs_polygonArray() -> Void {
     #if arch(wasm32)
-    let ret = polygonArray(_: [PolygonReference].bridgeJSStackPop().map { Polygon.bridgeFromJS($0) })
-    ret.map { $0.bridgeToJS() }.bridgeJSStackPush()
+    let ret = polygonArray(_: [Polygon].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -87,15 +87,15 @@ public func _bjs_polygonArray() -> Void {
 public func _bjs_validatePolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     do {
-        let ret = try validatePolygon(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
-        return ret.bridgeToJS().bridgeJSLowerReturn()
+        let ret = try validatePolygon(_: Polygon.bridgeJSLiftParameter(polygon))
+        return ret.bridgeJSLowerReturn()
     } catch let error {
         if let error = error.thrownValue.object {
             withExtendedLifetime(error) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -112,7 +112,7 @@ public func _bjs_validatePolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMu
 public func _bjs_makeTag(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = makeTag(_: String.bridgeJSLiftParameter(nameBytes, nameLength))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -122,8 +122,8 @@ public func _bjs_makeTag(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutab
 @_cdecl("bjs_roundtripTags")
 public func _bjs_roundtripTags() -> Void {
     #if arch(wasm32)
-    let ret = roundtripTags(_: [Optional<InnerTag>].bridgeJSStackPop().map { $0.map { AliasedTag.bridgeFromJS($0) } })
-    ret.map { $0.map { $0.bridgeToJS() } }.bridgeJSStackPush()
+    let ret = roundtripTags(_: [Optional<AliasedTag>].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -144,7 +144,7 @@ public func _bjs_describeUser(_ owner: Int32) -> Int32 {
 @_cdecl("bjs_PolygonReference_init")
 public func _bjs_PolygonReference_init(_ underlying: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PolygonReference(underlying: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(underlying)))
+    let ret = PolygonReference(underlying: Polygon.bridgeJSLiftParameter(underlying))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -156,7 +156,7 @@ public func _bjs_PolygonReference_init(_ underlying: UnsafeMutableRawPointer) ->
 public func _bjs_PolygonReference_snapshot(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = PolygonReference.bridgeJSLiftParameter(_self).snapshot()
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -166,8 +166,8 @@ public func _bjs_PolygonReference_snapshot(_ _self: UnsafeMutableRawPointer) -> 
 @_cdecl("bjs_PolygonReference_merge")
 public func _bjs_PolygonReference_merge(_ _self: UnsafeMutableRawPointer, _ other: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PolygonReference.bridgeJSLiftParameter(_self).merge(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(other)))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    let ret = PolygonReference.bridgeJSLiftParameter(_self).merge(_: Polygon.bridgeJSLiftParameter(other))
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -178,7 +178,7 @@ public func _bjs_PolygonReference_merge(_ _self: UnsafeMutableRawPointer, _ othe
 public func _bjs_PolygonReference_static_origin() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = PolygonReference.origin()
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -219,7 +219,7 @@ fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPo
 @_cdecl("bjs_TagReference_init")
 public func _bjs_TagReference_init(_ underlying: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = TagReference(underlying: Tag.bridgeFromJS(TagReference.bridgeJSLiftParameter(underlying)))
+    let ret = TagReference(underlying: Tag.bridgeJSLiftParameter(underlying))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -257,6 +257,18 @@ fileprivate func _bjs_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointe
     return _bjs_TagReference_wrap_extern(pointer)
 }
 
+extension Polygon: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
+extension Tag: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
+extension Tagged: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
+extension Canvas: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
+extension AliasedTag: _BridgedSwiftAlias, _BridgedSwiftAssociatedValueEnum {}
+
+extension UserId: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
 #if arch(wasm32)
 @_extern(wasm, module: "TestModule", name: "bjs_acceptTagged")
 fileprivate func bjs_acceptTagged_extern(_ taggedBytes: Int32, _ taggedLength: Int32) -> Void
@@ -270,7 +282,7 @@ fileprivate func bjs_acceptTagged_extern(_ taggedBytes: Int32, _ taggedLength: I
 }
 
 func _$acceptTagged(_ tagged: Tagged) throws(JSException) -> Void {
-    tagged.bridgeToJS().bridgeJSWithLoweredParameter { (taggedBytes, taggedLength) in
+    tagged.bridgeJSWithLoweredParameter { (taggedBytes, taggedLength) in
         bjs_acceptTagged(taggedBytes, taggedLength)
     }
     if let error = _swift_js_take_exception() {
@@ -291,9 +303,7 @@ fileprivate func bjs_acceptOptionalTagged_extern(_ taggedIsSome: Int32, _ tagged
 }
 
 func _$acceptOptionalTagged(_ tagged: Optional<Tagged>) throws(JSException) -> Void {
-    tagged.map {
-        $0.bridgeToJS()
-    } .bridgeJSWithLoweredParameter { (taggedIsSome, taggedBytes, taggedLength) in
+    tagged.bridgeJSWithLoweredParameter { (taggedIsSome, taggedBytes, taggedLength) in
         bjs_acceptOptionalTagged(taggedIsSome, taggedBytes, taggedLength)
     }
     if let error = _swift_js_take_exception() {
@@ -314,7 +324,7 @@ fileprivate func bjs_roundtripTagged_extern(_ taggedBytes: Int32, _ taggedLength
 }
 
 func _$roundtripTagged(_ tagged: Tagged) throws(JSException) -> Tagged {
-    let ret0 = tagged.bridgeToJS().bridgeJSWithLoweredParameter { (taggedBytes, taggedLength) in
+    let ret0 = tagged.bridgeJSWithLoweredParameter { (taggedBytes, taggedLength) in
         let ret = bjs_roundtripTagged(taggedBytes, taggedLength)
         return ret
     }
@@ -322,7 +332,7 @@ func _$roundtripTagged(_ tagged: Tagged) throws(JSException) -> Tagged {
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Tagged.bridgeFromJS(String.bridgeJSLiftReturn(ret))
+    return Tagged.bridgeJSLiftReturn(ret)
 }
 
 #if arch(wasm32)
@@ -342,9 +352,7 @@ func _$produceOptionalCanvas() throws(JSException) -> Optional<Canvas> {
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<Surface>.bridgeJSLiftReturn().map {
-        Canvas.bridgeFromJS($0)
-    }
+    return Optional<Canvas>.bridgeJSLiftReturn()
 }
 
 #if arch(wasm32)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.json
@@ -1,0 +1,145 @@
+{
+  "exported" : {
+    "aliases" : [
+      {
+        "swiftCallName" : "Polygon",
+        "underlying" : {
+          "swiftHeapObject" : {
+            "_0" : "PolygonReference"
+          }
+        }
+      }
+    ],
+    "classes" : [
+      {
+        "constructor" : {
+          "abiName" : "bjs_PolygonReference_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "sides",
+              "name" : "sides",
+              "type" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+
+        ],
+        "name" : "PolygonReference",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "PolygonReference"
+      }
+    ],
+    "enums" : [
+
+    ],
+    "exposeToGlobal" : false,
+    "functions" : [
+      {
+        "abiName" : "bjs_makePolygonFactory",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makePolygonFactory",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : false,
+              "isThrows" : false,
+              "mangleName" : "10TestModuley_Al7Polygon",
+              "moduleName" : "TestModule",
+              "parameters" : [
+
+              ],
+              "returnType" : {
+                "alias" : {
+                  "name" : "Polygon",
+                  "underlying" : {
+                    "swiftHeapObject" : {
+                      "_0" : "PolygonReference"
+                    }
+                  }
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : false
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makePolygonInspector",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makePolygonInspector",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : false,
+              "isThrows" : false,
+              "mangleName" : "10TestModuleAl7Polygon_Si",
+              "moduleName" : "TestModule",
+              "parameters" : [
+                {
+                  "alias" : {
+                    "name" : "Polygon",
+                    "underlying" : {
+                      "swiftHeapObject" : {
+                        "_0" : "PolygonReference"
+                      }
+                    }
+                  }
+                }
+              ],
+              "returnType" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : false
+          }
+        }
+      }
+    ],
+    "protocols" : [
+
+    ],
+    "structs" : [
+
+    ]
+  },
+  "moduleName" : "TestModule",
+  "usedExternalModules" : [
+
+  ]
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.swift
@@ -28,7 +28,7 @@ private enum _BJS_Closure_10TestModuleAl7Polygon_Si {
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
-            let param0Pointer = param0.bridgeToJS().bridgeJSLowerParameter()
+            let param0Pointer = param0.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si(callbackValue, param0Pointer)
             return Int.bridgeJSLiftReturn(ret)
             #else
@@ -54,7 +54,7 @@ extension JSTypedClosure where Signature == (Polygon) -> Int {
 public func _invoke_swift_closure_TestModule_10TestModuleAl7Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<(Polygon) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(param0)))
+    let result = closure(Polygon.bridgeJSLiftParameter(param0))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -92,7 +92,7 @@ private enum _BJS_Closure_10TestModuley_Al7Polygon {
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuley_Al7Polygon(callbackValue)
-            return Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftReturn(ret))
+            return Polygon.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -117,7 +117,7 @@ public func _invoke_swift_closure_TestModule_10TestModuley_Al7Polygon(_ boxPtr: 
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<() -> Polygon>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     let result = closure()
-    return result.bridgeToJS().bridgeJSLowerReturn()
+    return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -186,3 +186,5 @@ fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPo
 @inline(never) fileprivate func _bjs_PolygonReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     return _bjs_PolygonReference_wrap_extern(pointer)
 }
+
+extension Polygon: _BridgedSwiftAlias, _BridgedSwiftStackType {}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.swift
@@ -1,0 +1,188 @@
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si")
+fileprivate func invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleAl7Polygon_Si")
+fileprivate func make_swift_closure_TestModule_10TestModuleAl7Polygon_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModuleAl7Polygon_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleAl7Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleAl7Polygon_Si_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModuleAl7Polygon_Si {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Polygon) -> Int {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0Pointer = param0.bridgeToJS().bridgeJSLowerParameter()
+            let ret = invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si(callbackValue, param0Pointer)
+            return Int.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (Polygon) -> Int {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Polygon) -> Int) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModuleAl7Polygon_Si,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleAl7Polygon_Si")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleAl7Polygon_Si")
+public func _invoke_swift_closure_TestModule_10TestModuleAl7Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Polygon) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(param0)))
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuley_Al7Polygon")
+fileprivate func invoke_js_callback_TestModule_10TestModuley_Al7Polygon_extern(_ callback: Int32) -> UnsafeMutableRawPointer
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModuley_Al7Polygon_extern(_ callback: Int32) -> UnsafeMutableRawPointer {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuley_Al7Polygon(_ callback: Int32) -> UnsafeMutableRawPointer {
+    return invoke_js_callback_TestModule_10TestModuley_Al7Polygon_extern(callback)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuley_Al7Polygon")
+fileprivate func make_swift_closure_TestModule_10TestModuley_Al7Polygon_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModuley_Al7Polygon_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuley_Al7Polygon(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuley_Al7Polygon_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModuley_Al7Polygon {
+    static func bridgeJSLift(_ callbackId: Int32) -> () -> Polygon {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let ret = invoke_js_callback_TestModule_10TestModuley_Al7Polygon(callbackValue)
+            return Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftReturn(ret))
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == () -> Polygon {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping () -> Polygon) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModuley_Al7Polygon,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuley_Al7Polygon")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuley_Al7Polygon")
+public func _invoke_swift_closure_TestModule_10TestModuley_Al7Polygon(_ boxPtr: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<() -> Polygon>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure()
+    return result.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makePolygonFactory")
+@_cdecl("bjs_makePolygonFactory")
+public func _bjs_makePolygonFactory() -> Int32 {
+    #if arch(wasm32)
+    let ret = makePolygonFactory()
+    return JSTypedClosure(ret).bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makePolygonInspector")
+@_cdecl("bjs_makePolygonInspector")
+public func _bjs_makePolygonInspector() -> Int32 {
+    #if arch(wasm32)
+    let ret = makePolygonInspector()
+    return JSTypedClosure(ret).bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_init")
+@_cdecl("bjs_PolygonReference_init")
+public func _bjs_PolygonReference_init(_ sides: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = PolygonReference(sides: Int.bridgeJSLiftParameter(sides))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_deinit")
+@_cdecl("bjs_PolygonReference_deinit")
+public func _bjs_PolygonReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<PolygonReference>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension PolygonReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_PolygonReference_wrap")
+fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_PolygonReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_PolygonReference_wrap_extern(pointer)
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "methods" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AsyncAssociatedValueEnum.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AsyncAssociatedValueEnum.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileExtension.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileExtension.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileFunctionTypes.ReverseOrder.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileFunctionTypes.ReverseOrder.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileFunctionTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileFunctionTypes.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.ReverseOrder.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.ReverseOrder.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "methods" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DictionaryTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DictionaryTypes.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "methods" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DocComments.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DocComments.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAlias.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAlias.json
@@ -1,0 +1,96 @@
+{
+  "exported" : {
+    "aliases" : [
+      {
+        "swiftCallName" : "Color",
+        "underlying" : {
+          "swiftHeapObject" : {
+            "_0" : "ColorBox"
+          }
+        }
+      }
+    ],
+    "classes" : [
+      {
+        "constructor" : {
+          "abiName" : "bjs_ColorBox_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "name",
+              "name" : "name",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+
+        ],
+        "name" : "ColorBox",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "ColorBox"
+      }
+    ],
+    "enums" : [
+
+    ],
+    "exposeToGlobal" : false,
+    "functions" : [
+      {
+        "abiName" : "bjs_roundtripColor",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundtripColor",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "color",
+            "type" : {
+              "alias" : {
+                "name" : "Color",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "ColorBox"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Color",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "ColorBox"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "protocols" : [
+
+    ],
+    "structs" : [
+
+    ]
+  },
+  "moduleName" : "TestModule",
+  "usedExternalModules" : [
+
+  ]
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAlias.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAlias.swift
@@ -2,8 +2,8 @@
 @_cdecl("bjs_roundtripColor")
 public func _bjs_roundtripColor(_ color: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = roundtripColor(_: Color.bridgeFromJS(ColorBox.bridgeJSLiftParameter(color)))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    let ret = roundtripColor(_: Color.bridgeJSLiftParameter(color))
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -50,3 +50,5 @@ fileprivate func _bjs_ColorBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -
 @inline(never) fileprivate func _bjs_ColorBox_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     return _bjs_ColorBox_wrap_extern(pointer)
 }
+
+extension Color: _BridgedSwiftAlias, _BridgedSwiftStackType {}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAlias.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAlias.swift
@@ -1,0 +1,52 @@
+@_expose(wasm, "bjs_roundtripColor")
+@_cdecl("bjs_roundtripColor")
+public func _bjs_roundtripColor(_ color: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = roundtripColor(_: Color.bridgeFromJS(ColorBox.bridgeJSLiftParameter(color)))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ColorBox_init")
+@_cdecl("bjs_ColorBox_init")
+public func _bjs_ColorBox_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = ColorBox(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ColorBox_deinit")
+@_cdecl("bjs_ColorBox_deinit")
+public func _bjs_ColorBox_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<ColorBox>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension ColorBox: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_ColorBox_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_ColorBox_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_ColorBox_wrap")
+fileprivate func _bjs_ColorBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_ColorBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_ColorBox_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_ColorBox_wrap_extern(pointer)
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "methods" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValueImport.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValueImport.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCase.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCase.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCaseImport.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCaseImport.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.Global.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.Global.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumRawType.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumRawType.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/FixedWidthIntegers.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/FixedWidthIntegers.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/IdentityModeClass.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/IdentityModeClass.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSTypedArrayTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSTypedArrayTypes.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSValue.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSValue.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/MixedGlobal.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/MixedGlobal.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/MixedPrivate.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/MixedPrivate.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.Global.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.Global.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/NestedType.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/NestedType.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "methods" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveParameters.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveParameters.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveReturn.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PropertyTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PropertyTypes.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ProtocolInClosure.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ProtocolInClosure.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.Global.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.Global.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.Global.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.Global.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StringParameter.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StringParameter.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StringReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StringReturn.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClass.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClass.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosureImports.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosureImports.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Throws.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Throws.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/UnsafePointer.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/UnsafePointer.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/VoidParameterVoidReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/VoidParameterVoidReturn.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
 
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Alias.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Alias.d.ts
@@ -1,0 +1,71 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export interface HasOptionalUserId {
+    readonly userId: number | null;
+}
+
+export const InnerTagValues: {
+    readonly Tag: {
+        readonly Payload: 0;
+        readonly Empty: 1;
+    };
+};
+
+export type InnerTagTag =
+  { tag: typeof InnerTagValues.Tag.Payload; param0: number } | { tag: typeof InnerTagValues.Tag.Empty }
+
+export type InnerTagObject = typeof InnerTagValues;
+
+/// Represents a Swift heap object like a class instance or an actor instance.
+export interface SwiftHeapObject {
+    /// Release the heap object.
+    ///
+    /// Note: Calling this method will release the heap object and it will no longer be accessible.
+    release(): void;
+}
+export interface PolygonReference extends SwiftHeapObject {
+    snapshot(): PolygonReference;
+    merge(other: PolygonReference): PolygonReference;
+}
+export interface TagReference extends SwiftHeapObject {
+}
+export interface Surface {
+    readonly label: string;
+}
+export type Exports = {
+    PolygonReference: {
+        new(underlying: PolygonReference): PolygonReference;
+        origin(): PolygonReference;
+    }
+    TagReference: {
+        new(underlying: TagReference): TagReference;
+    }
+    roundtripPolygon(polygon: PolygonReference): PolygonReference;
+    optionalPolygon(polygon: PolygonReference | null): PolygonReference | null;
+    polygonArray(polygons: PolygonReference[]): PolygonReference[];
+    validatePolygon(polygon: PolygonReference): PolygonReference;
+    makeTag(name: string): TagReference;
+    roundtripTags(xs: (InnerTagTag | null)[]): (InnerTagTag | null)[];
+    describeUser(owner: HasOptionalUserId): HasOptionalUserId;
+    InnerTag: InnerTagObject
+}
+export type Imports = {
+    acceptTagged(tagged: string): void;
+    acceptOptionalTagged(tagged: string | null): void;
+    roundtripTagged(tagged: string): string;
+    produceOptionalCanvas(): Surface | null;
+    Surface: {
+        new(): Surface;
+    }
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Alias.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Alias.js
@@ -1,0 +1,517 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export const InnerTagValues = {
+    Tag: {
+        Payload: 0,
+        Empty: 1,
+    },
+};
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    let decodeString;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let strStack = [];
+    let i32Stack = [];
+    let i64Stack = [];
+    let f32Stack = [];
+    let f64Stack = [];
+    let ptrStack = [];
+    let taStack = [];
+    const enumHelpers = {};
+    const structHelpers = {};
+
+    let _exports = null;
+    let bjs = null;
+    const __bjs_createInnerTagValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case InnerTagValues.Tag.Payload: {
+                    i32Stack.push((value.param0 | 0));
+                    return InnerTagValues.Tag.Payload;
+                }
+                case InnerTagValues.Tag.Empty: {
+                    return InnerTagValues.Tag.Empty;
+                }
+                default: throw new Error("Unknown InnerTagValues tag: " + String(enumTag));
+            }
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case InnerTagValues.Tag.Payload: {
+                    const int = i32Stack.pop();
+                    return { tag: InnerTagValues.Tag.Payload, param0: int };
+                }
+                case InnerTagValues.Tag.Empty: return { tag: InnerTagValues.Tag.Empty };
+                default: throw new Error("Unknown InnerTagValues tag returned from Swift: " + String(tag));
+            }
+        }
+    });
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            bjs = {};
+            importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                tmpRetString = decodeString(ptr, len);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                return swift.memory.retain(decodeString(ptr, len));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr, len);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_i32"] = function(v) {
+                i32Stack.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                f32Stack.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                f64Stack.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const value = decodeString(ptr, len);
+                strStack.push(value);
+            }
+            bjs["swift_js_pop_i32"] = function() {
+                return i32Stack.pop();
+            }
+            bjs["swift_js_pop_f32"] = function() {
+                return f32Stack.pop();
+            }
+            bjs["swift_js_pop_f64"] = function() {
+                return f64Stack.pop();
+            }
+            bjs["swift_js_push_pointer"] = function(pointer) {
+                ptrStack.push(pointer);
+            }
+            bjs["swift_js_pop_pointer"] = function() {
+                return ptrStack.pop();
+            }
+            bjs["swift_js_push_i64"] = function(v) {
+                i64Stack.push(v);
+            }
+            bjs["swift_js_pop_i64"] = function() {
+                return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = decodeString(ptr, len);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            bjs["swift_js_get_optional_int_presence"] = function() {
+                return tmpRetOptionalInt != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_int_value"] = function() {
+                const value = tmpRetOptionalInt;
+                tmpRetOptionalInt = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_string"] = function() {
+                const str = tmpRetString;
+                tmpRetString = undefined;
+                if (str == null) {
+                    return -1;
+                } else {
+                    const bytes = textEncoder.encode(str);
+                    tmpRetBytes = bytes;
+                    return bytes.length;
+                }
+            }
+            bjs["swift_js_get_optional_float_presence"] = function() {
+                return tmpRetOptionalFloat != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_float_value"] = function() {
+                const value = tmpRetOptionalFloat;
+                tmpRetOptionalFloat = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_double_presence"] = function() {
+                return tmpRetOptionalDouble != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_double_value"] = function() {
+                const value = tmpRetOptionalDouble;
+                tmpRetOptionalDouble = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_heap_object_pointer"] = function() {
+                const pointer = tmpRetOptionalHeapObject;
+                tmpRetOptionalHeapObject = undefined;
+                return pointer || 0;
+            }
+            bjs["swift_js_closure_unregister"] = function(funcRef) {}
+            // Wrapper functions for module: TestModule
+            if (!importObject["TestModule"]) {
+                importObject["TestModule"] = {};
+            }
+            importObject["TestModule"]["bjs_PolygonReference_wrap"] = function(pointer) {
+                const obj = _exports['PolygonReference'].__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+            importObject["TestModule"]["bjs_TagReference_wrap"] = function(pointer) {
+                const obj = _exports['TagReference'].__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
+            TestModule["bjs_acceptTagged"] = function bjs_acceptTagged(taggedBytes, taggedCount) {
+                try {
+                    const string = decodeString(taggedBytes, taggedCount);
+                    imports.acceptTagged(string);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_acceptOptionalTagged"] = function bjs_acceptOptionalTagged(taggedIsSome, taggedBytes, taggedCount) {
+                try {
+                    let optResult;
+                    if (taggedIsSome) {
+                        const string = decodeString(taggedBytes, taggedCount);
+                        optResult = string;
+                    } else {
+                        optResult = null;
+                    }
+                    imports.acceptOptionalTagged(optResult);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_roundtripTagged"] = function bjs_roundtripTagged(taggedBytes, taggedCount) {
+                try {
+                    const string = decodeString(taggedBytes, taggedCount);
+                    let ret = imports.roundtripTagged(string);
+                    tmpRetBytes = textEncoder.encode(ret);
+                    return tmpRetBytes.length;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_produceOptionalCanvas"] = function bjs_produceOptionalCanvas() {
+                try {
+                    let ret = imports.produceOptionalCanvas();
+                    const isSome = ret != null;
+                    if (isSome) {
+                        const objId = swift.memory.retain(ret);
+                        i32Stack.push(objId);
+                    }
+                    i32Stack.push(isSome ? 1 : 0);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_Surface_init"] = function bjs_Surface_init() {
+                try {
+                    return swift.memory.retain(new imports.Surface());
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_Surface_label_get"] = function bjs_Surface_label_get(self) {
+                try {
+                    let ret = swift.memory.getObject(self).label;
+                    tmpRetBytes = textEncoder.encode(ret);
+                    return tmpRetBytes.length;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_HasOptionalUserId_userId_get"] = function bjs_HasOptionalUserId_userId_get(self) {
+                try {
+                    let ret = swift.memory.getObject(self).userId;
+                    tmpRetOptionalInt = ret;
+                } catch (error) {
+                    setException(error);
+                }
+            }
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            decodeString = (ptr, len) => { const bytes = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0); return textDecoder.decode(bytes); }
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            const swiftHeapObjectFinalizationRegistry = (typeof FinalizationRegistry === "undefined") ? { register: () => {}, unregister: () => {} } : new FinalizationRegistry((state) => {
+                if (state.hasReleased) {
+                    return;
+                }
+                state.hasReleased = true;
+                state.identityMap?.delete(state.pointer);
+                state.deinit(state.pointer);
+            });
+
+            /// Represents a Swift heap object like a class instance or an actor instance.
+            class SwiftHeapObject {
+                static __wrap(pointer, deinit, prototype, identityCache) {
+                    const makeFresh = (identityMap) => {
+                        const obj = Object.create(prototype);
+                        const state = { pointer, deinit, hasReleased: false, identityMap };
+                        obj.pointer = pointer;
+                        obj.__swiftHeapObjectState = state;
+                        swiftHeapObjectFinalizationRegistry.register(obj, state, state);
+                        if (identityMap) {
+                            identityMap.set(pointer, new WeakRef(obj));
+                        }
+                        return obj;
+                    };
+
+                    if (!identityCache) {
+                        return makeFresh(null);
+                    }
+
+                    const cached = identityCache.get(pointer)?.deref();
+                    if (cached && !cached.__swiftHeapObjectState.hasReleased) {
+                        deinit(pointer);
+                        return cached;
+                    }
+                    if (identityCache.has(pointer)) {
+                        identityCache.delete(pointer);
+                    }
+
+                    return makeFresh(identityCache);
+                }
+
+                release() {
+                    const state = this.__swiftHeapObjectState;
+                    if (state.hasReleased) {
+                        return;
+                    }
+                    state.hasReleased = true;
+                    swiftHeapObjectFinalizationRegistry.unregister(state);
+                    state.identityMap?.delete(state.pointer);
+                    state.deinit(state.pointer);
+                }
+            }
+            class PolygonReference extends SwiftHeapObject {
+                static __construct(ptr) {
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PolygonReference_deinit, PolygonReference.prototype, null);
+                }
+
+                constructor(underlying) {
+                    const ret = instance.exports.bjs_PolygonReference_init(underlying.pointer);
+                    return PolygonReference.__construct(ret);
+                }
+                snapshot() {
+                    const ret = instance.exports.bjs_PolygonReference_snapshot(this.pointer);
+                    return PolygonReference.__construct(ret);
+                }
+                merge(other) {
+                    const ret = instance.exports.bjs_PolygonReference_merge(this.pointer, other.pointer);
+                    return PolygonReference.__construct(ret);
+                }
+                static origin() {
+                    const ret = instance.exports.bjs_PolygonReference_static_origin();
+                    return PolygonReference.__construct(ret);
+                }
+            }
+            class TagReference extends SwiftHeapObject {
+                static __construct(ptr) {
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TagReference_deinit, TagReference.prototype, null);
+                }
+
+                constructor(underlying) {
+                    const ret = instance.exports.bjs_TagReference_init(underlying.pointer);
+                    return TagReference.__construct(ret);
+                }
+            }
+            const InnerTagHelpers = __bjs_createInnerTagValuesHelpers();
+            enumHelpers.InnerTag = InnerTagHelpers;
+
+            const exports = {
+                PolygonReference,
+                TagReference,
+                roundtripPolygon: function bjs_roundtripPolygon(polygon) {
+                    const ret = instance.exports.bjs_roundtripPolygon(polygon.pointer);
+                    return PolygonReference.__construct(ret);
+                },
+                optionalPolygon: function bjs_optionalPolygon(polygon) {
+                    const isSome = polygon != null;
+                    let result;
+                    if (isSome) {
+                        result = polygon.pointer;
+                    } else {
+                        result = 0;
+                    }
+                    instance.exports.bjs_optionalPolygon(+isSome, result);
+                    const pointer = tmpRetOptionalHeapObject;
+                    tmpRetOptionalHeapObject = undefined;
+                    const optResult = pointer === null ? null : PolygonReference.__construct(pointer);
+                    return optResult;
+                },
+                polygonArray: function bjs_polygonArray(polygons) {
+                    for (const elem of polygons) {
+                        ptrStack.push(elem.pointer);
+                    }
+                    i32Stack.push(polygons.length);
+                    instance.exports.bjs_polygonArray();
+                    const arrayLen = i32Stack.pop();
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const ptr = ptrStack.pop();
+                            const obj = PolygonReference.__construct(ptr);
+                            arrayResult.push(obj);
+                        }
+                        arrayResult.reverse();
+                    }
+                    return arrayResult;
+                },
+                validatePolygon: function bjs_validatePolygon(polygon) {
+                    const ret = instance.exports.bjs_validatePolygon(polygon.pointer);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return PolygonReference.__construct(ret);
+                },
+                makeTag: function bjs_makeTag(name) {
+                    const nameBytes = textEncoder.encode(name);
+                    const nameId = swift.memory.retain(nameBytes);
+                    const ret = instance.exports.bjs_makeTag(nameId, nameBytes.length);
+                    return TagReference.__construct(ret);
+                },
+                roundtripTags: function bjs_roundtripTags(xs) {
+                    for (const elem of xs) {
+                        const isSome = elem != null ? 1 : 0;
+                        if (isSome) {
+                            const caseId = enumHelpers.InnerTag.lower(elem);
+                            i32Stack.push(caseId);
+                        } else {
+                            i32Stack.push(-1);
+                        }
+                    }
+                    i32Stack.push(xs.length);
+                    instance.exports.bjs_roundtripTags();
+                    const arrayLen = i32Stack.pop();
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const caseId1 = i32Stack.pop();
+                            let optValue;
+                            if (caseId1 === -1) {
+                                optValue = null;
+                            } else {
+                                optValue = enumHelpers.InnerTag.lift(caseId1);
+                            }
+                            arrayResult.push(optValue);
+                        }
+                        arrayResult.reverse();
+                    }
+                    return arrayResult;
+                },
+                describeUser: function bjs_describeUser(owner) {
+                    const ret = instance.exports.bjs_describeUser(swift.memory.retain(owner));
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                InnerTag: InnerTagValues,
+            };
+            _exports = exports;
+            return exports;
+        },
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Alias.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Alias.js
@@ -78,14 +78,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -345,6 +345,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Alias.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Alias.js
@@ -139,6 +139,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AliasInClosure.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AliasInClosure.d.ts
@@ -1,0 +1,31 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+/// Represents a Swift heap object like a class instance or an actor instance.
+export interface SwiftHeapObject {
+    /// Release the heap object.
+    ///
+    /// Note: Calling this method will release the heap object and it will no longer be accessible.
+    release(): void;
+}
+export interface PolygonReference extends SwiftHeapObject {
+}
+export type Exports = {
+    PolygonReference: {
+        new(sides: number): PolygonReference;
+    }
+    makePolygonFactory(): () => PolygonReference;
+    makePolygonInspector(): (arg0: PolygonReference) => number;
+}
+export type Imports = {
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AliasInClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AliasInClosure.js
@@ -131,6 +131,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AliasInClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AliasInClosure.js
@@ -39,7 +39,7 @@ export async function createInstantiator(options, swift) {
         const state = { pointer, file, line, unregistered: false };
         const real = (...args) => {
             if (state.unregistered) {
-                const bytes = new Uint8Array(memory.buffer, state.file);
+                const bytes = new Uint8Array(memory.buffer, state.file >>> 0);
                 let length = 0;
                 while (bytes[length] !== 0) { length += 1; }
                 const fileID = decodeString(state.file, length);
@@ -70,14 +70,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -312,6 +312,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AliasInClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AliasInClosure.js
@@ -1,0 +1,372 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    let decodeString;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let strStack = [];
+    let i32Stack = [];
+    let i64Stack = [];
+    let f32Stack = [];
+    let f64Stack = [];
+    let ptrStack = [];
+    let taStack = [];
+    const enumHelpers = {};
+    const structHelpers = {};
+
+    let _exports = null;
+    let bjs = null;
+    const swiftClosureRegistry = (typeof FinalizationRegistry === "undefined") ? { register: () => {}, unregister: () => {} } : new FinalizationRegistry((state) => {
+        if (state.unregistered) { return; }
+        instance?.exports?.bjs_release_swift_closure(state.pointer);
+    });
+    const makeClosure = (pointer, file, line, func) => {
+        const state = { pointer, file, line, unregistered: false };
+        const real = (...args) => {
+            if (state.unregistered) {
+                const bytes = new Uint8Array(memory.buffer, state.file);
+                let length = 0;
+                while (bytes[length] !== 0) { length += 1; }
+                const fileID = decodeString(state.file, length);
+                throw new Error(`Attempted to call a released JSTypedClosure created at ${fileID}:${state.line}`);
+            }
+            return func(...args);
+        };
+        real.__unregister = () => {
+            if (state.unregistered) { return; }
+            state.unregistered = true;
+            swiftClosureRegistry.unregister(state);
+        };
+        swiftClosureRegistry.register(real, state, state);
+        return swift.memory.retain(real);
+    };
+
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            bjs = {};
+            importObject["bjs"] = bjs;
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                tmpRetString = decodeString(ptr, len);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                return swift.memory.retain(decodeString(ptr, len));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr, len);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_i32"] = function(v) {
+                i32Stack.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                f32Stack.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                f64Stack.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const value = decodeString(ptr, len);
+                strStack.push(value);
+            }
+            bjs["swift_js_pop_i32"] = function() {
+                return i32Stack.pop();
+            }
+            bjs["swift_js_pop_f32"] = function() {
+                return f32Stack.pop();
+            }
+            bjs["swift_js_pop_f64"] = function() {
+                return f64Stack.pop();
+            }
+            bjs["swift_js_push_pointer"] = function(pointer) {
+                ptrStack.push(pointer);
+            }
+            bjs["swift_js_pop_pointer"] = function() {
+                return ptrStack.pop();
+            }
+            bjs["swift_js_push_i64"] = function(v) {
+                i64Stack.push(v);
+            }
+            bjs["swift_js_pop_i64"] = function() {
+                return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = decodeString(ptr, len);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            bjs["swift_js_get_optional_int_presence"] = function() {
+                return tmpRetOptionalInt != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_int_value"] = function() {
+                const value = tmpRetOptionalInt;
+                tmpRetOptionalInt = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_string"] = function() {
+                const str = tmpRetString;
+                tmpRetString = undefined;
+                if (str == null) {
+                    return -1;
+                } else {
+                    const bytes = textEncoder.encode(str);
+                    tmpRetBytes = bytes;
+                    return bytes.length;
+                }
+            }
+            bjs["swift_js_get_optional_float_presence"] = function() {
+                return tmpRetOptionalFloat != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_float_value"] = function() {
+                const value = tmpRetOptionalFloat;
+                tmpRetOptionalFloat = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_double_presence"] = function() {
+                return tmpRetOptionalDouble != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_double_value"] = function() {
+                const value = tmpRetOptionalDouble;
+                tmpRetOptionalDouble = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_heap_object_pointer"] = function() {
+                const pointer = tmpRetOptionalHeapObject;
+                tmpRetOptionalHeapObject = undefined;
+                return pointer || 0;
+            }
+            bjs["swift_js_closure_unregister"] = function(funcRef) {}
+            bjs["swift_js_closure_unregister"] = function(funcRef) {
+                const func = swift.memory.getObject(funcRef);
+                func.__unregister();
+            }
+            bjs["invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si"] = function(callbackId, param0) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    let ret = callback(_exports['PolygonReference'].__construct(param0));
+                    return ret;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModuleAl7Polygon_Si"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleAl7Polygon_Si = function(param0) {
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleAl7Polygon_Si(boxPtr, param0.pointer);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return ret;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleAl7Polygon_Si);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModuley_Al7Polygon"] = function(callbackId) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    let ret = callback();
+                    return ret.pointer;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModuley_Al7Polygon"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuley_Al7Polygon = function() {
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuley_Al7Polygon(boxPtr);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return _exports['PolygonReference'].__construct(ret);
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuley_Al7Polygon);
+            }
+            // Wrapper functions for module: TestModule
+            if (!importObject["TestModule"]) {
+                importObject["TestModule"] = {};
+            }
+            importObject["TestModule"]["bjs_PolygonReference_wrap"] = function(pointer) {
+                const obj = _exports['PolygonReference'].__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            decodeString = (ptr, len) => { const bytes = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0); return textDecoder.decode(bytes); }
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            const swiftHeapObjectFinalizationRegistry = (typeof FinalizationRegistry === "undefined") ? { register: () => {}, unregister: () => {} } : new FinalizationRegistry((state) => {
+                if (state.hasReleased) {
+                    return;
+                }
+                state.hasReleased = true;
+                state.identityMap?.delete(state.pointer);
+                state.deinit(state.pointer);
+            });
+
+            /// Represents a Swift heap object like a class instance or an actor instance.
+            class SwiftHeapObject {
+                static __wrap(pointer, deinit, prototype, identityCache) {
+                    const makeFresh = (identityMap) => {
+                        const obj = Object.create(prototype);
+                        const state = { pointer, deinit, hasReleased: false, identityMap };
+                        obj.pointer = pointer;
+                        obj.__swiftHeapObjectState = state;
+                        swiftHeapObjectFinalizationRegistry.register(obj, state, state);
+                        if (identityMap) {
+                            identityMap.set(pointer, new WeakRef(obj));
+                        }
+                        return obj;
+                    };
+
+                    if (!identityCache) {
+                        return makeFresh(null);
+                    }
+
+                    const cached = identityCache.get(pointer)?.deref();
+                    if (cached && !cached.__swiftHeapObjectState.hasReleased) {
+                        deinit(pointer);
+                        return cached;
+                    }
+                    if (identityCache.has(pointer)) {
+                        identityCache.delete(pointer);
+                    }
+
+                    return makeFresh(identityCache);
+                }
+
+                release() {
+                    const state = this.__swiftHeapObjectState;
+                    if (state.hasReleased) {
+                        return;
+                    }
+                    state.hasReleased = true;
+                    swiftHeapObjectFinalizationRegistry.unregister(state);
+                    state.identityMap?.delete(state.pointer);
+                    state.deinit(state.pointer);
+                }
+            }
+            class PolygonReference extends SwiftHeapObject {
+                static __construct(ptr) {
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PolygonReference_deinit, PolygonReference.prototype, null);
+                }
+
+                constructor(sides) {
+                    const ret = instance.exports.bjs_PolygonReference_init(sides);
+                    return PolygonReference.__construct(ret);
+                }
+            }
+            const exports = {
+                PolygonReference,
+                makePolygonFactory: function bjs_makePolygonFactory() {
+                    const ret = instance.exports.bjs_makePolygonFactory();
+                    return swift.memory.getObject(ret);
+                },
+                makePolygonInspector: function bjs_makePolygonInspector() {
+                    const ret = instance.exports.bjs_makePolygonInspector();
+                    return swift.memory.getObject(ret);
+                },
+            };
+            _exports = exports;
+            return exports;
+        },
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAlias.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAlias.d.ts
@@ -1,0 +1,30 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+/// Represents a Swift heap object like a class instance or an actor instance.
+export interface SwiftHeapObject {
+    /// Release the heap object.
+    ///
+    /// Note: Calling this method will release the heap object and it will no longer be accessible.
+    release(): void;
+}
+export interface ColorBox extends SwiftHeapObject {
+}
+export type Exports = {
+    ColorBox: {
+        new(name: string): ColorBox;
+    }
+    roundtripColor(color: ColorBox): ColorBox;
+}
+export type Imports = {
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAlias.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAlias.js
@@ -1,0 +1,295 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    let decodeString;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let strStack = [];
+    let i32Stack = [];
+    let i64Stack = [];
+    let f32Stack = [];
+    let f64Stack = [];
+    let ptrStack = [];
+    let taStack = [];
+    const enumHelpers = {};
+    const structHelpers = {};
+
+    let _exports = null;
+    let bjs = null;
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            bjs = {};
+            importObject["bjs"] = bjs;
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                tmpRetString = decodeString(ptr, len);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                return swift.memory.retain(decodeString(ptr, len));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr, len);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_i32"] = function(v) {
+                i32Stack.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                f32Stack.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                f64Stack.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const value = decodeString(ptr, len);
+                strStack.push(value);
+            }
+            bjs["swift_js_pop_i32"] = function() {
+                return i32Stack.pop();
+            }
+            bjs["swift_js_pop_f32"] = function() {
+                return f32Stack.pop();
+            }
+            bjs["swift_js_pop_f64"] = function() {
+                return f64Stack.pop();
+            }
+            bjs["swift_js_push_pointer"] = function(pointer) {
+                ptrStack.push(pointer);
+            }
+            bjs["swift_js_pop_pointer"] = function() {
+                return ptrStack.pop();
+            }
+            bjs["swift_js_push_i64"] = function(v) {
+                i64Stack.push(v);
+            }
+            bjs["swift_js_pop_i64"] = function() {
+                return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = decodeString(ptr, len);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            bjs["swift_js_get_optional_int_presence"] = function() {
+                return tmpRetOptionalInt != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_int_value"] = function() {
+                const value = tmpRetOptionalInt;
+                tmpRetOptionalInt = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_string"] = function() {
+                const str = tmpRetString;
+                tmpRetString = undefined;
+                if (str == null) {
+                    return -1;
+                } else {
+                    const bytes = textEncoder.encode(str);
+                    tmpRetBytes = bytes;
+                    return bytes.length;
+                }
+            }
+            bjs["swift_js_get_optional_float_presence"] = function() {
+                return tmpRetOptionalFloat != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_float_value"] = function() {
+                const value = tmpRetOptionalFloat;
+                tmpRetOptionalFloat = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_double_presence"] = function() {
+                return tmpRetOptionalDouble != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_double_value"] = function() {
+                const value = tmpRetOptionalDouble;
+                tmpRetOptionalDouble = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_heap_object_pointer"] = function() {
+                const pointer = tmpRetOptionalHeapObject;
+                tmpRetOptionalHeapObject = undefined;
+                return pointer || 0;
+            }
+            bjs["swift_js_closure_unregister"] = function(funcRef) {}
+            // Wrapper functions for module: TestModule
+            if (!importObject["TestModule"]) {
+                importObject["TestModule"] = {};
+            }
+            importObject["TestModule"]["bjs_ColorBox_wrap"] = function(pointer) {
+                const obj = _exports['ColorBox'].__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            decodeString = (ptr, len) => { const bytes = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0); return textDecoder.decode(bytes); }
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            const swiftHeapObjectFinalizationRegistry = (typeof FinalizationRegistry === "undefined") ? { register: () => {}, unregister: () => {} } : new FinalizationRegistry((state) => {
+                if (state.hasReleased) {
+                    return;
+                }
+                state.hasReleased = true;
+                state.identityMap?.delete(state.pointer);
+                state.deinit(state.pointer);
+            });
+
+            /// Represents a Swift heap object like a class instance or an actor instance.
+            class SwiftHeapObject {
+                static __wrap(pointer, deinit, prototype, identityCache) {
+                    const makeFresh = (identityMap) => {
+                        const obj = Object.create(prototype);
+                        const state = { pointer, deinit, hasReleased: false, identityMap };
+                        obj.pointer = pointer;
+                        obj.__swiftHeapObjectState = state;
+                        swiftHeapObjectFinalizationRegistry.register(obj, state, state);
+                        if (identityMap) {
+                            identityMap.set(pointer, new WeakRef(obj));
+                        }
+                        return obj;
+                    };
+
+                    if (!identityCache) {
+                        return makeFresh(null);
+                    }
+
+                    const cached = identityCache.get(pointer)?.deref();
+                    if (cached && !cached.__swiftHeapObjectState.hasReleased) {
+                        deinit(pointer);
+                        return cached;
+                    }
+                    if (identityCache.has(pointer)) {
+                        identityCache.delete(pointer);
+                    }
+
+                    return makeFresh(identityCache);
+                }
+
+                release() {
+                    const state = this.__swiftHeapObjectState;
+                    if (state.hasReleased) {
+                        return;
+                    }
+                    state.hasReleased = true;
+                    swiftHeapObjectFinalizationRegistry.unregister(state);
+                    state.identityMap?.delete(state.pointer);
+                    state.deinit(state.pointer);
+                }
+            }
+            class ColorBox extends SwiftHeapObject {
+                static __construct(ptr) {
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_ColorBox_deinit, ColorBox.prototype, null);
+                }
+
+                constructor(name) {
+                    const nameBytes = textEncoder.encode(name);
+                    const nameId = swift.memory.retain(nameBytes);
+                    const ret = instance.exports.bjs_ColorBox_init(nameId, nameBytes.length);
+                    return ColorBox.__construct(ret);
+                }
+            }
+            const exports = {
+                ColorBox,
+                roundtripColor: function bjs_roundtripColor(color) {
+                    const ret = instance.exports.bjs_roundtripColor(color.pointer);
+                    return ColorBox.__construct(ret);
+                },
+            };
+            _exports = exports;
+            return exports;
+        },
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAlias.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAlias.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAlias.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAlias.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -237,6 +237,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -217,6 +217,294 @@ extension Optional: _BridgedAsOptional {
     public init(optional: Wrapped?) { self = optional }
 }
 
+// MARK: - _BridgedSwiftAlias
+
+/// Types that are bridged using a separate JavaScript representation (`@JS(as:)`).
+public protocol _BridgedSwiftAlias {
+    associatedtype JSRepresentation
+    consuming func bridgeToJS() -> JSRepresentation
+    static func bridgeFromJS(_ value: consuming JSRepresentation) -> Self
+}
+
+extension _BridgedSwiftAlias where JSRepresentation: _BridgedSwiftHeapObject {
+    // MARK: ImportTS
+    @_spi(BridgeJS) public consuming func bridgeJSLowerParameter() -> UnsafeMutableRawPointer {
+        bridgeToJS().bridgeJSLowerParameter()
+    }
+    @_spi(BridgeJS) public static func bridgeJSLiftReturn(_ pointer: UnsafeMutableRawPointer) -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSLiftReturn(pointer))
+    }
+    // MARK: ExportSwift
+    @_spi(BridgeJS) public static func bridgeJSLiftParameter(_ pointer: UnsafeMutableRawPointer) -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSLiftParameter(pointer))
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> UnsafeMutableRawPointer {
+        bridgeToJS().bridgeJSLowerReturn()
+    }
+    // MARK: Stack ABI
+    @_spi(BridgeJS) public static func bridgeJSStackPop() -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSStackPop())
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSStackPush() {
+        bridgeToJS().bridgeJSStackPush()
+    }
+}
+
+extension _BridgedAsOptional where Wrapped: _BridgedSwiftAlias, Wrapped.JSRepresentation: _BridgedSwiftHeapObject {
+    @_spi(BridgeJS) public consuming func bridgeJSLowerParameter() -> (
+        isSome: Int32, pointer: UnsafeMutableRawPointer
+    ) {
+        asOptional.map { $0.bridgeToJS() }.bridgeJSLowerParameter()
+    }
+
+    @_spi(BridgeJS) public static func bridgeJSLiftReturn(_ pointer: UnsafeMutableRawPointer) -> Self {
+        Self(optional: Optional<Wrapped.JSRepresentation>.bridgeJSLiftReturn(pointer).map { Wrapped.bridgeFromJS($0) })
+    }
+
+    @_spi(BridgeJS) public static func bridgeJSLiftParameter(
+        _ isSome: Int32,
+        _ pointer: UnsafeMutableRawPointer
+    ) -> Self {
+        Self(
+            optional: Optional<Wrapped.JSRepresentation>.bridgeJSLiftParameter(isSome, pointer)
+                .map { Wrapped.bridgeFromJS($0) }
+        )
+    }
+
+    @_spi(BridgeJS) public static func bridgeJSLiftReturnFromSideChannel() -> Self {
+        Self(
+            optional: Optional<Wrapped.JSRepresentation>.bridgeJSLiftReturnFromSideChannel()
+                .map { Wrapped.bridgeFromJS($0) }
+        )
+    }
+
+    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Void {
+        asOptional.map { $0.bridgeToJS() }.bridgeJSLowerReturn()
+    }
+}
+
+extension _BridgedSwiftAlias where JSRepresentation: _JSBridgedClass {
+    // MARK: ImportTS
+    @_spi(BridgeJS) public consuming func bridgeJSLowerParameter() -> Int32 {
+        bridgeToJS().bridgeJSLowerParameter()
+    }
+    @_spi(BridgeJS) public static func bridgeJSLiftReturn(_ id: Int32) -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSLiftReturn(id))
+    }
+    // MARK: ExportSwift
+    @_spi(BridgeJS) public static func bridgeJSLiftParameter(_ id: Int32) -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSLiftParameter(id))
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Int32 {
+        bridgeToJS().bridgeJSLowerReturn()
+    }
+    // MARK: Stack ABI
+    @_spi(BridgeJS) public static func bridgeJSStackPop() -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSStackPop())
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSStackPush() {
+        bridgeToJS().bridgeJSStackPush()
+    }
+}
+
+extension _BridgedSwiftAlias where JSRepresentation: _BridgedSwiftTypeLoweredIntoSingleWasmCoreType {
+    // MARK: ImportTS
+    @_spi(BridgeJS) public consuming func bridgeJSLowerParameter() -> JSRepresentation.WasmCoreType {
+        bridgeToJS().bridgeJSLowerParameter()
+    }
+    @_spi(BridgeJS) public static func bridgeJSLiftReturn(_ value: JSRepresentation.WasmCoreType) -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSLiftReturn(value))
+    }
+    // MARK: ExportSwift
+    @_spi(BridgeJS) public static func bridgeJSLiftParameter(_ value: JSRepresentation.WasmCoreType) -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSLiftParameter(value))
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> JSRepresentation.WasmCoreType {
+        bridgeToJS().bridgeJSLowerReturn()
+    }
+}
+
+extension _BridgedSwiftAlias
+where
+    JSRepresentation: _BridgedSwiftTypeLoweredIntoSingleWasmCoreType, JSRepresentation: _BridgedSwiftStackType,
+    JSRepresentation.StackLiftResult == JSRepresentation
+{
+    @_spi(BridgeJS) public static func bridgeJSStackPop() -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSStackPop())
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSStackPush() {
+        bridgeToJS().bridgeJSStackPush()
+    }
+}
+
+extension _BridgedAsOptional
+where Wrapped: _BridgedSwiftAlias, Wrapped.JSRepresentation: _BridgedSwiftOptionalScalarBridge {
+    @_spi(BridgeJS) public consuming func bridgeJSLowerParameter() -> (
+        isSome: Int32, value: Wrapped.JSRepresentation.WasmCoreType
+    ) {
+        asOptional.map { $0.bridgeToJS() }.bridgeJSLowerParameter()
+    }
+    @_spi(BridgeJS) public static func bridgeJSLiftParameter(
+        _ isSome: Int32,
+        _ value: Wrapped.JSRepresentation.WasmCoreType
+    ) -> Self {
+        Self(
+            optional: Optional<Wrapped.JSRepresentation>.bridgeJSLiftParameter(isSome, value)
+                .map { Wrapped.bridgeFromJS($0) }
+        )
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Void {
+        asOptional.map { $0.bridgeToJS() }.bridgeJSLowerReturn()
+    }
+}
+
+extension _BridgedAsOptional
+where Wrapped: _BridgedSwiftAlias, Wrapped.JSRepresentation: _BridgedSwiftOptionalScalarSideChannelBridge {
+    @_spi(BridgeJS) public static func bridgeJSLiftReturnFromSideChannel() -> Self {
+        Self(
+            optional: Optional<Wrapped.JSRepresentation>.bridgeJSLiftReturnFromSideChannel()
+                .map { Wrapped.bridgeFromJS($0) }
+        )
+    }
+}
+
+extension _BridgedSwiftAlias where JSRepresentation: _BridgedSwiftStruct {
+    // MARK: ExportSwift
+    @_spi(BridgeJS) public static func bridgeJSStackPop() -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSStackPop())
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSStackPush() {
+        bridgeToJS().bridgeJSStackPush()
+    }
+
+    public init(unsafelyCopying jsObject: JSObject) {
+        self = Self.bridgeFromJS(JSRepresentation(unsafelyCopying: jsObject))
+    }
+    public func toJSObject() -> JSObject {
+        return self.bridgeToJS().toJSObject()
+    }
+}
+
+extension _BridgedSwiftAlias where JSRepresentation: _BridgedSwiftCaseEnum {
+    // MARK: ImportTS
+    @_spi(BridgeJS) public consuming func bridgeJSLowerParameter() -> Int32 {
+        bridgeToJS().bridgeJSLowerParameter()
+    }
+    @_spi(BridgeJS) public static func bridgeJSLiftReturn(_ value: Int32) -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSLiftReturn(value))
+    }
+    // MARK: ExportSwift
+    @_spi(BridgeJS) public static func bridgeJSLiftParameter(_ value: Int32) -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSLiftParameter(value))
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Int32 {
+        bridgeToJS().bridgeJSLowerReturn()
+    }
+}
+
+extension _BridgedSwiftAlias where JSRepresentation: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Self {
+        bridgeFromJS(JSRepresentation.bridgeJSStackPopPayload(caseId))
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSStackPushPayload() -> Int32 {
+        bridgeToJS().bridgeJSStackPushPayload()
+    }
+}
+
+extension _BridgedSwiftAlias where JSRepresentation == String {
+    // MARK: ImportTS
+    @_spi(BridgeJS) public consuming func bridgeJSWithLoweredParameter<T>(_ body: (Int32, Int32) -> T) -> T {
+        bridgeToJS().bridgeJSWithLoweredParameter(body)
+    }
+    @_spi(BridgeJS) public static func bridgeJSLiftReturn(_ bytesCount: Int32) -> Self {
+        bridgeFromJS(String.bridgeJSLiftReturn(bytesCount))
+    }
+    // MARK: ExportSwift
+    @_spi(BridgeJS) public static func bridgeJSLiftParameter(_ bytes: Int32, _ count: Int32) -> Self {
+        bridgeFromJS(String.bridgeJSLiftParameter(bytes, count))
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Void {
+        bridgeToJS().bridgeJSLowerReturn()
+    }
+    // MARK: Stack ABI
+    @_spi(BridgeJS) public static func bridgeJSStackPop() -> Self {
+        bridgeFromJS(String.bridgeJSStackPop())
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSStackPush() {
+        bridgeToJS().bridgeJSStackPush()
+    }
+}
+
+extension _BridgedAsOptional where Wrapped: _BridgedSwiftAlias, Wrapped.JSRepresentation == String {
+    @_spi(BridgeJS) public consuming func bridgeJSWithLoweredParameter<T>(
+        _ body: (Int32, Int32, Int32) -> T
+    ) -> T {
+        asOptional.map { $0.bridgeToJS() }.bridgeJSWithLoweredParameter(body)
+    }
+    @_spi(BridgeJS) public static func bridgeJSLiftParameter(
+        _ isSome: Int32,
+        _ bytes: Int32,
+        _ count: Int32
+    ) -> Self {
+        Self(optional: Optional<String>.bridgeJSLiftParameter(isSome, bytes, count).map { Wrapped.bridgeFromJS($0) })
+    }
+    @_spi(BridgeJS) public static func bridgeJSLiftReturnFromSideChannel() -> Self {
+        Self(optional: Optional<String>.bridgeJSLiftReturnFromSideChannel().map { Wrapped.bridgeFromJS($0) })
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Void {
+        asOptional.map { $0.bridgeToJS() }.bridgeJSLowerReturn()
+    }
+}
+
+extension _BridgedSwiftAlias where JSRepresentation == JSValue {
+    // MARK: ImportTS
+    @_spi(BridgeJS) public consuming func bridgeJSLowerParameter() -> (kind: Int32, payload1: Int32, payload2: Double) {
+        bridgeToJS().bridgeJSLowerParameter()
+    }
+    @_spi(BridgeJS) public static func bridgeJSLiftReturn() -> Self {
+        bridgeFromJS(JSValue.bridgeJSLiftReturn())
+    }
+    // MARK: ExportSwift
+    @_spi(BridgeJS) public static func bridgeJSLiftParameter(
+        _ kind: Int32,
+        _ payload1: Int32,
+        _ payload2: Double
+    ) -> Self {
+        bridgeFromJS(JSValue.bridgeJSLiftParameter(kind, payload1, payload2))
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Void {
+        bridgeToJS().bridgeJSLowerReturn()
+    }
+    @_spi(BridgeJS) public static func bridgeJSStackPop() -> Self {
+        bridgeFromJS(JSValue.bridgeJSStackPop())
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSStackPush() {
+        bridgeToJS().bridgeJSStackPush()
+    }
+}
+
+extension _BridgedAsOptional where Wrapped: _BridgedSwiftAlias, Wrapped.JSRepresentation == JSValue {
+    @_spi(BridgeJS) public consuming func bridgeJSLowerParameter() -> (
+        isSome: Int32, kind: Int32, payload1: Int32, payload2: Double
+    ) {
+        asOptional.map { $0.bridgeToJS() }.bridgeJSLowerParameter()
+    }
+    @_spi(BridgeJS) public static func bridgeJSLiftParameter(
+        _ isSome: Int32,
+        _ kind: Int32,
+        _ payload1: Int32,
+        _ payload2: Double
+    ) -> Self {
+        Self(
+            optional: Optional<JSValue>.bridgeJSLiftParameter(isSome, kind, payload1, payload2)
+                .map { Wrapped.bridgeFromJS($0) }
+        )
+    }
+    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Void {
+        asOptional.map { $0.bridgeToJS() }.bridgeJSLowerReturn()
+    }
+}
+
 extension Bool: _BridgedSwiftTypeLoweredIntoSingleWasmCoreType, _BridgedSwiftStackType {
     // MARK: ImportTS
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift-to-JavaScript.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift-to-JavaScript.md
@@ -22,6 +22,7 @@ Configure your package and build for JavaScript as described in <doc:Setting-up-
 - <doc:Exporting-Swift-Closure>
 - <doc:Exporting-Swift-Protocols>
 - <doc:Exporting-Swift-Optional>
+- <doc:Exporting-Swift-Custom-Representation>
 - <doc:Exporting-Swift-Default-Parameters>
 - <doc:Exporting-Swift-Static-Functions>
 - <doc:Exporting-Swift-Static-Properties>

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Custom-Representation.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Custom-Representation.md
@@ -1,0 +1,114 @@
+# Exporting a Type With a Custom JS Representation
+
+Learn how to give a Swift type a different representation on the JavaScript side using `@JS(as:)`.
+
+## Overview
+
+> Tip: You can quickly preview what interfaces will be exposed on the Swift/JavaScript/TypeScript sides using the [BridgeJS Playground](https://swiftwasm.org/JavaScriptKit/PlayBridgeJS/).
+
+BridgeJS picks a sensible default representation for each exported type - structs cross by copy, classes by reference, and so on. Sometimes that default is a poor fit:
+
+- A struct copied at the boundary is expensive when it holds a large payload (for example a polygon with thousands of vertices).
+- A type uses a feature BridgeJS does not export directly (for example a dictionary with integer keys).
+
+`@JS(as:)` is the escape hatch. It lets a Swift type keep its idiomatic shape while being bridged to JavaScript through a different `@JS` type that you control, without duplicating the surrounding API.
+
+Mark the type with `@JS(as: OtherType.self)` and provide two conversions:
+
+```swift
+import JavaScriptKit
+
+@JS(as: JSPolygon.self) struct Polygon {
+    var vertices: [Point]
+
+    consuming func bridgeToJS() -> JSPolygon {
+        JSPolygon(underlying: self)
+    }
+
+    static func bridgeFromJS(_ value: consuming JSPolygon) -> Polygon {
+        value.underlying
+    }
+}
+
+@JS final class JSPolygon {
+    var underlying: Polygon
+
+    @JS init(underlying: Polygon) {
+        self.underlying = underlying
+    }
+
+    @JS var vertexCount: Int { underlying.vertices.count }
+}
+
+@JS func merge(_ a: Polygon, _ b: Polygon) -> Polygon
+```
+
+Existing Swift code keeps using the idiomatic `Polygon`. Anywhere `Polygon` crosses the boundary - parameters, return values, optionals, arrays - BridgeJS substitutes `JSPolygon`, so JavaScript sees the reference type and avoids copying.
+
+The generated TypeScript declarations refer to the representation type:
+
+```typescript
+export interface JSPolygon extends SwiftHeapObject {
+    readonly vertexCount: number;
+}
+
+export type Exports = {
+    JSPolygon: {
+        new(underlying: JSPolygon): JSPolygon;
+    }
+    merge(a: JSPolygon, b: JSPolygon): JSPolygon;
+}
+```
+
+## The Bridging Contract
+
+A type marked `@JS(as: R.self)` must provide both halves of the conversion to and from its representation `R`:
+
+```swift
+consuming func bridgeToJS() -> R
+static func bridgeFromJS(_ value: consuming R) -> Self
+```
+
+BridgeJS inserts a call to `bridgeToJS()` at the first opportunity when a value leaves Swift, and `bridgeFromJS(_:)` at the last opportunity when one enters. The rest of the generated glue just uses `R`'s ABI, so the conversions are the only code you write.
+
+## Wrapping a Primitive
+
+The representation does not have to be a class. A small wrapper over a primitive is a common case - for example exposing a strongly-typed identifier as a plain string:
+
+```swift
+@JS(as: String.self) struct UUID {
+    var rawValue: String
+
+    consuming func bridgeToJS() -> String { rawValue }
+    static func bridgeFromJS(_ value: consuming String) -> UUID { UUID(rawValue: value) }
+}
+
+@JS func currentUser() -> UUID
+```
+
+JavaScript sees a `string`, while Swift keeps the distinct `UUID` type.
+
+## Supported Representations
+
+The representation type (the `as:` target) must itself be a type BridgeJS can export by value or reference:
+
+| Representation | Status |
+|:---------------|:-------|
+| `@JS class` | ✅ |
+| `@JSClass` (imported) | ✅ |
+| `@JS struct` | ✅ |
+| Primitives (`Int`, `Double`, `Float`, `Bool`, `String`) | ✅ |
+| `JSValue` | ✅ |
+| Case enums and associated-value enums | ✅ |
+| Raw-value enums | ❌ |
+| `@JS protocol` | ❌ |
+| Another `@JS(as:)` type (chained aliases) | ❌ |
+| Closures, arrays, dictionaries, optionals as the direct target | ❌ |
+
+`@JS(as:)` cannot be combined with `namespace:` - an aliased type adopts its representation's placement.
+
+## See Also
+
+- <doc:Exporting-Swift-Struct>
+- <doc:Exporting-Swift-Class>
+- <doc:Supported-Types>

--- a/Sources/JavaScriptKit/Macros.swift
+++ b/Sources/JavaScriptKit/Macros.swift
@@ -113,8 +113,12 @@ public enum JSImportFrom: String {
 ///
 /// - Important: This feature is still experimental. No API stability is guaranteed, and the API may change in future releases.
 @attached(peer)
-public macro JS(namespace: String? = nil, enumStyle: JSEnumStyle = .const, identityMode: Bool = false) =
-    Builtin.ExternalMacro
+public macro JS(
+    as aliasOf: Any.Type? = nil,
+    namespace: String? = nil,
+    enumStyle: JSEnumStyle = .const,
+    identityMode: Bool = false
+) = Builtin.ExternalMacro
 
 /// A macro that generates a Swift getter that reads a value from JavaScript.
 ///

--- a/Tests/BridgeJSGlobalTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSGlobalTests/Generated/JavaScript/BridgeJS.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Tests/BridgeJSIdentityTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSIdentityTests/Generated/JavaScript/BridgeJS.json
@@ -1,5 +1,8 @@
 {
   "exported" : {
+    "aliases" : [
+
+    ],
     "classes" : [
       {
         "constructor" : {

--- a/Tests/BridgeJSRuntimeTests/AliasAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/AliasAPIs.swift
@@ -116,44 +116,8 @@ import JavaScriptKit
     return polygon.vertices.map { Polygon(vertices: [$0], label: polygon.label) }
 }
 
-@JS(as: TokenReference.self) struct Token: ~Copyable {
-    let value: Int
-
-    consuming func bridgeToJS() -> TokenReference {
-        return TokenReference(value: value)
-    }
-
-    static func bridgeFromJS(_ value: consuming TokenReference) -> Token {
-        return Token(value: value.value)
-    }
-}
-
-@JS final class TokenReference {
-    let value: Int
-
-    @JS init(value: Int) {
-        self.value = value
-    }
-
-    @JS func read() -> Int {
-        return value
-    }
-}
-
-@JS func incrementToken(_ token: borrowing Token) -> Token {
-    return Token(value: token.value + 1)
-}
-
-@JS func makeToken(_ value: Int) -> Token {
-    return Token(value: value)
-}
-
 @JS func makePolygonInspector() -> (Polygon) -> Int {
     return { polygon in polygon.vertices.count }
-}
-
-@JS func asyncMakePolygon(_ label: String) async -> Polygon {
-    return Polygon(vertices: [9, 9], label: label)
 }
 
 @JS func roundTripOptionalPolygonArray(_ polygons: [Polygon?]) -> [Polygon?] {
@@ -294,38 +258,6 @@ import JavaScriptKit
     return Alert(level: level)
 }
 
-@JS(as: SessionState.self) class Session {
-    var token: String
-
-    init(token: String) {
-        self.token = token
-    }
-
-    consuming func bridgeToJS() -> SessionState {
-        return SessionState(token: token)
-    }
-
-    static func bridgeFromJS(_ value: consuming SessionState) -> Session {
-        return Session(token: value.token)
-    }
-}
-
-@JS struct SessionState {
-    var token: String
-
-    @JS init(token: String) {
-        self.token = token
-    }
-}
-
-@JS func roundTripSession(_ session: Session) -> Session {
-    return session
-}
-
-@JS func makeSession(_ token: String) -> Session {
-    return Session(token: token)
-}
-
 @JS enum Shape {
     case polygon(Polygon)
     case empty
@@ -341,6 +273,30 @@ import JavaScriptKit
 
 @JS func makeShapeEmpty() -> Shape {
     return .empty
+}
+
+@JS(as: Int.self) struct UserId {
+    var rawValue: Int
+
+    consuming func bridgeToJS() -> Int {
+        return rawValue
+    }
+
+    static func bridgeFromJS(_ value: consuming Int) -> UserId {
+        return UserId(rawValue: value)
+    }
+}
+
+@JS func roundTripUserId(_ id: UserId) -> UserId {
+    return id
+}
+
+@JS func roundTripOptionalUserId(_ id: UserId?) -> UserId? {
+    return id
+}
+
+@JS func roundTripUserIdArray(_ ids: [UserId]) -> [UserId] {
+    return ids
 }
 
 // MARK: - Imports
@@ -391,6 +347,26 @@ import JavaScriptKit
     }
 }
 
+@JS(as: JSValue.self) struct Boxed {
+    var value: JSValue
+
+    consuming func bridgeToJS() -> JSValue {
+        return value
+    }
+
+    static func bridgeFromJS(_ value: consuming JSValue) -> Boxed {
+        return Boxed(value: value)
+    }
+}
+
+@JS func roundTripBoxed(_ boxed: Boxed) -> Boxed {
+    return boxed
+}
+
+@JS func roundTripOptionalBoxed(_ boxed: Boxed?) -> Boxed? {
+    return boxed
+}
+
 @JSClass struct AliasImports {
     @JSFunction static func jsRoundTripTagged(_ value: Tagged) throws(JSException) -> Tagged
     @JSFunction static func jsRoundTripOptionalTagged(_ value: Tagged?) throws(JSException) -> Tagged?
@@ -398,4 +374,6 @@ import JavaScriptKit
     @JSFunction static func jsRoundTripAliasedTags(_ values: [AliasedTag?]) throws(JSException) -> [AliasedTag?]
     @JSFunction static func jsRoundTripPolygon(_ value: Polygon) throws(JSException) -> Polygon
     @JSFunction static func jsRoundTripCoordinate(_ value: Coordinate) throws(JSException) -> Coordinate
+    @JSFunction static func jsRoundTripUserId(_ value: UserId) throws(JSException) -> UserId
+    @JSFunction static func jsRoundTripOptionalUserId(_ value: UserId?) throws(JSException) -> UserId?
 }

--- a/Tests/BridgeJSRuntimeTests/AliasAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/AliasAPIs.swift
@@ -1,0 +1,401 @@
+import JavaScriptKit
+
+@JS(as: PolygonReference.self) struct Polygon {
+    var vertices: [Double]
+    var label: String
+
+    consuming func bridgeToJS() -> PolygonReference {
+        return PolygonReference(underlying: self)
+    }
+
+    static func bridgeFromJS(_ value: consuming PolygonReference) -> Polygon {
+        return value.underlying
+    }
+}
+
+@JS final class PolygonReference {
+    var underlying: Polygon
+
+    @JS init(verticesData: [Double], label: String) {
+        self.underlying = Polygon(vertices: verticesData, label: label)
+    }
+
+    init(underlying: Polygon) {
+        self.underlying = underlying
+    }
+
+    @JS func vertexCount() -> Int {
+        return underlying.vertices.count
+    }
+
+    @JS func summary() -> String {
+        return "\(underlying.label)(\(underlying.vertices.count))"
+    }
+
+    @JS func snapshot() -> Polygon {
+        return underlying
+    }
+
+    @JS func merge(_ other: Polygon) -> Polygon {
+        var combined = underlying
+        combined.vertices.append(contentsOf: other.vertices)
+        return combined
+    }
+
+    @JS static func origin(label: String) -> Polygon {
+        return Polygon(vertices: [], label: label)
+    }
+}
+
+@JS(as: TagReference.self) struct Tag {
+    var name: String
+
+    consuming func bridgeToJS() -> TagReference {
+        return TagReference(underlying: self)
+    }
+
+    static func bridgeFromJS(_ value: consuming TagReference) -> Tag {
+        return value.underlying
+    }
+}
+
+@JS final class TagReference {
+    var underlying: Tag
+
+    init(underlying: Tag) {
+        self.underlying = underlying
+    }
+
+    @JS func describe() -> String {
+        return "tag:\(underlying.name)"
+    }
+}
+
+@JS func makeTag(_ name: String) -> Tag {
+    return Tag(name: name)
+}
+
+@JS func roundTripPolygon(_ polygon: Polygon) -> Polygon {
+    return polygon
+}
+
+@JS func appendVertex(_ polygon: Polygon, _ value: Double) -> Polygon {
+    var copy = polygon
+    copy.vertices.append(value)
+    return copy
+}
+
+@JS func optionalRoundTripPolygon(_ polygon: Polygon?) -> Polygon? {
+    return polygon
+}
+
+@JS func polygonVertexCount(_ polygon: Polygon) -> Int {
+    return polygon.vertices.count
+}
+
+@JS func roundTripPolygonArray(_ polygons: [Polygon]) -> [Polygon] {
+    return polygons
+}
+
+@JS func concatPolygons(_ polygons: [Polygon]) -> Polygon {
+    var combined = Polygon(vertices: [], label: "concat")
+    for p in polygons {
+        combined.vertices.append(contentsOf: p.vertices)
+    }
+    return combined
+}
+
+@JS func validatePolygon(_ polygon: Polygon) throws(JSException) -> Polygon {
+    if polygon.vertices.isEmpty {
+        throw JSException(JSError(message: "empty polygon").jsValue)
+    }
+    return polygon
+}
+
+@JS func splitPolygon(_ polygon: Polygon) -> [Polygon] {
+    return polygon.vertices.map { Polygon(vertices: [$0], label: polygon.label) }
+}
+
+@JS(as: TokenReference.self) struct Token: ~Copyable {
+    let value: Int
+
+    consuming func bridgeToJS() -> TokenReference {
+        return TokenReference(value: value)
+    }
+
+    static func bridgeFromJS(_ value: consuming TokenReference) -> Token {
+        return Token(value: value.value)
+    }
+}
+
+@JS final class TokenReference {
+    let value: Int
+
+    @JS init(value: Int) {
+        self.value = value
+    }
+
+    @JS func read() -> Int {
+        return value
+    }
+}
+
+@JS func incrementToken(_ token: borrowing Token) -> Token {
+    return Token(value: token.value + 1)
+}
+
+@JS func makeToken(_ value: Int) -> Token {
+    return Token(value: value)
+}
+
+@JS func makePolygonInspector() -> (Polygon) -> Int {
+    return { polygon in polygon.vertices.count }
+}
+
+@JS func asyncMakePolygon(_ label: String) async -> Polygon {
+    return Polygon(vertices: [9, 9], label: label)
+}
+
+@JS func roundTripOptionalPolygonArray(_ polygons: [Polygon?]) -> [Polygon?] {
+    return polygons
+}
+
+@JS(as: TagHolderReference.self) struct TagHolder {
+    var tag: Tag
+    var version: Int
+
+    consuming func bridgeToJS() -> TagHolderReference {
+        return TagHolderReference(tag: tag, version: version)
+    }
+
+    static func bridgeFromJS(_ value: consuming TagHolderReference) -> TagHolder {
+        return TagHolder(tag: value.tag, version: value.version)
+    }
+}
+
+@JS final class TagHolderReference {
+    @JS var tag: Tag
+    @JS var version: Int
+
+    @JS init(tag: Tag, version: Int) {
+        self.tag = tag
+        self.version = version
+    }
+
+    @JS func describe() -> String {
+        return "holder(\(tag.name), v\(version))"
+    }
+}
+
+@JS func makeTagHolder(_ name: String, _ version: Int) -> TagHolder {
+    return TagHolder(tag: Tag(name: name), version: version)
+}
+
+@JS(as: JSCoordinate.self) struct Coordinate {
+    var latitude: Double
+    var longitude: Double
+
+    var hemisphere: String {
+        latitude >= 0 ? "northern" : "southern"
+    }
+
+    consuming func bridgeToJS() -> JSCoordinate {
+        return JSCoordinate(latitude: latitude, longitude: longitude)
+    }
+
+    static func bridgeFromJS(_ value: consuming JSCoordinate) -> Coordinate {
+        return Coordinate(latitude: value.latitude, longitude: value.longitude)
+    }
+}
+
+@JS struct JSCoordinate {
+    var latitude: Double
+    var longitude: Double
+
+    @JS init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}
+
+@JS func roundTripCoordinate(_ coordinate: Coordinate) -> Coordinate {
+    return coordinate
+}
+
+@JS(as: PriorityReference.self) enum Priority {
+    case low, medium, high
+
+    consuming func bridgeToJS() -> PriorityReference {
+        return PriorityReference(underlying: self)
+    }
+
+    static func bridgeFromJS(_ value: consuming PriorityReference) -> Priority {
+        return value.underlying
+    }
+}
+
+@JS final class PriorityReference {
+    let underlying: Priority
+
+    init(underlying: Priority) {
+        self.underlying = underlying
+    }
+
+    @JS func describe() -> String {
+        switch underlying {
+        case .low: return "low"
+        case .medium: return "medium"
+        case .high: return "high"
+        }
+    }
+
+    @JS func weight() -> Int {
+        switch underlying {
+        case .low: return 1
+        case .medium: return 5
+        case .high: return 10
+        }
+    }
+
+    @JS static func low() -> Priority { return .low }
+    @JS static func medium() -> Priority { return .medium }
+    @JS static func high() -> Priority { return .high }
+}
+
+@JS func roundTripPriority(_ priority: Priority) -> Priority {
+    return priority
+}
+
+@JS(as: Severity.self) struct Alert {
+    let level: Severity
+
+    var requiresImmediateAction: Bool {
+        level == .error
+    }
+
+    consuming func bridgeToJS() -> Severity {
+        return level
+    }
+
+    static func bridgeFromJS(_ value: consuming Severity) -> Alert {
+        return Alert(level: value)
+    }
+}
+
+@JS enum Severity {
+    case notice, warning, error
+}
+
+@JS func roundTripAlert(_ alert: Alert) -> Alert {
+    return alert
+}
+
+@JS func makeAlert(_ level: Severity) -> Alert {
+    return Alert(level: level)
+}
+
+@JS(as: SessionState.self) class Session {
+    var token: String
+
+    init(token: String) {
+        self.token = token
+    }
+
+    consuming func bridgeToJS() -> SessionState {
+        return SessionState(token: token)
+    }
+
+    static func bridgeFromJS(_ value: consuming SessionState) -> Session {
+        return Session(token: value.token)
+    }
+}
+
+@JS struct SessionState {
+    var token: String
+
+    @JS init(token: String) {
+        self.token = token
+    }
+}
+
+@JS func roundTripSession(_ session: Session) -> Session {
+    return session
+}
+
+@JS func makeSession(_ token: String) -> Session {
+    return Session(token: token)
+}
+
+@JS enum Shape {
+    case polygon(Polygon)
+    case empty
+}
+
+@JS func roundTripShape(_ s: Shape) -> Shape {
+    return s
+}
+
+@JS func makeShapePolygon(_ polygon: Polygon) -> Shape {
+    return .polygon(polygon)
+}
+
+@JS func makeShapeEmpty() -> Shape {
+    return .empty
+}
+
+// MARK: - Imports
+
+@JS(as: String.self) struct Tagged {
+    var raw: String
+
+    consuming func bridgeToJS() -> String {
+        return raw
+    }
+
+    static func bridgeFromJS(_ value: consuming String) -> Tagged {
+        return Tagged(raw: value)
+    }
+}
+
+@JSClass struct Surface {
+    @JSFunction init(_ label: String) throws(JSException)
+    @JSGetter var label: String
+}
+
+@JS(as: Surface.self) struct Canvas {
+    var label: String
+
+    consuming func bridgeToJS() -> Surface {
+        return try! Surface(label)
+    }
+
+    static func bridgeFromJS(_ value: consuming Surface) -> Canvas {
+        return Canvas(label: (try? value.label) ?? "")
+    }
+}
+
+@JS enum InnerTag {
+    case payload(Int)
+    case empty
+}
+
+@JS(as: InnerTag.self) struct AliasedTag {
+    var underlying: InnerTag
+
+    consuming func bridgeToJS() -> InnerTag {
+        return underlying
+    }
+
+    static func bridgeFromJS(_ value: consuming InnerTag) -> AliasedTag {
+        return AliasedTag(underlying: value)
+    }
+}
+
+@JSClass struct AliasImports {
+    @JSFunction static func jsRoundTripTagged(_ value: Tagged) throws(JSException) -> Tagged
+    @JSFunction static func jsRoundTripOptionalTagged(_ value: Tagged?) throws(JSException) -> Tagged?
+    @JSFunction static func jsProduceOptionalCanvas(_ label: String?) throws(JSException) -> Canvas?
+    @JSFunction static func jsRoundTripAliasedTags(_ values: [AliasedTag?]) throws(JSException) -> [AliasedTag?]
+    @JSFunction static func jsRoundTripPolygon(_ value: Polygon) throws(JSException) -> Polygon
+    @JSFunction static func jsRoundTripCoordinate(_ value: Coordinate) throws(JSException) -> Coordinate
+}

--- a/Tests/BridgeJSRuntimeTests/AliasTests.swift
+++ b/Tests/BridgeJSRuntimeTests/AliasTests.swift
@@ -10,10 +10,6 @@ final class AliasTests: XCTestCase {
         runAliasWorks()
     }
 
-    func testAliasAsyncEndToEnd() async throws {
-        try await runAliasAsyncWorks()
-    }
-
     // MARK: - Imports
 
     func testRoundTripTagged() throws {
@@ -68,5 +64,16 @@ final class AliasTests: XCTestCase {
         let echoed = try AliasImports.jsRoundTripCoordinate(coordinate)
         XCTAssertEqual(echoed.latitude, 12.5)
         XCTAssertEqual(echoed.longitude, -34.25)
+    }
+
+    func testRoundTripUserIdImport() throws {
+        let echoed = try AliasImports.jsRoundTripUserId(UserId(rawValue: 42))
+        XCTAssertEqual(echoed.rawValue, 42)
+    }
+
+    func testRoundTripOptionalUserIdImport() throws {
+        XCTAssertNil(try AliasImports.jsRoundTripOptionalUserId(nil))
+        XCTAssertEqual(try AliasImports.jsRoundTripOptionalUserId(UserId(rawValue: 0))?.rawValue, 0)
+        XCTAssertEqual(try AliasImports.jsRoundTripOptionalUserId(UserId(rawValue: 7))?.rawValue, 7)
     }
 }

--- a/Tests/BridgeJSRuntimeTests/AliasTests.swift
+++ b/Tests/BridgeJSRuntimeTests/AliasTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+import JavaScriptKit
+
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "runAliasWorks")
+@_extern(c)
+func runAliasWorks() -> Void
+
+final class AliasTests: XCTestCase {
+    func testAliasEndToEnd() {
+        runAliasWorks()
+    }
+
+    func testAliasAsyncEndToEnd() async throws {
+        try await runAliasAsyncWorks()
+    }
+
+    // MARK: - Imports
+
+    func testRoundTripTagged() throws {
+        let result = try AliasImports.jsRoundTripTagged(Tagged(raw: "hello"))
+        XCTAssertEqual(result.raw, "hello")
+    }
+
+    func testRoundTripOptionalTagged() throws {
+        XCTAssertNil(try AliasImports.jsRoundTripOptionalTagged(nil))
+        let echoed = try AliasImports.jsRoundTripOptionalTagged(Tagged(raw: "present"))
+        XCTAssertEqual(echoed?.raw, "present")
+    }
+
+    func testProduceOptionalCanvas() throws {
+        XCTAssertNil(try AliasImports.jsProduceOptionalCanvas(nil))
+        let canvas = try AliasImports.jsProduceOptionalCanvas("hello")
+        XCTAssertEqual(canvas?.label, "hello")
+    }
+
+    func testRoundTripAliasedTagArray() throws {
+        let inputs: [AliasedTag?] = [
+            AliasedTag(underlying: .payload(7)),
+            nil,
+            AliasedTag(underlying: .empty),
+            nil,
+        ]
+        let echoed = try AliasImports.jsRoundTripAliasedTags(inputs)
+        XCTAssertEqual(echoed.count, 4)
+        if case .payload(let n) = echoed[0]?.underlying {
+            XCTAssertEqual(n, 7)
+        } else {
+            XCTFail("expected .payload(7) at index 0")
+        }
+        XCTAssertNil(echoed[1])
+        if case .empty = echoed[2]?.underlying {
+            // ok
+        } else {
+            XCTFail("expected .empty at index 2")
+        }
+        XCTAssertNil(echoed[3])
+    }
+
+    func testRoundTripPolygonImport() throws {
+        let polygon = Polygon(vertices: [1, 2, 3], label: "import")
+        let echoed = try AliasImports.jsRoundTripPolygon(polygon)
+        XCTAssertEqual(echoed.label, "import")
+        XCTAssertEqual(echoed.vertices, [1, 2, 3])
+    }
+
+    func testRoundTripCoordinateImport() throws {
+        let coordinate = Coordinate(latitude: 12.5, longitude: -34.25)
+        let echoed = try AliasImports.jsRoundTripCoordinate(coordinate)
+        XCTAssertEqual(echoed.latitude, 12.5)
+        XCTAssertEqual(echoed.longitude, -34.25)
+    }
+}

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.Macros.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.Macros.swift
@@ -44,6 +44,8 @@ extension FeatureFlag: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {}
 
 @JSFunction func runAsyncWorks() async throws(JSException) -> Void
 
+@JSFunction func runAliasAsyncWorks() async throws(JSException) -> Void
+
 @JSFunction func fetchWeatherData(_ city: String) async throws(JSException) -> WeatherData
 
 @JSClass struct WeatherData {

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.Macros.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.Macros.swift
@@ -44,8 +44,6 @@ extension FeatureFlag: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {}
 
 @JSFunction func runAsyncWorks() async throws(JSException) -> Void
 
-@JSFunction func runAliasAsyncWorks() async throws(JSException) -> Void
-
 @JSFunction func fetchWeatherData(_ city: String) async throws(JSException) -> WeatherData
 
 @JSClass struct WeatherData {

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -674,7 +674,7 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsAl7Polygon_Si {
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
-            let param0Pointer = param0.bridgeToJS().bridgeJSLowerParameter()
+            let param0Pointer = param0.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si(callbackValue, param0Pointer)
             return Int.bridgeJSLiftReturn(ret)
             #else
@@ -700,8 +700,174 @@ extension JSTypedClosure where Signature == (Polygon) -> Int {
 public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<(Polygon) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(param0)))
+    let result = closure(Polygon.bridgeJSLiftParameter(param0))
     return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsKSS_Sb {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) throws(JSException) -> Bool {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) throws(JSException) -> Bool in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(callbackValue, param0Bytes, param0Length)
+                return ret
+            }
+            let ret = ret0
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return Bool.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) throws(JSException) -> Bool {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) throws(JSException) -> Bool) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) throws(JSException) -> Bool>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    do {
+        let result = try closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+        return result.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: error.description)
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsKSS_Si {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) throws(JSException) -> Int {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) throws(JSException) -> Int in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(callbackValue, param0Bytes, param0Length)
+                return ret
+            }
+            let ret = ret0
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return Int.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) throws(JSException) -> Int {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) throws(JSException) -> Int) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) throws(JSException) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    do {
+        let result = try closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+        return result.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: error.description)
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1865,6 +2031,358 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSqS
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSS_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) async throws(JSException) -> String {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) async throws(JSException) -> String in
+            #if arch(wasm32)
+            let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending String) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
+                }
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) async throws(JSException) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async throws(JSException) -> String) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async throws(JSException) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
+        return try await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSS_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) async throws(JSException) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) async throws(JSException) -> Void in
+            #if arch(wasm32)
+            try await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<() -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
+                }
+            }
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) async throws(JSException) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async throws(JSException) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async throws(JSException) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_y, reject: Promise_reject) { () async throws(JSException) in
+        try await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(resolveRef, rejectRef, callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Bool) async throws(JSException) -> AsyncPayloadResult {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: Bool) async throws(JSException) -> AsyncPayloadResult in
+            #if arch(wasm32)
+            let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending AsyncPayloadResult) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                let param0Value = param0.bridgeJSLowerParameter()
+                invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(resolveRef, rejectRef, callbackValue, param0Value)
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (Bool) async throws(JSException) -> AsyncPayloadResult {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Bool) async throws(JSException) -> AsyncPayloadResult) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Bool) async throws(JSException) -> AsyncPayloadResult>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_18AsyncPayloadResultO, reject: Promise_reject) { () async throws(JSException) -> AsyncPayloadResult in
+        return try await closure(Bool.bridgeJSLiftParameter(param0))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsYaSS_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) async -> String {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) async -> String in
+            #if arch(wasm32)
+            let resolved = try! await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending String) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
+                }
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) async -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async -> String) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) {
+        return await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(resolveRef, rejectRef, callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsYaSd_9DataPointV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Double) async -> DataPoint {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: Double) async -> DataPoint in
+            #if arch(wasm32)
+            let resolved = try! await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending DataPoint) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                let param0Value = param0.bridgeJSLowerParameter()
+                invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(resolveRef, rejectRef, callbackValue, param0Value)
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (Double) async -> DataPoint {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Double) async -> DataPoint) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(_ boxPtr: UnsafeMutableRawPointer, _ param0: Float64) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Double) async -> DataPoint>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_9DataPointV, reject: Promise_reject) {
+        return await closure(Double.bridgeJSLiftParameter(param0))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y")
 fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
 #else
@@ -1988,6 +2506,128 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(_ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending AsyncPayloadResult) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0CaseId = param0.bridgeJSLowerParameter()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(callbackValue, param0CaseId)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending AsyncPayloadResult) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending AsyncPayloadResult) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending AsyncPayloadResult) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(AsyncPayloadResult.bridgeJSLiftParameter(param0))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(_ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending AsyncImportedPayloadResult) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0CaseId = param0.bridgeJSLowerParameter()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(callbackValue, param0CaseId)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending AsyncImportedPayloadResult) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending AsyncImportedPayloadResult) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending AsyncImportedPayloadResult) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(AsyncImportedPayloadResult.bridgeJSLiftParameter(param0))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss7JSValueV_y")
 fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss7JSValueV_y_extern(_ callback: Int32, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void
 #else
@@ -2043,6 +2683,67 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss7J
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending JSValue) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     closure(JSValue.bridgeJSLiftParameter(param0Kind, param0Payload1, param0Payload2))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ callback: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ callback: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(_ callback: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(callback)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestss9DataPointV_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending DataPoint) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let _ = param0.bridgeJSLowerParameter()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(callbackValue)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending DataPoint) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending DataPoint) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(_ boxPtr: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending DataPoint) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(DataPoint.bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -2410,6 +3111,67 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSd
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending Double) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     closure(Double.bridgeJSLiftParameter(param0))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(callback, param0IsSome, param0CaseId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending Optional<AsyncImportedPayloadResult>) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let (param0IsSome, param0CaseId) = param0.bridgeJSLowerParameter()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(callbackValue, param0IsSome, param0CaseId)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending Optional<AsyncImportedPayloadResult>) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending Optional<AsyncImportedPayloadResult>) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending Optional<AsyncImportedPayloadResult>) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(Optional<AsyncImportedPayloadResult>.bridgeJSLiftParameter(param0IsSome, param0CaseId))
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -3438,7 +4200,7 @@ extension Shape: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Shape {
         switch caseId {
         case 0:
-            return .polygon(Polygon.bridgeFromJS(PolygonReference.bridgeJSStackPop()))
+            return .polygon(Polygon.bridgeJSStackPop())
         case 1:
             return .empty
         default:
@@ -3449,7 +4211,7 @@ extension Shape: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
         switch self {
         case .polygon(let param0):
-            param0.bridgeToJS().bridgeJSStackPush()
+            param0.bridgeJSStackPush()
             return Int32(0)
         case .empty:
             return Int32(1)
@@ -3964,6 +4726,34 @@ public func _bjs_ArraySupportExports_static_multiOptionalArraySecond() -> Void {
     #endif
 }
 
+extension AsyncImportedPayloadResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> AsyncImportedPayloadResult {
+        switch caseId {
+        case 0:
+            return .success(String.bridgeJSStackPop())
+        case 1:
+            return .failure(Int.bridgeJSStackPop())
+        case 2:
+            return .idle
+        default:
+            fatalError("Unknown AsyncImportedPayloadResult case ID: \(caseId)")
+        }
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
+        switch self {
+        case .success(let param0):
+            param0.bridgeJSStackPush()
+            return Int32(0)
+        case .failure(let param0):
+            param0.bridgeJSStackPush()
+            return Int32(1)
+        case .idle:
+            return Int32(2)
+        }
+    }
+}
+
 @_expose(wasm, "bjs_DefaultArgumentExports_static_testStringDefault")
 @_cdecl("bjs_DefaultArgumentExports_static_testStringDefault")
 public func _bjs_DefaultArgumentExports_static_testStringDefault(_ messageBytes: Int32, _ messageLength: Int32) -> Void {
@@ -4273,6 +5063,34 @@ extension TSDirection: _BridgedSwiftCaseEnum {
 }
 
 extension TSTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+}
+
+extension AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> AsyncPayloadResult {
+        switch caseId {
+        case 0:
+            return .success(String.bridgeJSStackPop())
+        case 1:
+            return .failure(Int.bridgeJSStackPop())
+        case 2:
+            return .idle
+        default:
+            fatalError("Unknown AsyncPayloadResult case ID: \(caseId)")
+        }
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
+        switch self {
+        case .success(let param0):
+            param0.bridgeJSStackPush()
+            return Int32(0)
+        case .failure(let param0):
+            param0.bridgeJSStackPush()
+            return Int32(1)
+        case .idle:
+            return Int32(2)
+        }
+    }
 }
 
 @_expose(wasm, "bjs_Utils_StringUtils_static_uppercase")
@@ -4979,6 +5797,73 @@ public func _bjs_NestedStructGroupB_static_roundtripMetadata() -> Void {
     #endif
 }
 
+extension LightColor: _BridgedSwiftCaseEnum {
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
+        return bridgeJSRawValue
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> LightColor {
+        return bridgeJSLiftParameter(value)
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> LightColor {
+        return LightColor(bridgeJSRawValue: value)!
+    }
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
+        return bridgeJSLowerParameter()
+    }
+
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
+        switch bridgeJSRawValue {
+        case 0:
+            self = .red
+        case 1:
+            self = .yellow
+        case 2:
+            self = .green
+        default:
+            return nil
+        }
+    }
+
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
+        switch self {
+        case .red:
+            return 0
+        case .yellow:
+            return 1
+        case .green:
+            return 2
+        }
+    }
+}
+
+extension ImportedPayloadSignal: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> ImportedPayloadSignal {
+        switch caseId {
+        case 0:
+            return .start(String.bridgeJSStackPop())
+        case 1:
+            return .stop(Int.bridgeJSStackPop())
+        case 2:
+            return .idle
+        default:
+            fatalError("Unknown ImportedPayloadSignal case ID: \(caseId)")
+        }
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
+        switch self {
+        case .start(let param0):
+            param0.bridgeJSStackPush()
+            return Int32(0)
+        case .stop(let param0):
+            param0.bridgeJSStackPush()
+            return Int32(1)
+        case .idle:
+            return Int32(2)
+        }
+    }
+}
+
 @_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripInt")
 @_cdecl("bjs_IntegerTypesSupportExports_static_roundTripInt")
 public func _bjs_IntegerTypesSupportExports_static_roundTripInt(_ v: Int32) -> Int32 {
@@ -5586,63 +6471,6 @@ fileprivate func _bjs_struct_lift_JSCoordinate_extern() -> Int32 {
 public func _bjs_JSCoordinate_init(_ latitude: Float64, _ longitude: Float64) -> Void {
     #if arch(wasm32)
     let ret = JSCoordinate(latitude: Double.bridgeJSLiftParameter(latitude), longitude: Double.bridgeJSLiftParameter(longitude))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-extension SessionState: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> SessionState {
-        let token = String.bridgeJSStackPop()
-        return SessionState(token: token)
-    }
-
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
-        self.token.bridgeJSStackPush()
-    }
-
-    init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_SessionState(jsObject.bridgeJSLowerParameter())
-        self = Self.bridgeJSStackPop()
-    }
-
-    func toJSObject() -> JSObject {
-        let __bjs_self = self
-        __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_SessionState()))
-    }
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_SessionState")
-fileprivate func _bjs_struct_lower_SessionState_extern(_ objectId: Int32) -> Void
-#else
-fileprivate func _bjs_struct_lower_SessionState_extern(_ objectId: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func _bjs_struct_lower_SessionState(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_SessionState_extern(objectId)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_SessionState")
-fileprivate func _bjs_struct_lift_SessionState_extern() -> Int32
-#else
-fileprivate func _bjs_struct_lift_SessionState_extern() -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func _bjs_struct_lift_SessionState() -> Int32 {
-    return _bjs_struct_lift_SessionState_extern()
-}
-
-@_expose(wasm, "bjs_SessionState_init")
-@_cdecl("bjs_SessionState_init")
-public func _bjs_SessionState_init(_ tokenBytes: Int32, _ tokenLength: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = SessionState(token: String.bridgeJSLiftParameter(tokenBytes, tokenLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -6998,7 +7826,7 @@ public func _bjs_ArrayMembers_firstString() -> Void {
 public func _bjs_makeTag(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = makeTag(_: String.bridgeJSLiftParameter(nameBytes, nameLength))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7008,8 +7836,8 @@ public func _bjs_makeTag(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutab
 @_cdecl("bjs_roundTripPolygon")
 public func _bjs_roundTripPolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = roundTripPolygon(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    let ret = roundTripPolygon(_: Polygon.bridgeJSLiftParameter(polygon))
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7019,8 +7847,8 @@ public func _bjs_roundTripPolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeM
 @_cdecl("bjs_appendVertex")
 public func _bjs_appendVertex(_ polygon: UnsafeMutableRawPointer, _ value: Float64) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = appendVertex(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)), _: Double.bridgeJSLiftParameter(value))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    let ret = appendVertex(_: Polygon.bridgeJSLiftParameter(polygon), _: Double.bridgeJSLiftParameter(value))
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7030,8 +7858,8 @@ public func _bjs_appendVertex(_ polygon: UnsafeMutableRawPointer, _ value: Float
 @_cdecl("bjs_optionalRoundTripPolygon")
 public func _bjs_optionalRoundTripPolygon(_ polygonIsSome: Int32, _ polygonValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = optionalRoundTripPolygon(_: Optional<PolygonReference>.bridgeJSLiftParameter(polygonIsSome, polygonValue).map { Polygon.bridgeFromJS($0) })
-    return ret.map { $0.bridgeToJS() }.bridgeJSLowerReturn()
+    let ret = optionalRoundTripPolygon(_: Optional<Polygon>.bridgeJSLiftParameter(polygonIsSome, polygonValue))
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7041,7 +7869,7 @@ public func _bjs_optionalRoundTripPolygon(_ polygonIsSome: Int32, _ polygonValue
 @_cdecl("bjs_polygonVertexCount")
 public func _bjs_polygonVertexCount(_ polygon: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = polygonVertexCount(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
+    let ret = polygonVertexCount(_: Polygon.bridgeJSLiftParameter(polygon))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -7052,8 +7880,8 @@ public func _bjs_polygonVertexCount(_ polygon: UnsafeMutableRawPointer) -> Int32
 @_cdecl("bjs_roundTripPolygonArray")
 public func _bjs_roundTripPolygonArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripPolygonArray(_: [PolygonReference].bridgeJSStackPop().map { Polygon.bridgeFromJS($0) })
-    ret.map { $0.bridgeToJS() }.bridgeJSStackPush()
+    let ret = roundTripPolygonArray(_: [Polygon].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7063,8 +7891,8 @@ public func _bjs_roundTripPolygonArray() -> Void {
 @_cdecl("bjs_concatPolygons")
 public func _bjs_concatPolygons() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = concatPolygons(_: [PolygonReference].bridgeJSStackPop().map { Polygon.bridgeFromJS($0) })
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    let ret = concatPolygons(_: [Polygon].bridgeJSStackPop())
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7075,15 +7903,15 @@ public func _bjs_concatPolygons() -> UnsafeMutableRawPointer {
 public func _bjs_validatePolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     do {
-        let ret = try validatePolygon(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
-        return ret.bridgeToJS().bridgeJSLowerReturn()
+        let ret = try validatePolygon(_: Polygon.bridgeJSLiftParameter(polygon))
+        return ret.bridgeJSLowerReturn()
     } catch let error {
         if let error = error.thrownValue.object {
             withExtendedLifetime(error) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7099,30 +7927,8 @@ public func _bjs_validatePolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMu
 @_cdecl("bjs_splitPolygon")
 public func _bjs_splitPolygon(_ polygon: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = splitPolygon(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
-    ret.map { $0.bridgeToJS() }.bridgeJSStackPush()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_incrementToken")
-@_cdecl("bjs_incrementToken")
-public func _bjs_incrementToken(_ token: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
-    #if arch(wasm32)
-    let ret = incrementToken(_: Token.bridgeFromJS(TokenReference.bridgeJSLiftParameter(token)))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_makeToken")
-@_cdecl("bjs_makeToken")
-public func _bjs_makeToken(_ value: Int32) -> UnsafeMutableRawPointer {
-    #if arch(wasm32)
-    let ret = makeToken(_: Int.bridgeJSLiftParameter(value))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    let ret = splitPolygon(_: Polygon.bridgeJSLiftParameter(polygon))
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7139,25 +7945,12 @@ public func _bjs_makePolygonInspector() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncMakePolygon")
-@_cdecl("bjs_asyncMakePolygon")
-public func _bjs_asyncMakePolygon(_ labelBytes: Int32, _ labelLength: Int32) -> Int32 {
-    #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncMakePolygon(_: String.bridgeJSLiftParameter(labelBytes, labelLength)).bridgeToJS().jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
 @_expose(wasm, "bjs_roundTripOptionalPolygonArray")
 @_cdecl("bjs_roundTripOptionalPolygonArray")
 public func _bjs_roundTripOptionalPolygonArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalPolygonArray(_: [Optional<PolygonReference>].bridgeJSStackPop().map { $0.map { Polygon.bridgeFromJS($0) } })
-    ret.map { $0.map { $0.bridgeToJS() } }.bridgeJSStackPush()
+    let ret = roundTripOptionalPolygonArray(_: [Optional<Polygon>].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7168,7 +7961,7 @@ public func _bjs_roundTripOptionalPolygonArray() -> Void {
 public func _bjs_makeTagHolder(_ nameBytes: Int32, _ nameLength: Int32, _ version: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = makeTagHolder(_: String.bridgeJSLiftParameter(nameBytes, nameLength), _: Int.bridgeJSLiftParameter(version))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7178,8 +7971,8 @@ public func _bjs_makeTagHolder(_ nameBytes: Int32, _ nameLength: Int32, _ versio
 @_cdecl("bjs_roundTripCoordinate")
 public func _bjs_roundTripCoordinate() -> Void {
     #if arch(wasm32)
-    let ret = roundTripCoordinate(_: Coordinate.bridgeFromJS(JSCoordinate.bridgeJSLiftParameter()))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    let ret = roundTripCoordinate(_: Coordinate.bridgeJSLiftParameter())
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7189,8 +7982,8 @@ public func _bjs_roundTripCoordinate() -> Void {
 @_cdecl("bjs_roundTripPriority")
 public func _bjs_roundTripPriority(_ priority: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = roundTripPriority(_: Priority.bridgeFromJS(PriorityReference.bridgeJSLiftParameter(priority)))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    let ret = roundTripPriority(_: Priority.bridgeJSLiftParameter(priority))
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7200,8 +7993,8 @@ public func _bjs_roundTripPriority(_ priority: UnsafeMutableRawPointer) -> Unsaf
 @_cdecl("bjs_roundTripAlert")
 public func _bjs_roundTripAlert(_ alert: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundTripAlert(_: Alert.bridgeFromJS(Severity.bridgeJSLiftParameter(alert)))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    let ret = roundTripAlert(_: Alert.bridgeJSLiftParameter(alert))
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7212,29 +8005,7 @@ public func _bjs_roundTripAlert(_ alert: Int32) -> Int32 {
 public func _bjs_makeAlert(_ level: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = makeAlert(_: Severity.bridgeJSLiftParameter(level))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripSession")
-@_cdecl("bjs_roundTripSession")
-public func _bjs_roundTripSession() -> Void {
-    #if arch(wasm32)
-    let ret = roundTripSession(_: Session.bridgeFromJS(SessionState.bridgeJSLiftParameter()))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_makeSession")
-@_cdecl("bjs_makeSession")
-public func _bjs_makeSession(_ tokenBytes: Int32, _ tokenLength: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = makeSession(_: String.bridgeJSLiftParameter(tokenBytes, tokenLength))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7255,7 +8026,7 @@ public func _bjs_roundTripShape(_ s: Int32) -> Void {
 @_cdecl("bjs_makeShapePolygon")
 public func _bjs_makeShapePolygon(_ polygon: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = makeShapePolygon(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
+    let ret = makeShapePolygon(_: Polygon.bridgeJSLiftParameter(polygon))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -7268,6 +8039,187 @@ public func _bjs_makeShapeEmpty() -> Void {
     #if arch(wasm32)
     let ret = makeShapeEmpty()
     return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripUserId")
+@_cdecl("bjs_roundTripUserId")
+public func _bjs_roundTripUserId(_ id: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = roundTripUserId(_: UserId.bridgeJSLiftParameter(id))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalUserId")
+@_cdecl("bjs_roundTripOptionalUserId")
+public func _bjs_roundTripOptionalUserId(_ idIsSome: Int32, _ idValue: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalUserId(_: Optional<UserId>.bridgeJSLiftParameter(idIsSome, idValue))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripUserIdArray")
+@_cdecl("bjs_roundTripUserIdArray")
+public func _bjs_roundTripUserIdArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripUserIdArray(_: [UserId].bridgeJSStackPop())
+    ret.bridgeJSStackPush()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripBoxed")
+@_cdecl("bjs_roundTripBoxed")
+public func _bjs_roundTripBoxed(_ boxedKind: Int32, _ boxedPayload1: Int32, _ boxedPayload2: Float64) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripBoxed(_: Boxed.bridgeJSLiftParameter(boxedKind, boxedPayload1, boxedPayload2))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalBoxed")
+@_cdecl("bjs_roundTripOptionalBoxed")
+public func _bjs_roundTripOptionalBoxed(_ boxedIsSome: Int32, _ boxedKind: Int32, _ boxedPayload1: Int32, _ boxedPayload2: Float64) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalBoxed(_: Optional<Boxed>.bridgeJSLiftParameter(boxedIsSome, boxedKind, boxedPayload1, boxedPayload2))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_awaitAsyncCallback")
+@_cdecl("bjs_awaitAsyncCallback")
+public func _bjs_awaitAsyncCallback(_ fetch: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
+        return try await awaitAsyncCallback(_: _BJS_Closure_20BridgeJSRuntimeTestsYaKSS_SS.bridgeJSLift(fetch))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAsyncParser")
+@_cdecl("bjs_makeAsyncParser")
+public func _bjs_makeAsyncParser() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAsyncParser()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAsyncEcho")
+@_cdecl("bjs_makeAsyncEcho")
+public func _bjs_makeAsyncEcho() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAsyncEcho()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAsyncRecorder")
+@_cdecl("bjs_makeAsyncRecorder")
+public func _bjs_makeAsyncRecorder() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAsyncRecorder()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_lastRecordedValue")
+@_cdecl("bjs_lastRecordedValue")
+public func _bjs_lastRecordedValue() -> Void {
+    #if arch(wasm32)
+    let ret = lastRecordedValue()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAsyncPayloadLoader")
+@_cdecl("bjs_makeAsyncPayloadLoader")
+public func _bjs_makeAsyncPayloadLoader() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAsyncPayloadLoader()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_awaitPayloadCallback")
+@_cdecl("bjs_awaitPayloadCallback")
+public func _bjs_awaitPayloadCallback(_ load: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
+        return try await awaitPayloadCallback(_: _BJS_Closure_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO.bridgeJSLift(load))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAsyncPointMaker")
+@_cdecl("bjs_makeAsyncPointMaker")
+public func _bjs_makeAsyncPointMaker() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAsyncPointMaker()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeThrowingParser")
+@_cdecl("bjs_makeThrowingParser")
+public func _bjs_makeThrowingParser() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeThrowingParser()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_runValidator")
+@_cdecl("bjs_runValidator")
+public func _bjs_runValidator(_ validate: Int32) -> Int32 {
+    #if arch(wasm32)
+    do {
+        let ret = try runValidator(_: _BJS_Closure_20BridgeJSRuntimeTestsKSS_Sb.bridgeJSLift(validate))
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: error.description)
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7472,13 +8424,24 @@ public func _bjs_makeImportedFoo(_ valueBytes: Int32, _ valueLength: Int32) -> I
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         }
         return 0
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalImportedClass")
+@_cdecl("bjs_roundTripOptionalImportedClass")
+public func _bjs_roundTripOptionalImportedClass(_ vIsSome: Int32, _ vValue: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalImportedClass(v: Optional<Foo>.bridgeJSLiftParameter(vIsSome, vValue))
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7496,7 +8459,7 @@ public func _bjs_throwsSwiftError(_ shouldThrow: Int32) -> Void {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7521,7 +8484,7 @@ public func _bjs_throwsWithIntResult() -> Int32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7546,7 +8509,7 @@ public func _bjs_throwsWithStringResult() -> Void {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7571,7 +8534,7 @@ public func _bjs_throwsWithBoolResult() -> Int32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7596,7 +8559,7 @@ public func _bjs_throwsWithFloatResult() -> Float32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7621,7 +8584,7 @@ public func _bjs_throwsWithDoubleResult() -> Float64 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7646,7 +8609,7 @@ public func _bjs_throwsWithSwiftHeapObjectResult() -> UnsafeMutableRawPointer {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7671,7 +8634,7 @@ public func _bjs_throwsWithJSObjectResult() -> Int32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7683,14 +8646,27 @@ public func _bjs_throwsWithJSObjectResult() -> Int32 {
     #endif
 }
 
+@_expose(wasm, "bjs_zeroArgAsyncThrows")
+@_cdecl("bjs_zeroArgAsyncThrows")
+public func _bjs_zeroArgAsyncThrows() -> Int32 {
+    #if arch(wasm32)
+    let __bjs_capture = 0
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { [__bjs_capture] () async throws(JSException) -> String in
+        _ = __bjs_capture
+        return try await zeroArgAsyncThrows()
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_asyncRoundTripVoid")
 @_cdecl("bjs_asyncRoundTripVoid")
 public func _bjs_asyncRoundTripVoid() -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
+    return _bjs_makePromise(resolve: Promise_resolve_y, reject: Promise_reject) {
         await asyncRoundTripVoid()
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7700,10 +8676,9 @@ public func _bjs_asyncRoundTripVoid() -> Int32 {
 @_cdecl("bjs_asyncRoundTripInt")
 public func _bjs_asyncRoundTripInt(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripInt(v: Int.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_Si, reject: Promise_reject) {
+        return await asyncRoundTripInt(v: Int.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7713,10 +8688,9 @@ public func _bjs_asyncRoundTripInt(_ v: Int32) -> Int32 {
 @_cdecl("bjs_asyncRoundTripFloat")
 public func _bjs_asyncRoundTripFloat(_ v: Float32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripFloat(v: Float.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_Sf, reject: Promise_reject) {
+        return await asyncRoundTripFloat(v: Float.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7726,10 +8700,9 @@ public func _bjs_asyncRoundTripFloat(_ v: Float32) -> Int32 {
 @_cdecl("bjs_asyncRoundTripDouble")
 public func _bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripDouble(v: Double.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_Sd, reject: Promise_reject) {
+        return await asyncRoundTripDouble(v: Double.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7739,10 +8712,9 @@ public func _bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
 @_cdecl("bjs_asyncRoundTripBool")
 public func _bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripBool(v: Bool.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_Sb, reject: Promise_reject) {
+        return await asyncRoundTripBool(v: Bool.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7752,10 +8724,9 @@ public func _bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
 @_cdecl("bjs_asyncRoundTripString")
 public func _bjs_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripString(v: String.bridgeJSLiftParameter(vBytes, vLength)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) {
+        return await asyncRoundTripString(v: String.bridgeJSLiftParameter(vBytes, vLength))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7765,10 +8736,9 @@ public func _bjs_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int3
 @_cdecl("bjs_asyncRoundTripSwiftHeapObject")
 public func _bjs_asyncRoundTripSwiftHeapObject(_ v: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripSwiftHeapObject(v: Greeter.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_7GreeterC, reject: Promise_reject) {
+        return await asyncRoundTripSwiftHeapObject(v: Greeter.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7778,10 +8748,9 @@ public func _bjs_asyncRoundTripSwiftHeapObject(_ v: UnsafeMutableRawPointer) -> 
 @_cdecl("bjs_asyncRoundTripJSObject")
 public func _bjs_asyncRoundTripJSObject(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripJSObject(v: JSObject.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_8JSObjectC, reject: Promise_reject) {
+        return await asyncRoundTripJSObject(v: JSObject.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7902,6 +8871,156 @@ public func _bjs_getTheme() -> Void {
     #if arch(wasm32)
     let ret = getTheme()
     return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripTheme")
+@_cdecl("bjs_asyncRoundTripTheme")
+public func _bjs_asyncRoundTripTheme(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_5ThemeO, reject: Promise_reject) {
+        return await asyncRoundTripTheme(_: Theme.bridgeJSLiftParameter(vBytes, vLength))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripDirection")
+@_cdecl("bjs_asyncRoundTripDirection")
+public func _bjs_asyncRoundTripDirection(_ v: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_9DirectionO, reject: Promise_reject) {
+        return await asyncRoundTripDirection(_: Direction.bridgeJSLiftParameter(v))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripOptionalTheme")
+@_cdecl("bjs_asyncRoundTripOptionalTheme")
+public func _bjs_asyncRoundTripOptionalTheme(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_Sq5ThemeO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalTheme(_: Optional<Theme>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripOptionalDirection")
+@_cdecl("bjs_asyncRoundTripOptionalDirection")
+public func _bjs_asyncRoundTripOptionalDirection(_ vIsSome: Int32, _ vValue: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_Sq9DirectionO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalDirection(_: Optional<Direction>.bridgeJSLiftParameter(vIsSome, vValue))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripDirectionArray")
+@_cdecl("bjs_asyncRoundTripDirectionArray")
+public func _bjs_asyncRoundTripDirectionArray() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = [Direction].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa9DirectionO, reject: Promise_reject) {
+        return await asyncRoundTripDirectionArray(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripDirectionDict")
+@_cdecl("bjs_asyncRoundTripDirectionDict")
+public func _bjs_asyncRoundTripDirectionDict() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = [String: Direction].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD9DirectionO, reject: Promise_reject) {
+        return await asyncRoundTripDirectionDict(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripThemeArray")
+@_cdecl("bjs_asyncRoundTripThemeArray")
+public func _bjs_asyncRoundTripThemeArray() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = [Theme].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa5ThemeO, reject: Promise_reject) {
+        return await asyncRoundTripThemeArray(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripThemeDict")
+@_cdecl("bjs_asyncRoundTripThemeDict")
+public func _bjs_asyncRoundTripThemeDict() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = [String: Theme].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD5ThemeO, reject: Promise_reject) {
+        return await asyncRoundTripThemeDict(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripFileSize")
+@_cdecl("bjs_asyncRoundTripFileSize")
+public func _bjs_asyncRoundTripFileSize(_ v: Int64) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_8FileSizeO, reject: Promise_reject) {
+        return await asyncRoundTripFileSize(_: FileSize.bridgeJSLiftParameter(v))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripOptionalFileSize")
+@_cdecl("bjs_asyncRoundTripOptionalFileSize")
+public func _bjs_asyncRoundTripOptionalFileSize(_ vIsSome: Int32, _ vValue: Int64) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_Sq8FileSizeO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalFileSize(_: Optional<FileSize>.bridgeJSLiftParameter(vIsSome, vValue))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripAssociatedValueEnum")
+@_cdecl("bjs_asyncRoundTripAssociatedValueEnum")
+public func _bjs_asyncRoundTripAssociatedValueEnum(_ v: Int32) -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = AsyncPayloadResult.bridgeJSLiftParameter(v)
+    return _bjs_makePromise(resolve: Promise_resolve_18AsyncPayloadResultO, reject: Promise_reject) {
+        return await asyncRoundTripAssociatedValueEnum(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripOptionalAssociatedValueEnum")
+@_cdecl("bjs_asyncRoundTripOptionalAssociatedValueEnum")
+public func _bjs_asyncRoundTripOptionalAssociatedValueEnum(_ vIsSome: Int32, _ vCaseId: Int32) -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = Optional<AsyncPayloadResult>.bridgeJSLiftParameter(vIsSome, vCaseId)
+    return _bjs_makePromise(resolve: Promise_resolve_Sq18AsyncPayloadResultO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalAssociatedValueEnum(_: _tmp_v)
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8555,6 +9674,110 @@ public func _bjs_roundTripPublicPoint() -> Void {
     #endif
 }
 
+@_expose(wasm, "bjs_asyncRoundTripPublicPoint")
+@_cdecl("bjs_asyncRoundTripPublicPoint")
+public func _bjs_asyncRoundTripPublicPoint() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_point = PublicPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) {
+        return await asyncRoundTripPublicPoint(_: _tmp_point)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripPublicPointThrows")
+@_cdecl("bjs_asyncRoundTripPublicPointThrows")
+public func _bjs_asyncRoundTripPublicPointThrows() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_point = PublicPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) { () async throws(JSException) -> PublicPoint in
+        return try await asyncRoundTripPublicPointThrows(_: _tmp_point)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncStructOrThrow")
+@_cdecl("bjs_asyncStructOrThrow")
+public func _bjs_asyncStructOrThrow(_ shouldThrow: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) { () async throws(JSException) -> PublicPoint in
+        return try await asyncStructOrThrow(_: Bool.bridgeJSLiftParameter(shouldThrow))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncCombinePublicPoints")
+@_cdecl("bjs_asyncCombinePublicPoints")
+public func _bjs_asyncCombinePublicPoints() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_b = PublicPoint.bridgeJSLiftParameter()
+    let _tmp_a = PublicPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) {
+        return await asyncCombinePublicPoints(_: _tmp_a, _: _tmp_b)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripContact")
+@_cdecl("bjs_asyncRoundTripContact")
+public func _bjs_asyncRoundTripContact() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_contact = Contact.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_7ContactV, reject: Promise_reject) {
+        return await asyncRoundTripContact(_: _tmp_contact)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripPublicPointArray")
+@_cdecl("bjs_asyncRoundTripPublicPointArray")
+public func _bjs_asyncRoundTripPublicPointArray() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_points = [PublicPoint].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa11PublicPointV, reject: Promise_reject) {
+        return await asyncRoundTripPublicPointArray(_: _tmp_points)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripOptionalPublicPoint")
+@_cdecl("bjs_asyncRoundTripOptionalPublicPoint")
+public func _bjs_asyncRoundTripOptionalPublicPoint() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_point = Optional<PublicPoint>.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_Sq11PublicPointV, reject: Promise_reject) {
+        return await asyncRoundTripOptionalPublicPoint(_: _tmp_point)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripPublicPointDict")
+@_cdecl("bjs_asyncRoundTripPublicPointDict")
+public func _bjs_asyncRoundTripPublicPointDict() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_points = [String: PublicPoint].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD11PublicPointV, reject: Promise_reject) {
+        return await asyncRoundTripPublicPointDict(_: _tmp_points)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_roundTripContact")
 @_cdecl("bjs_roundTripContact")
 public func _bjs_roundTripContact() -> Void {
@@ -8742,7 +9965,7 @@ public func _bjs_PolygonReference_summary(_ _self: UnsafeMutableRawPointer) -> V
 public func _bjs_PolygonReference_snapshot(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = PolygonReference.bridgeJSLiftParameter(_self).snapshot()
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8752,8 +9975,8 @@ public func _bjs_PolygonReference_snapshot(_ _self: UnsafeMutableRawPointer) -> 
 @_cdecl("bjs_PolygonReference_merge")
 public func _bjs_PolygonReference_merge(_ _self: UnsafeMutableRawPointer, _ other: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PolygonReference.bridgeJSLiftParameter(_self).merge(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(other)))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    let ret = PolygonReference.bridgeJSLiftParameter(_self).merge(_: Polygon.bridgeJSLiftParameter(other))
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8764,7 +9987,7 @@ public func _bjs_PolygonReference_merge(_ _self: UnsafeMutableRawPointer, _ othe
 public func _bjs_PolygonReference_static_origin(_ labelBytes: Int32, _ labelLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = PolygonReference.origin(label: String.bridgeJSLiftParameter(labelBytes, labelLength))
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8843,64 +10066,11 @@ fileprivate func _bjs_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointe
     return _bjs_TagReference_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_TokenReference_init")
-@_cdecl("bjs_TokenReference_init")
-public func _bjs_TokenReference_init(_ value: Int32) -> UnsafeMutableRawPointer {
-    #if arch(wasm32)
-    let ret = TokenReference(value: Int.bridgeJSLiftParameter(value))
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_TokenReference_read")
-@_cdecl("bjs_TokenReference_read")
-public func _bjs_TokenReference_read(_ _self: UnsafeMutableRawPointer) -> Int32 {
-    #if arch(wasm32)
-    let ret = TokenReference.bridgeJSLiftParameter(_self).read()
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_TokenReference_deinit")
-@_cdecl("bjs_TokenReference_deinit")
-public func _bjs_TokenReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    Unmanaged<TokenReference>.fromOpaque(pointer).release()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-extension TokenReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
-    var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_TokenReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
-    }
-    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_TokenReference_wrap(Unmanaged.passRetained(self).toOpaque())
-    }
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_TokenReference_wrap")
-fileprivate func _bjs_TokenReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
-#else
-fileprivate func _bjs_TokenReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func _bjs_TokenReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_TokenReference_wrap_extern(pointer)
-}
-
 @_expose(wasm, "bjs_TagHolderReference_init")
 @_cdecl("bjs_TagHolderReference_init")
 public func _bjs_TagHolderReference_init(_ tag: UnsafeMutableRawPointer, _ version: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = TagHolderReference(tag: Tag.bridgeFromJS(TagReference.bridgeJSLiftParameter(tag)), version: Int.bridgeJSLiftParameter(version))
+    let ret = TagHolderReference(tag: Tag.bridgeJSLiftParameter(tag), version: Int.bridgeJSLiftParameter(version))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -8923,7 +10093,7 @@ public func _bjs_TagHolderReference_describe(_ _self: UnsafeMutableRawPointer) -
 public func _bjs_TagHolderReference_tag_get(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = TagHolderReference.bridgeJSLiftParameter(_self).tag
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8933,7 +10103,7 @@ public func _bjs_TagHolderReference_tag_get(_ _self: UnsafeMutableRawPointer) ->
 @_cdecl("bjs_TagHolderReference_tag_set")
 public func _bjs_TagHolderReference_tag_set(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    TagHolderReference.bridgeJSLiftParameter(_self).tag = Tag.bridgeFromJS(TagReference.bridgeJSLiftParameter(value))
+    TagHolderReference.bridgeJSLiftParameter(_self).tag = Tag.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -9018,7 +10188,7 @@ public func _bjs_PriorityReference_weight(_ _self: UnsafeMutableRawPointer) -> I
 public func _bjs_PriorityReference_static_low() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = PriorityReference.low()
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -9029,7 +10199,7 @@ public func _bjs_PriorityReference_static_low() -> UnsafeMutableRawPointer {
 public func _bjs_PriorityReference_static_medium() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = PriorityReference.medium()
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -9040,7 +10210,7 @@ public func _bjs_PriorityReference_static_medium() -> UnsafeMutableRawPointer {
 public func _bjs_PriorityReference_static_high() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = PriorityReference.high()
-    return ret.bridgeToJS().bridgeJSLowerReturn()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -9532,6 +10702,18 @@ public func _bjs_Calculator_add(_ _self: UnsafeMutableRawPointer, _ a: Int32, _ 
     #if arch(wasm32)
     let ret = Calculator.bridgeJSLiftParameter(_self).add(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_Calculator_asyncMakePoint")
+@_cdecl("bjs_Calculator_asyncMakePoint")
+public func _bjs_Calculator_asyncMakePoint(_ _self: UnsafeMutableRawPointer, _ x: Int32, _ y: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) {
+        return await Calculator.bridgeJSLiftParameter(_self).asyncMakePoint(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -12017,6 +13199,597 @@ fileprivate func _bjs_LeakCheck_wrap_extern(_ pointer: UnsafeMutableRawPointer) 
     return _bjs_LeakCheck_wrap_extern(pointer)
 }
 
+@JSFunction func Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_reject_BridgeJSRuntimeTests")
+fileprivate func promise_reject_BridgeJSRuntimeTests_extern(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void
+#else
+fileprivate func promise_reject_BridgeJSRuntimeTests_extern(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_reject_BridgeJSRuntimeTests(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+    return promise_reject_BridgeJSRuntimeTests_extern(promise, valueKind, valuePayload1, valuePayload2)
+}
+
+func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let (valueKind, valuePayload1, valuePayload2) = value.bridgeJSLowerParameter()
+    promise_reject_BridgeJSRuntimeTests(promiseValue, valueKind, valuePayload1, valuePayload2)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SS")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SS(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_SS_extern(promise, valueBytes, valueLength)
+}
+
+func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        promise_resolve_BridgeJSRuntimeTests_SS(promiseValue, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_y(_ promise: JSObject) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_y")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_y_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_y_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_y(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_y_extern(promise)
+}
+
+func _$Promise_resolve_y(_ promise: JSObject) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_y(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Si(_ promise: JSObject, _ value: Int) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Si")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Si_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Si_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Si(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Si_extern(promise, value)
+}
+
+func _$Promise_resolve_Si(_ promise: JSObject, _ value: Int) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Si(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sf(_ promise: JSObject, _ value: Float) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sf")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sf_extern(_ promise: Int32, _ value: Float32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sf_extern(_ promise: Int32, _ value: Float32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sf(_ promise: Int32, _ value: Float32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sf_extern(promise, value)
+}
+
+func _$Promise_resolve_Sf(_ promise: JSObject, _ value: Float) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sf(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sd(_ promise: JSObject, _ value: Double) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sd")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sd_extern(_ promise: Int32, _ value: Float64) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sd_extern(_ promise: Int32, _ value: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sd(_ promise: Int32, _ value: Float64) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sd_extern(promise, value)
+}
+
+func _$Promise_resolve_Sd(_ promise: JSObject, _ value: Double) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sd(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sb(_ promise: JSObject, _ value: Bool) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sb")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sb_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sb_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sb(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sb_extern(promise, value)
+}
+
+func _$Promise_resolve_Sb(_ promise: JSObject, _ value: Bool) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sb(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_7GreeterC(_ promise: JSObject, _ value: Greeter) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_7GreeterC")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(promise, value)
+}
+
+func _$Promise_resolve_7GreeterC(_ promise: JSObject, _ value: Greeter) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valuePointer = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_7GreeterC(promiseValue, valuePointer)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_8JSObjectC(_ promise: JSObject, _ value: JSObject) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_8JSObjectC")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_8JSObjectC_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_8JSObjectC_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_8JSObjectC(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_8JSObjectC_extern(promise, value)
+}
+
+func _$Promise_resolve_8JSObjectC(_ promise: JSObject, _ value: JSObject) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_8JSObjectC(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_5ThemeO(_ promise: JSObject, _ value: Theme) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_5ThemeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(promise, valueBytes, valueLength)
+}
+
+func _$Promise_resolve_5ThemeO(_ promise: JSObject, _ value: Theme) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        promise_resolve_BridgeJSRuntimeTests_5ThemeO(promiseValue, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_9DirectionO(_ promise: JSObject, _ value: Direction) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_9DirectionO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(promise, value)
+}
+
+func _$Promise_resolve_9DirectionO(_ promise: JSObject, _ value: Direction) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_9DirectionO(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sq5ThemeO(_ promise: JSObject, _ value: Optional<Theme>) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(promise, valueIsSome, valueBytes, valueLength)
+}
+
+func _$Promise_resolve_Sq5ThemeO(_ promise: JSObject, _ value: Optional<Theme>) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    value.bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
+        promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO(promiseValue, valueIsSome, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sq9DirectionO(_ promise: JSObject, _ value: Optional<Direction>) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(promise, valueIsSome, valueValue)
+}
+
+func _$Promise_resolve_Sq9DirectionO(_ promise: JSObject, _ value: Optional<Direction>) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO(promiseValue, valueIsSome, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sa9DirectionO(_ promise: JSObject, _ value: [Direction]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(promise)
+}
+
+func _$Promise_resolve_Sa9DirectionO(_ promise: JSObject, _ value: [Direction]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SD9DirectionO(_ promise: JSObject, _ value: [String: Direction]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD9DirectionO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(promise)
+}
+
+func _$Promise_resolve_SD9DirectionO(_ promise: JSObject, _ value: [String: Direction]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_SD9DirectionO(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sa5ThemeO(_ promise: JSObject, _ value: [Theme]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(promise)
+}
+
+func _$Promise_resolve_Sa5ThemeO(_ promise: JSObject, _ value: [Theme]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SD5ThemeO(_ promise: JSObject, _ value: [String: Theme]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD5ThemeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(promise)
+}
+
+func _$Promise_resolve_SD5ThemeO(_ promise: JSObject, _ value: [String: Theme]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_SD5ThemeO(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_8FileSizeO(_ promise: JSObject, _ value: FileSize) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_8FileSizeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(_ promise: Int32, _ value: Int64) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(_ promise: Int32, _ value: Int64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO(_ promise: Int32, _ value: Int64) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(promise, value)
+}
+
+func _$Promise_resolve_8FileSizeO(_ promise: JSObject, _ value: FileSize) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_8FileSizeO(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sq8FileSizeO(_ promise: JSObject, _ value: Optional<FileSize>) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(promise, valueIsSome, valueValue)
+}
+
+func _$Promise_resolve_Sq8FileSizeO(_ promise: JSObject, _ value: Optional<FileSize>) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO(promiseValue, valueIsSome, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_18AsyncPayloadResultO(_ promise: JSObject, _ value: AsyncPayloadResult) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO_extern(promise, value)
+}
+
+func _$Promise_resolve_18AsyncPayloadResultO(_ promise: JSObject, _ value: AsyncPayloadResult) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueCaseId = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO(promiseValue, valueCaseId)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sq18AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<AsyncPayloadResult>) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO_extern(promise, valueIsSome, valueCaseId)
+}
+
+func _$Promise_resolve_Sq18AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<AsyncPayloadResult>) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let (valueIsSome, valueCaseId) = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO(promiseValue, valueIsSome, valueCaseId)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_11PublicPointV(_ promise: JSObject, _ value: PublicPoint) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_11PublicPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(promise, value)
+}
+
+func _$Promise_resolve_11PublicPointV(_ promise: JSObject, _ value: PublicPoint) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueObjectId = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_11PublicPointV(promiseValue, valueObjectId)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_7ContactV(_ promise: JSObject, _ value: Contact) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_7ContactV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(promise, value)
+}
+
+func _$Promise_resolve_7ContactV(_ promise: JSObject, _ value: Contact) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueObjectId = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_7ContactV(promiseValue, valueObjectId)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sa11PublicPointV(_ promise: JSObject, _ value: [PublicPoint]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(promise)
+}
+
+func _$Promise_resolve_Sa11PublicPointV(_ promise: JSObject, _ value: [PublicPoint]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sq11PublicPointV(_ promise: JSObject, _ value: Optional<PublicPoint>) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(promise, value)
+}
+
+func _$Promise_resolve_Sq11PublicPointV(_ promise: JSObject, _ value: Optional<PublicPoint>) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueIsSome = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(promiseValue, valueIsSome)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SD11PublicPointV(_ promise: JSObject, _ value: [String: PublicPoint]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(promise)
+}
+
+func _$Promise_resolve_SD11PublicPointV(_ promise: JSObject, _ value: [String: PublicPoint]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_9DataPointV(_ promise: JSObject, _ value: DataPoint) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_9DataPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(promise, value)
+}
+
+func _$Promise_resolve_9DataPointV(_ promise: JSObject, _ value: DataPoint) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueObjectId = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_9DataPointV(promiseValue, valueObjectId)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+extension Polygon: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
+extension Tag: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
+extension TagHolder: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
+extension Coordinate: _BridgedSwiftAlias, _BridgedSwiftStruct {}
+
+extension Priority: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
+extension Alert: _BridgedSwiftAlias, _BridgedSwiftCaseEnum {}
+
+extension UserId: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
+extension Tagged: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
+extension Canvas: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
+extension AliasedTag: _BridgedSwiftAlias, _BridgedSwiftAssociatedValueEnum {}
+
+extension Boxed: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+
 #if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Surface_init")
 fileprivate func bjs_Surface_init_extern(_ labelBytes: Int32, _ labelLength: Int32) -> Int32
@@ -12134,8 +13907,32 @@ fileprivate func bjs_AliasImports_jsRoundTripCoordinate_static_extern(_ value: I
     return bjs_AliasImports_jsRoundTripCoordinate_static_extern(value)
 }
 
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_AliasImports_jsRoundTripUserId_static")
+fileprivate func bjs_AliasImports_jsRoundTripUserId_static_extern(_ value: Int32) -> Int32
+#else
+fileprivate func bjs_AliasImports_jsRoundTripUserId_static_extern(_ value: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_AliasImports_jsRoundTripUserId_static(_ value: Int32) -> Int32 {
+    return bjs_AliasImports_jsRoundTripUserId_static_extern(value)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_AliasImports_jsRoundTripOptionalUserId_static")
+fileprivate func bjs_AliasImports_jsRoundTripOptionalUserId_static_extern(_ valueIsSome: Int32, _ valueValue: Int32) -> Void
+#else
+fileprivate func bjs_AliasImports_jsRoundTripOptionalUserId_static_extern(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_AliasImports_jsRoundTripOptionalUserId_static(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    return bjs_AliasImports_jsRoundTripOptionalUserId_static_extern(valueIsSome, valueValue)
+}
+
 func _$AliasImports_jsRoundTripTagged(_ value: Tagged) throws(JSException) -> Tagged {
-    let ret0 = value.bridgeToJS().bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+    let ret0 = value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
         let ret = bjs_AliasImports_jsRoundTripTagged_static(valueBytes, valueLength)
         return ret
     }
@@ -12143,21 +13940,17 @@ func _$AliasImports_jsRoundTripTagged(_ value: Tagged) throws(JSException) -> Ta
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Tagged.bridgeFromJS(String.bridgeJSLiftReturn(ret))
+    return Tagged.bridgeJSLiftReturn(ret)
 }
 
 func _$AliasImports_jsRoundTripOptionalTagged(_ value: Optional<Tagged>) throws(JSException) -> Optional<Tagged> {
-    value.map {
-        $0.bridgeToJS()
-    } .bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
+    value.bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
         bjs_AliasImports_jsRoundTripOptionalTagged_static(valueIsSome, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<String>.bridgeJSLiftReturnFromSideChannel().map {
-        Tagged.bridgeFromJS($0)
-    }
+    return Optional<Tagged>.bridgeJSLiftReturnFromSideChannel()
 }
 
 func _$AliasImports_jsProduceOptionalCanvas(_ label: Optional<String>) throws(JSException) -> Optional<Canvas> {
@@ -12167,44 +13960,52 @@ func _$AliasImports_jsProduceOptionalCanvas(_ label: Optional<String>) throws(JS
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<Surface>.bridgeJSLiftReturn().map {
-        Canvas.bridgeFromJS($0)
-    }
+    return Optional<Canvas>.bridgeJSLiftReturn()
 }
 
 func _$AliasImports_jsRoundTripAliasedTags(_ values: [Optional<AliasedTag>]) throws(JSException) -> [Optional<AliasedTag>] {
-    let _ = values.map {
-        $0.map {
-            $0.bridgeToJS()
-        }
-    } .bridgeJSLowerParameter()
+    let _ = values.bridgeJSLowerParameter()
     bjs_AliasImports_jsRoundTripAliasedTags_static()
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return [Optional<InnerTag>].bridgeJSLiftReturn().map {
-        $0.map {
-            AliasedTag.bridgeFromJS($0)
-        }
-    }
+    return [Optional<AliasedTag>].bridgeJSLiftReturn()
 }
 
 func _$AliasImports_jsRoundTripPolygon(_ value: Polygon) throws(JSException) -> Polygon {
-    let valuePointer = value.bridgeToJS().bridgeJSLowerParameter()
+    let valuePointer = value.bridgeJSLowerParameter()
     let ret = bjs_AliasImports_jsRoundTripPolygon_static(valuePointer)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftReturn(ret))
+    return Polygon.bridgeJSLiftReturn(ret)
 }
 
 func _$AliasImports_jsRoundTripCoordinate(_ value: Coordinate) throws(JSException) -> Coordinate {
-    let valueObjectId = value.bridgeToJS().bridgeJSLowerParameter()
+    let valueObjectId = value.bridgeJSLowerParameter()
     let ret = bjs_AliasImports_jsRoundTripCoordinate_static(valueObjectId)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Coordinate.bridgeFromJS(JSCoordinate.bridgeJSLiftReturn(ret))
+    return Coordinate.bridgeJSLiftReturn(ret)
+}
+
+func _$AliasImports_jsRoundTripUserId(_ value: UserId) throws(JSException) -> UserId {
+    let valueValue = value.bridgeJSLowerParameter()
+    let ret = bjs_AliasImports_jsRoundTripUserId_static(valueValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return UserId.bridgeJSLiftReturn(ret)
+}
+
+func _$AliasImports_jsRoundTripOptionalUserId(_ value: Optional<UserId>) throws(JSException) -> Optional<UserId> {
+    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    bjs_AliasImports_jsRoundTripOptionalUserId_static(valueIsSome, valueValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<UserId>.bridgeJSLiftReturnFromSideChannel()
 }
 
 #if arch(wasm32)
@@ -12726,6 +14527,30 @@ fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripFeatureFlag_static_exter
     return bjs_AsyncImportImports_jsAsyncRoundTripFeatureFlag_static_extern(resolveRef, rejectRef, vBytes, vLength)
 }
 
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum_static")
+fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum_static_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ v: Int32) -> Void
+#else
+fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum_static_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ v: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum_static(_ resolveRef: Int32, _ rejectRef: Int32, _ v: Int32) -> Void {
+    return bjs_AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum_static_extern(resolveRef, rejectRef, v)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum_static")
+fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum_static_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ vIsSome: Int32, _ vCaseId: Int32) -> Void
+#else
+fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum_static_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ vIsSome: Int32, _ vCaseId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum_static(_ resolveRef: Int32, _ rejectRef: Int32, _ vIsSome: Int32, _ vCaseId: Int32) -> Void {
+    return bjs_AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum_static_extern(resolveRef, rejectRef, vIsSome, vCaseId)
+}
+
 func _$AsyncImportImports_jsAsyncRoundTripVoid() async throws(JSException) -> Void {
     try await _bjs_awaitPromise(makeResolveClosure: {
             JSTypedClosure<() -> Void>($0)
@@ -12845,6 +14670,52 @@ func _$AsyncImportImports_jsAsyncRoundTripFeatureFlag(_ v: FeatureFlag) async th
         }
     }
     return resolved
+}
+
+func _$AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum(_ v: AsyncImportedPayloadResult) async throws(JSException) -> AsyncImportedPayloadResult {
+    let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
+            JSTypedClosure<(sending AsyncImportedPayloadResult) -> Void>($0)
+        }, makeRejectClosure: {
+            JSTypedClosure<(sending JSValue) -> Void>($0)
+        }) { resolveRef, rejectRef in
+        let vCaseId = v.bridgeJSLowerParameter()
+        bjs_AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum_static(resolveRef, rejectRef, vCaseId)
+    }
+    return resolved
+}
+
+func _$AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum(_ v: Optional<AsyncImportedPayloadResult>) async throws(JSException) -> Optional<AsyncImportedPayloadResult> {
+    let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
+            JSTypedClosure<(sending Optional<AsyncImportedPayloadResult>) -> Void>($0)
+        }, makeRejectClosure: {
+            JSTypedClosure<(sending JSValue) -> Void>($0)
+        }) { resolveRef, rejectRef in
+        let (vIsSome, vCaseId) = v.bridgeJSLowerParameter()
+        bjs_AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum_static(resolveRef, rejectRef, vIsSome, vCaseId)
+    }
+    return resolved
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ClosureAsyncImports_runJsClosureAsyncTests_static")
+fileprivate func bjs_ClosureAsyncImports_runJsClosureAsyncTests_static_extern(_ resolveRef: Int32, _ rejectRef: Int32) -> Void
+#else
+fileprivate func bjs_ClosureAsyncImports_runJsClosureAsyncTests_static_extern(_ resolveRef: Int32, _ rejectRef: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_ClosureAsyncImports_runJsClosureAsyncTests_static(_ resolveRef: Int32, _ rejectRef: Int32) -> Void {
+    return bjs_ClosureAsyncImports_runJsClosureAsyncTests_static_extern(resolveRef, rejectRef)
+}
+
+func _$ClosureAsyncImports_runJsClosureAsyncTests() async throws(JSException) -> Void {
+    try await _bjs_awaitPromise(makeResolveClosure: {
+            JSTypedClosure<() -> Void>($0)
+        }, makeRejectClosure: {
+            JSTypedClosure<(sending JSValue) -> Void>($0)
+        }) { resolveRef, rejectRef in
+        bjs_ClosureAsyncImports_runJsClosureAsyncTests_static(resolveRef, rejectRef)
+    }
 }
 
 #if arch(wasm32)
@@ -13224,6 +15095,25 @@ func _$ClosureSupportImports_jsHeapCount() throws(JSException) -> Int {
 
 func _$ClosureSupportImports_runJsClosureSupportTests() throws(JSException) -> Void {
     bjs_ClosureSupportImports_runJsClosureSupportTests_static()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ClosureThrowsImports_runJsClosureThrowsTests_static")
+fileprivate func bjs_ClosureThrowsImports_runJsClosureThrowsTests_static_extern() -> Void
+#else
+fileprivate func bjs_ClosureThrowsImports_runJsClosureThrowsTests_static_extern() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_ClosureThrowsImports_runJsClosureThrowsTests_static() -> Void {
+    return bjs_ClosureThrowsImports_runJsClosureThrowsTests_static_extern()
+}
+
+func _$ClosureThrowsImports_runJsClosureThrowsTests() throws(JSException) -> Void {
+    bjs_ClosureThrowsImports_runJsClosureThrowsTests_static()
     if let error = _swift_js_take_exception() {
         throw error
     }
@@ -13671,28 +15561,6 @@ func _$runAsyncWorks() async throws(JSException) -> Void {
             JSTypedClosure<(sending JSValue) -> Void>($0)
         }) { resolveRef, rejectRef in
         bjs_runAsyncWorks(resolveRef, rejectRef)
-    }
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_runAliasAsyncWorks")
-fileprivate func bjs_runAliasAsyncWorks_extern(_ resolveRef: Int32, _ rejectRef: Int32) -> Void
-#else
-fileprivate func bjs_runAliasAsyncWorks_extern(_ resolveRef: Int32, _ rejectRef: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func bjs_runAliasAsyncWorks(_ resolveRef: Int32, _ rejectRef: Int32) -> Void {
-    return bjs_runAliasAsyncWorks_extern(resolveRef, rejectRef)
-}
-
-func _$runAliasAsyncWorks() async throws(JSException) -> Void {
-    try await _bjs_awaitPromise(makeResolveClosure: {
-            JSTypedClosure<() -> Void>($0)
-        }, makeRejectClosure: {
-            JSTypedClosure<(sending JSValue) -> Void>($0)
-        }) { resolveRef, rejectRef in
-        bjs_runAliasAsyncWorks(resolveRef, rejectRef)
     }
 }
 
@@ -14386,6 +16254,69 @@ func _$Animal_getIsCat(_ self: JSObject) throws(JSException) -> Bool {
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripLightColor")
+fileprivate func bjs_jsRoundTripLightColor_extern(_ value: Int32) -> Int32
+#else
+fileprivate func bjs_jsRoundTripLightColor_extern(_ value: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsRoundTripLightColor(_ value: Int32) -> Int32 {
+    return bjs_jsRoundTripLightColor_extern(value)
+}
+
+func _$jsRoundTripLightColor(_ value: LightColor) throws(JSException) -> LightColor {
+    let valueValue = value.bridgeJSLowerParameter()
+    let ret = bjs_jsRoundTripLightColor(valueValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return LightColor.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripImportedPayloadSignal")
+fileprivate func bjs_jsRoundTripImportedPayloadSignal_extern(_ value: Int32) -> Int32
+#else
+fileprivate func bjs_jsRoundTripImportedPayloadSignal_extern(_ value: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsRoundTripImportedPayloadSignal(_ value: Int32) -> Int32 {
+    return bjs_jsRoundTripImportedPayloadSignal_extern(value)
+}
+
+func _$jsRoundTripImportedPayloadSignal(_ value: ImportedPayloadSignal) throws(JSException) -> ImportedPayloadSignal {
+    let valueCaseId = value.bridgeJSLowerParameter()
+    let ret = bjs_jsRoundTripImportedPayloadSignal(valueCaseId)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return ImportedPayloadSignal.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripOptionalImportedPayloadSignal")
+fileprivate func bjs_jsRoundTripOptionalImportedPayloadSignal_extern(_ valueIsSome: Int32, _ valueCaseId: Int32) -> Int32
+#else
+fileprivate func bjs_jsRoundTripOptionalImportedPayloadSignal_extern(_ valueIsSome: Int32, _ valueCaseId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsRoundTripOptionalImportedPayloadSignal(_ valueIsSome: Int32, _ valueCaseId: Int32) -> Int32 {
+    return bjs_jsRoundTripOptionalImportedPayloadSignal_extern(valueIsSome, valueCaseId)
+}
+
+func _$jsRoundTripOptionalImportedPayloadSignal(_ value: Optional<ImportedPayloadSignal>) throws(JSException) -> Optional<ImportedPayloadSignal> {
+    let (valueIsSome, valueCaseId) = value.bridgeJSLowerParameter()
+    let ret = bjs_jsRoundTripOptionalImportedPayloadSignal(valueIsSome, valueCaseId)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<ImportedPayloadSignal>.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsTranslatePoint")
 fileprivate func bjs_jsTranslatePoint_extern(_ point: Int32, _ dx: Int32, _ dy: Int32) -> Int32
 #else
@@ -14406,6 +16337,27 @@ func _$jsTranslatePoint(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException
         throw error
     }
     return Point.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripOptionalPoint")
+fileprivate func bjs_jsRoundTripOptionalPoint_extern(_ point: Int32) -> Void
+#else
+fileprivate func bjs_jsRoundTripOptionalPoint_extern(_ point: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsRoundTripOptionalPoint(_ point: Int32) -> Void {
+    return bjs_jsRoundTripOptionalPoint_extern(point)
+}
+
+func _$jsRoundTripOptionalPoint(_ point: Optional<Point>) throws(JSException) -> Optional<Point> {
+    let pointIsSome = point.bridgeJSLowerParameter()
+    bjs_jsRoundTripOptionalPoint(pointIsSome)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<Point>.bridgeJSLiftReturn()
 }
 
 #if arch(wasm32)
@@ -15206,6 +17158,18 @@ fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDic
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalSupportImports_jsRoundTripOptionalJSObjectNull_static")
+fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSObjectNull_static_extern(_ valueIsSome: Int32, _ valueValue: Int32) -> Void
+#else
+fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSObjectNull_static_extern(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSObjectNull_static(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    return bjs_OptionalSupportImports_jsRoundTripOptionalJSObjectNull_static_extern(valueIsSome, valueValue)
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalSupportImports_runJsOptionalSupportTests_static")
 fileprivate func bjs_OptionalSupportImports_runJsOptionalSupportTests_static_extern() -> Void
 #else
@@ -15289,6 +17253,15 @@ func _$OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefin
         throw error
     }
     return JSUndefinedOr<[String: String]>.bridgeJSLiftReturn()
+}
+
+func _$OptionalSupportImports_jsRoundTripOptionalJSObjectNull(_ value: Optional<JSObject>) throws(JSException) -> Optional<JSObject> {
+    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    bjs_OptionalSupportImports_jsRoundTripOptionalJSObjectNull_static(valueIsSome, valueValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<JSObject>.bridgeJSLiftReturn()
 }
 
 func _$OptionalSupportImports_runJsOptionalSupportTests() throws(JSException) -> Void {

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -645,126 +645,37 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9Di
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(callback, param0Bytes, param0Length)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si_extern(callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsKSS_Sb {
-    static func bridgeJSLift(_ callbackId: Int32) -> (String) throws(JSException) -> Bool {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsAl7Polygon_Si {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Polygon) -> Int {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] (param0: String) throws(JSException) -> Bool in
+        return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
-            let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
-                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(callbackValue, param0Bytes, param0Length)
-                return ret
-            }
-            let ret = ret0
-            if let error = _swift_js_take_exception() {
-                throw error
-            }
-            return Bool.bridgeJSLiftReturn(ret)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (String) throws(JSException) -> Bool {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) throws(JSException) -> Bool) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) throws(JSException) -> Bool>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    do {
-        let result = try closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
-        return result.bridgeJSLowerReturn()
-    } catch let error {
-        if let error = error.thrownValue.object {
-            withExtendedLifetime(error) {
-                _swift_js_throw(Int32(bitPattern: $0.id))
-            }
-        } else {
-            let jsError = JSError(message: error.description)
-            withExtendedLifetime(jsError.jsObject) {
-                _swift_js_throw(Int32(bitPattern: $0.id))
-            }
-        }
-        return 0
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(callback, param0Bytes, param0Length)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestsKSS_Si {
-    static func bridgeJSLift(_ callbackId: Int32) -> (String) throws(JSException) -> Int {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] (param0: String) throws(JSException) -> Int in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
-                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(callbackValue, param0Bytes, param0Length)
-                return ret
-            }
-            let ret = ret0
-            if let error = _swift_js_take_exception() {
-                throw error
-            }
+            let param0Pointer = param0.bridgeToJS().bridgeJSLowerParameter()
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si(callbackValue, param0Pointer)
             return Int.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
@@ -773,10 +684,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsKSS_Si {
     }
 }
 
-extension JSTypedClosure where Signature == (String) throws(JSException) -> Int {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) throws(JSException) -> Int) {
+extension JSTypedClosure where Signature == (Polygon) -> Int {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Polygon) -> Int) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si,
             body: body,
             fileID: fileID,
             line: line
@@ -784,27 +695,13 @@ extension JSTypedClosure where Signature == (String) throws(JSException) -> Int 
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) throws(JSException) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    do {
-        let result = try closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
-        return result.bridgeJSLowerReturn()
-    } catch let error {
-        if let error = error.thrownValue.object {
-            withExtendedLifetime(error) {
-                _swift_js_throw(Int32(bitPattern: $0.id))
-            }
-        } else {
-            let jsError = JSError(message: error.description)
-            withExtendedLifetime(jsError.jsObject) {
-                _swift_js_throw(Int32(bitPattern: $0.id))
-            }
-        }
-        return 0
-    }
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Polygon) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(param0)))
+    return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1968,358 +1865,6 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSqS
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSS_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (String) async throws(JSException) -> String {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] (param0: String) async throws(JSException) -> String in
-            #if arch(wasm32)
-            let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
-                    JSTypedClosure<(sending String) -> Void>($0)
-                }, makeRejectClosure: {
-                    JSTypedClosure<(sending JSValue) -> Void>($0)
-                }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
-                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
-                    invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
-                }
-            }
-            return resolved
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (String) async throws(JSException) -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async throws(JSException) -> String) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async throws(JSException) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
-        return try await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSS_y {
-    static func bridgeJSLift(_ callbackId: Int32) -> (String) async throws(JSException) -> Void {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] (param0: String) async throws(JSException) -> Void in
-            #if arch(wasm32)
-            try await _bjs_awaitPromise(makeResolveClosure: {
-                    JSTypedClosure<() -> Void>($0)
-                }, makeRejectClosure: {
-                    JSTypedClosure<(sending JSValue) -> Void>($0)
-                }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
-                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
-                    invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
-                }
-            }
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (String) async throws(JSException) -> Void {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async throws(JSException) -> Void) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async throws(JSException) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    return _bjs_makePromise(resolve: Promise_resolve_y, reject: Promise_reject) { () async throws(JSException) in
-        try await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(resolveRef, rejectRef, callback, param0)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Bool) async throws(JSException) -> AsyncPayloadResult {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] (param0: Bool) async throws(JSException) -> AsyncPayloadResult in
-            #if arch(wasm32)
-            let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
-                    JSTypedClosure<(sending AsyncPayloadResult) -> Void>($0)
-                }, makeRejectClosure: {
-                    JSTypedClosure<(sending JSValue) -> Void>($0)
-                }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
-                let param0Value = param0.bridgeJSLowerParameter()
-                invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(resolveRef, rejectRef, callbackValue, param0Value)
-            }
-            return resolved
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (Bool) async throws(JSException) -> AsyncPayloadResult {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Bool) async throws(JSException) -> AsyncPayloadResult) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Bool) async throws(JSException) -> AsyncPayloadResult>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    return _bjs_makePromise(resolve: Promise_resolve_18AsyncPayloadResultO, reject: Promise_reject) { () async throws(JSException) -> AsyncPayloadResult in
-        return try await closure(Bool.bridgeJSLiftParameter(param0))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestsYaSS_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (String) async -> String {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] (param0: String) async -> String in
-            #if arch(wasm32)
-            let resolved = try! await _bjs_awaitPromise(makeResolveClosure: {
-                    JSTypedClosure<(sending String) -> Void>($0)
-                }, makeRejectClosure: {
-                    JSTypedClosure<(sending JSValue) -> Void>($0)
-                }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
-                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
-                    invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
-                }
-            }
-            return resolved
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (String) async -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async -> String) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) {
-        return await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(resolveRef, rejectRef, callback, param0)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestsYaSd_9DataPointV {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Double) async -> DataPoint {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] (param0: Double) async -> DataPoint in
-            #if arch(wasm32)
-            let resolved = try! await _bjs_awaitPromise(makeResolveClosure: {
-                    JSTypedClosure<(sending DataPoint) -> Void>($0)
-                }, makeRejectClosure: {
-                    JSTypedClosure<(sending JSValue) -> Void>($0)
-                }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
-                let param0Value = param0.bridgeJSLowerParameter()
-                invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(resolveRef, rejectRef, callbackValue, param0Value)
-            }
-            return resolved
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (Double) async -> DataPoint {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Double) async -> DataPoint) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(_ boxPtr: UnsafeMutableRawPointer, _ param0: Float64) -> Int32 {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Double) async -> DataPoint>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    return _bjs_makePromise(resolve: Promise_resolve_9DataPointV, reject: Promise_reject) {
-        return await closure(Double.bridgeJSLiftParameter(param0))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y")
 fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
 #else
@@ -2443,128 +1988,6 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(_ callback: Int32, _ param0: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(callback, param0)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y {
-    static func bridgeJSLift(_ callbackId: Int32) -> (sending AsyncPayloadResult) -> Void {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0CaseId = param0.bridgeJSLowerParameter()
-            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(callbackValue, param0CaseId)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (sending AsyncPayloadResult) -> Void {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending AsyncPayloadResult) -> Void) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending AsyncPayloadResult) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    closure(AsyncPayloadResult.bridgeJSLiftParameter(param0))
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(_ callback: Int32, _ param0: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(callback, param0)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y {
-    static func bridgeJSLift(_ callbackId: Int32) -> (sending AsyncImportedPayloadResult) -> Void {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0CaseId = param0.bridgeJSLowerParameter()
-            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(callbackValue, param0CaseId)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (sending AsyncImportedPayloadResult) -> Void {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending AsyncImportedPayloadResult) -> Void) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending AsyncImportedPayloadResult) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    closure(AsyncImportedPayloadResult.bridgeJSLiftParameter(param0))
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss7JSValueV_y")
 fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss7JSValueV_y_extern(_ callback: Int32, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void
 #else
@@ -2620,67 +2043,6 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss7J
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending JSValue) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     closure(JSValue.bridgeJSLiftParameter(param0Kind, param0Payload1, param0Payload2))
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ callback: Int32) -> Void
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ callback: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(_ callback: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(callback)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestss9DataPointV_y {
-    static func bridgeJSLift(_ callbackId: Int32) -> (sending DataPoint) -> Void {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let _ = param0.bridgeJSLowerParameter()
-            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(callbackValue)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (sending DataPoint) -> Void {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending DataPoint) -> Void) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(_ boxPtr: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending DataPoint) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    closure(DataPoint.bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -3048,67 +2410,6 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSd
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending Double) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     closure(Double.bridgeJSLiftParameter(param0))
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(callback, param0IsSome, param0CaseId)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y {
-    static func bridgeJSLift(_ callbackId: Int32) -> (sending Optional<AsyncImportedPayloadResult>) -> Void {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let (param0IsSome, param0CaseId) = param0.bridgeJSLowerParameter()
-            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(callbackValue, param0IsSome, param0CaseId)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (sending Optional<AsyncImportedPayloadResult>) -> Void {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending Optional<AsyncImportedPayloadResult>) -> Void) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending Optional<AsyncImportedPayloadResult>) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    closure(Optional<AsyncImportedPayloadResult>.bridgeJSLiftParameter(param0IsSome, param0CaseId))
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -4094,6 +3395,91 @@ fileprivate func bjs_DataProcessor_optionalHelper_set_extern(_ jsObject: Int32, 
     return bjs_DataProcessor_optionalHelper_set_extern(jsObject, newValueIsSome, newValuePointer)
 }
 
+extension Severity: _BridgedSwiftCaseEnum {
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
+        return bridgeJSRawValue
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Severity {
+        return bridgeJSLiftParameter(value)
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Severity {
+        return Severity(bridgeJSRawValue: value)!
+    }
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
+        return bridgeJSLowerParameter()
+    }
+
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
+        switch bridgeJSRawValue {
+        case 0:
+            self = .notice
+        case 1:
+            self = .warning
+        case 2:
+            self = .error
+        default:
+            return nil
+        }
+    }
+
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
+        switch self {
+        case .notice:
+            return 0
+        case .warning:
+            return 1
+        case .error:
+            return 2
+        }
+    }
+}
+
+extension Shape: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Shape {
+        switch caseId {
+        case 0:
+            return .polygon(Polygon.bridgeFromJS(PolygonReference.bridgeJSStackPop()))
+        case 1:
+            return .empty
+        default:
+            fatalError("Unknown Shape case ID: \(caseId)")
+        }
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
+        switch self {
+        case .polygon(let param0):
+            param0.bridgeToJS().bridgeJSStackPush()
+            return Int32(0)
+        case .empty:
+            return Int32(1)
+        }
+    }
+}
+
+extension InnerTag: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> InnerTag {
+        switch caseId {
+        case 0:
+            return .payload(Int.bridgeJSStackPop())
+        case 1:
+            return .empty
+        default:
+            fatalError("Unknown InnerTag case ID: \(caseId)")
+        }
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
+        switch self {
+        case .payload(let param0):
+            param0.bridgeJSStackPush()
+            return Int32(0)
+        case .empty:
+            return Int32(1)
+        }
+    }
+}
+
 @_expose(wasm, "bjs_ArraySupportExports_static_roundTripIntArray")
 @_cdecl("bjs_ArraySupportExports_static_roundTripIntArray")
 public func _bjs_ArraySupportExports_static_roundTripIntArray() -> Void {
@@ -4578,34 +3964,6 @@ public func _bjs_ArraySupportExports_static_multiOptionalArraySecond() -> Void {
     #endif
 }
 
-extension AsyncImportedPayloadResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> AsyncImportedPayloadResult {
-        switch caseId {
-        case 0:
-            return .success(String.bridgeJSStackPop())
-        case 1:
-            return .failure(Int.bridgeJSStackPop())
-        case 2:
-            return .idle
-        default:
-            fatalError("Unknown AsyncImportedPayloadResult case ID: \(caseId)")
-        }
-    }
-
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
-        switch self {
-        case .success(let param0):
-            param0.bridgeJSStackPush()
-            return Int32(0)
-        case .failure(let param0):
-            param0.bridgeJSStackPush()
-            return Int32(1)
-        case .idle:
-            return Int32(2)
-        }
-    }
-}
-
 @_expose(wasm, "bjs_DefaultArgumentExports_static_testStringDefault")
 @_cdecl("bjs_DefaultArgumentExports_static_testStringDefault")
 public func _bjs_DefaultArgumentExports_static_testStringDefault(_ messageBytes: Int32, _ messageLength: Int32) -> Void {
@@ -4915,34 +4273,6 @@ extension TSDirection: _BridgedSwiftCaseEnum {
 }
 
 extension TSTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
-}
-
-extension AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> AsyncPayloadResult {
-        switch caseId {
-        case 0:
-            return .success(String.bridgeJSStackPop())
-        case 1:
-            return .failure(Int.bridgeJSStackPop())
-        case 2:
-            return .idle
-        default:
-            fatalError("Unknown AsyncPayloadResult case ID: \(caseId)")
-        }
-    }
-
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
-        switch self {
-        case .success(let param0):
-            param0.bridgeJSStackPush()
-            return Int32(0)
-        case .failure(let param0):
-            param0.bridgeJSStackPush()
-            return Int32(1)
-        case .idle:
-            return Int32(2)
-        }
-    }
 }
 
 @_expose(wasm, "bjs_Utils_StringUtils_static_uppercase")
@@ -5649,73 +4979,6 @@ public func _bjs_NestedStructGroupB_static_roundtripMetadata() -> Void {
     #endif
 }
 
-extension LightColor: _BridgedSwiftCaseEnum {
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
-        return bridgeJSRawValue
-    }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> LightColor {
-        return bridgeJSLiftParameter(value)
-    }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> LightColor {
-        return LightColor(bridgeJSRawValue: value)!
-    }
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
-        return bridgeJSLowerParameter()
-    }
-
-    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
-        switch bridgeJSRawValue {
-        case 0:
-            self = .red
-        case 1:
-            self = .yellow
-        case 2:
-            self = .green
-        default:
-            return nil
-        }
-    }
-
-    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
-        switch self {
-        case .red:
-            return 0
-        case .yellow:
-            return 1
-        case .green:
-            return 2
-        }
-    }
-}
-
-extension ImportedPayloadSignal: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> ImportedPayloadSignal {
-        switch caseId {
-        case 0:
-            return .start(String.bridgeJSStackPop())
-        case 1:
-            return .stop(Int.bridgeJSStackPop())
-        case 2:
-            return .idle
-        default:
-            fatalError("Unknown ImportedPayloadSignal case ID: \(caseId)")
-        }
-    }
-
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
-        switch self {
-        case .start(let param0):
-            param0.bridgeJSStackPush()
-            return Int32(0)
-        case .stop(let param0):
-            param0.bridgeJSStackPush()
-            return Int32(1)
-        case .idle:
-            return Int32(2)
-        }
-    }
-}
-
 @_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripInt")
 @_cdecl("bjs_IntegerTypesSupportExports_static_roundTripInt")
 public func _bjs_IntegerTypesSupportExports_static_roundTripInt(_ v: Int32) -> Int32 {
@@ -6268,6 +5531,122 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
             return Int32(2)
         }
     }
+}
+
+extension JSCoordinate: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> JSCoordinate {
+        let longitude = Double.bridgeJSStackPop()
+        let latitude = Double.bridgeJSStackPop()
+        return JSCoordinate(latitude: latitude, longitude: longitude)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.latitude.bridgeJSStackPush()
+        self.longitude.bridgeJSStackPush()
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_JSCoordinate(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_JSCoordinate()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_JSCoordinate")
+fileprivate func _bjs_struct_lower_JSCoordinate_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_JSCoordinate_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_JSCoordinate(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_JSCoordinate_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_JSCoordinate")
+fileprivate func _bjs_struct_lift_JSCoordinate_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_JSCoordinate_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_JSCoordinate() -> Int32 {
+    return _bjs_struct_lift_JSCoordinate_extern()
+}
+
+@_expose(wasm, "bjs_JSCoordinate_init")
+@_cdecl("bjs_JSCoordinate_init")
+public func _bjs_JSCoordinate_init(_ latitude: Float64, _ longitude: Float64) -> Void {
+    #if arch(wasm32)
+    let ret = JSCoordinate(latitude: Double.bridgeJSLiftParameter(latitude), longitude: Double.bridgeJSLiftParameter(longitude))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension SessionState: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> SessionState {
+        let token = String.bridgeJSStackPop()
+        return SessionState(token: token)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.token.bridgeJSStackPush()
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_SessionState(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_SessionState()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_SessionState")
+fileprivate func _bjs_struct_lower_SessionState_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_SessionState_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_SessionState(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_SessionState_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_SessionState")
+fileprivate func _bjs_struct_lift_SessionState_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_SessionState_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_SessionState() -> Int32 {
+    return _bjs_struct_lift_SessionState_extern()
+}
+
+@_expose(wasm, "bjs_SessionState_init")
+@_cdecl("bjs_SessionState_init")
+public func _bjs_SessionState_init(_ tokenBytes: Int32, _ tokenLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = SessionState(token: String.bridgeJSLiftParameter(tokenBytes, tokenLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
 }
 
 extension NestedStructGroupA.Metadata: _BridgedSwiftStruct {
@@ -7614,127 +6993,281 @@ public func _bjs_ArrayMembers_firstString() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_awaitAsyncCallback")
-@_cdecl("bjs_awaitAsyncCallback")
-public func _bjs_awaitAsyncCallback(_ fetch: Int32) -> Int32 {
+@_expose(wasm, "bjs_makeTag")
+@_cdecl("bjs_makeTag")
+public func _bjs_makeTag(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
-        return try await awaitAsyncCallback(_: _BJS_Closure_20BridgeJSRuntimeTestsYaKSS_SS.bridgeJSLift(fetch))
-    }
+    let ret = makeTag(_: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeAsyncParser")
-@_cdecl("bjs_makeAsyncParser")
-public func _bjs_makeAsyncParser() -> Int32 {
+@_expose(wasm, "bjs_roundTripPolygon")
+@_cdecl("bjs_roundTripPolygon")
+public func _bjs_roundTripPolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = makeAsyncParser()
+    let ret = roundTripPolygon(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_appendVertex")
+@_cdecl("bjs_appendVertex")
+public func _bjs_appendVertex(_ polygon: UnsafeMutableRawPointer, _ value: Float64) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = appendVertex(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)), _: Double.bridgeJSLiftParameter(value))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_optionalRoundTripPolygon")
+@_cdecl("bjs_optionalRoundTripPolygon")
+public func _bjs_optionalRoundTripPolygon(_ polygonIsSome: Int32, _ polygonValue: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = optionalRoundTripPolygon(_: Optional<PolygonReference>.bridgeJSLiftParameter(polygonIsSome, polygonValue).map { Polygon.bridgeFromJS($0) })
+    return ret.map { $0.bridgeToJS() }.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_polygonVertexCount")
+@_cdecl("bjs_polygonVertexCount")
+public func _bjs_polygonVertexCount(_ polygon: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = polygonVertexCount(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeAsyncEcho")
-@_cdecl("bjs_makeAsyncEcho")
-public func _bjs_makeAsyncEcho() -> Int32 {
+@_expose(wasm, "bjs_roundTripPolygonArray")
+@_cdecl("bjs_roundTripPolygonArray")
+public func _bjs_roundTripPolygonArray() -> Void {
     #if arch(wasm32)
-    let ret = makeAsyncEcho()
-    return ret.bridgeJSLowerReturn()
+    let ret = roundTripPolygonArray(_: [PolygonReference].bridgeJSStackPop().map { Polygon.bridgeFromJS($0) })
+    ret.map { $0.bridgeToJS() }.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeAsyncRecorder")
-@_cdecl("bjs_makeAsyncRecorder")
-public func _bjs_makeAsyncRecorder() -> Int32 {
+@_expose(wasm, "bjs_concatPolygons")
+@_cdecl("bjs_concatPolygons")
+public func _bjs_concatPolygons() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = makeAsyncRecorder()
-    return ret.bridgeJSLowerReturn()
+    let ret = concatPolygons(_: [PolygonReference].bridgeJSStackPop().map { Polygon.bridgeFromJS($0) })
+    return ret.bridgeToJS().bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_lastRecordedValue")
-@_cdecl("bjs_lastRecordedValue")
-public func _bjs_lastRecordedValue() -> Void {
-    #if arch(wasm32)
-    let ret = lastRecordedValue()
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_makeAsyncPayloadLoader")
-@_cdecl("bjs_makeAsyncPayloadLoader")
-public func _bjs_makeAsyncPayloadLoader() -> Int32 {
-    #if arch(wasm32)
-    let ret = makeAsyncPayloadLoader()
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_awaitPayloadCallback")
-@_cdecl("bjs_awaitPayloadCallback")
-public func _bjs_awaitPayloadCallback(_ load: Int32) -> Int32 {
-    #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
-        return try await awaitPayloadCallback(_: _BJS_Closure_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO.bridgeJSLift(load))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_makeAsyncPointMaker")
-@_cdecl("bjs_makeAsyncPointMaker")
-public func _bjs_makeAsyncPointMaker() -> Int32 {
-    #if arch(wasm32)
-    let ret = makeAsyncPointMaker()
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_makeThrowingParser")
-@_cdecl("bjs_makeThrowingParser")
-public func _bjs_makeThrowingParser() -> Int32 {
-    #if arch(wasm32)
-    let ret = makeThrowingParser()
-    return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_runValidator")
-@_cdecl("bjs_runValidator")
-public func _bjs_runValidator(_ validate: Int32) -> Int32 {
+@_expose(wasm, "bjs_validatePolygon")
+@_cdecl("bjs_validatePolygon")
+public func _bjs_validatePolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     do {
-        let ret = try runValidator(_: _BJS_Closure_20BridgeJSRuntimeTestsKSS_Sb.bridgeJSLift(validate))
-        return ret.bridgeJSLowerReturn()
+        let ret = try validatePolygon(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
+        return ret.bridgeToJS().bridgeJSLowerReturn()
     } catch let error {
         if let error = error.thrownValue.object {
             withExtendedLifetime(error) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: error.description)
+            let jsError = JSError(message: String(describing: error))
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         }
-        return 0
+        return UnsafeMutableRawPointer(bitPattern: -1).unsafelyUnwrapped
     }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_splitPolygon")
+@_cdecl("bjs_splitPolygon")
+public func _bjs_splitPolygon(_ polygon: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = splitPolygon(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
+    ret.map { $0.bridgeToJS() }.bridgeJSStackPush()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_incrementToken")
+@_cdecl("bjs_incrementToken")
+public func _bjs_incrementToken(_ token: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = incrementToken(_: Token.bridgeFromJS(TokenReference.bridgeJSLiftParameter(token)))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeToken")
+@_cdecl("bjs_makeToken")
+public func _bjs_makeToken(_ value: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = makeToken(_: Int.bridgeJSLiftParameter(value))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makePolygonInspector")
+@_cdecl("bjs_makePolygonInspector")
+public func _bjs_makePolygonInspector() -> Int32 {
+    #if arch(wasm32)
+    let ret = makePolygonInspector()
+    return JSTypedClosure(ret).bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncMakePolygon")
+@_cdecl("bjs_asyncMakePolygon")
+public func _bjs_asyncMakePolygon(_ labelBytes: Int32, _ labelLength: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSPromise.async {
+        return await asyncMakePolygon(_: String.bridgeJSLiftParameter(labelBytes, labelLength)).bridgeToJS().jsValue
+    }.jsObject
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripOptionalPolygonArray")
+@_cdecl("bjs_roundTripOptionalPolygonArray")
+public func _bjs_roundTripOptionalPolygonArray() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripOptionalPolygonArray(_: [Optional<PolygonReference>].bridgeJSStackPop().map { $0.map { Polygon.bridgeFromJS($0) } })
+    ret.map { $0.map { $0.bridgeToJS() } }.bridgeJSStackPush()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeTagHolder")
+@_cdecl("bjs_makeTagHolder")
+public func _bjs_makeTagHolder(_ nameBytes: Int32, _ nameLength: Int32, _ version: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = makeTagHolder(_: String.bridgeJSLiftParameter(nameBytes, nameLength), _: Int.bridgeJSLiftParameter(version))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripCoordinate")
+@_cdecl("bjs_roundTripCoordinate")
+public func _bjs_roundTripCoordinate() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripCoordinate(_: Coordinate.bridgeFromJS(JSCoordinate.bridgeJSLiftParameter()))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripPriority")
+@_cdecl("bjs_roundTripPriority")
+public func _bjs_roundTripPriority(_ priority: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = roundTripPriority(_: Priority.bridgeFromJS(PriorityReference.bridgeJSLiftParameter(priority)))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripAlert")
+@_cdecl("bjs_roundTripAlert")
+public func _bjs_roundTripAlert(_ alert: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = roundTripAlert(_: Alert.bridgeFromJS(Severity.bridgeJSLiftParameter(alert)))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAlert")
+@_cdecl("bjs_makeAlert")
+public func _bjs_makeAlert(_ level: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAlert(_: Severity.bridgeJSLiftParameter(level))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripSession")
+@_cdecl("bjs_roundTripSession")
+public func _bjs_roundTripSession() -> Void {
+    #if arch(wasm32)
+    let ret = roundTripSession(_: Session.bridgeFromJS(SessionState.bridgeJSLiftParameter()))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeSession")
+@_cdecl("bjs_makeSession")
+public func _bjs_makeSession(_ tokenBytes: Int32, _ tokenLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = makeSession(_: String.bridgeJSLiftParameter(tokenBytes, tokenLength))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_roundTripShape")
+@_cdecl("bjs_roundTripShape")
+public func _bjs_roundTripShape(_ s: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = roundTripShape(_: Shape.bridgeJSLiftParameter(s))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeShapePolygon")
+@_cdecl("bjs_makeShapePolygon")
+public func _bjs_makeShapePolygon(_ polygon: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = makeShapePolygon(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(polygon)))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeShapeEmpty")
+@_cdecl("bjs_makeShapeEmpty")
+public func _bjs_makeShapeEmpty() -> Void {
+    #if arch(wasm32)
+    let ret = makeShapeEmpty()
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7939,24 +7472,13 @@ public func _bjs_makeImportedFoo(_ valueBytes: Int32, _ valueLength: Int32) -> I
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: error.description)
+            let jsError = JSError(message: String(describing: error))
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         }
         return 0
     }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_roundTripOptionalImportedClass")
-@_cdecl("bjs_roundTripOptionalImportedClass")
-public func _bjs_roundTripOptionalImportedClass(_ vIsSome: Int32, _ vValue: Int32) -> Void {
-    #if arch(wasm32)
-    let ret = roundTripOptionalImportedClass(v: Optional<Foo>.bridgeJSLiftParameter(vIsSome, vValue))
-    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7974,7 +7496,7 @@ public func _bjs_throwsSwiftError(_ shouldThrow: Int32) -> Void {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: error.description)
+            let jsError = JSError(message: String(describing: error))
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7999,7 +7521,7 @@ public func _bjs_throwsWithIntResult() -> Int32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: error.description)
+            let jsError = JSError(message: String(describing: error))
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -8024,7 +7546,7 @@ public func _bjs_throwsWithStringResult() -> Void {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: error.description)
+            let jsError = JSError(message: String(describing: error))
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -8049,7 +7571,7 @@ public func _bjs_throwsWithBoolResult() -> Int32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: error.description)
+            let jsError = JSError(message: String(describing: error))
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -8074,7 +7596,7 @@ public func _bjs_throwsWithFloatResult() -> Float32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: error.description)
+            let jsError = JSError(message: String(describing: error))
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -8099,7 +7621,7 @@ public func _bjs_throwsWithDoubleResult() -> Float64 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: error.description)
+            let jsError = JSError(message: String(describing: error))
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -8124,7 +7646,7 @@ public func _bjs_throwsWithSwiftHeapObjectResult() -> UnsafeMutableRawPointer {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: error.description)
+            let jsError = JSError(message: String(describing: error))
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -8149,7 +7671,7 @@ public func _bjs_throwsWithJSObjectResult() -> Int32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: error.description)
+            let jsError = JSError(message: String(describing: error))
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -8161,27 +7683,14 @@ public func _bjs_throwsWithJSObjectResult() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_zeroArgAsyncThrows")
-@_cdecl("bjs_zeroArgAsyncThrows")
-public func _bjs_zeroArgAsyncThrows() -> Int32 {
-    #if arch(wasm32)
-    let __bjs_capture = 0
-    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { [__bjs_capture] () async throws(JSException) -> String in
-        _ = __bjs_capture
-        return try await zeroArgAsyncThrows()
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
 @_expose(wasm, "bjs_asyncRoundTripVoid")
 @_cdecl("bjs_asyncRoundTripVoid")
 public func _bjs_asyncRoundTripVoid() -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_y, reject: Promise_reject) {
+    let ret = JSPromise.async {
         await asyncRoundTripVoid()
-    }
+    }.jsObject
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8191,9 +7700,10 @@ public func _bjs_asyncRoundTripVoid() -> Int32 {
 @_cdecl("bjs_asyncRoundTripInt")
 public func _bjs_asyncRoundTripInt(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_Si, reject: Promise_reject) {
-        return await asyncRoundTripInt(v: Int.bridgeJSLiftParameter(v))
-    }
+    let ret = JSPromise.async {
+        return await asyncRoundTripInt(v: Int.bridgeJSLiftParameter(v)).jsValue
+    }.jsObject
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8203,9 +7713,10 @@ public func _bjs_asyncRoundTripInt(_ v: Int32) -> Int32 {
 @_cdecl("bjs_asyncRoundTripFloat")
 public func _bjs_asyncRoundTripFloat(_ v: Float32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_Sf, reject: Promise_reject) {
-        return await asyncRoundTripFloat(v: Float.bridgeJSLiftParameter(v))
-    }
+    let ret = JSPromise.async {
+        return await asyncRoundTripFloat(v: Float.bridgeJSLiftParameter(v)).jsValue
+    }.jsObject
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8215,9 +7726,10 @@ public func _bjs_asyncRoundTripFloat(_ v: Float32) -> Int32 {
 @_cdecl("bjs_asyncRoundTripDouble")
 public func _bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_Sd, reject: Promise_reject) {
-        return await asyncRoundTripDouble(v: Double.bridgeJSLiftParameter(v))
-    }
+    let ret = JSPromise.async {
+        return await asyncRoundTripDouble(v: Double.bridgeJSLiftParameter(v)).jsValue
+    }.jsObject
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8227,9 +7739,10 @@ public func _bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
 @_cdecl("bjs_asyncRoundTripBool")
 public func _bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_Sb, reject: Promise_reject) {
-        return await asyncRoundTripBool(v: Bool.bridgeJSLiftParameter(v))
-    }
+    let ret = JSPromise.async {
+        return await asyncRoundTripBool(v: Bool.bridgeJSLiftParameter(v)).jsValue
+    }.jsObject
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8239,9 +7752,10 @@ public func _bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
 @_cdecl("bjs_asyncRoundTripString")
 public func _bjs_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) {
-        return await asyncRoundTripString(v: String.bridgeJSLiftParameter(vBytes, vLength))
-    }
+    let ret = JSPromise.async {
+        return await asyncRoundTripString(v: String.bridgeJSLiftParameter(vBytes, vLength)).jsValue
+    }.jsObject
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8251,9 +7765,10 @@ public func _bjs_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int3
 @_cdecl("bjs_asyncRoundTripSwiftHeapObject")
 public func _bjs_asyncRoundTripSwiftHeapObject(_ v: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_7GreeterC, reject: Promise_reject) {
-        return await asyncRoundTripSwiftHeapObject(v: Greeter.bridgeJSLiftParameter(v))
-    }
+    let ret = JSPromise.async {
+        return await asyncRoundTripSwiftHeapObject(v: Greeter.bridgeJSLiftParameter(v)).jsValue
+    }.jsObject
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8263,9 +7778,10 @@ public func _bjs_asyncRoundTripSwiftHeapObject(_ v: UnsafeMutableRawPointer) -> 
 @_cdecl("bjs_asyncRoundTripJSObject")
 public func _bjs_asyncRoundTripJSObject(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_8JSObjectC, reject: Promise_reject) {
-        return await asyncRoundTripJSObject(v: JSObject.bridgeJSLiftParameter(v))
-    }
+    let ret = JSPromise.async {
+        return await asyncRoundTripJSObject(v: JSObject.bridgeJSLiftParameter(v)).jsValue
+    }.jsObject
+    return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8386,156 +7902,6 @@ public func _bjs_getTheme() -> Void {
     #if arch(wasm32)
     let ret = getTheme()
     return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripTheme")
-@_cdecl("bjs_asyncRoundTripTheme")
-public func _bjs_asyncRoundTripTheme(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
-    #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_5ThemeO, reject: Promise_reject) {
-        return await asyncRoundTripTheme(_: Theme.bridgeJSLiftParameter(vBytes, vLength))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripDirection")
-@_cdecl("bjs_asyncRoundTripDirection")
-public func _bjs_asyncRoundTripDirection(_ v: Int32) -> Int32 {
-    #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_9DirectionO, reject: Promise_reject) {
-        return await asyncRoundTripDirection(_: Direction.bridgeJSLiftParameter(v))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripOptionalTheme")
-@_cdecl("bjs_asyncRoundTripOptionalTheme")
-public func _bjs_asyncRoundTripOptionalTheme(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Int32 {
-    #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_Sq5ThemeO, reject: Promise_reject) {
-        return await asyncRoundTripOptionalTheme(_: Optional<Theme>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripOptionalDirection")
-@_cdecl("bjs_asyncRoundTripOptionalDirection")
-public func _bjs_asyncRoundTripOptionalDirection(_ vIsSome: Int32, _ vValue: Int32) -> Int32 {
-    #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_Sq9DirectionO, reject: Promise_reject) {
-        return await asyncRoundTripOptionalDirection(_: Optional<Direction>.bridgeJSLiftParameter(vIsSome, vValue))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripDirectionArray")
-@_cdecl("bjs_asyncRoundTripDirectionArray")
-public func _bjs_asyncRoundTripDirectionArray() -> Int32 {
-    #if arch(wasm32)
-    let _tmp_v = [Direction].bridgeJSStackPop()
-    return _bjs_makePromise(resolve: Promise_resolve_Sa9DirectionO, reject: Promise_reject) {
-        return await asyncRoundTripDirectionArray(_: _tmp_v)
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripDirectionDict")
-@_cdecl("bjs_asyncRoundTripDirectionDict")
-public func _bjs_asyncRoundTripDirectionDict() -> Int32 {
-    #if arch(wasm32)
-    let _tmp_v = [String: Direction].bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_SD9DirectionO, reject: Promise_reject) {
-        return await asyncRoundTripDirectionDict(_: _tmp_v)
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripThemeArray")
-@_cdecl("bjs_asyncRoundTripThemeArray")
-public func _bjs_asyncRoundTripThemeArray() -> Int32 {
-    #if arch(wasm32)
-    let _tmp_v = [Theme].bridgeJSStackPop()
-    return _bjs_makePromise(resolve: Promise_resolve_Sa5ThemeO, reject: Promise_reject) {
-        return await asyncRoundTripThemeArray(_: _tmp_v)
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripThemeDict")
-@_cdecl("bjs_asyncRoundTripThemeDict")
-public func _bjs_asyncRoundTripThemeDict() -> Int32 {
-    #if arch(wasm32)
-    let _tmp_v = [String: Theme].bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_SD5ThemeO, reject: Promise_reject) {
-        return await asyncRoundTripThemeDict(_: _tmp_v)
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripFileSize")
-@_cdecl("bjs_asyncRoundTripFileSize")
-public func _bjs_asyncRoundTripFileSize(_ v: Int64) -> Int32 {
-    #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_8FileSizeO, reject: Promise_reject) {
-        return await asyncRoundTripFileSize(_: FileSize.bridgeJSLiftParameter(v))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripOptionalFileSize")
-@_cdecl("bjs_asyncRoundTripOptionalFileSize")
-public func _bjs_asyncRoundTripOptionalFileSize(_ vIsSome: Int32, _ vValue: Int64) -> Int32 {
-    #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_Sq8FileSizeO, reject: Promise_reject) {
-        return await asyncRoundTripOptionalFileSize(_: Optional<FileSize>.bridgeJSLiftParameter(vIsSome, vValue))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripAssociatedValueEnum")
-@_cdecl("bjs_asyncRoundTripAssociatedValueEnum")
-public func _bjs_asyncRoundTripAssociatedValueEnum(_ v: Int32) -> Int32 {
-    #if arch(wasm32)
-    let _tmp_v = AsyncPayloadResult.bridgeJSLiftParameter(v)
-    return _bjs_makePromise(resolve: Promise_resolve_18AsyncPayloadResultO, reject: Promise_reject) {
-        return await asyncRoundTripAssociatedValueEnum(_: _tmp_v)
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripOptionalAssociatedValueEnum")
-@_cdecl("bjs_asyncRoundTripOptionalAssociatedValueEnum")
-public func _bjs_asyncRoundTripOptionalAssociatedValueEnum(_ vIsSome: Int32, _ vCaseId: Int32) -> Int32 {
-    #if arch(wasm32)
-    let _tmp_v = Optional<AsyncPayloadResult>.bridgeJSLiftParameter(vIsSome, vCaseId)
-    return _bjs_makePromise(resolve: Promise_resolve_Sq18AsyncPayloadResultO, reject: Promise_reject) {
-        return await asyncRoundTripOptionalAssociatedValueEnum(_: _tmp_v)
-    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -9189,110 +8555,6 @@ public func _bjs_roundTripPublicPoint() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripPublicPoint")
-@_cdecl("bjs_asyncRoundTripPublicPoint")
-public func _bjs_asyncRoundTripPublicPoint() -> Int32 {
-    #if arch(wasm32)
-    let _tmp_point = PublicPoint.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) {
-        return await asyncRoundTripPublicPoint(_: _tmp_point)
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripPublicPointThrows")
-@_cdecl("bjs_asyncRoundTripPublicPointThrows")
-public func _bjs_asyncRoundTripPublicPointThrows() -> Int32 {
-    #if arch(wasm32)
-    let _tmp_point = PublicPoint.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) { () async throws(JSException) -> PublicPoint in
-        return try await asyncRoundTripPublicPointThrows(_: _tmp_point)
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncStructOrThrow")
-@_cdecl("bjs_asyncStructOrThrow")
-public func _bjs_asyncStructOrThrow(_ shouldThrow: Int32) -> Int32 {
-    #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) { () async throws(JSException) -> PublicPoint in
-        return try await asyncStructOrThrow(_: Bool.bridgeJSLiftParameter(shouldThrow))
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncCombinePublicPoints")
-@_cdecl("bjs_asyncCombinePublicPoints")
-public func _bjs_asyncCombinePublicPoints() -> Int32 {
-    #if arch(wasm32)
-    let _tmp_b = PublicPoint.bridgeJSLiftParameter()
-    let _tmp_a = PublicPoint.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) {
-        return await asyncCombinePublicPoints(_: _tmp_a, _: _tmp_b)
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripContact")
-@_cdecl("bjs_asyncRoundTripContact")
-public func _bjs_asyncRoundTripContact() -> Int32 {
-    #if arch(wasm32)
-    let _tmp_contact = Contact.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_7ContactV, reject: Promise_reject) {
-        return await asyncRoundTripContact(_: _tmp_contact)
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripPublicPointArray")
-@_cdecl("bjs_asyncRoundTripPublicPointArray")
-public func _bjs_asyncRoundTripPublicPointArray() -> Int32 {
-    #if arch(wasm32)
-    let _tmp_points = [PublicPoint].bridgeJSStackPop()
-    return _bjs_makePromise(resolve: Promise_resolve_Sa11PublicPointV, reject: Promise_reject) {
-        return await asyncRoundTripPublicPointArray(_: _tmp_points)
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripOptionalPublicPoint")
-@_cdecl("bjs_asyncRoundTripOptionalPublicPoint")
-public func _bjs_asyncRoundTripOptionalPublicPoint() -> Int32 {
-    #if arch(wasm32)
-    let _tmp_point = Optional<PublicPoint>.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_Sq11PublicPointV, reject: Promise_reject) {
-        return await asyncRoundTripOptionalPublicPoint(_: _tmp_point)
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_asyncRoundTripPublicPointDict")
-@_cdecl("bjs_asyncRoundTripPublicPointDict")
-public func _bjs_asyncRoundTripPublicPointDict() -> Int32 {
-    #if arch(wasm32)
-    let _tmp_points = [String: PublicPoint].bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_SD11PublicPointV, reject: Promise_reject) {
-        return await asyncRoundTripPublicPointDict(_: _tmp_points)
-    }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
 @_expose(wasm, "bjs_roundTripContact")
 @_cdecl("bjs_roundTripContact")
 public func _bjs_roundTripContact() -> Void {
@@ -9440,6 +8702,379 @@ public func _bjs_arrayMembersFirst() -> Void {
     #else
     fatalError("Only available on WebAssembly")
     #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_init")
+@_cdecl("bjs_PolygonReference_init")
+public func _bjs_PolygonReference_init(_ labelBytes: Int32, _ labelLength: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = PolygonReference(verticesData: [Double].bridgeJSStackPop(), label: String.bridgeJSLiftParameter(labelBytes, labelLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_vertexCount")
+@_cdecl("bjs_PolygonReference_vertexCount")
+public func _bjs_PolygonReference_vertexCount(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = PolygonReference.bridgeJSLiftParameter(_self).vertexCount()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_summary")
+@_cdecl("bjs_PolygonReference_summary")
+public func _bjs_PolygonReference_summary(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = PolygonReference.bridgeJSLiftParameter(_self).summary()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_snapshot")
+@_cdecl("bjs_PolygonReference_snapshot")
+public func _bjs_PolygonReference_snapshot(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = PolygonReference.bridgeJSLiftParameter(_self).snapshot()
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_merge")
+@_cdecl("bjs_PolygonReference_merge")
+public func _bjs_PolygonReference_merge(_ _self: UnsafeMutableRawPointer, _ other: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = PolygonReference.bridgeJSLiftParameter(_self).merge(_: Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftParameter(other)))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_static_origin")
+@_cdecl("bjs_PolygonReference_static_origin")
+public func _bjs_PolygonReference_static_origin(_ labelBytes: Int32, _ labelLength: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = PolygonReference.origin(label: String.bridgeJSLiftParameter(labelBytes, labelLength))
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PolygonReference_deinit")
+@_cdecl("bjs_PolygonReference_deinit")
+public func _bjs_PolygonReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<PolygonReference>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension PolygonReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_PolygonReference_wrap")
+fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_PolygonReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_PolygonReference_wrap_extern(pointer)
+}
+
+@_expose(wasm, "bjs_TagReference_describe")
+@_cdecl("bjs_TagReference_describe")
+public func _bjs_TagReference_describe(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = TagReference.bridgeJSLiftParameter(_self).describe()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_TagReference_deinit")
+@_cdecl("bjs_TagReference_deinit")
+public func _bjs_TagReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<TagReference>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension TagReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TagReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_TagReference_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_TagReference_wrap")
+fileprivate func _bjs_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_TagReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TagReference_wrap_extern(pointer)
+}
+
+@_expose(wasm, "bjs_TokenReference_init")
+@_cdecl("bjs_TokenReference_init")
+public func _bjs_TokenReference_init(_ value: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = TokenReference(value: Int.bridgeJSLiftParameter(value))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_TokenReference_read")
+@_cdecl("bjs_TokenReference_read")
+public func _bjs_TokenReference_read(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = TokenReference.bridgeJSLiftParameter(_self).read()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_TokenReference_deinit")
+@_cdecl("bjs_TokenReference_deinit")
+public func _bjs_TokenReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<TokenReference>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension TokenReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TokenReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_TokenReference_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_TokenReference_wrap")
+fileprivate func _bjs_TokenReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_TokenReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_TokenReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TokenReference_wrap_extern(pointer)
+}
+
+@_expose(wasm, "bjs_TagHolderReference_init")
+@_cdecl("bjs_TagHolderReference_init")
+public func _bjs_TagHolderReference_init(_ tag: UnsafeMutableRawPointer, _ version: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = TagHolderReference(tag: Tag.bridgeFromJS(TagReference.bridgeJSLiftParameter(tag)), version: Int.bridgeJSLiftParameter(version))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_TagHolderReference_describe")
+@_cdecl("bjs_TagHolderReference_describe")
+public func _bjs_TagHolderReference_describe(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = TagHolderReference.bridgeJSLiftParameter(_self).describe()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_TagHolderReference_tag_get")
+@_cdecl("bjs_TagHolderReference_tag_get")
+public func _bjs_TagHolderReference_tag_get(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = TagHolderReference.bridgeJSLiftParameter(_self).tag
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_TagHolderReference_tag_set")
+@_cdecl("bjs_TagHolderReference_tag_set")
+public func _bjs_TagHolderReference_tag_set(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    TagHolderReference.bridgeJSLiftParameter(_self).tag = Tag.bridgeFromJS(TagReference.bridgeJSLiftParameter(value))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_TagHolderReference_version_get")
+@_cdecl("bjs_TagHolderReference_version_get")
+public func _bjs_TagHolderReference_version_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = TagHolderReference.bridgeJSLiftParameter(_self).version
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_TagHolderReference_version_set")
+@_cdecl("bjs_TagHolderReference_version_set")
+public func _bjs_TagHolderReference_version_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+    #if arch(wasm32)
+    TagHolderReference.bridgeJSLiftParameter(_self).version = Int.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_TagHolderReference_deinit")
+@_cdecl("bjs_TagHolderReference_deinit")
+public func _bjs_TagHolderReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<TagHolderReference>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension TagHolderReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TagHolderReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_TagHolderReference_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_TagHolderReference_wrap")
+fileprivate func _bjs_TagHolderReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_TagHolderReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_TagHolderReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TagHolderReference_wrap_extern(pointer)
+}
+
+@_expose(wasm, "bjs_PriorityReference_describe")
+@_cdecl("bjs_PriorityReference_describe")
+public func _bjs_PriorityReference_describe(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = PriorityReference.bridgeJSLiftParameter(_self).describe()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PriorityReference_weight")
+@_cdecl("bjs_PriorityReference_weight")
+public func _bjs_PriorityReference_weight(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = PriorityReference.bridgeJSLiftParameter(_self).weight()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PriorityReference_static_low")
+@_cdecl("bjs_PriorityReference_static_low")
+public func _bjs_PriorityReference_static_low() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = PriorityReference.low()
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PriorityReference_static_medium")
+@_cdecl("bjs_PriorityReference_static_medium")
+public func _bjs_PriorityReference_static_medium() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = PriorityReference.medium()
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PriorityReference_static_high")
+@_cdecl("bjs_PriorityReference_static_high")
+public func _bjs_PriorityReference_static_high() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = PriorityReference.high()
+    return ret.bridgeToJS().bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_PriorityReference_deinit")
+@_cdecl("bjs_PriorityReference_deinit")
+public func _bjs_PriorityReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<PriorityReference>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension PriorityReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_PriorityReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_PriorityReference_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_PriorityReference_wrap")
+fileprivate func _bjs_PriorityReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_PriorityReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_PriorityReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_PriorityReference_wrap_extern(pointer)
 }
 
 @_expose(wasm, "bjs_ClosureSupportExports_static_makeIntToInt")
@@ -9897,18 +9532,6 @@ public func _bjs_Calculator_add(_ _self: UnsafeMutableRawPointer, _ a: Int32, _ 
     #if arch(wasm32)
     let ret = Calculator.bridgeJSLiftParameter(_self).add(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_Calculator_asyncMakePoint")
-@_cdecl("bjs_Calculator_asyncMakePoint")
-public func _bjs_Calculator_asyncMakePoint(_ _self: UnsafeMutableRawPointer, _ x: Int32, _ y: Int32) -> Int32 {
-    #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) {
-        return await Calculator.bridgeJSLiftParameter(_self).asyncMakePoint(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
-    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -12394,573 +12017,194 @@ fileprivate func _bjs_LeakCheck_wrap_extern(_ pointer: UnsafeMutableRawPointer) 
     return _bjs_LeakCheck_wrap_extern(pointer)
 }
 
-@JSFunction func Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException)
-
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_reject_BridgeJSRuntimeTests")
-fileprivate func promise_reject_BridgeJSRuntimeTests_extern(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Surface_init")
+fileprivate func bjs_Surface_init_extern(_ labelBytes: Int32, _ labelLength: Int32) -> Int32
 #else
-fileprivate func promise_reject_BridgeJSRuntimeTests_extern(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+fileprivate func bjs_Surface_init_extern(_ labelBytes: Int32, _ labelLength: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_reject_BridgeJSRuntimeTests(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
-    return promise_reject_BridgeJSRuntimeTests_extern(promise, valueKind, valuePayload1, valuePayload2)
+@inline(never) fileprivate func bjs_Surface_init(_ labelBytes: Int32, _ labelLength: Int32) -> Int32 {
+    return bjs_Surface_init_extern(labelBytes, labelLength)
 }
-
-func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let (valueKind, valuePayload1, valuePayload2) = value.bridgeJSLowerParameter()
-    promise_reject_BridgeJSRuntimeTests(promiseValue, valueKind, valuePayload1, valuePayload2)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SS")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Surface_label_get")
+fileprivate func bjs_Surface_label_get_extern(_ self: Int32) -> Int32
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+fileprivate func bjs_Surface_label_get_extern(_ self: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SS(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_SS_extern(promise, valueBytes, valueLength)
+@inline(never) fileprivate func bjs_Surface_label_get(_ self: Int32) -> Int32 {
+    return bjs_Surface_label_get_extern(self)
 }
 
-func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
-        promise_resolve_BridgeJSRuntimeTests_SS(promiseValue, valueBytes, valueLength)
+func _$Surface_init(_ label: String) throws(JSException) -> JSObject {
+    let ret0 = label.bridgeJSWithLoweredParameter { (labelBytes, labelLength) in
+        let ret = bjs_Surface_init(labelBytes, labelLength)
+        return ret
     }
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_y(_ promise: JSObject) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_y")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_y_extern(_ promise: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_y_extern(_ promise: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_y(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_y_extern(promise)
-}
-
-func _$Promise_resolve_y(_ promise: JSObject) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_y(promiseValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_Si(_ promise: JSObject, _ value: Int) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Si")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Si_extern(_ promise: Int32, _ value: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Si_extern(_ promise: Int32, _ value: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Si(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Si_extern(promise, value)
-}
-
-func _$Promise_resolve_Si(_ promise: JSObject, _ value: Int) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valueValue = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Si(promiseValue, valueValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_Sf(_ promise: JSObject, _ value: Float) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sf")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sf_extern(_ promise: Int32, _ value: Float32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sf_extern(_ promise: Int32, _ value: Float32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sf(_ promise: Int32, _ value: Float32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sf_extern(promise, value)
-}
-
-func _$Promise_resolve_Sf(_ promise: JSObject, _ value: Float) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valueValue = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sf(promiseValue, valueValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_Sd(_ promise: JSObject, _ value: Double) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sd")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sd_extern(_ promise: Int32, _ value: Float64) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sd_extern(_ promise: Int32, _ value: Float64) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sd(_ promise: Int32, _ value: Float64) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sd_extern(promise, value)
-}
-
-func _$Promise_resolve_Sd(_ promise: JSObject, _ value: Double) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valueValue = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sd(promiseValue, valueValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_Sb(_ promise: JSObject, _ value: Bool) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sb")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sb_extern(_ promise: Int32, _ value: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sb_extern(_ promise: Int32, _ value: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sb(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sb_extern(promise, value)
-}
-
-func _$Promise_resolve_Sb(_ promise: JSObject, _ value: Bool) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valueValue = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sb(promiseValue, valueValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_7GreeterC(_ promise: JSObject, _ value: Greeter) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_7GreeterC")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(promise, value)
-}
-
-func _$Promise_resolve_7GreeterC(_ promise: JSObject, _ value: Greeter) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valuePointer = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_7GreeterC(promiseValue, valuePointer)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_8JSObjectC(_ promise: JSObject, _ value: JSObject) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_8JSObjectC")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_8JSObjectC_extern(_ promise: Int32, _ value: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_8JSObjectC_extern(_ promise: Int32, _ value: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_8JSObjectC(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_8JSObjectC_extern(promise, value)
-}
-
-func _$Promise_resolve_8JSObjectC(_ promise: JSObject, _ value: JSObject) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valueValue = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_8JSObjectC(promiseValue, valueValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_5ThemeO(_ promise: JSObject, _ value: Theme) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_5ThemeO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(promise, valueBytes, valueLength)
-}
-
-func _$Promise_resolve_5ThemeO(_ promise: JSObject, _ value: Theme) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
-        promise_resolve_BridgeJSRuntimeTests_5ThemeO(promiseValue, valueBytes, valueLength)
+    let ret = ret0
+    if let error = _swift_js_take_exception() {
+        throw error
     }
-    if let error = _swift_js_take_exception() { throw error }
+    return JSObject.bridgeJSLiftReturn(ret)
 }
 
-@JSFunction func Promise_resolve_9DirectionO(_ promise: JSObject, _ value: Direction) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_9DirectionO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(_ promise: Int32, _ value: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(_ promise: Int32, _ value: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(promise, value)
-}
-
-func _$Promise_resolve_9DirectionO(_ promise: JSObject, _ value: Direction) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valueValue = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_9DirectionO(promiseValue, valueValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_Sq5ThemeO(_ promise: JSObject, _ value: Optional<Theme>) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(promise, valueIsSome, valueBytes, valueLength)
-}
-
-func _$Promise_resolve_Sq5ThemeO(_ promise: JSObject, _ value: Optional<Theme>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    value.bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
-        promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO(promiseValue, valueIsSome, valueBytes, valueLength)
+func _$Surface_label_get(_ self: JSObject) throws(JSException) -> String {
+    let selfValue = self.bridgeJSLowerParameter()
+    let ret = bjs_Surface_label_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
     }
-    if let error = _swift_js_take_exception() { throw error }
+    return String.bridgeJSLiftReturn(ret)
 }
 
-@JSFunction func Promise_resolve_Sq9DirectionO(_ promise: JSObject, _ value: Optional<Direction>) throws(JSException)
-
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_AliasImports_jsRoundTripTagged_static")
+fileprivate func bjs_AliasImports_jsRoundTripTagged_static_extern(_ valueBytes: Int32, _ valueLength: Int32) -> Int32
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+fileprivate func bjs_AliasImports_jsRoundTripTagged_static_extern(_ valueBytes: Int32, _ valueLength: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(promise, valueIsSome, valueValue)
+@inline(never) fileprivate func bjs_AliasImports_jsRoundTripTagged_static(_ valueBytes: Int32, _ valueLength: Int32) -> Int32 {
+    return bjs_AliasImports_jsRoundTripTagged_static_extern(valueBytes, valueLength)
 }
-
-func _$Promise_resolve_Sq9DirectionO(_ promise: JSObject, _ value: Optional<Direction>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO(promiseValue, valueIsSome, valueValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_Sa9DirectionO(_ promise: JSObject, _ value: [Direction]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_AliasImports_jsRoundTripOptionalTagged_static")
+fileprivate func bjs_AliasImports_jsRoundTripOptionalTagged_static_extern(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(_ promise: Int32) -> Void {
+fileprivate func bjs_AliasImports_jsRoundTripOptionalTagged_static_extern(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(promise)
+@inline(never) fileprivate func bjs_AliasImports_jsRoundTripOptionalTagged_static(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return bjs_AliasImports_jsRoundTripOptionalTagged_static_extern(valueIsSome, valueBytes, valueLength)
 }
-
-func _$Promise_resolve_Sa9DirectionO(_ promise: JSObject, _ value: [Direction]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let _ = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO(promiseValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_SD9DirectionO(_ promise: JSObject, _ value: [String: Direction]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD9DirectionO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_AliasImports_jsProduceOptionalCanvas_static")
+fileprivate func bjs_AliasImports_jsProduceOptionalCanvas_static_extern(_ labelIsSome: Int32, _ labelBytes: Int32, _ labelLength: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(_ promise: Int32) -> Void {
+fileprivate func bjs_AliasImports_jsProduceOptionalCanvas_static_extern(_ labelIsSome: Int32, _ labelBytes: Int32, _ labelLength: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(promise)
+@inline(never) fileprivate func bjs_AliasImports_jsProduceOptionalCanvas_static(_ labelIsSome: Int32, _ labelBytes: Int32, _ labelLength: Int32) -> Void {
+    return bjs_AliasImports_jsProduceOptionalCanvas_static_extern(labelIsSome, labelBytes, labelLength)
 }
-
-func _$Promise_resolve_SD9DirectionO(_ promise: JSObject, _ value: [String: Direction]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let _ = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_SD9DirectionO(promiseValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_Sa5ThemeO(_ promise: JSObject, _ value: [Theme]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_AliasImports_jsRoundTripAliasedTags_static")
+fileprivate func bjs_AliasImports_jsRoundTripAliasedTags_static_extern() -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(_ promise: Int32) -> Void {
+fileprivate func bjs_AliasImports_jsRoundTripAliasedTags_static_extern() -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(promise)
+@inline(never) fileprivate func bjs_AliasImports_jsRoundTripAliasedTags_static() -> Void {
+    return bjs_AliasImports_jsRoundTripAliasedTags_static_extern()
 }
-
-func _$Promise_resolve_Sa5ThemeO(_ promise: JSObject, _ value: [Theme]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let _ = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO(promiseValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_SD5ThemeO(_ promise: JSObject, _ value: [String: Theme]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD5ThemeO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_AliasImports_jsRoundTripPolygon_static")
+fileprivate func bjs_AliasImports_jsRoundTripPolygon_static_extern(_ value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(_ promise: Int32) -> Void {
+fileprivate func bjs_AliasImports_jsRoundTripPolygon_static_extern(_ value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(promise)
+@inline(never) fileprivate func bjs_AliasImports_jsRoundTripPolygon_static(_ value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    return bjs_AliasImports_jsRoundTripPolygon_static_extern(value)
 }
-
-func _$Promise_resolve_SD5ThemeO(_ promise: JSObject, _ value: [String: Theme]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let _ = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_SD5ThemeO(promiseValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_8FileSizeO(_ promise: JSObject, _ value: FileSize) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_8FileSizeO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(_ promise: Int32, _ value: Int64) -> Void
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_AliasImports_jsRoundTripCoordinate_static")
+fileprivate func bjs_AliasImports_jsRoundTripCoordinate_static_extern(_ value: Int32) -> Int32
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(_ promise: Int32, _ value: Int64) -> Void {
+fileprivate func bjs_AliasImports_jsRoundTripCoordinate_static_extern(_ value: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO(_ promise: Int32, _ value: Int64) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(promise, value)
+@inline(never) fileprivate func bjs_AliasImports_jsRoundTripCoordinate_static(_ value: Int32) -> Int32 {
+    return bjs_AliasImports_jsRoundTripCoordinate_static_extern(value)
 }
 
-func _$Promise_resolve_8FileSizeO(_ promise: JSObject, _ value: FileSize) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valueValue = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_8FileSizeO(promiseValue, valueValue)
-    if let error = _swift_js_take_exception() { throw error }
+func _$AliasImports_jsRoundTripTagged(_ value: Tagged) throws(JSException) -> Tagged {
+    let ret0 = value.bridgeToJS().bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        let ret = bjs_AliasImports_jsRoundTripTagged_static(valueBytes, valueLength)
+        return ret
+    }
+    let ret = ret0
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Tagged.bridgeFromJS(String.bridgeJSLiftReturn(ret))
 }
 
-@JSFunction func Promise_resolve_Sq8FileSizeO(_ promise: JSObject, _ value: Optional<FileSize>) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(promise, valueIsSome, valueValue)
-}
-
-func _$Promise_resolve_Sq8FileSizeO(_ promise: JSObject, _ value: Optional<FileSize>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO(promiseValue, valueIsSome, valueValue)
-    if let error = _swift_js_take_exception() { throw error }
+func _$AliasImports_jsRoundTripOptionalTagged(_ value: Optional<Tagged>) throws(JSException) -> Optional<Tagged> {
+    value.map {
+        $0.bridgeToJS()
+    } .bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
+        bjs_AliasImports_jsRoundTripOptionalTagged_static(valueIsSome, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<String>.bridgeJSLiftReturnFromSideChannel().map {
+        Tagged.bridgeFromJS($0)
+    }
 }
 
-@JSFunction func Promise_resolve_18AsyncPayloadResultO(_ promise: JSObject, _ value: AsyncPayloadResult) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO_extern(_ promise: Int32, _ value: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO_extern(_ promise: Int32, _ value: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO_extern(promise, value)
+func _$AliasImports_jsProduceOptionalCanvas(_ label: Optional<String>) throws(JSException) -> Optional<Canvas> {
+    label.bridgeJSWithLoweredParameter { (labelIsSome, labelBytes, labelLength) in
+        bjs_AliasImports_jsProduceOptionalCanvas_static(labelIsSome, labelBytes, labelLength)
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<Surface>.bridgeJSLiftReturn().map {
+        Canvas.bridgeFromJS($0)
+    }
 }
 
-func _$Promise_resolve_18AsyncPayloadResultO(_ promise: JSObject, _ value: AsyncPayloadResult) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valueCaseId = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO(promiseValue, valueCaseId)
-    if let error = _swift_js_take_exception() { throw error }
+func _$AliasImports_jsRoundTripAliasedTags(_ values: [Optional<AliasedTag>]) throws(JSException) -> [Optional<AliasedTag>] {
+    let _ = values.map {
+        $0.map {
+            $0.bridgeToJS()
+        }
+    } .bridgeJSLowerParameter()
+    bjs_AliasImports_jsRoundTripAliasedTags_static()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return [Optional<InnerTag>].bridgeJSLiftReturn().map {
+        $0.map {
+            AliasedTag.bridgeFromJS($0)
+        }
+    }
 }
 
-@JSFunction func Promise_resolve_Sq18AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<AsyncPayloadResult>) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO_extern(promise, valueIsSome, valueCaseId)
+func _$AliasImports_jsRoundTripPolygon(_ value: Polygon) throws(JSException) -> Polygon {
+    let valuePointer = value.bridgeToJS().bridgeJSLowerParameter()
+    let ret = bjs_AliasImports_jsRoundTripPolygon_static(valuePointer)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Polygon.bridgeFromJS(PolygonReference.bridgeJSLiftReturn(ret))
 }
 
-func _$Promise_resolve_Sq18AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<AsyncPayloadResult>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let (valueIsSome, valueCaseId) = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO(promiseValue, valueIsSome, valueCaseId)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_11PublicPointV(_ promise: JSObject, _ value: PublicPoint) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_11PublicPointV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(promise, value)
-}
-
-func _$Promise_resolve_11PublicPointV(_ promise: JSObject, _ value: PublicPoint) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valueObjectId = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_11PublicPointV(promiseValue, valueObjectId)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_7ContactV(_ promise: JSObject, _ value: Contact) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_7ContactV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(_ promise: Int32, _ value: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(_ promise: Int32, _ value: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(promise, value)
-}
-
-func _$Promise_resolve_7ContactV(_ promise: JSObject, _ value: Contact) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valueObjectId = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_7ContactV(promiseValue, valueObjectId)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_Sa11PublicPointV(_ promise: JSObject, _ value: [PublicPoint]) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(_ promise: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(_ promise: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(promise)
-}
-
-func _$Promise_resolve_Sa11PublicPointV(_ promise: JSObject, _ value: [PublicPoint]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let _ = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV(promiseValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_Sq11PublicPointV(_ promise: JSObject, _ value: Optional<PublicPoint>) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(promise, value)
-}
-
-func _$Promise_resolve_Sq11PublicPointV(_ promise: JSObject, _ value: Optional<PublicPoint>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valueIsSome = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(promiseValue, valueIsSome)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_SD11PublicPointV(_ promise: JSObject, _ value: [String: PublicPoint]) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(_ promise: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(_ promise: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(promise)
-}
-
-func _$Promise_resolve_SD11PublicPointV(_ promise: JSObject, _ value: [String: PublicPoint]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let _ = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV(promiseValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_9DataPointV(_ promise: JSObject, _ value: DataPoint) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_9DataPointV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(_ promise: Int32, _ value: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(promise, value)
-}
-
-func _$Promise_resolve_9DataPointV(_ promise: JSObject, _ value: DataPoint) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    let valueObjectId = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_9DataPointV(promiseValue, valueObjectId)
-    if let error = _swift_js_take_exception() { throw error }
+func _$AliasImports_jsRoundTripCoordinate(_ value: Coordinate) throws(JSException) -> Coordinate {
+    let valueObjectId = value.bridgeToJS().bridgeJSLowerParameter()
+    let ret = bjs_AliasImports_jsRoundTripCoordinate_static(valueObjectId)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Coordinate.bridgeFromJS(JSCoordinate.bridgeJSLiftReturn(ret))
 }
 
 #if arch(wasm32)
@@ -13482,30 +12726,6 @@ fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripFeatureFlag_static_exter
     return bjs_AsyncImportImports_jsAsyncRoundTripFeatureFlag_static_extern(resolveRef, rejectRef, vBytes, vLength)
 }
 
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum_static")
-fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum_static_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ v: Int32) -> Void
-#else
-fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum_static_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ v: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum_static(_ resolveRef: Int32, _ rejectRef: Int32, _ v: Int32) -> Void {
-    return bjs_AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum_static_extern(resolveRef, rejectRef, v)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum_static")
-fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum_static_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ vIsSome: Int32, _ vCaseId: Int32) -> Void
-#else
-fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum_static_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ vIsSome: Int32, _ vCaseId: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func bjs_AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum_static(_ resolveRef: Int32, _ rejectRef: Int32, _ vIsSome: Int32, _ vCaseId: Int32) -> Void {
-    return bjs_AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum_static_extern(resolveRef, rejectRef, vIsSome, vCaseId)
-}
-
 func _$AsyncImportImports_jsAsyncRoundTripVoid() async throws(JSException) -> Void {
     try await _bjs_awaitPromise(makeResolveClosure: {
             JSTypedClosure<() -> Void>($0)
@@ -13625,52 +12845,6 @@ func _$AsyncImportImports_jsAsyncRoundTripFeatureFlag(_ v: FeatureFlag) async th
         }
     }
     return resolved
-}
-
-func _$AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum(_ v: AsyncImportedPayloadResult) async throws(JSException) -> AsyncImportedPayloadResult {
-    let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
-            JSTypedClosure<(sending AsyncImportedPayloadResult) -> Void>($0)
-        }, makeRejectClosure: {
-            JSTypedClosure<(sending JSValue) -> Void>($0)
-        }) { resolveRef, rejectRef in
-        let vCaseId = v.bridgeJSLowerParameter()
-        bjs_AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum_static(resolveRef, rejectRef, vCaseId)
-    }
-    return resolved
-}
-
-func _$AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum(_ v: Optional<AsyncImportedPayloadResult>) async throws(JSException) -> Optional<AsyncImportedPayloadResult> {
-    let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
-            JSTypedClosure<(sending Optional<AsyncImportedPayloadResult>) -> Void>($0)
-        }, makeRejectClosure: {
-            JSTypedClosure<(sending JSValue) -> Void>($0)
-        }) { resolveRef, rejectRef in
-        let (vIsSome, vCaseId) = v.bridgeJSLowerParameter()
-        bjs_AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum_static(resolveRef, rejectRef, vIsSome, vCaseId)
-    }
-    return resolved
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ClosureAsyncImports_runJsClosureAsyncTests_static")
-fileprivate func bjs_ClosureAsyncImports_runJsClosureAsyncTests_static_extern(_ resolveRef: Int32, _ rejectRef: Int32) -> Void
-#else
-fileprivate func bjs_ClosureAsyncImports_runJsClosureAsyncTests_static_extern(_ resolveRef: Int32, _ rejectRef: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func bjs_ClosureAsyncImports_runJsClosureAsyncTests_static(_ resolveRef: Int32, _ rejectRef: Int32) -> Void {
-    return bjs_ClosureAsyncImports_runJsClosureAsyncTests_static_extern(resolveRef, rejectRef)
-}
-
-func _$ClosureAsyncImports_runJsClosureAsyncTests() async throws(JSException) -> Void {
-    try await _bjs_awaitPromise(makeResolveClosure: {
-            JSTypedClosure<() -> Void>($0)
-        }, makeRejectClosure: {
-            JSTypedClosure<(sending JSValue) -> Void>($0)
-        }) { resolveRef, rejectRef in
-        bjs_ClosureAsyncImports_runJsClosureAsyncTests_static(resolveRef, rejectRef)
-    }
 }
 
 #if arch(wasm32)
@@ -14050,25 +13224,6 @@ func _$ClosureSupportImports_jsHeapCount() throws(JSException) -> Int {
 
 func _$ClosureSupportImports_runJsClosureSupportTests() throws(JSException) -> Void {
     bjs_ClosureSupportImports_runJsClosureSupportTests_static()
-    if let error = _swift_js_take_exception() {
-        throw error
-    }
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ClosureThrowsImports_runJsClosureThrowsTests_static")
-fileprivate func bjs_ClosureThrowsImports_runJsClosureThrowsTests_static_extern() -> Void
-#else
-fileprivate func bjs_ClosureThrowsImports_runJsClosureThrowsTests_static_extern() -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func bjs_ClosureThrowsImports_runJsClosureThrowsTests_static() -> Void {
-    return bjs_ClosureThrowsImports_runJsClosureThrowsTests_static_extern()
-}
-
-func _$ClosureThrowsImports_runJsClosureThrowsTests() throws(JSException) -> Void {
-    bjs_ClosureThrowsImports_runJsClosureThrowsTests_static()
     if let error = _swift_js_take_exception() {
         throw error
     }
@@ -14516,6 +13671,28 @@ func _$runAsyncWorks() async throws(JSException) -> Void {
             JSTypedClosure<(sending JSValue) -> Void>($0)
         }) { resolveRef, rejectRef in
         bjs_runAsyncWorks(resolveRef, rejectRef)
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_runAliasAsyncWorks")
+fileprivate func bjs_runAliasAsyncWorks_extern(_ resolveRef: Int32, _ rejectRef: Int32) -> Void
+#else
+fileprivate func bjs_runAliasAsyncWorks_extern(_ resolveRef: Int32, _ rejectRef: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_runAliasAsyncWorks(_ resolveRef: Int32, _ rejectRef: Int32) -> Void {
+    return bjs_runAliasAsyncWorks_extern(resolveRef, rejectRef)
+}
+
+func _$runAliasAsyncWorks() async throws(JSException) -> Void {
+    try await _bjs_awaitPromise(makeResolveClosure: {
+            JSTypedClosure<() -> Void>($0)
+        }, makeRejectClosure: {
+            JSTypedClosure<(sending JSValue) -> Void>($0)
+        }) { resolveRef, rejectRef in
+        bjs_runAliasAsyncWorks(resolveRef, rejectRef)
     }
 }
 
@@ -15209,69 +14386,6 @@ func _$Animal_getIsCat(_ self: JSObject) throws(JSException) -> Bool {
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripLightColor")
-fileprivate func bjs_jsRoundTripLightColor_extern(_ value: Int32) -> Int32
-#else
-fileprivate func bjs_jsRoundTripLightColor_extern(_ value: Int32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func bjs_jsRoundTripLightColor(_ value: Int32) -> Int32 {
-    return bjs_jsRoundTripLightColor_extern(value)
-}
-
-func _$jsRoundTripLightColor(_ value: LightColor) throws(JSException) -> LightColor {
-    let valueValue = value.bridgeJSLowerParameter()
-    let ret = bjs_jsRoundTripLightColor(valueValue)
-    if let error = _swift_js_take_exception() {
-        throw error
-    }
-    return LightColor.bridgeJSLiftReturn(ret)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripImportedPayloadSignal")
-fileprivate func bjs_jsRoundTripImportedPayloadSignal_extern(_ value: Int32) -> Int32
-#else
-fileprivate func bjs_jsRoundTripImportedPayloadSignal_extern(_ value: Int32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func bjs_jsRoundTripImportedPayloadSignal(_ value: Int32) -> Int32 {
-    return bjs_jsRoundTripImportedPayloadSignal_extern(value)
-}
-
-func _$jsRoundTripImportedPayloadSignal(_ value: ImportedPayloadSignal) throws(JSException) -> ImportedPayloadSignal {
-    let valueCaseId = value.bridgeJSLowerParameter()
-    let ret = bjs_jsRoundTripImportedPayloadSignal(valueCaseId)
-    if let error = _swift_js_take_exception() {
-        throw error
-    }
-    return ImportedPayloadSignal.bridgeJSLiftReturn(ret)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripOptionalImportedPayloadSignal")
-fileprivate func bjs_jsRoundTripOptionalImportedPayloadSignal_extern(_ valueIsSome: Int32, _ valueCaseId: Int32) -> Int32
-#else
-fileprivate func bjs_jsRoundTripOptionalImportedPayloadSignal_extern(_ valueIsSome: Int32, _ valueCaseId: Int32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func bjs_jsRoundTripOptionalImportedPayloadSignal(_ valueIsSome: Int32, _ valueCaseId: Int32) -> Int32 {
-    return bjs_jsRoundTripOptionalImportedPayloadSignal_extern(valueIsSome, valueCaseId)
-}
-
-func _$jsRoundTripOptionalImportedPayloadSignal(_ value: Optional<ImportedPayloadSignal>) throws(JSException) -> Optional<ImportedPayloadSignal> {
-    let (valueIsSome, valueCaseId) = value.bridgeJSLowerParameter()
-    let ret = bjs_jsRoundTripOptionalImportedPayloadSignal(valueIsSome, valueCaseId)
-    if let error = _swift_js_take_exception() {
-        throw error
-    }
-    return Optional<ImportedPayloadSignal>.bridgeJSLiftReturn(ret)
-}
-
-#if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsTranslatePoint")
 fileprivate func bjs_jsTranslatePoint_extern(_ point: Int32, _ dx: Int32, _ dy: Int32) -> Int32
 #else
@@ -15292,27 +14406,6 @@ func _$jsTranslatePoint(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException
         throw error
     }
     return Point.bridgeJSLiftReturn(ret)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripOptionalPoint")
-fileprivate func bjs_jsRoundTripOptionalPoint_extern(_ point: Int32) -> Void
-#else
-fileprivate func bjs_jsRoundTripOptionalPoint_extern(_ point: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func bjs_jsRoundTripOptionalPoint(_ point: Int32) -> Void {
-    return bjs_jsRoundTripOptionalPoint_extern(point)
-}
-
-func _$jsRoundTripOptionalPoint(_ point: Optional<Point>) throws(JSException) -> Optional<Point> {
-    let pointIsSome = point.bridgeJSLowerParameter()
-    bjs_jsRoundTripOptionalPoint(pointIsSome)
-    if let error = _swift_js_take_exception() {
-        throw error
-    }
-    return Optional<Point>.bridgeJSLiftReturn()
 }
 
 #if arch(wasm32)
@@ -16113,18 +15206,6 @@ fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDic
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalSupportImports_jsRoundTripOptionalJSObjectNull_static")
-fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSObjectNull_static_extern(_ valueIsSome: Int32, _ valueValue: Int32) -> Void
-#else
-fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSObjectNull_static_extern(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSObjectNull_static(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
-    return bjs_OptionalSupportImports_jsRoundTripOptionalJSObjectNull_static_extern(valueIsSome, valueValue)
-}
-
-#if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalSupportImports_runJsOptionalSupportTests_static")
 fileprivate func bjs_OptionalSupportImports_runJsOptionalSupportTests_static_extern() -> Void
 #else
@@ -16208,15 +15289,6 @@ func _$OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefin
         throw error
     }
     return JSUndefinedOr<[String: String]>.bridgeJSLiftReturn()
-}
-
-func _$OptionalSupportImports_jsRoundTripOptionalJSObjectNull(_ value: Optional<JSObject>) throws(JSException) -> Optional<JSObject> {
-    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
-    bjs_OptionalSupportImports_jsRoundTripOptionalJSObjectNull_static(valueIsSome, valueValue)
-    if let error = _swift_js_take_exception() {
-        throw error
-    }
-    return Optional<JSObject>.bridgeJSLiftReturn()
 }
 
 func _$OptionalSupportImports_runJsOptionalSupportTests() throws(JSException) -> Void {

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -1,6 +1,559 @@
 {
   "exported" : {
+    "aliases" : [
+      {
+        "swiftCallName" : "Polygon",
+        "underlying" : {
+          "swiftHeapObject" : {
+            "_0" : "PolygonReference"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "Tag",
+        "underlying" : {
+          "swiftHeapObject" : {
+            "_0" : "TagReference"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "Token",
+        "underlying" : {
+          "swiftHeapObject" : {
+            "_0" : "TokenReference"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "TagHolder",
+        "underlying" : {
+          "swiftHeapObject" : {
+            "_0" : "TagHolderReference"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "Coordinate",
+        "underlying" : {
+          "swiftStruct" : {
+            "_0" : "JSCoordinate"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "Priority",
+        "underlying" : {
+          "swiftHeapObject" : {
+            "_0" : "PriorityReference"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "Alert",
+        "underlying" : {
+          "caseEnum" : {
+            "_0" : "Severity"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "Session",
+        "underlying" : {
+          "swiftStruct" : {
+            "_0" : "SessionState"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "Tagged",
+        "underlying" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "swiftCallName" : "Canvas",
+        "underlying" : {
+          "jsObject" : {
+            "_0" : "Surface"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "AliasedTag",
+        "underlying" : {
+          "associatedValueEnum" : {
+            "_0" : "InnerTag"
+          }
+        }
+      }
+    ],
     "classes" : [
+      {
+        "constructor" : {
+          "abiName" : "bjs_PolygonReference_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "verticesData",
+              "name" : "verticesData",
+              "type" : {
+                "array" : {
+                  "_0" : {
+                    "double" : {
+
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "label" : "label",
+              "name" : "label",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+          {
+            "abiName" : "bjs_PolygonReference_vertexCount",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "vertexCount",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_PolygonReference_summary",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "summary",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_PolygonReference_snapshot",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "snapshot",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_PolygonReference_merge",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "merge",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "other",
+                "type" : {
+                  "alias" : {
+                    "name" : "Polygon",
+                    "underlying" : {
+                      "swiftHeapObject" : {
+                        "_0" : "PolygonReference"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_PolygonReference_static_origin",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "origin",
+            "parameters" : [
+              {
+                "label" : "label",
+                "name" : "label",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            },
+            "staticContext" : {
+              "className" : {
+                "_0" : "PolygonReference"
+              }
+            }
+          }
+        ],
+        "name" : "PolygonReference",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "PolygonReference"
+      },
+      {
+        "methods" : [
+          {
+            "abiName" : "bjs_TagReference_describe",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "describe",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "name" : "TagReference",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "TagReference"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_TokenReference_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "value",
+              "name" : "value",
+              "type" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+          {
+            "abiName" : "bjs_TokenReference_read",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "read",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "name" : "TokenReference",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "TokenReference"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_TagHolderReference_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "tag",
+              "name" : "tag",
+              "type" : {
+                "alias" : {
+                  "name" : "Tag",
+                  "underlying" : {
+                    "swiftHeapObject" : {
+                      "_0" : "TagReference"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "label" : "version",
+              "name" : "version",
+              "type" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+          {
+            "abiName" : "bjs_TagHolderReference_describe",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "describe",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "name" : "TagHolderReference",
+        "properties" : [
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "name" : "tag",
+            "type" : {
+              "alias" : {
+                "name" : "Tag",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "TagReference"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "name" : "version",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "TagHolderReference"
+      },
+      {
+        "methods" : [
+          {
+            "abiName" : "bjs_PriorityReference_describe",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "describe",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_PriorityReference_weight",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "weight",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_PriorityReference_static_low",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "low",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "alias" : {
+                "name" : "Priority",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PriorityReference"
+                  }
+                }
+              }
+            },
+            "staticContext" : {
+              "className" : {
+                "_0" : "PriorityReference"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_PriorityReference_static_medium",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "medium",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "alias" : {
+                "name" : "Priority",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PriorityReference"
+                  }
+                }
+              }
+            },
+            "staticContext" : {
+              "className" : {
+                "_0" : "PriorityReference"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_PriorityReference_static_high",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "name" : "high",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "alias" : {
+                "name" : "Priority",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PriorityReference"
+                  }
+                }
+              }
+            },
+            "staticContext" : {
+              "className" : {
+                "_0" : "PriorityReference"
+              }
+            }
+          }
+        ],
+        "name" : "PriorityReference",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "PriorityReference"
+      },
       {
         "methods" : [
           {
@@ -906,46 +1459,6 @@
                   "isSigned" : true,
                   "width" : "word"
                 }
-              }
-            }
-          },
-          {
-            "abiName" : "bjs_Calculator_asyncMakePoint",
-            "effects" : {
-              "isAsync" : true,
-              "isStatic" : false,
-              "isThrows" : false
-            },
-            "name" : "asyncMakePoint",
-            "parameters" : [
-              {
-                "label" : "x",
-                "name" : "x",
-                "type" : {
-                  "integer" : {
-                    "_0" : {
-                      "isSigned" : true,
-                      "width" : "word"
-                    }
-                  }
-                }
-              },
-              {
-                "label" : "y",
-                "name" : "y",
-                "type" : {
-                  "integer" : {
-                    "_0" : {
-                      "isSigned" : true,
-                      "width" : "word"
-                    }
-                  }
-                }
-              }
-            ],
-            "returnType" : {
-              "swiftStruct" : {
-                "_0" : "PublicPoint"
               }
             }
           }
@@ -4451,6 +4964,110 @@
     "enums" : [
       {
         "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "notice"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "warning"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "error"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "Severity",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "Severity",
+        "tsFullPath" : "Severity"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "alias" : {
+                    "name" : "Polygon",
+                    "underlying" : {
+                      "swiftHeapObject" : {
+                        "_0" : "PolygonReference"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "name" : "polygon"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "empty"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "Shape",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "Shape",
+        "tsFullPath" : "Shape"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "name" : "payload"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "empty"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "InnerTag",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "InnerTag",
+        "tsFullPath" : "InnerTag"
+      },
+      {
+        "cases" : [
 
         ],
         "emitStyle" : "const",
@@ -6552,53 +7169,6 @@
       },
       {
         "cases" : [
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "string" : {
-
-                  }
-                }
-              }
-            ],
-            "name" : "success"
-          },
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "integer" : {
-                    "_0" : {
-                      "isSigned" : true,
-                      "width" : "word"
-                    }
-                  }
-                }
-              }
-            ],
-            "name" : "failure"
-          },
-          {
-            "associatedValues" : [
-
-            ],
-            "name" : "idle"
-          }
-        ],
-        "emitStyle" : "const",
-        "name" : "AsyncImportedPayloadResult",
-        "staticMethods" : [
-
-        ],
-        "staticProperties" : [
-
-        ],
-        "swiftCallName" : "AsyncImportedPayloadResult",
-        "tsFullPath" : "AsyncImportedPayloadResult"
-      },
-      {
-        "cases" : [
 
         ],
         "emitStyle" : "const",
@@ -7761,53 +8331,6 @@
         ],
         "swiftCallName" : "TSTheme",
         "tsFullPath" : "TSTheme"
-      },
-      {
-        "cases" : [
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "string" : {
-
-                  }
-                }
-              }
-            ],
-            "name" : "success"
-          },
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "integer" : {
-                    "_0" : {
-                      "isSigned" : true,
-                      "width" : "word"
-                    }
-                  }
-                }
-              }
-            ],
-            "name" : "failure"
-          },
-          {
-            "associatedValues" : [
-
-            ],
-            "name" : "idle"
-          }
-        ],
-        "emitStyle" : "const",
-        "name" : "AsyncPayloadResult",
-        "staticMethods" : [
-
-        ],
-        "staticProperties" : [
-
-        ],
-        "swiftCallName" : "AsyncPayloadResult",
-        "tsFullPath" : "AsyncPayloadResult"
       },
       {
         "cases" : [
@@ -9387,85 +9910,6 @@
         ],
         "swiftCallName" : "NestedStructGroupB",
         "tsFullPath" : "NestedStructGroupB"
-      },
-      {
-        "cases" : [
-          {
-            "associatedValues" : [
-
-            ],
-            "name" : "red"
-          },
-          {
-            "associatedValues" : [
-
-            ],
-            "name" : "yellow"
-          },
-          {
-            "associatedValues" : [
-
-            ],
-            "name" : "green"
-          }
-        ],
-        "emitStyle" : "const",
-        "name" : "LightColor",
-        "staticMethods" : [
-
-        ],
-        "staticProperties" : [
-
-        ],
-        "swiftCallName" : "LightColor",
-        "tsFullPath" : "LightColor"
-      },
-      {
-        "cases" : [
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "string" : {
-
-                  }
-                }
-              }
-            ],
-            "name" : "start"
-          },
-          {
-            "associatedValues" : [
-              {
-                "type" : {
-                  "integer" : {
-                    "_0" : {
-                      "isSigned" : true,
-                      "width" : "word"
-                    }
-                  }
-                }
-              }
-            ],
-            "name" : "stop"
-          },
-          {
-            "associatedValues" : [
-
-            ],
-            "name" : "idle"
-          }
-        ],
-        "emitStyle" : "const",
-        "name" : "ImportedPayloadSignal",
-        "staticMethods" : [
-
-        ],
-        "staticProperties" : [
-
-        ],
-        "swiftCallName" : "ImportedPayloadSignal",
-        "tsFullPath" : "ImportedPayloadSignal"
       },
       {
         "cases" : [
@@ -11605,298 +12049,424 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_awaitAsyncCallback",
+        "abiName" : "bjs_makeTag",
         "effects" : {
-          "isAsync" : true,
+          "isAsync" : false,
           "isStatic" : false,
-          "isThrows" : true
+          "isThrows" : false
         },
-        "name" : "awaitAsyncCallback",
+        "name" : "makeTag",
         "parameters" : [
           {
             "label" : "_",
-            "name" : "fetch",
+            "name" : "name",
             "type" : {
-              "closure" : {
-                "_0" : {
-                  "isAsync" : true,
-                  "isThrows" : true,
-                  "mangleName" : "20BridgeJSRuntimeTestsYaKSS_SS",
-                  "moduleName" : "BridgeJSRuntimeTests",
-                  "parameters" : [
-                    {
-                      "string" : {
+              "string" : {
 
-                      }
-                    }
-                  ],
-                  "returnType" : {
-                    "string" : {
-
-                    }
-                  },
-                  "sendingParameters" : false
-                },
-                "useJSTypedClosure" : false
               }
             }
           }
         ],
         "returnType" : {
-          "string" : {
-
+          "alias" : {
+            "name" : "Tag",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "TagReference"
+              }
+            }
           }
         }
       },
       {
-        "abiName" : "bjs_makeAsyncParser",
+        "abiName" : "bjs_roundTripPolygon",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
           "isThrows" : false
         },
-        "name" : "makeAsyncParser",
-        "parameters" : [
-
-        ],
-        "returnType" : {
-          "closure" : {
-            "_0" : {
-              "isAsync" : true,
-              "isThrows" : true,
-              "mangleName" : "20BridgeJSRuntimeTestsYaKSS_SS",
-              "moduleName" : "BridgeJSRuntimeTests",
-              "parameters" : [
-                {
-                  "string" : {
-
-                  }
-                }
-              ],
-              "returnType" : {
-                "string" : {
-
-                }
-              },
-              "sendingParameters" : false
-            },
-            "useJSTypedClosure" : true
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_makeAsyncEcho",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "makeAsyncEcho",
-        "parameters" : [
-
-        ],
-        "returnType" : {
-          "closure" : {
-            "_0" : {
-              "isAsync" : true,
-              "isThrows" : false,
-              "mangleName" : "20BridgeJSRuntimeTestsYaSS_SS",
-              "moduleName" : "BridgeJSRuntimeTests",
-              "parameters" : [
-                {
-                  "string" : {
-
-                  }
-                }
-              ],
-              "returnType" : {
-                "string" : {
-
-                }
-              },
-              "sendingParameters" : false
-            },
-            "useJSTypedClosure" : true
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_makeAsyncRecorder",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "makeAsyncRecorder",
-        "parameters" : [
-
-        ],
-        "returnType" : {
-          "closure" : {
-            "_0" : {
-              "isAsync" : true,
-              "isThrows" : true,
-              "mangleName" : "20BridgeJSRuntimeTestsYaKSS_y",
-              "moduleName" : "BridgeJSRuntimeTests",
-              "parameters" : [
-                {
-                  "string" : {
-
-                  }
-                }
-              ],
-              "returnType" : {
-                "void" : {
-
-                }
-              },
-              "sendingParameters" : false
-            },
-            "useJSTypedClosure" : true
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_lastRecordedValue",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "lastRecordedValue",
-        "parameters" : [
-
-        ],
-        "returnType" : {
-          "string" : {
-
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_makeAsyncPayloadLoader",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "makeAsyncPayloadLoader",
-        "parameters" : [
-
-        ],
-        "returnType" : {
-          "closure" : {
-            "_0" : {
-              "isAsync" : true,
-              "isThrows" : true,
-              "mangleName" : "20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO",
-              "moduleName" : "BridgeJSRuntimeTests",
-              "parameters" : [
-                {
-                  "bool" : {
-
-                  }
-                }
-              ],
-              "returnType" : {
-                "associatedValueEnum" : {
-                  "_0" : "AsyncPayloadResult"
-                }
-              },
-              "sendingParameters" : false
-            },
-            "useJSTypedClosure" : true
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_awaitPayloadCallback",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : true
-        },
-        "name" : "awaitPayloadCallback",
+        "name" : "roundTripPolygon",
         "parameters" : [
           {
             "label" : "_",
-            "name" : "load",
+            "name" : "polygon",
             "type" : {
-              "closure" : {
-                "_0" : {
-                  "isAsync" : true,
-                  "isThrows" : true,
-                  "mangleName" : "20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO",
-                  "moduleName" : "BridgeJSRuntimeTests",
-                  "parameters" : [
-                    {
-                      "bool" : {
-
-                      }
-                    }
-                  ],
-                  "returnType" : {
-                    "associatedValueEnum" : {
-                      "_0" : "AsyncPayloadResult"
-                    }
-                  },
-                  "sendingParameters" : false
-                },
-                "useJSTypedClosure" : false
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
               }
             }
           }
         ],
         "returnType" : {
-          "string" : {
-
+          "alias" : {
+            "name" : "Polygon",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "PolygonReference"
+              }
+            }
           }
         }
       },
       {
-        "abiName" : "bjs_makeAsyncPointMaker",
+        "abiName" : "bjs_appendVertex",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
           "isThrows" : false
         },
-        "name" : "makeAsyncPointMaker",
+        "name" : "appendVertex",
         "parameters" : [
-
-        ],
-        "returnType" : {
-          "closure" : {
-            "_0" : {
-              "isAsync" : true,
-              "isThrows" : false,
-              "mangleName" : "20BridgeJSRuntimeTestsYaSd_9DataPointV",
-              "moduleName" : "BridgeJSRuntimeTests",
-              "parameters" : [
-                {
-                  "double" : {
-
+          {
+            "label" : "_",
+            "name" : "polygon",
+            "type" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
                   }
                 }
-              ],
-              "returnType" : {
-                "swiftStruct" : {
-                  "_0" : "DataPoint"
-                }
-              },
-              "sendingParameters" : false
-            },
-            "useJSTypedClosure" : true
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "double" : {
+
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Polygon",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "PolygonReference"
+              }
+            }
           }
         }
       },
       {
-        "abiName" : "bjs_makeThrowingParser",
+        "abiName" : "bjs_optionalRoundTripPolygon",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
           "isThrows" : false
         },
-        "name" : "makeThrowingParser",
+        "name" : "optionalRoundTripPolygon",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "polygon",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "alias" : {
+                    "name" : "Polygon",
+                    "underlying" : {
+                      "swiftHeapObject" : {
+                        "_0" : "PolygonReference"
+                      }
+                    }
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_polygonVertexCount",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "polygonVertexCount",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "polygon",
+            "type" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "integer" : {
+            "_0" : {
+              "isSigned" : true,
+              "width" : "word"
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripPolygonArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripPolygonArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "polygons",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "alias" : {
+                    "name" : "Polygon",
+                    "underlying" : {
+                      "swiftHeapObject" : {
+                        "_0" : "PolygonReference"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_concatPolygons",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "concatPolygons",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "polygons",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "alias" : {
+                    "name" : "Polygon",
+                    "underlying" : {
+                      "swiftHeapObject" : {
+                        "_0" : "PolygonReference"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Polygon",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "PolygonReference"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_validatePolygon",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "validatePolygon",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "polygon",
+            "type" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Polygon",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "PolygonReference"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_splitPolygon",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "splitPolygon",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "polygon",
+            "type" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_incrementToken",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "incrementToken",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "token",
+            "type" : {
+              "alias" : {
+                "name" : "Token",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "TokenReference"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Token",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "TokenReference"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeToken",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeToken",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Token",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "TokenReference"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makePolygonInspector",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makePolygonInspector",
         "parameters" : [
 
         ],
@@ -11904,13 +12474,18 @@
           "closure" : {
             "_0" : {
               "isAsync" : false,
-              "isThrows" : true,
-              "mangleName" : "20BridgeJSRuntimeTestsKSS_Si",
+              "isThrows" : false,
+              "mangleName" : "20BridgeJSRuntimeTestsAl7Polygon_Si",
               "moduleName" : "BridgeJSRuntimeTests",
               "parameters" : [
                 {
-                  "string" : {
-
+                  "alias" : {
+                    "name" : "Polygon",
+                    "underlying" : {
+                      "swiftHeapObject" : {
+                        "_0" : "PolygonReference"
+                      }
+                    }
                   }
                 }
               ],
@@ -11924,51 +12499,404 @@
               },
               "sendingParameters" : false
             },
-            "useJSTypedClosure" : true
+            "useJSTypedClosure" : false
           }
         }
       },
       {
-        "abiName" : "bjs_runValidator",
+        "abiName" : "bjs_asyncMakePolygon",
         "effects" : {
-          "isAsync" : false,
+          "isAsync" : true,
           "isStatic" : false,
-          "isThrows" : true
+          "isThrows" : false
         },
-        "name" : "runValidator",
+        "name" : "asyncMakePolygon",
         "parameters" : [
           {
             "label" : "_",
-            "name" : "validate",
+            "name" : "label",
             "type" : {
-              "closure" : {
-                "_0" : {
-                  "isAsync" : false,
-                  "isThrows" : true,
-                  "mangleName" : "20BridgeJSRuntimeTestsKSS_Sb",
-                  "moduleName" : "BridgeJSRuntimeTests",
-                  "parameters" : [
-                    {
-                      "string" : {
+              "string" : {
 
-                      }
-                    }
-                  ],
-                  "returnType" : {
-                    "bool" : {
-
-                    }
-                  },
-                  "sendingParameters" : false
-                },
-                "useJSTypedClosure" : false
               }
             }
           }
         ],
         "returnType" : {
-          "bool" : {
+          "alias" : {
+            "name" : "Polygon",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "PolygonReference"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalPolygonArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalPolygonArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "polygons",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "nullable" : {
+                    "_0" : {
+                      "alias" : {
+                        "name" : "Polygon",
+                        "underlying" : {
+                          "swiftHeapObject" : {
+                            "_0" : "PolygonReference"
+                          }
+                        }
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "nullable" : {
+                "_0" : {
+                  "alias" : {
+                    "name" : "Polygon",
+                    "underlying" : {
+                      "swiftHeapObject" : {
+                        "_0" : "PolygonReference"
+                      }
+                    }
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeTagHolder",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeTagHolder",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "name",
+            "type" : {
+              "string" : {
 
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "version",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "TagHolder",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "TagHolderReference"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripCoordinate",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripCoordinate",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "coordinate",
+            "type" : {
+              "alias" : {
+                "name" : "Coordinate",
+                "underlying" : {
+                  "swiftStruct" : {
+                    "_0" : "JSCoordinate"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Coordinate",
+            "underlying" : {
+              "swiftStruct" : {
+                "_0" : "JSCoordinate"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripPriority",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripPriority",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "priority",
+            "type" : {
+              "alias" : {
+                "name" : "Priority",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PriorityReference"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Priority",
+            "underlying" : {
+              "swiftHeapObject" : {
+                "_0" : "PriorityReference"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripAlert",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripAlert",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "alert",
+            "type" : {
+              "alias" : {
+                "name" : "Alert",
+                "underlying" : {
+                  "caseEnum" : {
+                    "_0" : "Severity"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Alert",
+            "underlying" : {
+              "caseEnum" : {
+                "_0" : "Severity"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAlert",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAlert",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "level",
+            "type" : {
+              "caseEnum" : {
+                "_0" : "Severity"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Alert",
+            "underlying" : {
+              "caseEnum" : {
+                "_0" : "Severity"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripSession",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripSession",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "session",
+            "type" : {
+              "alias" : {
+                "name" : "Session",
+                "underlying" : {
+                  "swiftStruct" : {
+                    "_0" : "SessionState"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Session",
+            "underlying" : {
+              "swiftStruct" : {
+                "_0" : "SessionState"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeSession",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeSession",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "token",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Session",
+            "underlying" : {
+              "swiftStruct" : {
+                "_0" : "SessionState"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripShape",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripShape",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "s",
+            "type" : {
+              "associatedValueEnum" : {
+                "_0" : "Shape"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "associatedValueEnum" : {
+            "_0" : "Shape"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeShapePolygon",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeShapePolygon",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "polygon",
+            "type" : {
+              "alias" : {
+                "name" : "Polygon",
+                "underlying" : {
+                  "swiftHeapObject" : {
+                    "_0" : "PolygonReference"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "associatedValueEnum" : {
+            "_0" : "Shape"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeShapeEmpty",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeShapeEmpty",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "associatedValueEnum" : {
+            "_0" : "Shape"
           }
         }
       },
@@ -12499,41 +13427,6 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalImportedClass",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripOptionalImportedClass",
-        "parameters" : [
-          {
-            "label" : "v",
-            "name" : "v",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "jsObject" : {
-                    "_0" : "Foo"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "jsObject" : {
-                "_0" : "Foo"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
         "abiName" : "bjs_throwsSwiftError",
         "effects" : {
           "isAsync" : false,
@@ -12676,23 +13569,6 @@
         ],
         "returnType" : {
           "jsObject" : {
-
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_zeroArgAsyncThrows",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : true
-        },
-        "name" : "zeroArgAsyncThrows",
-        "parameters" : [
-
-        ],
-        "returnType" : {
-          "string" : {
 
           }
         }
@@ -13166,390 +14042,6 @@
           "rawValueEnum" : {
             "_0" : "Theme",
             "_1" : "String"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripTheme",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripTheme",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "v",
-            "type" : {
-              "rawValueEnum" : {
-                "_0" : "Theme",
-                "_1" : "String"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "rawValueEnum" : {
-            "_0" : "Theme",
-            "_1" : "String"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripDirection",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripDirection",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "v",
-            "type" : {
-              "caseEnum" : {
-                "_0" : "Direction"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "caseEnum" : {
-            "_0" : "Direction"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripOptionalTheme",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripOptionalTheme",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "v",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "rawValueEnum" : {
-                    "_0" : "Theme",
-                    "_1" : "String"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "rawValueEnum" : {
-                "_0" : "Theme",
-                "_1" : "String"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripOptionalDirection",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripOptionalDirection",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "v",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "caseEnum" : {
-                    "_0" : "Direction"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "caseEnum" : {
-                "_0" : "Direction"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripDirectionArray",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripDirectionArray",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "v",
-            "type" : {
-              "array" : {
-                "_0" : {
-                  "caseEnum" : {
-                    "_0" : "Direction"
-                  }
-                }
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "array" : {
-            "_0" : {
-              "caseEnum" : {
-                "_0" : "Direction"
-              }
-            }
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripDirectionDict",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripDirectionDict",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "v",
-            "type" : {
-              "dictionary" : {
-                "_0" : {
-                  "caseEnum" : {
-                    "_0" : "Direction"
-                  }
-                }
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "dictionary" : {
-            "_0" : {
-              "caseEnum" : {
-                "_0" : "Direction"
-              }
-            }
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripThemeArray",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripThemeArray",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "v",
-            "type" : {
-              "array" : {
-                "_0" : {
-                  "rawValueEnum" : {
-                    "_0" : "Theme",
-                    "_1" : "String"
-                  }
-                }
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "array" : {
-            "_0" : {
-              "rawValueEnum" : {
-                "_0" : "Theme",
-                "_1" : "String"
-              }
-            }
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripThemeDict",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripThemeDict",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "v",
-            "type" : {
-              "dictionary" : {
-                "_0" : {
-                  "rawValueEnum" : {
-                    "_0" : "Theme",
-                    "_1" : "String"
-                  }
-                }
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "dictionary" : {
-            "_0" : {
-              "rawValueEnum" : {
-                "_0" : "Theme",
-                "_1" : "String"
-              }
-            }
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripFileSize",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripFileSize",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "v",
-            "type" : {
-              "rawValueEnum" : {
-                "_0" : "FileSize",
-                "_1" : "Int64"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "rawValueEnum" : {
-            "_0" : "FileSize",
-            "_1" : "Int64"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripOptionalFileSize",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripOptionalFileSize",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "v",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "rawValueEnum" : {
-                    "_0" : "FileSize",
-                    "_1" : "Int64"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "rawValueEnum" : {
-                "_0" : "FileSize",
-                "_1" : "Int64"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripAssociatedValueEnum",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripAssociatedValueEnum",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "v",
-            "type" : {
-              "associatedValueEnum" : {
-                "_0" : "AsyncPayloadResult"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "associatedValueEnum" : {
-            "_0" : "AsyncPayloadResult"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripOptionalAssociatedValueEnum",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripOptionalAssociatedValueEnum",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "v",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "associatedValueEnum" : {
-                    "_0" : "AsyncPayloadResult"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "associatedValueEnum" : {
-                "_0" : "AsyncPayloadResult"
-              }
-            },
-            "_1" : "null"
           }
         }
       },
@@ -15346,241 +15838,6 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripPublicPoint",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripPublicPoint",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "point",
-            "type" : {
-              "swiftStruct" : {
-                "_0" : "PublicPoint"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "swiftStruct" : {
-            "_0" : "PublicPoint"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripPublicPointThrows",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : true
-        },
-        "name" : "asyncRoundTripPublicPointThrows",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "point",
-            "type" : {
-              "swiftStruct" : {
-                "_0" : "PublicPoint"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "swiftStruct" : {
-            "_0" : "PublicPoint"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncStructOrThrow",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : true
-        },
-        "name" : "asyncStructOrThrow",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "shouldThrow",
-            "type" : {
-              "bool" : {
-
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "swiftStruct" : {
-            "_0" : "PublicPoint"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncCombinePublicPoints",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncCombinePublicPoints",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "a",
-            "type" : {
-              "swiftStruct" : {
-                "_0" : "PublicPoint"
-              }
-            }
-          },
-          {
-            "label" : "_",
-            "name" : "b",
-            "type" : {
-              "swiftStruct" : {
-                "_0" : "PublicPoint"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "swiftStruct" : {
-            "_0" : "PublicPoint"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripContact",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripContact",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "contact",
-            "type" : {
-              "swiftStruct" : {
-                "_0" : "Contact"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "swiftStruct" : {
-            "_0" : "Contact"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripPublicPointArray",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripPublicPointArray",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "points",
-            "type" : {
-              "array" : {
-                "_0" : {
-                  "swiftStruct" : {
-                    "_0" : "PublicPoint"
-                  }
-                }
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "array" : {
-            "_0" : {
-              "swiftStruct" : {
-                "_0" : "PublicPoint"
-              }
-            }
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripOptionalPublicPoint",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripOptionalPublicPoint",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "point",
-            "type" : {
-              "nullable" : {
-                "_0" : {
-                  "swiftStruct" : {
-                    "_0" : "PublicPoint"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "nullable" : {
-            "_0" : {
-              "swiftStruct" : {
-                "_0" : "PublicPoint"
-              }
-            },
-            "_1" : "null"
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncRoundTripPublicPointDict",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncRoundTripPublicPointDict",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "points",
-            "type" : {
-              "dictionary" : {
-                "_0" : {
-                  "swiftStruct" : {
-                    "_0" : "PublicPoint"
-                  }
-                }
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "dictionary" : {
-            "_0" : {
-              "swiftStruct" : {
-                "_0" : "PublicPoint"
-              }
-            }
-          }
-        }
-      },
-      {
         "abiName" : "bjs_roundTripContact",
         "effects" : {
           "isAsync" : false,
@@ -16382,6 +16639,101 @@
       }
     ],
     "structs" : [
+      {
+        "constructor" : {
+          "abiName" : "bjs_JSCoordinate_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "latitude",
+              "name" : "latitude",
+              "type" : {
+                "double" : {
+
+                }
+              }
+            },
+            {
+              "label" : "longitude",
+              "name" : "longitude",
+              "type" : {
+                "double" : {
+
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+
+        ],
+        "name" : "JSCoordinate",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "latitude",
+            "type" : {
+              "double" : {
+
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "longitude",
+            "type" : {
+              "double" : {
+
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "JSCoordinate"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_SessionState_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "token",
+              "name" : "token",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+
+        ],
+        "name" : "SessionState",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "token",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "SessionState"
+      },
       {
         "methods" : [
 
@@ -18079,6 +18431,302 @@
               "accessLevel" : "internal",
               "parameters" : [
                 {
+                  "name" : "label",
+                  "type" : {
+                    "string" : {
+
+                    }
+                  }
+                }
+              ]
+            },
+            "getters" : [
+              {
+                "accessLevel" : "internal",
+                "name" : "label",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "methods" : [
+
+            ],
+            "name" : "Surface",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+
+            ]
+          },
+          {
+            "accessLevel" : "internal",
+            "getters" : [
+
+            ],
+            "methods" : [
+
+            ],
+            "name" : "AliasImports",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsRoundTripTagged",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "alias" : {
+                        "name" : "Tagged",
+                        "underlying" : {
+                          "string" : {
+
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "alias" : {
+                    "name" : "Tagged",
+                    "underlying" : {
+                      "string" : {
+
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsRoundTripOptionalTagged",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "nullable" : {
+                        "_0" : {
+                          "alias" : {
+                            "name" : "Tagged",
+                            "underlying" : {
+                              "string" : {
+
+                              }
+                            }
+                          }
+                        },
+                        "_1" : "null"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "nullable" : {
+                    "_0" : {
+                      "alias" : {
+                        "name" : "Tagged",
+                        "underlying" : {
+                          "string" : {
+
+                          }
+                        }
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsProduceOptionalCanvas",
+                "parameters" : [
+                  {
+                    "name" : "label",
+                    "type" : {
+                      "nullable" : {
+                        "_0" : {
+                          "string" : {
+
+                          }
+                        },
+                        "_1" : "null"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "nullable" : {
+                    "_0" : {
+                      "alias" : {
+                        "name" : "Canvas",
+                        "underlying" : {
+                          "jsObject" : {
+                            "_0" : "Surface"
+                          }
+                        }
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsRoundTripAliasedTags",
+                "parameters" : [
+                  {
+                    "name" : "values",
+                    "type" : {
+                      "array" : {
+                        "_0" : {
+                          "nullable" : {
+                            "_0" : {
+                              "alias" : {
+                                "name" : "AliasedTag",
+                                "underlying" : {
+                                  "associatedValueEnum" : {
+                                    "_0" : "InnerTag"
+                                  }
+                                }
+                              }
+                            },
+                            "_1" : "null"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "array" : {
+                    "_0" : {
+                      "nullable" : {
+                        "_0" : {
+                          "alias" : {
+                            "name" : "AliasedTag",
+                            "underlying" : {
+                              "associatedValueEnum" : {
+                                "_0" : "InnerTag"
+                              }
+                            }
+                          }
+                        },
+                        "_1" : "null"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsRoundTripPolygon",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "alias" : {
+                        "name" : "Polygon",
+                        "underlying" : {
+                          "swiftHeapObject" : {
+                            "_0" : "PolygonReference"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "alias" : {
+                    "name" : "Polygon",
+                    "underlying" : {
+                      "swiftHeapObject" : {
+                        "_0" : "PolygonReference"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsRoundTripCoordinate",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "alias" : {
+                        "name" : "Coordinate",
+                        "underlying" : {
+                          "swiftStruct" : {
+                            "_0" : "JSCoordinate"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "alias" : {
+                    "name" : "Coordinate",
+                    "underlying" : {
+                      "swiftStruct" : {
+                        "_0" : "JSCoordinate"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "functions" : [
+
+        ],
+        "types" : [
+          {
+            "accessLevel" : "internal",
+            "constructor" : {
+              "accessLevel" : "internal",
+              "parameters" : [
+                {
                   "name" : "id",
                   "type" : {
                     "string" : {
@@ -19011,103 +19659,6 @@
                     "_1" : "String"
                   }
                 }
-              },
-              {
-                "accessLevel" : "internal",
-                "effects" : {
-                  "isAsync" : true,
-                  "isStatic" : false,
-                  "isThrows" : true
-                },
-                "name" : "jsAsyncRoundTripAssociatedValueEnum",
-                "parameters" : [
-                  {
-                    "name" : "v",
-                    "type" : {
-                      "associatedValueEnum" : {
-                        "_0" : "AsyncImportedPayloadResult"
-                      }
-                    }
-                  }
-                ],
-                "returnType" : {
-                  "associatedValueEnum" : {
-                    "_0" : "AsyncImportedPayloadResult"
-                  }
-                }
-              },
-              {
-                "accessLevel" : "internal",
-                "effects" : {
-                  "isAsync" : true,
-                  "isStatic" : false,
-                  "isThrows" : true
-                },
-                "name" : "jsAsyncRoundTripOptionalAssociatedValueEnum",
-                "parameters" : [
-                  {
-                    "name" : "v",
-                    "type" : {
-                      "nullable" : {
-                        "_0" : {
-                          "associatedValueEnum" : {
-                            "_0" : "AsyncImportedPayloadResult"
-                          }
-                        },
-                        "_1" : "null"
-                      }
-                    }
-                  }
-                ],
-                "returnType" : {
-                  "nullable" : {
-                    "_0" : {
-                      "associatedValueEnum" : {
-                        "_0" : "AsyncImportedPayloadResult"
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "functions" : [
-
-        ],
-        "types" : [
-          {
-            "accessLevel" : "internal",
-            "getters" : [
-
-            ],
-            "methods" : [
-
-            ],
-            "name" : "ClosureAsyncImports",
-            "setters" : [
-
-            ],
-            "staticMethods" : [
-              {
-                "accessLevel" : "internal",
-                "effects" : {
-                  "isAsync" : true,
-                  "isStatic" : false,
-                  "isThrows" : true
-                },
-                "name" : "runJsClosureAsyncTests",
-                "parameters" : [
-
-                ],
-                "returnType" : {
-                  "void" : {
-
-                  }
-                }
               }
             ]
           }
@@ -19944,45 +20495,6 @@
             "methods" : [
 
             ],
-            "name" : "ClosureThrowsImports",
-            "setters" : [
-
-            ],
-            "staticMethods" : [
-              {
-                "accessLevel" : "internal",
-                "effects" : {
-                  "isAsync" : false,
-                  "isStatic" : false,
-                  "isThrows" : true
-                },
-                "name" : "runJsClosureThrowsTests",
-                "parameters" : [
-
-                ],
-                "returnType" : {
-                  "void" : {
-
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "functions" : [
-
-        ],
-        "types" : [
-          {
-            "accessLevel" : "internal",
-            "getters" : [
-
-            ],
-            "methods" : [
-
-            ],
             "name" : "DefaultArgumentImports",
             "setters" : [
 
@@ -20526,6 +21038,23 @@
               "isThrows" : true
             },
             "name" : "runAsyncWorks",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "void" : {
+
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : true,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "runAliasAsyncWorks",
             "parameters" : [
 
             ],
@@ -21095,95 +21624,6 @@
               "isStatic" : false,
               "isThrows" : true
             },
-            "name" : "jsRoundTripLightColor",
-            "parameters" : [
-              {
-                "name" : "value",
-                "type" : {
-                  "caseEnum" : {
-                    "_0" : "LightColor"
-                  }
-                }
-              }
-            ],
-            "returnType" : {
-              "caseEnum" : {
-                "_0" : "LightColor"
-              }
-            }
-          },
-          {
-            "accessLevel" : "internal",
-            "effects" : {
-              "isAsync" : false,
-              "isStatic" : false,
-              "isThrows" : true
-            },
-            "name" : "jsRoundTripImportedPayloadSignal",
-            "parameters" : [
-              {
-                "name" : "value",
-                "type" : {
-                  "associatedValueEnum" : {
-                    "_0" : "ImportedPayloadSignal"
-                  }
-                }
-              }
-            ],
-            "returnType" : {
-              "associatedValueEnum" : {
-                "_0" : "ImportedPayloadSignal"
-              }
-            }
-          },
-          {
-            "accessLevel" : "internal",
-            "effects" : {
-              "isAsync" : false,
-              "isStatic" : false,
-              "isThrows" : true
-            },
-            "name" : "jsRoundTripOptionalImportedPayloadSignal",
-            "parameters" : [
-              {
-                "name" : "value",
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "associatedValueEnum" : {
-                        "_0" : "ImportedPayloadSignal"
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              }
-            ],
-            "returnType" : {
-              "nullable" : {
-                "_0" : {
-                  "associatedValueEnum" : {
-                    "_0" : "ImportedPayloadSignal"
-                  }
-                },
-                "_1" : "null"
-              }
-            }
-          }
-        ],
-        "types" : [
-
-        ]
-      },
-      {
-        "functions" : [
-          {
-            "accessLevel" : "internal",
-            "effects" : {
-              "isAsync" : false,
-              "isStatic" : false,
-              "isThrows" : true
-            },
             "name" : "jsTranslatePoint",
             "parameters" : [
               {
@@ -21220,40 +21660,6 @@
             "returnType" : {
               "swiftStruct" : {
                 "_0" : "Point"
-              }
-            }
-          },
-          {
-            "accessLevel" : "internal",
-            "effects" : {
-              "isAsync" : false,
-              "isStatic" : false,
-              "isThrows" : true
-            },
-            "name" : "jsRoundTripOptionalPoint",
-            "parameters" : [
-              {
-                "name" : "point",
-                "type" : {
-                  "nullable" : {
-                    "_0" : {
-                      "swiftStruct" : {
-                        "_0" : "Point"
-                      }
-                    },
-                    "_1" : "null"
-                  }
-                }
-              }
-            ],
-            "returnType" : {
-              "nullable" : {
-                "_0" : {
-                  "swiftStruct" : {
-                    "_0" : "Point"
-                  }
-                },
-                "_1" : "null"
               }
             }
           }
@@ -22520,40 +22926,6 @@
                       }
                     },
                     "_1" : "undefined"
-                  }
-                }
-              },
-              {
-                "accessLevel" : "internal",
-                "effects" : {
-                  "isAsync" : false,
-                  "isStatic" : false,
-                  "isThrows" : true
-                },
-                "name" : "jsRoundTripOptionalJSObjectNull",
-                "parameters" : [
-                  {
-                    "name" : "value",
-                    "type" : {
-                      "nullable" : {
-                        "_0" : {
-                          "jsObject" : {
-
-                          }
-                        },
-                        "_1" : "null"
-                      }
-                    }
-                  }
-                ],
-                "returnType" : {
-                  "nullable" : {
-                    "_0" : {
-                      "jsObject" : {
-
-                      }
-                    },
-                    "_1" : "null"
                   }
                 }
               },

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -18,14 +18,6 @@
         }
       },
       {
-        "swiftCallName" : "Token",
-        "underlying" : {
-          "swiftHeapObject" : {
-            "_0" : "TokenReference"
-          }
-        }
-      },
-      {
         "swiftCallName" : "TagHolder",
         "underlying" : {
           "swiftHeapObject" : {
@@ -58,10 +50,13 @@
         }
       },
       {
-        "swiftCallName" : "Session",
+        "swiftCallName" : "UserId",
         "underlying" : {
-          "swiftStruct" : {
-            "_0" : "SessionState"
+          "integer" : {
+            "_0" : {
+              "isSigned" : true,
+              "width" : "word"
+            }
           }
         }
       },
@@ -86,6 +81,14 @@
         "underlying" : {
           "associatedValueEnum" : {
             "_0" : "InnerTag"
+          }
+        }
+      },
+      {
+        "swiftCallName" : "Boxed",
+        "underlying" : {
+          "jsValue" : {
+
           }
         }
       }
@@ -286,57 +289,6 @@
 
         ],
         "swiftCallName" : "TagReference"
-      },
-      {
-        "constructor" : {
-          "abiName" : "bjs_TokenReference_init",
-          "effects" : {
-            "isAsync" : false,
-            "isStatic" : false,
-            "isThrows" : false
-          },
-          "parameters" : [
-            {
-              "label" : "value",
-              "name" : "value",
-              "type" : {
-                "integer" : {
-                  "_0" : {
-                    "isSigned" : true,
-                    "width" : "word"
-                  }
-                }
-              }
-            }
-          ]
-        },
-        "methods" : [
-          {
-            "abiName" : "bjs_TokenReference_read",
-            "effects" : {
-              "isAsync" : false,
-              "isStatic" : false,
-              "isThrows" : false
-            },
-            "name" : "read",
-            "parameters" : [
-
-            ],
-            "returnType" : {
-              "integer" : {
-                "_0" : {
-                  "isSigned" : true,
-                  "width" : "word"
-                }
-              }
-            }
-          }
-        ],
-        "name" : "TokenReference",
-        "properties" : [
-
-        ],
-        "swiftCallName" : "TokenReference"
       },
       {
         "constructor" : {
@@ -1459,6 +1411,46 @@
                   "isSigned" : true,
                   "width" : "word"
                 }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_Calculator_asyncMakePoint",
+            "effects" : {
+              "isAsync" : true,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "asyncMakePoint",
+            "parameters" : [
+              {
+                "label" : "x",
+                "name" : "x",
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              },
+              {
+                "label" : "y",
+                "name" : "y",
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
               }
             }
           }
@@ -7169,6 +7161,53 @@
       },
       {
         "cases" : [
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "name" : "success"
+          },
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "name" : "failure"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "idle"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "AsyncImportedPayloadResult",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "AsyncImportedPayloadResult",
+        "tsFullPath" : "AsyncImportedPayloadResult"
+      },
+      {
+        "cases" : [
 
         ],
         "emitStyle" : "const",
@@ -8331,6 +8370,53 @@
         ],
         "swiftCallName" : "TSTheme",
         "tsFullPath" : "TSTheme"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "name" : "success"
+          },
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "name" : "failure"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "idle"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "AsyncPayloadResult",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "AsyncPayloadResult",
+        "tsFullPath" : "AsyncPayloadResult"
       },
       {
         "cases" : [
@@ -9910,6 +9996,85 @@
         ],
         "swiftCallName" : "NestedStructGroupB",
         "tsFullPath" : "NestedStructGroupB"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "red"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "yellow"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "green"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "LightColor",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "LightColor",
+        "tsFullPath" : "LightColor"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "name" : "start"
+          },
+          {
+            "associatedValues" : [
+              {
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "name" : "stop"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "idle"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "ImportedPayloadSignal",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "ImportedPayloadSignal",
+        "tsFullPath" : "ImportedPayloadSignal"
       },
       {
         "cases" : [
@@ -12392,74 +12557,6 @@
         }
       },
       {
-        "abiName" : "bjs_incrementToken",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "incrementToken",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "token",
-            "type" : {
-              "alias" : {
-                "name" : "Token",
-                "underlying" : {
-                  "swiftHeapObject" : {
-                    "_0" : "TokenReference"
-                  }
-                }
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "alias" : {
-            "name" : "Token",
-            "underlying" : {
-              "swiftHeapObject" : {
-                "_0" : "TokenReference"
-              }
-            }
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_makeToken",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "makeToken",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "value",
-            "type" : {
-              "integer" : {
-                "_0" : {
-                  "isSigned" : true,
-                  "width" : "word"
-                }
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "alias" : {
-            "name" : "Token",
-            "underlying" : {
-              "swiftHeapObject" : {
-                "_0" : "TokenReference"
-              }
-            }
-          }
-        }
-      },
-      {
         "abiName" : "bjs_makePolygonInspector",
         "effects" : {
           "isAsync" : false,
@@ -12500,36 +12597,6 @@
               "sendingParameters" : false
             },
             "useJSTypedClosure" : false
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_asyncMakePolygon",
-        "effects" : {
-          "isAsync" : true,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "asyncMakePolygon",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "label",
-            "type" : {
-              "string" : {
-
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "alias" : {
-            "name" : "Polygon",
-            "underlying" : {
-              "swiftHeapObject" : {
-                "_0" : "PolygonReference"
-              }
-            }
           }
         }
       },
@@ -12764,71 +12831,6 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripSession",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "roundTripSession",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "session",
-            "type" : {
-              "alias" : {
-                "name" : "Session",
-                "underlying" : {
-                  "swiftStruct" : {
-                    "_0" : "SessionState"
-                  }
-                }
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "alias" : {
-            "name" : "Session",
-            "underlying" : {
-              "swiftStruct" : {
-                "_0" : "SessionState"
-              }
-            }
-          }
-        }
-      },
-      {
-        "abiName" : "bjs_makeSession",
-        "effects" : {
-          "isAsync" : false,
-          "isStatic" : false,
-          "isThrows" : false
-        },
-        "name" : "makeSession",
-        "parameters" : [
-          {
-            "label" : "_",
-            "name" : "token",
-            "type" : {
-              "string" : {
-
-              }
-            }
-          }
-        ],
-        "returnType" : {
-          "alias" : {
-            "name" : "Session",
-            "underlying" : {
-              "swiftStruct" : {
-                "_0" : "SessionState"
-              }
-            }
-          }
-        }
-      },
-      {
         "abiName" : "bjs_roundTripShape",
         "effects" : {
           "isAsync" : false,
@@ -12897,6 +12899,595 @@
         "returnType" : {
           "associatedValueEnum" : {
             "_0" : "Shape"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripUserId",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripUserId",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "id",
+            "type" : {
+              "alias" : {
+                "name" : "UserId",
+                "underlying" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "UserId",
+            "underlying" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalUserId",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalUserId",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "id",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "alias" : {
+                    "name" : "UserId",
+                    "underlying" : {
+                      "integer" : {
+                        "_0" : {
+                          "isSigned" : true,
+                          "width" : "word"
+                        }
+                      }
+                    }
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "alias" : {
+                "name" : "UserId",
+                "underlying" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripUserIdArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripUserIdArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "ids",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "alias" : {
+                    "name" : "UserId",
+                    "underlying" : {
+                      "integer" : {
+                        "_0" : {
+                          "isSigned" : true,
+                          "width" : "word"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "alias" : {
+                "name" : "UserId",
+                "underlying" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripBoxed",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripBoxed",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "boxed",
+            "type" : {
+              "alias" : {
+                "name" : "Boxed",
+                "underlying" : {
+                  "jsValue" : {
+
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "alias" : {
+            "name" : "Boxed",
+            "underlying" : {
+              "jsValue" : {
+
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_roundTripOptionalBoxed",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalBoxed",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "boxed",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "alias" : {
+                    "name" : "Boxed",
+                    "underlying" : {
+                      "jsValue" : {
+
+                      }
+                    }
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "alias" : {
+                "name" : "Boxed",
+                "underlying" : {
+                  "jsValue" : {
+
+                  }
+                }
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_awaitAsyncCallback",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "awaitAsyncCallback",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "fetch",
+            "type" : {
+              "closure" : {
+                "_0" : {
+                  "isAsync" : true,
+                  "isThrows" : true,
+                  "mangleName" : "20BridgeJSRuntimeTestsYaKSS_SS",
+                  "moduleName" : "BridgeJSRuntimeTests",
+                  "parameters" : [
+                    {
+                      "string" : {
+
+                      }
+                    }
+                  ],
+                  "returnType" : {
+                    "string" : {
+
+                    }
+                  },
+                  "sendingParameters" : false
+                },
+                "useJSTypedClosure" : false
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAsyncParser",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAsyncParser",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : true,
+              "mangleName" : "20BridgeJSRuntimeTestsYaKSS_SS",
+              "moduleName" : "BridgeJSRuntimeTests",
+              "parameters" : [
+                {
+                  "string" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "string" : {
+
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAsyncEcho",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAsyncEcho",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : false,
+              "mangleName" : "20BridgeJSRuntimeTestsYaSS_SS",
+              "moduleName" : "BridgeJSRuntimeTests",
+              "parameters" : [
+                {
+                  "string" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "string" : {
+
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAsyncRecorder",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAsyncRecorder",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : true,
+              "mangleName" : "20BridgeJSRuntimeTestsYaKSS_y",
+              "moduleName" : "BridgeJSRuntimeTests",
+              "parameters" : [
+                {
+                  "string" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "void" : {
+
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_lastRecordedValue",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "lastRecordedValue",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAsyncPayloadLoader",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAsyncPayloadLoader",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : true,
+              "mangleName" : "20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO",
+              "moduleName" : "BridgeJSRuntimeTests",
+              "parameters" : [
+                {
+                  "bool" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "associatedValueEnum" : {
+                  "_0" : "AsyncPayloadResult"
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_awaitPayloadCallback",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "awaitPayloadCallback",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "load",
+            "type" : {
+              "closure" : {
+                "_0" : {
+                  "isAsync" : true,
+                  "isThrows" : true,
+                  "mangleName" : "20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO",
+                  "moduleName" : "BridgeJSRuntimeTests",
+                  "parameters" : [
+                    {
+                      "bool" : {
+
+                      }
+                    }
+                  ],
+                  "returnType" : {
+                    "associatedValueEnum" : {
+                      "_0" : "AsyncPayloadResult"
+                    }
+                  },
+                  "sendingParameters" : false
+                },
+                "useJSTypedClosure" : false
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAsyncPointMaker",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAsyncPointMaker",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : false,
+              "mangleName" : "20BridgeJSRuntimeTestsYaSd_9DataPointV",
+              "moduleName" : "BridgeJSRuntimeTests",
+              "parameters" : [
+                {
+                  "double" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "swiftStruct" : {
+                  "_0" : "DataPoint"
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeThrowingParser",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeThrowingParser",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : false,
+              "isThrows" : true,
+              "mangleName" : "20BridgeJSRuntimeTestsKSS_Si",
+              "moduleName" : "BridgeJSRuntimeTests",
+              "parameters" : [
+                {
+                  "string" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_runValidator",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "runValidator",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "validate",
+            "type" : {
+              "closure" : {
+                "_0" : {
+                  "isAsync" : false,
+                  "isThrows" : true,
+                  "mangleName" : "20BridgeJSRuntimeTestsKSS_Sb",
+                  "moduleName" : "BridgeJSRuntimeTests",
+                  "parameters" : [
+                    {
+                      "string" : {
+
+                      }
+                    }
+                  ],
+                  "returnType" : {
+                    "bool" : {
+
+                    }
+                  },
+                  "sendingParameters" : false
+                },
+                "useJSTypedClosure" : false
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "bool" : {
+
           }
         }
       },
@@ -13427,6 +14018,41 @@
         }
       },
       {
+        "abiName" : "bjs_roundTripOptionalImportedClass",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "roundTripOptionalImportedClass",
+        "parameters" : [
+          {
+            "label" : "v",
+            "name" : "v",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "jsObject" : {
+                    "_0" : "Foo"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "jsObject" : {
+                "_0" : "Foo"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
         "abiName" : "bjs_throwsSwiftError",
         "effects" : {
           "isAsync" : false,
@@ -13569,6 +14195,23 @@
         ],
         "returnType" : {
           "jsObject" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_zeroArgAsyncThrows",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "zeroArgAsyncThrows",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "string" : {
 
           }
         }
@@ -14042,6 +14685,390 @@
           "rawValueEnum" : {
             "_0" : "Theme",
             "_1" : "String"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripTheme",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripTheme",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "rawValueEnum" : {
+                "_0" : "Theme",
+                "_1" : "String"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "rawValueEnum" : {
+            "_0" : "Theme",
+            "_1" : "String"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripDirection",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripDirection",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "caseEnum" : {
+                "_0" : "Direction"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "caseEnum" : {
+            "_0" : "Direction"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripOptionalTheme",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripOptionalTheme",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "Theme",
+                    "_1" : "String"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "Theme",
+                "_1" : "String"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripOptionalDirection",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripOptionalDirection",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Direction"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "Direction"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripDirectionArray",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripDirectionArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Direction"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "Direction"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripDirectionDict",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripDirectionDict",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "dictionary" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Direction"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "dictionary" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "Direction"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripThemeArray",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripThemeArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "Theme",
+                    "_1" : "String"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "Theme",
+                "_1" : "String"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripThemeDict",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripThemeDict",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "dictionary" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "Theme",
+                    "_1" : "String"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "dictionary" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "Theme",
+                "_1" : "String"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripFileSize",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripFileSize",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "rawValueEnum" : {
+                "_0" : "FileSize",
+                "_1" : "Int64"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "rawValueEnum" : {
+            "_0" : "FileSize",
+            "_1" : "Int64"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripOptionalFileSize",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripOptionalFileSize",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "FileSize",
+                    "_1" : "Int64"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "FileSize",
+                "_1" : "Int64"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripAssociatedValueEnum",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripAssociatedValueEnum",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "associatedValueEnum" : {
+                "_0" : "AsyncPayloadResult"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "associatedValueEnum" : {
+            "_0" : "AsyncPayloadResult"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripOptionalAssociatedValueEnum",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripOptionalAssociatedValueEnum",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "associatedValueEnum" : {
+                    "_0" : "AsyncPayloadResult"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "associatedValueEnum" : {
+                "_0" : "AsyncPayloadResult"
+              }
+            },
+            "_1" : "null"
           }
         }
       },
@@ -15838,6 +16865,241 @@
         }
       },
       {
+        "abiName" : "bjs_asyncRoundTripPublicPoint",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripPublicPoint",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "point",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "PublicPoint"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripPublicPointThrows",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "asyncRoundTripPublicPointThrows",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "point",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "PublicPoint"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncStructOrThrow",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "asyncStructOrThrow",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "shouldThrow",
+            "type" : {
+              "bool" : {
+
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "PublicPoint"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncCombinePublicPoints",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncCombinePublicPoints",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "a",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "b",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "PublicPoint"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripContact",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripContact",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "contact",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "Contact"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "Contact"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripPublicPointArray",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripPublicPointArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "points",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "PublicPoint"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripOptionalPublicPoint",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripOptionalPublicPoint",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "point",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "PublicPoint"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripPublicPointDict",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripPublicPointDict",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "points",
+            "type" : {
+              "dictionary" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "PublicPoint"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "dictionary" : {
+            "_0" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
+          }
+        }
+      },
+      {
         "abiName" : "bjs_roundTripContact",
         "effects" : {
           "isAsync" : false,
@@ -16695,44 +17957,6 @@
           }
         ],
         "swiftCallName" : "JSCoordinate"
-      },
-      {
-        "constructor" : {
-          "abiName" : "bjs_SessionState_init",
-          "effects" : {
-            "isAsync" : false,
-            "isStatic" : false,
-            "isThrows" : false
-          },
-          "parameters" : [
-            {
-              "label" : "token",
-              "name" : "token",
-              "type" : {
-                "string" : {
-
-                }
-              }
-            }
-          ]
-        },
-        "methods" : [
-
-        ],
-        "name" : "SessionState",
-        "properties" : [
-          {
-            "isReadonly" : true,
-            "isStatic" : false,
-            "name" : "token",
-            "type" : {
-              "string" : {
-
-              }
-            }
-          }
-        ],
-        "swiftCallName" : "SessionState"
       },
       {
         "methods" : [
@@ -18711,6 +19935,96 @@
                     }
                   }
                 }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsRoundTripUserId",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "alias" : {
+                        "name" : "UserId",
+                        "underlying" : {
+                          "integer" : {
+                            "_0" : {
+                              "isSigned" : true,
+                              "width" : "word"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "alias" : {
+                    "name" : "UserId",
+                    "underlying" : {
+                      "integer" : {
+                        "_0" : {
+                          "isSigned" : true,
+                          "width" : "word"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsRoundTripOptionalUserId",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "nullable" : {
+                        "_0" : {
+                          "alias" : {
+                            "name" : "UserId",
+                            "underlying" : {
+                              "integer" : {
+                                "_0" : {
+                                  "isSigned" : true,
+                                  "width" : "word"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "_1" : "null"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "nullable" : {
+                    "_0" : {
+                      "alias" : {
+                        "name" : "UserId",
+                        "underlying" : {
+                          "integer" : {
+                            "_0" : {
+                              "isSigned" : true,
+                              "width" : "word"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
               }
             ]
           }
@@ -19659,6 +20973,103 @@
                     "_1" : "String"
                   }
                 }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : true,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsAsyncRoundTripAssociatedValueEnum",
+                "parameters" : [
+                  {
+                    "name" : "v",
+                    "type" : {
+                      "associatedValueEnum" : {
+                        "_0" : "AsyncImportedPayloadResult"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "associatedValueEnum" : {
+                    "_0" : "AsyncImportedPayloadResult"
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : true,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsAsyncRoundTripOptionalAssociatedValueEnum",
+                "parameters" : [
+                  {
+                    "name" : "v",
+                    "type" : {
+                      "nullable" : {
+                        "_0" : {
+                          "associatedValueEnum" : {
+                            "_0" : "AsyncImportedPayloadResult"
+                          }
+                        },
+                        "_1" : "null"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "nullable" : {
+                    "_0" : {
+                      "associatedValueEnum" : {
+                        "_0" : "AsyncImportedPayloadResult"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "functions" : [
+
+        ],
+        "types" : [
+          {
+            "accessLevel" : "internal",
+            "getters" : [
+
+            ],
+            "methods" : [
+
+            ],
+            "name" : "ClosureAsyncImports",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : true,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "runJsClosureAsyncTests",
+                "parameters" : [
+
+                ],
+                "returnType" : {
+                  "void" : {
+
+                  }
+                }
               }
             ]
           }
@@ -20495,6 +21906,45 @@
             "methods" : [
 
             ],
+            "name" : "ClosureThrowsImports",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "runJsClosureThrowsTests",
+                "parameters" : [
+
+                ],
+                "returnType" : {
+                  "void" : {
+
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "functions" : [
+
+        ],
+        "types" : [
+          {
+            "accessLevel" : "internal",
+            "getters" : [
+
+            ],
+            "methods" : [
+
+            ],
             "name" : "DefaultArgumentImports",
             "setters" : [
 
@@ -21038,23 +22488,6 @@
               "isThrows" : true
             },
             "name" : "runAsyncWorks",
-            "parameters" : [
-
-            ],
-            "returnType" : {
-              "void" : {
-
-              }
-            }
-          },
-          {
-            "accessLevel" : "internal",
-            "effects" : {
-              "isAsync" : true,
-              "isStatic" : false,
-              "isThrows" : true
-            },
-            "name" : "runAliasAsyncWorks",
             "parameters" : [
 
             ],
@@ -21624,6 +23057,95 @@
               "isStatic" : false,
               "isThrows" : true
             },
+            "name" : "jsRoundTripLightColor",
+            "parameters" : [
+              {
+                "name" : "value",
+                "type" : {
+                  "caseEnum" : {
+                    "_0" : "LightColor"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "caseEnum" : {
+                "_0" : "LightColor"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "jsRoundTripImportedPayloadSignal",
+            "parameters" : [
+              {
+                "name" : "value",
+                "type" : {
+                  "associatedValueEnum" : {
+                    "_0" : "ImportedPayloadSignal"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "associatedValueEnum" : {
+                "_0" : "ImportedPayloadSignal"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "jsRoundTripOptionalImportedPayloadSignal",
+            "parameters" : [
+              {
+                "name" : "value",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "associatedValueEnum" : {
+                        "_0" : "ImportedPayloadSignal"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "associatedValueEnum" : {
+                    "_0" : "ImportedPayloadSignal"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "types" : [
+
+        ]
+      },
+      {
+        "functions" : [
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
             "name" : "jsTranslatePoint",
             "parameters" : [
               {
@@ -21660,6 +23182,40 @@
             "returnType" : {
               "swiftStruct" : {
                 "_0" : "Point"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "jsRoundTripOptionalPoint",
+            "parameters" : [
+              {
+                "name" : "point",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "Point"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "Point"
+                  }
+                },
+                "_1" : "null"
               }
             }
           }
@@ -22926,6 +24482,40 @@
                       }
                     },
                     "_1" : "undefined"
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "jsRoundTripOptionalJSObjectNull",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "nullable" : {
+                        "_0" : {
+                          "jsObject" : {
+
+                          }
+                        },
+                        "_1" : "null"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "nullable" : {
+                    "_0" : {
+                      "jsObject" : {
+
+                      }
+                    },
+                    "_1" : "null"
                   }
                 }
               },

--- a/Tests/BridgeJSRuntimeTests/JavaScript/AliasTests.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/AliasTests.mjs
@@ -31,6 +31,12 @@ export function getImports(importsContext) {
         jsRoundTripCoordinate: (value) => {
             return { ...value };
         },
+        jsRoundTripUserId: (value) => {
+            return value;
+        },
+        jsRoundTripOptionalUserId: (value) => {
+            return value ?? null;
+        },
     };
 }
 
@@ -45,19 +51,15 @@ export function runAliasWorks(exports) {
     runMultipleAliases(exports);
     runArrays(exports);
     runThrows(exports);
-    runNonCopyable(exports);
+    runJSValueAlias(exports);
+    runScalarAlias(exports);
     runClosureWithAliasParameter(exports);
     runOptionalInArray(exports);
     runClassPropertyAndInitWithAlias(exports);
     runAssociatedValueEnumPayload(exports);
     runStructToStructAlias(exports);
     runStructToEnumAlias(exports);
-    runClassToStructAlias(exports);
     runEnumToClassAlias(exports);
-}
-
-export async function runAliasAsyncWorks(exports) {
-    await runAsyncReturningAlias(exports);
 }
 
 /**
@@ -194,15 +196,28 @@ function runThrows(exports) {
 /**
  * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
  */
-function runNonCopyable(exports) {
-    const seed = exports.makeToken(7);
-    assert.equal(seed.read(), 7);
+function runJSValueAlias(exports) {
+    assert.equal(exports.roundTripBoxed(42), 42);
+    assert.equal(exports.roundTripBoxed("hello"), "hello");
+    assert.deepStrictEqual(exports.roundTripBoxed({ a: 1 }), { a: 1 });
 
-    const next = exports.incrementToken(seed);
-    assert.equal(next.read(), 8);
+    assert.equal(exports.roundTripOptionalBoxed(null), null);
+    assert.equal(exports.roundTripOptionalBoxed("present"), "present");
+}
 
-    next.release();
-    seed.release();
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runScalarAlias(exports) {
+    assert.equal(exports.roundTripUserId(42), 42);
+    assert.equal(exports.roundTripUserId(-1), -1);
+
+    assert.equal(exports.roundTripOptionalUserId(null), null);
+    assert.equal(exports.roundTripOptionalUserId(0), 0);
+    assert.equal(exports.roundTripOptionalUserId(7), 7);
+
+    assert.deepStrictEqual(exports.roundTripUserIdArray([]), []);
+    assert.deepStrictEqual(exports.roundTripUserIdArray([1, 2, 3]), [1, 2, 3]);
 }
 
 /**
@@ -322,17 +337,6 @@ function runStructToEnumAlias(exports) {
 /**
  * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
  */
-function runClassToStructAlias(exports) {
-    const made = exports.makeSession("hello");
-    assert.deepStrictEqual(made, { token: "hello" });
-
-    const echoed = exports.roundTripSession({ token: "world" });
-    assert.deepStrictEqual(echoed, { token: "world" });
-}
-
-/**
- * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
- */
 function runEnumToClassAlias(exports) {
     const seed = exports.PriorityReference.medium();
     assert.equal(seed.describe(), "medium");
@@ -344,14 +348,4 @@ function runEnumToClassAlias(exports) {
 
     seed.release();
     echoed.release();
-}
-
-/**
- * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
- */
-async function runAsyncReturningAlias(exports) {
-    const result = await exports.asyncMakePolygon("async");
-    assert.equal(result.vertexCount(), 2);
-    assert.equal(result.summary(), "async(2)");
-    result.release();
 }

--- a/Tests/BridgeJSRuntimeTests/JavaScript/AliasTests.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/AliasTests.mjs
@@ -1,0 +1,357 @@
+// @ts-check
+import assert from "node:assert";
+
+export class Surface {
+    constructor(label) {
+        this.label = label;
+    }
+};
+
+/**
+ * @returns {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Imports["AliasImports"]}
+ */
+export function getImports(importsContext) {
+    return {
+        jsRoundTripTagged: (value) => {
+            return value;
+        },
+        jsRoundTripOptionalTagged: (value) => {
+            return value ?? null;
+        },
+        jsProduceOptionalCanvas: (label) => {
+            if (label === null || label === undefined) return null;
+            return new Surface(label);
+        },
+        jsRoundTripAliasedTags: (values) => {
+            return values.map((tag) => tag ?? null);
+        },
+        jsRoundTripPolygon: (value) => {
+            return value;
+        },
+        jsRoundTripCoordinate: (value) => {
+            return { ...value };
+        },
+    };
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+export function runAliasWorks(exports) {
+    runBasicRoundTrip(exports);
+    runOptional(exports);
+    runMethodsOnTarget(exports);
+    runStaticReturn(exports);
+    runMultipleAliases(exports);
+    runArrays(exports);
+    runThrows(exports);
+    runNonCopyable(exports);
+    runClosureWithAliasParameter(exports);
+    runOptionalInArray(exports);
+    runClassPropertyAndInitWithAlias(exports);
+    runAssociatedValueEnumPayload(exports);
+    runStructToStructAlias(exports);
+    runStructToEnumAlias(exports);
+    runClassToStructAlias(exports);
+    runEnumToClassAlias(exports);
+}
+
+export async function runAliasAsyncWorks(exports) {
+    await runAsyncReturningAlias(exports);
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runBasicRoundTrip(exports) {
+    const seed = new exports.PolygonReference([1, 2, 3], "seed");
+    assert.equal(seed.vertexCount(), 3);
+    assert.equal(seed.summary(), "seed(3)");
+
+    const roundtrip = exports.roundTripPolygon(seed);
+    assert.equal(roundtrip.vertexCount(), 3);
+    assert.equal(roundtrip.summary(), "seed(3)");
+
+    assert.equal(exports.polygonVertexCount(seed), 3);
+
+    const appended = exports.appendVertex(seed, 4);
+    assert.equal(appended.vertexCount(), 4);
+    assert.equal(appended.summary(), "seed(4)");
+
+    seed.release();
+    roundtrip.release();
+    appended.release();
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runOptional(exports) {
+    assert.equal(exports.optionalRoundTripPolygon(null), null);
+
+    const original = new exports.PolygonReference([7, 8, 9], "opt");
+    const echoed = exports.optionalRoundTripPolygon(original);
+    assert.notEqual(echoed, null);
+    if (echoed) {
+        assert.equal(echoed.vertexCount(), 3);
+        echoed.release();
+    }
+    original.release();
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runMethodsOnTarget(exports) {
+    const a = new exports.PolygonReference([1, 2], "a");
+
+    const snap = a.snapshot();
+    assert.equal(snap.summary(), "a(2)");
+
+    const b = new exports.PolygonReference([3, 4, 5], "b");
+    const merged = a.merge(b);
+    assert.equal(merged.vertexCount(), 5);
+    assert.equal(merged.summary(), "a(5)");
+
+    a.release();
+    b.release();
+    snap.release();
+    merged.release();
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runStaticReturn(exports) {
+    const o = exports.PolygonReference.origin("o");
+    assert.equal(o.vertexCount(), 0);
+    assert.equal(o.summary(), "o(0)");
+    o.release();
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runMultipleAliases(exports) {
+    const tag = exports.makeTag("hello");
+    assert.equal(tag.describe(), "tag:hello");
+    tag.release();
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runArrays(exports) {
+    const a = new exports.PolygonReference([1], "a");
+    const b = new exports.PolygonReference([2, 3], "b");
+    const c = new exports.PolygonReference([4, 5, 6], "c");
+
+    const roundtripped = exports.roundTripPolygonArray([a, b, c]);
+    assert.equal(roundtripped.length, 3);
+    assert.equal(roundtripped[0].vertexCount(), 1);
+    assert.equal(roundtripped[1].vertexCount(), 2);
+    assert.equal(roundtripped[2].vertexCount(), 3);
+    assert.equal(roundtripped[0].summary(), "a(1)");
+    assert.equal(roundtripped[1].summary(), "b(2)");
+    assert.equal(roundtripped[2].summary(), "c(3)");
+
+    const combined = exports.concatPolygons([a, b, c]);
+    assert.equal(combined.vertexCount(), 6);
+    assert.equal(combined.summary(), "concat(6)");
+
+    const empty = exports.roundTripPolygonArray([]);
+    assert.equal(empty.length, 0);
+
+    const split = exports.splitPolygon(combined);
+    assert.equal(split.length, 6);
+    for (const piece of split) {
+        assert.equal(piece.vertexCount(), 1);
+        piece.release();
+    }
+
+    a.release();
+    b.release();
+    c.release();
+    combined.release();
+    for (const r of roundtripped) r.release();
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runThrows(exports) {
+    const valid = new exports.PolygonReference([1, 2], "v");
+    const echoed = exports.validatePolygon(valid);
+    assert.equal(echoed.summary(), "v(2)");
+    echoed.release();
+    valid.release();
+
+    const empty = new exports.PolygonReference([], "empty");
+    assert.throws(() => exports.validatePolygon(empty), /empty polygon/);
+    empty.release();
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runNonCopyable(exports) {
+    const seed = exports.makeToken(7);
+    assert.equal(seed.read(), 7);
+
+    const next = exports.incrementToken(seed);
+    assert.equal(next.read(), 8);
+
+    next.release();
+    seed.release();
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runClosureWithAliasParameter(exports) {
+    const inspector = exports.makePolygonInspector();
+    const poly = new exports.PolygonReference([10, 20, 30, 40], "inspect");
+    assert.equal(inspector(poly), 4);
+    poly.release();
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runOptionalInArray(exports) {
+    const a = new exports.PolygonReference([1], "a");
+    const b = new exports.PolygonReference([2, 3], "b");
+
+    const echoed = exports.roundTripOptionalPolygonArray([a, null, b, null]);
+    assert.equal(echoed.length, 4);
+    assert.notEqual(echoed[0], null);
+    assert.equal(echoed[1], null);
+    assert.notEqual(echoed[2], null);
+    assert.equal(echoed[3], null);
+    if (echoed[0]) {
+        assert.equal(echoed[0].vertexCount(), 1);
+    }
+    if (echoed[2]) {
+        assert.equal(echoed[2].vertexCount(), 2);
+    }
+
+    a.release();
+    b.release();
+    for (const e of echoed) {
+        if (e) {
+            e.release();
+        }
+    }
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runClassPropertyAndInitWithAlias(exports) {
+    const made = exports.makeTagHolder("origin", 1);
+    assert.equal(made.describe(), "holder(origin, v1)");
+    const initial = made.tag;
+    assert.equal(initial.describe(), "tag:origin");
+
+    const replacement = exports.makeTag("renamed");
+    made.tag = replacement;
+    assert.equal(made.describe(), "holder(renamed, v1)");
+    made.version = 7;
+    assert.equal(made.describe(), "holder(renamed, v7)");
+
+    const fresh = exports.makeTag("constructed");
+    const ctor = new exports.TagHolderReference(fresh, 99);
+    assert.equal(ctor.describe(), "holder(constructed, v99)");
+
+    initial.release();
+    replacement.release();
+    fresh.release();
+    made.release();
+    ctor.release();
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runAssociatedValueEnumPayload(exports) {
+    const poly = new exports.PolygonReference([1, 2, 3], "shape");
+    const wrapped = exports.makeShapePolygon(poly);
+    assert.equal(wrapped.tag, exports.Shape.Tag.Polygon);
+    if (wrapped.tag === exports.Shape.Tag.Polygon) {
+        assert.equal(wrapped.param0.vertexCount(), 3);
+    }
+
+    const echoed = exports.roundTripShape(wrapped);
+    assert.equal(echoed.tag, exports.Shape.Tag.Polygon);
+    if (echoed.tag === exports.Shape.Tag.Polygon) {
+        assert.equal(echoed.param0.vertexCount(), 3);
+        echoed.param0.release();
+    }
+
+    const empty = exports.makeShapeEmpty();
+    assert.equal(empty.tag, exports.Shape.Tag.Empty);
+    const emptyEcho = exports.roundTripShape(empty);
+    assert.equal(emptyEcho.tag, exports.Shape.Tag.Empty);
+
+    if (wrapped.tag === exports.Shape.Tag.Polygon) {
+        wrapped.param0.release();
+    }
+    poly.release();
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runStructToStructAlias(exports) {
+    const seed = { latitude: 45.5, longitude: -73.5 };
+    const echoed = exports.roundTripCoordinate(seed);
+    assert.deepStrictEqual(echoed, seed);
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runStructToEnumAlias(exports) {
+    const made = exports.makeAlert(exports.Severity.Warning);
+    assert.equal(made, exports.Severity.Warning);
+
+    const echoed = exports.roundTripAlert(exports.Severity.Error);
+    assert.equal(echoed, exports.Severity.Error);
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runClassToStructAlias(exports) {
+    const made = exports.makeSession("hello");
+    assert.deepStrictEqual(made, { token: "hello" });
+
+    const echoed = exports.roundTripSession({ token: "world" });
+    assert.deepStrictEqual(echoed, { token: "world" });
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+function runEnumToClassAlias(exports) {
+    const seed = exports.PriorityReference.medium();
+    assert.equal(seed.describe(), "medium");
+    assert.equal(seed.weight(), 5);
+
+    const echoed = exports.roundTripPriority(seed);
+    assert.equal(echoed.describe(), "medium");
+    assert.equal(echoed.weight(), 5);
+
+    seed.release();
+    echoed.release();
+}
+
+/**
+ * @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports
+ */
+async function runAsyncReturningAlias(exports) {
+    const result = await exports.asyncMakePolygon("async");
+    assert.equal(result.vertexCount(), 2);
+    assert.equal(result.summary(), "async(2)");
+    result.release();
+}

--- a/Tests/BridgeJSRuntimeTests/bridge-js.d.ts
+++ b/Tests/BridgeJSRuntimeTests/bridge-js.d.ts
@@ -26,6 +26,8 @@ export class JsGreeter {
 
 export function runAsyncWorks(): Promise<void>;
 
+export function runAliasAsyncWorks(): Promise<void>;
+
 export interface WeatherData {
     temperature: number;
     description: string;

--- a/Tests/BridgeJSRuntimeTests/bridge-js.d.ts
+++ b/Tests/BridgeJSRuntimeTests/bridge-js.d.ts
@@ -26,8 +26,6 @@ export class JsGreeter {
 
 export function runAsyncWorks(): Promise<void>;
 
-export function runAliasAsyncWorks(): Promise<void>;
-
 export interface WeatherData {
     temperature: number;
     description: string;

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -5,6 +5,7 @@ import {
 } from '../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.js';
 import { ImportedFoo } from './BridgeJSRuntimeTests/JavaScript/Types.mjs';
 import { runJsOptionalSupportTests } from './BridgeJSRuntimeTests/JavaScript/OptionalSupportTests.mjs';
+import { runAliasWorks, runAliasAsyncWorks, getImports as getAliasImports, Surface } from './BridgeJSRuntimeTests/JavaScript/AliasTests.mjs';
 import { getImports as getClosureSupportImports } from './BridgeJSRuntimeTests/JavaScript/ClosureSupportTests.mjs';
 import { getImports as getClosureThrowsImports } from './BridgeJSRuntimeTests/JavaScript/ClosureThrowsTests.mjs';
 import { getImports as getClosureAsyncImports } from './BridgeJSRuntimeTests/JavaScript/ClosureAsyncTests.mjs';
@@ -107,6 +108,7 @@ export async function setupOptions(options, context) {
                 },
                 ArrayElementObject,
                 JSClassWithArrayMembers,
+                Surface,
                 JsGreeter: class {
                     /**
                      * @param {string} name
@@ -141,6 +143,14 @@ export async function setupOptions(options, context) {
                     await runAsyncWorksTests(exports);
                     return;
                 },
+                runAliasAsyncWorks: async () => {
+                    const exports = importsContext.getExports();
+                    if (!exports) {
+                        throw new Error("No exports!?");
+                    }
+                    await runAliasAsyncWorks(exports);
+                    return;
+                },
                 AsyncImportImports: getAsyncImportImports(importsContext),
                 fetchWeatherData: (city) => {
                     return Promise.resolve({
@@ -173,6 +183,7 @@ export async function setupOptions(options, context) {
                 IntegerTypesSupportImports: getIntegerTypesSupportImports(importsContext),
                 JSTypedArrayImports: getJSTypedArrayImports(importsContext),
                 IdentityModeTestImports: getIdentityModeTestImports(importsContext),
+                AliasImports: getAliasImports(importsContext),
             };
         },
         addToCoreImports(importObject, importsContext) {
@@ -195,6 +206,13 @@ export async function setupOptions(options, context) {
                     throw new Error("No exports!?");
                 }
                 return BridgeJSRuntimeTests_runJsStructWorks(exports);
+            }
+            bridgeJSRuntimeTests["runAliasWorks"] = () => {
+                const exports = getExports();
+                if (!exports) {
+                    throw new Error("No exports!?");
+                }
+                runAliasWorks(exports);
             }
             const bridgeJSGlobalTests = importObject["BridgeJSGlobalTests"] || {};
             bridgeJSGlobalTests["runJsWorksGlobal"] = () => {

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -5,7 +5,7 @@ import {
 } from '../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.js';
 import { ImportedFoo } from './BridgeJSRuntimeTests/JavaScript/Types.mjs';
 import { runJsOptionalSupportTests } from './BridgeJSRuntimeTests/JavaScript/OptionalSupportTests.mjs';
-import { runAliasWorks, runAliasAsyncWorks, getImports as getAliasImports, Surface } from './BridgeJSRuntimeTests/JavaScript/AliasTests.mjs';
+import { runAliasWorks, getImports as getAliasImports, Surface } from './BridgeJSRuntimeTests/JavaScript/AliasTests.mjs';
 import { getImports as getClosureSupportImports } from './BridgeJSRuntimeTests/JavaScript/ClosureSupportTests.mjs';
 import { getImports as getClosureThrowsImports } from './BridgeJSRuntimeTests/JavaScript/ClosureThrowsTests.mjs';
 import { getImports as getClosureAsyncImports } from './BridgeJSRuntimeTests/JavaScript/ClosureAsyncTests.mjs';
@@ -141,14 +141,6 @@ export async function setupOptions(options, context) {
                         throw new Error("No exports!?");
                     }
                     await runAsyncWorksTests(exports);
-                    return;
-                },
-                runAliasAsyncWorks: async () => {
-                    const exports = importsContext.getExports();
-                    if (!exports) {
-                        throw new Error("No exports!?");
-                    }
-                    await runAliasAsyncWorks(exports);
                     return;
                 },
                 AsyncImportImports: getAsyncImportImports(importsContext),


### PR DESCRIPTION
Note that this PR is much smaller than it looks! The vast majority of the lines added are tests/generated code.

Adds `@JS(as:)` to let types provide an alternative JavaScript representation, providing an escape hatch when BridgeJS’s defaults don't fit.

# Motivation

BridgeJS provides sensible defaults when exporting Swift code to JavaScript. For example, structs are exported using copy semantics: each field in the Swift struct is copied when crossing the boundary. BridgeJS also only supports exporting a subset of Swift features, which makes sense given there are many things in the Swift language which would be difficult to expose to JavaScript.

While this approach makes sense, sometimes the defaults used by BridgeJS won’t work well in a specific situation. For example, a Swift `struct Polygon { var vertices: [Point] }` will be exported to JavaScript using copy semantics. In a project where polygons could contain thousands of points, copying at the boundary every time provides unacceptable performance. Currently, there is no escape hatch for situations like these. Either the Swift code has to be modified to be less idiomatic (e.g. in this case by making `Polygon` a class), or a duplicate type could be created (say a `JSPolygon`) and exposed to JavaScript that wraps the underlying Swift type. A similar situation could be encountered when using a feature which BridgeJS doesn’t support, for example dictionaries with integer keys. The same two options are available: less idiomatic Swift code (using String keys everywhere), or duplicating types.

At first, the “duplicated types” approach sounds reasonable. Unfortunately, it starts to break down as the project scales. For example, a large existing codebase could use `Polygon` **in hundreds of types and hundreds of methods**. Creating a duplicate JS hierarchy here introduces a huge maintenance cost, where most of the duplication is providing no value since BridgeJS’s defaults likely make sense the majority of the time. The same situation occurs with unsupported features: a leaf type might introduce a dictionary with integer keys, requiring the creation of a vast hierarchy of duplicated JS-safe types.

# Solution

Allow types to provide an alternative JS representation. This works as follows:

```swift
@JS(as: JSPolygon.self) public struct Polygon {

    public var vertices: [Point]

    public consuming func bridgeToJS() -> JSPolygon {
        JSPolygon(underlying: self)
    }

    public static func bridgeFromJS(_ value: consuming JSPolygon) -> Polygon {
        value.underlying
    }

}

@JS public final class JSPolygon {

    var underlying: Polygon

    @JS public init(underlying: Polygon) {
        self.underlying = underlying
    }

    @JS var boundingBox: Rect { underlying.boundingBox }

}
```

Now, the existing Swift code can continue to use the Swift-idiomatic `Polygon` while JavaScript gets the appropriate `JSPolygon` type.

# Design

This is implemented by inserting calls to `bridgeToJS()` and `bridgeFromJS` at the first and last possible opportunity respectively. This means that code generation changes are minimal, everything just uses the ABI of the JavaScript type. I’ve added a new case to `BridgeType` `indirect case alias(name: String, underlying: BridgeType)`. I’m very much not sold on the name `alias`, but I couldn’t think of anything better.

# Alternatives

- PR https://github.com/swiftwasm/JavaScriptKit/pull/740 aimed to solve a similar problem, but was more narrow (and required more complex changes). While this approach requires more boilerplate for something like the `Polygon` case, it is also more general.
- In https://github.com/swiftwasm/JavaScriptKit/issues/737, @krodak suggested using a custom code-generation tool. While this is a possible approach, implementing this correctly is tricky and it makes sense to me for BridgeJS to have built-in support for what is likely going to be a common problem.
- Not doing anything: the status quo of requiring users to modify their Swift code to be less idiomatic or create a duplicate hierarchy of types. This would likely be an impediment to adopting BridgeJS, especially in larger projects who may have more consumers than just JavaScript.