### PR TITLE
Change Data.construct(from uint8Array:) return type from Data? to Data

### DIFF
--- a/Sources/JavaScriptFoundationCompat/Data+JSValue.swift
+++ b/Sources/JavaScriptFoundationCompat/Data+JSValue.swift
@@ -22,7 +22,7 @@ extension Data: ConvertibleToJSValue, ConstructibleFromJSValue {
     public var jsValue: JSValue { jsTypedArray.jsValue }
 
     /// Construct a Data from a JSTypedArray<UInt8>.
-    public static func construct(from uint8Array: JSTypedArray<UInt8>) -> Data? {
+    public static func construct(from uint8Array: JSTypedArray<UInt8>) -> Data {
         // First, allocate the data storage
         var data = Data(count: uint8Array.lengthInBytes)
         // Then, copy the byte contents into the Data buffer


### PR DESCRIPTION
## Summary
- change `Data.construct(from uint8Array:)` return type from `Data?` to `Data`
- keep `Data.construct(from jsValue:)` optional, since converting from `JSValue` can fail

## Rationale
Constructing from an already-typed `JSTypedArray<UInt8>` cannot fail, so the optional return type is unnecessary.
