### PR TITLE
BridgeJS: Support optional @JS struct in imported function signatures

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -957,6 +957,10 @@ extension BridgeType {
             }
         case .namespaceEnum:
             throw BridgeJSCoreError("Namespace enums cannot be used as parameters")
+        case .nullable(.swiftStruct, _) where context == .importTS:
+            // Optional `@JS struct`s bridge through the stack (isSome discriminator + fields),
+            // like optional arrays/dictionaries, rather than the non-optional object-id ABI.
+            return LoweringParameterInfo(loweredParameters: [("isSome", .i32)])
         case .nullable(let wrappedType, _):
             let wrappedInfo = try wrappedType.loweringParameterInfo(context: context)
             var params = [("isSome", WasmCoreType.i32)]
@@ -1034,8 +1038,12 @@ extension BridgeType {
         case .namespaceEnum:
             throw BridgeJSCoreError("Namespace enums cannot be used as return values")
         case .nullable(let wrappedType, _):
-            // jsObject uses stack ABI for optionals — returns void, value goes through stacks
+            // jsObject and `@JS struct` use the stack ABI for optionals — the thunk returns
+            // void and the value (plus isSome discriminator) flows through the stacks.
             if case .jsObject = wrappedType {
+                return LiftingReturnInfo(valueToLift: nil)
+            }
+            if case .swiftStruct = wrappedType, context == .importTS {
                 return LiftingReturnInfo(valueToLift: nil)
             }
             let wrappedInfo = try wrappedType.liftingReturnInfo(context: context)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/SwiftStructImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/SwiftStructImports.swift
@@ -5,3 +5,5 @@ struct Point {
 }
 
 @JSFunction func translate(_ point: Point, dx: Int, dy: Int) throws(JSException) -> Point
+
+@JSFunction func roundTripOptional(_ point: Point?) throws(JSException) -> Point?

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.json
@@ -100,6 +100,40 @@
                 "_0" : "Point"
               }
             }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "roundTripOptional",
+            "parameters" : [
+              {
+                "name" : "point",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "Point"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "Point"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
           }
         ],
         "types" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
@@ -68,3 +68,24 @@ func _$translate(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException) -> Po
     }
     return Point.bridgeJSLiftReturn(ret)
 }
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_roundTripOptional")
+fileprivate func bjs_roundTripOptional_extern(_ point: Int32) -> Void
+#else
+fileprivate func bjs_roundTripOptional_extern(_ point: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_roundTripOptional(_ point: Int32) -> Void {
+    return bjs_roundTripOptional_extern(point)
+}
+
+func _$roundTripOptional(_ point: Optional<Point>) throws(JSException) -> Optional<Point> {
+    let pointIsSome = point.bridgeJSLowerParameter()
+    bjs_roundTripOptional(pointIsSome)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<Point>.bridgeJSLiftReturn()
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.d.ts
@@ -12,6 +12,7 @@ export type Exports = {
 }
 export type Imports = {
     translate(point: Point, dx: number, dy: number): Point;
+    roundTripOptional(point: Point | null): Point | null;
 }
 export function createInstantiator(options: {
     imports: Imports;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
@@ -226,6 +226,25 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
+            TestModule["bjs_roundTripOptional"] = function bjs_roundTripOptional(point) {
+                try {
+                    let optResult;
+                    if (point) {
+                        const struct = structHelpers.Point.lift();
+                        optResult = struct;
+                    } else {
+                        optResult = null;
+                    }
+                    let ret = imports.roundTripOptional(optResult);
+                    const isSome = ret != null;
+                    if (isSome) {
+                        structHelpers.Point.lower(ret);
+                    }
+                    i32Stack.push(isSome ? 1 : 0);
+                } catch (error) {
+                    setException(error);
+                }
+            }
         },
         setInstance: (i) => {
             instance = i;

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -13280,6 +13280,27 @@ func _$jsTranslatePoint(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripOptionalPoint")
+fileprivate func bjs_jsRoundTripOptionalPoint_extern(_ point: Int32) -> Void
+#else
+fileprivate func bjs_jsRoundTripOptionalPoint_extern(_ point: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsRoundTripOptionalPoint(_ point: Int32) -> Void {
+    return bjs_jsRoundTripOptionalPoint_extern(point)
+}
+
+func _$jsRoundTripOptionalPoint(_ point: Optional<Point>) throws(JSException) -> Optional<Point> {
+    let pointIsSome = point.bridgeJSLowerParameter()
+    bjs_jsRoundTripOptionalPoint(pointIsSome)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<Point>.bridgeJSLiftReturn()
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_IntegerTypesSupportImports_jsRoundTripInt_static")
 fileprivate func bjs_IntegerTypesSupportImports_jsRoundTripInt_static_extern(_ v: Int32) -> Int32
 #else

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -19745,6 +19745,40 @@
                 "_0" : "Point"
               }
             }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "jsRoundTripOptionalPoint",
+            "parameters" : [
+              {
+                "name" : "point",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "Point"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "Point"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
           }
         ],
         "types" : [

--- a/Tests/BridgeJSRuntimeTests/ImportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ImportAPITests.swift
@@ -59,6 +59,13 @@ class ImportAPITests: XCTestCase {
         }
     }
 
+    func testRoundTripOptionalStruct() throws {
+        let p = try jsRoundTripOptionalPoint(Point(x: 3, y: 4))
+        XCTAssertEqual(p?.x, 3)
+        XCTAssertEqual(p?.y, 4)
+        XCTAssertNil(try jsRoundTripOptionalPoint(nil))
+    }
+
     func ensureThrows<T>(_ f: (Bool) throws(JSException) -> T) throws {
         do {
             _ = try f(true)

--- a/Tests/BridgeJSRuntimeTests/ImportStructAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/ImportStructAPIs.swift
@@ -7,3 +7,5 @@ struct Point {
 }
 
 @JSFunction func jsTranslatePoint(_ point: Point, dx: Int, dy: Int) throws(JSException) -> Point
+
+@JSFunction func jsRoundTripOptionalPoint(_ point: Point?) throws(JSException) -> Point?

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -141,6 +141,7 @@ export async function setupOptions(options, context) {
                 jsTranslatePoint: (point, dx, dy) => {
                     return { x: (point.x | 0) + (dx | 0), y: (point.y | 0) + (dy | 0) };
                 },
+                jsRoundTripOptionalPoint: (point) => point,
                 roundTripArrayMembers: (value) => {
                     return value;
                 },


### PR DESCRIPTION
## Overview

Optional `@JS struct`s could not be used as parameters or return values of imported (`@JSFunction`) signatures. While an optional primitive works, an optional `@JS struct` did not:

```swift
@JS struct Point { var x: Int; var y: Int }

@JSFunction func roundTrip(_ point: Point?) throws(JSException) -> Point? // did not compile
```

The code generator lowered `Optional<Point>` using the non-optional object-id ABI (`[isSome, objectId]` for parameters, a single `Int32` word for returns), for which no `Optional` lowering exists in the runtime, so the generated thunk failed to compile.

This change bridges optional `@JS struct`s through the stack ABI instead, an `isSome` discriminator plus the struct fields, exactly like optional arrays and dictionaries. `@JS struct`s already conform to the stack-based bridging protocols, so the runtime's `_BridgedAsOptional`/stack extensions and the JS link's stack handling already support this shape. Only the import-side lowering and lifting in the code generator needed to change:

**1. Parameter lowering.** `.nullable(.swiftStruct)` in the import context now lowers to a single `isSome` flag, with the struct transferred on the stack, rather than appending the non-optional `objectId` word.

**2. Return lifting.** The optional struct return is now lifted from the stack rather than from a single object-id word.

Generated thunk, before:

```swift
let (pointIsSome, pointObjectId) = point.bridgeJSLowerParameter() // no such overload
let ret = bjs_roundTrip(pointIsSome, pointObjectId)
return Optional<Point>.bridgeJSLiftReturn(ret)
```

after:

```swift
let pointIsSome = point.bridgeJSLowerParameter()
bjs_roundTrip(pointIsSome)
return Optional<Point>.bridgeJSLiftReturn()
```

The export side already used the stack ABI for optional structs and is unchanged. The change is guarded to the import context, so non-optional struct imports keep their existing object-id ABI.

Adds an end-to-end runtime round-trip test (`some` and `none`) and a codegen snapshot covering the new import shape.
