### PR TITLE
BridgeJS: Use a BigInt zero placeholder for Wasm i64 in generated JS

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -3704,7 +3704,10 @@ extension BridgeType {
 extension WasmCoreType {
     fileprivate var placeholderValue: String {
         switch self {
-        case .i32, .i64, .f32, .f64, .pointer: return "0"
+        // A Wasm `i64` return is a JavaScript `BigInt`, so the error-path placeholder
+        // must be a BigInt literal rather than a plain number.
+        case .i64: return "0n"
+        case .i32, .f32, .f64, .pointer: return "0"
         }
     }
 }

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -2603,7 +2603,10 @@ fileprivate extension WasmCoreType {
     var jsZeroLiteral: String {
         switch self {
         case .f32, .f64: return "0.0"
-        case .i32, .i64, .pointer: return "0"
+        // A Wasm `i64` parameter is passed as a JavaScript `BigInt`, so its zero
+        // placeholder must be a BigInt literal rather than a plain number.
+        case .i64: return "0n"
+        case .i32, .pointer: return "0"
         }
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
@@ -440,7 +440,7 @@ export async function createInstantiator(options, swift) {
                 },
                 roundTripOptionalFileSize: function bjs_roundTripOptionalFileSize(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalFileSize(+isSome, isSome ? input : 0);
+                    instance.exports.bjs_roundTripOptionalFileSize(+isSome, isSome ? input : 0n);
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {
@@ -488,7 +488,7 @@ export async function createInstantiator(options, swift) {
                 },
                 roundTripOptionalSessionId: function bjs_roundTripOptionalSessionId(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalSessionId(+isSome, isSome ? input : 0);
+                    instance.exports.bjs_roundTripOptionalSessionId(+isSome, isSome ? input : 0n);
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/FixedWidthIntegers.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/FixedWidthIntegers.js
@@ -258,7 +258,7 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 } catch (error) {
                     setException(error);
-                    return 0
+                    return 0n
                 }
             }
             TestModule["bjs_roundTripUInt64"] = function bjs_roundTripUInt64(v) {
@@ -267,7 +267,7 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 } catch (error) {
                     setException(error);
-                    return 0
+                    return 0n
                 }
             }
         },

--- a/Tests/BridgeJSRuntimeTests/JavaScript/OptionalSupportTests.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/OptionalSupportTests.mjs
@@ -80,6 +80,10 @@ export function runJsOptionalSupportTests(rootExports) {
     assert.equal(exports.roundTripOptionalIntRawValueEnum(HttpStatus.Ok), HttpStatusValues.Ok);
     assert.equal(exports.roundTripOptionalInt64RawValueEnum(FileSize.Tiny), FileSizeValues.Tiny);
     assert.equal(exports.roundTripOptionalUInt64RawValueEnum(SessionId.Active), SessionIdValues.Active);
+    // The `none` case lowers the i64/u64 placeholder as a BigInt (`0n`); a plain `0`
+    // would throw "Cannot convert 0 to a BigInt" when calling the Wasm export.
+    assert.equal(exports.roundTripOptionalInt64RawValueEnum(null), null);
+    assert.equal(exports.roundTripOptionalUInt64RawValueEnum(null), null);
     assert.equal(exports.roundTripOptionalTSEnum(TSDirection.North), TSDirection.North);
     assert.equal(exports.roundTripOptionalTSStringEnum(TSTheme.Light), TSTheme.Light);
     assert.equal(exports.roundTripOptionalNamespacedEnum(Networking.API.Method.Get), Networking.API.Method.Get);


### PR DESCRIPTION
## Overview

A Wasm `i64` parameter or return value is represented as a JavaScript `BigInt`. The generated JS, however, used a plain `0` as the placeholder for two cases:

1. The absent value of an optional `i64` parameter when lowering a call into a Wasm export (`isSome ? v : 0`).
2. The error-path return of an imported thunk (the value returned from the `catch` block after an exception is recorded).

Passing a plain number `0` where the Wasm boundary expects an `i64` raises `TypeError: Cannot convert 0 to a BigInt`. So calling an export with an optional `Int64`/`UInt64` argument of `null`, or having an imported `i64`-returning function throw, crashed:

```js
// before
instance.exports.bjs_roundTripOptionalInt64RawValueEnum(+isSome, isSome ? v : 0)   // 0 -> TypeError
// after
instance.exports.bjs_roundTripOptionalInt64RawValueEnum(+isSome, isSome ? v : 0n)
```

The fix emits `0n` for `i64` in both placeholder paths (the optional-parameter zero literal and the imported-thunk return placeholder); other core types are unchanged.

This was latent because the optional `Int64`/`UInt64` round-trip tests only ever exercised the present case. The PR adds the `none` assertions that reproduce and lock down the fix.

This is the last in a short series of small, focused ABI fixes (optional `@JS struct` imports, case-enum imports, and now the `i64` BigInt placeholder) that together unblock complete async support for non-`ConvertibleToJSValue` return types across all bridged stack types.
