### PR TITLE
BridgeJS: Support non-ConvertibleToJSValue async exported return types

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -90,9 +90,75 @@ public class ExportSwift {
                 decls.append(contentsOf: try renderSingleExportedClass(klass: klass))
             }
         }
+
+        try withSpan("Render Async Promise Helpers") { [self] in
+            let asyncResolveTypes = skeleton.asyncPromiseResolveReturnTypes
+            if !asyncResolveTypes.isEmpty {
+                decls.append(contentsOf: try renderPromiseRejectHelper())
+                for type in asyncResolveTypes {
+                    decls.append(contentsOf: try renderPromiseResolveHelper(type))
+                }
+            }
+        }
         return withSpan("Format Export Glue") {
             return decls.map { $0.description }.joined(separator: "\n\n")
         }
+    }
+
+    /// Generates the per-type `Promise_resolve_<mangled>` settlement helper.
+    private func renderPromiseResolveHelper(_ type: BridgeType) throws -> [DeclSyntax] {
+        try renderPromiseSettleHelper(
+            functionName: "Promise_resolve_\(type.mangleTypeName)",
+            externName: "promise_resolve_\(moduleName)_\(type.mangleTypeName)",
+            valueType: type
+        )
+    }
+
+    /// Generates the shared `Promise_reject` settlement helper.
+    private func renderPromiseRejectHelper() throws -> [DeclSyntax] {
+        try renderPromiseSettleHelper(
+            functionName: "Promise_reject",
+            externName: "promise_reject_\(moduleName)",
+            valueType: .jsValue
+        )
+    }
+
+    /// Generates a `@JSFunction func <functionName>(_ promise: JSObject, _ value: T)` and its
+    /// glue, lowering `value` through the standard imported-parameter ABI.
+    private func renderPromiseSettleHelper(
+        functionName: String,
+        externName: String,
+        valueType: BridgeType
+    ) throws -> [DeclSyntax] {
+        let effects = Effects(isAsync: false, isThrows: true)
+        // `Void` can't cross the bridge as a parameter, so the void helper takes only the promise.
+        var parameters = [Parameter(label: nil, name: "promise", type: .jsObject(nil))]
+        if valueType != .void {
+            parameters.append(Parameter(label: nil, name: "value", type: valueType))
+        }
+        let builder = try ImportTS.CallJSEmission(
+            moduleName: "bjs",
+            abiName: externName,
+            effects: effects,
+            returnType: .void,
+            context: .importTS
+        )
+        for parameter in parameters {
+            try builder.lowerParameter(param: parameter)
+        }
+        try builder.call()
+        try builder.liftReturnValue()
+
+        let valueParam = valueType == .void ? "" : ", _ value: \(valueType.swiftType)"
+        let macroDecl: DeclSyntax =
+            "@JSFunction func \(raw: functionName)(_ promise: JSObject\(raw: valueParam)) throws(JSException)"
+        let glueDecl = builder.renderThunkDecl(
+            name: "_$\(functionName)",
+            parameters: parameters,
+            returnType: .void,
+            effects: effects
+        )
+        return [macroDecl, builder.renderImportDecl(), glueDecl]
     }
 
     class ExportedThunkBuilder {
@@ -104,8 +170,22 @@ public class ExportSwift {
         var externDecls: [DeclSyntax] = []
         let effects: Effects
 
-        init(effects: Effects) {
+        /// The async return type settled through `_bjs_makePromise`'s `Promise_resolve_<mangled>`
+        /// helper. Set for every `async` thunk.
+        var asyncResolveReturnType: BridgeType?
+
+        /// Stack-using parameter lifts hoisted ahead of the deferred async closure.
+        var asyncHoistedBindings: [CodeBlockItemSyntax] = []
+
+        init(effects: Effects, returnType: BridgeType) throws {
             self.effects = effects
+            guard effects.isAsync else { return }
+            guard returnType.isAsyncResolvable else {
+                throw BridgeJSCoreError(
+                    "Returning '\(returnType.swiftType)' from an async exported function is not yet supported"
+                )
+            }
+            self.asyncResolveReturnType = returnType
         }
 
         private func append(_ item: CodeBlockItemSyntax) {
@@ -200,7 +280,7 @@ public class ExportSwift {
             }
 
             if effects.isAsync, returnType != .void {
-                return CodeBlockItemSyntax(item: .init(StmtSyntax("return \(raw: callExpr).jsValue")))
+                return CodeBlockItemSyntax(item: .init(StmtSyntax("return \(raw: callExpr)")))
             }
 
             if returnType == .void {
@@ -242,6 +322,22 @@ public class ExportSwift {
         private func generateParameterLifting() {
             let stackParamIndices = parameters.enumerated().compactMap { index, param -> Int? in
                 param.type.isStackUsingParameter ? index : nil
+            }
+
+            if effects.isAsync {
+                // Drain stack parameters before the deferred `Task` or the shared stack is corrupted.
+                for index in stackParamIndices.reversed() {
+                    let param = parameters[index]
+                    let expr = liftedParameterExprs[index]
+                    let varName = "_tmp_\(param.name)"
+                    var binding: CodeBlockItemSyntax = "let \(raw: varName) = \(expr)"
+                    if !asyncHoistedBindings.isEmpty {
+                        binding = binding.with(\.leadingTrivia, .newline)
+                    }
+                    asyncHoistedBindings.append(binding)
+                    liftedParameterExprs[index] = ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(varName)))
+                }
+                return
             }
 
             guard stackParamIndices.count > 1 else { return }
@@ -293,8 +389,7 @@ public class ExportSwift {
                 return
             }
             if effects.isAsync {
-                // The return value of async function (T of `(...) async -> T`) is
-                // handled by the JSPromise.async, so we don't need to do anything here.
+                // The async return value is lowered by the generated `Promise_resolve_*` helper.
                 return
             }
 
@@ -328,25 +423,25 @@ public class ExportSwift {
             }
         }
 
+        /// A throwing async body needs an explicit closure type, otherwise Swift infers
+        /// `throws(any Error)` instead of `throws(JSException)`.
+        /// See: https://github.com/swiftlang/swift/issues/76165
+        private func asyncThrowsClosureHead(returnSpelling: String?) -> String {
+            guard effects.isThrows else { return "" }
+            let returns = returnSpelling.map { " -> \($0)" } ?? ""
+            return " () async throws(JSException)\(returns) in"
+        }
+
         func render(abiName: String) -> DeclSyntax {
             let body: CodeBlockItemListSyntax
-            if effects.isAsync {
-                // Explicit closure type annotation needed when throws is present
-                // so Swift infers throws(JSException) instead of throws(any Error)
-                // See: https://github.com/swiftlang/swift/issues/76165
-                let closureHead: String
-                if effects.isThrows {
-                    let hasReturn = self.body.contains { $0.description.contains("return ") }
-                    let ret = hasReturn ? " -> JSValue" : ""
-                    closureHead = " () async throws(JSException)\(ret) in"
-                } else {
-                    closureHead = ""
-                }
+            if effects.isAsync, let resolveType = asyncResolveReturnType {
+                let resolveName = "Promise_resolve_\(resolveType.mangleTypeName)"
+                let closureHead = asyncThrowsClosureHead(returnSpelling: resolveType.swiftType)
                 body = """
-                    let ret = JSPromise.async {\(raw: closureHead)
+                    \(CodeBlockItemListSyntax(asyncHoistedBindings))
+                    return _bjs_makePromise(resolve: \(raw: resolveName), reject: Promise_reject) {\(raw: closureHead)
                         \(CodeBlockItemListSyntax(self.body))
-                    }.jsObject
-                    return ret.bridgeJSLowerReturn()
+                    }
                     """
             } else if effects.isThrows {
                 body = """
@@ -457,7 +552,10 @@ public class ExportSwift {
         let className = context.className
         let isStatic = context.isStatic
 
-        let getterBuilder = ExportedThunkBuilder(effects: Effects(isAsync: false, isThrows: false, isStatic: isStatic))
+        let getterBuilder = try ExportedThunkBuilder(
+            effects: Effects(isAsync: false, isThrows: false, isStatic: isStatic),
+            returnType: property.type
+        )
 
         if !isStatic {
             try getterBuilder.liftParameter(
@@ -476,8 +574,9 @@ public class ExportSwift {
 
         // Generate property setter if not readonly
         if !property.isReadonly {
-            let setterBuilder = ExportedThunkBuilder(
-                effects: Effects(isAsync: false, isThrows: false, isStatic: isStatic)
+            let setterBuilder = try ExportedThunkBuilder(
+                effects: Effects(isAsync: false, isThrows: false, isStatic: isStatic),
+                returnType: .void
             )
 
             // Lift parameters based on property type
@@ -507,7 +606,7 @@ public class ExportSwift {
     }
 
     func renderSingleExportedFunction(function: ExportedFunction) throws -> DeclSyntax {
-        let builder = ExportedThunkBuilder(effects: function.effects)
+        let builder = try ExportedThunkBuilder(effects: function.effects, returnType: function.returnType)
         for param in function.parameters {
             try builder.liftParameter(param: param)
         }
@@ -536,7 +635,7 @@ public class ExportSwift {
         callName: String,
         returnType: BridgeType
     ) throws -> DeclSyntax {
-        let builder = ExportedThunkBuilder(effects: constructor.effects)
+        let builder = try ExportedThunkBuilder(effects: constructor.effects, returnType: returnType)
         for param in constructor.parameters {
             try builder.liftParameter(param: param)
         }
@@ -550,7 +649,7 @@ public class ExportSwift {
         ownerTypeName: String,
         instanceSelfType: BridgeType
     ) throws -> DeclSyntax {
-        let builder = ExportedThunkBuilder(effects: method.effects)
+        let builder = try ExportedThunkBuilder(effects: method.effects, returnType: method.returnType)
         if !method.effects.isStatic {
             try builder.liftParameter(param: Parameter(label: nil, name: "_self", type: instanceSelfType))
         }

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -356,6 +356,40 @@ public struct BridgeJSLink {
         ]
     }
 
+    /// JS const (in the import glue scope) holding the `Symbol` under which a promise's
+    /// resolve/reject settlers are stashed.
+    private static let promiseSettlersSymbol = "__bjs_promiseSettlers"
+
+    /// Renders a `bjs[...]` settlement handler that lifts `(promise, value)` and calls the
+    /// promise's stashed `resolve` / `reject` settler.
+    private func renderPromiseSettleHandler(
+        externName: String,
+        valueType: BridgeType,
+        settle: String,
+        into printer: CodeFragmentPrinter
+    ) throws {
+        let builder = ImportedThunkBuilder(
+            effects: Effects(isAsync: false, isThrows: true),
+            returnType: .void,
+            intrinsicRegistry: intrinsicRegistry
+        )
+        try builder.liftParameter(param: Parameter(label: nil, name: "promise", type: .jsObject(nil)))
+        // `Void` can't cross the bridge as a parameter, so the void resolve settles with `undefined`.
+        let valueArg: String
+        if valueType == .void {
+            valueArg = ""
+        } else {
+            try builder.liftParameter(param: Parameter(label: nil, name: "value", type: valueType))
+            valueArg = builder.parameterForwardings[1]
+        }
+        builder.body.write(
+            "\(builder.parameterForwardings[0])[\(Self.promiseSettlersSymbol)].\(settle)(\(valueArg));"
+        )
+        var lines = builder.renderFunction(name: nil)
+        lines[0] = "bjs[\"\(externName)\"] = \(lines[0])"
+        printer.write(lines: lines)
+    }
+
     private func generateAddImports(needsImportsObject: Bool) throws -> CodeFragmentPrinter {
         let printer = CodeFragmentPrinter()
         let allStructs = skeletons.compactMap { $0.exported?.structs }.flatMap { $0 }
@@ -524,6 +558,39 @@ public struct BridgeJSLink {
                         }
                         printer.write("}")
                     }
+                }
+
+                // Always provided: the runtime's `_bjs_makePromise` imports it unconditionally.
+                // The settlers are stored under a Symbol to avoid clashing with promise fields.
+                printer.write("const \(Self.promiseSettlersSymbol) = Symbol(\"JavaScriptKit.promiseSettlers\");")
+                printer.write("bjs[\"swift_js_make_promise\"] = function() {")
+                printer.indent {
+                    printer.write("let resolve, reject;")
+                    printer.write("const promise = new Promise((res, rej) => { resolve = res; reject = rej; });")
+                    printer.write("promise[\(Self.promiseSettlersSymbol)] = { resolve, reject };")
+                    printer.write(
+                        "return \(JSGlueVariableScope.reservedSwift).\(JSGlueVariableScope.reservedMemory).retain(promise);"
+                    )
+                }
+                printer.write("}")
+                for skeleton in skeletons {
+                    guard let exported = skeleton.exported else { continue }
+                    let asyncResolveTypes = exported.asyncPromiseResolveReturnTypes
+                    guard !asyncResolveTypes.isEmpty else { continue }
+                    for type in asyncResolveTypes {
+                        try renderPromiseSettleHandler(
+                            externName: "promise_resolve_\(skeleton.moduleName)_\(type.mangleTypeName)",
+                            valueType: type,
+                            settle: "resolve",
+                            into: printer
+                        )
+                    }
+                    try renderPromiseSettleHandler(
+                        externName: "promise_reject_\(skeleton.moduleName)",
+                        valueType: .jsValue,
+                        settle: "reject",
+                        into: printer
+                    )
                 }
 
                 printer.write("bjs[\"swift_js_return_optional_bool\"] = function(isSome, value) {")

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -1027,6 +1027,30 @@ public struct ExportedSkeleton: Codable {
     public var isEmpty: Bool {
         functions.isEmpty && classes.isEmpty && enums.isEmpty && structs.isEmpty && protocols.isEmpty
     }
+
+    /// Distinct `async` return types needing a `Promise_resolve_<mangled>` helper, deduplicated
+    /// by mangled name. Shared by the Swift codegen and JS link.
+    public var asyncPromiseResolveReturnTypes: [BridgeType] {
+        var seen = Set<String>()
+        var result: [BridgeType] = []
+        func consider(_ returnType: BridgeType, _ effects: Effects) {
+            guard effects.isAsync, returnType.isAsyncResolvable,
+                seen.insert(returnType.mangleTypeName).inserted
+            else { return }
+            result.append(returnType)
+        }
+        for function in functions { consider(function.returnType, function.effects) }
+        for klass in classes {
+            for method in klass.methods { consider(method.returnType, method.effects) }
+        }
+        for structDef in structs {
+            for method in structDef.methods { consider(method.returnType, method.effects) }
+        }
+        for enumDef in enums {
+            for method in enumDef.staticMethods { consider(method.returnType, method.effects) }
+        }
+        return result
+    }
 }
 
 // MARK: - Imported Skeleton
@@ -1582,6 +1606,25 @@ extension BridgeType {
     public var isOptional: Bool {
         if case .nullable = self { return true }
         return false
+    }
+
+    /// Whether a value of this type can be passed to a generated `Promise_resolve_<mangled>`
+    /// settlement helper, i.e. lowered through the imported-parameter ABI. Every `async`
+    /// exported return settles through `_bjs_makePromise`; the few types that cannot be lowered
+    /// (associated-value enums, protocols, namespace enums, and their compositions) are diagnosed.
+    public var isAsyncResolvable: Bool {
+        switch self {
+        case .associatedValueEnum, .swiftProtocol, .namespaceEnum:
+            return false
+        case .nullable(let wrapped, _):
+            return wrapped.isAsyncResolvable
+        case .array(let element):
+            return element.isAsyncResolvable
+        case .dictionary(let value):
+            return value.isAsyncResolvable
+        default:
+            return true
+        }
     }
 
     /// Simplified Swift ABI-style mangled name

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
@@ -305,6 +305,56 @@ import Testing
         #expect(skeleton.exported != nil)
     }
 
+    // MARK: - Async return validation
+
+    @Test
+    func asyncReturnOfUnsupportedTypeIsDiagnosed() throws {
+        // An associated-value enum can be neither lowered through the imported-parameter ABI
+        // nor settled via `_bjs_makePromise`, so an async return of one must be diagnosed.
+        let source = """
+            @JS enum Payload {
+                case text(String)
+                case number(Int)
+            }
+            @JS func loadPayload() async -> Payload {
+                .number(1)
+            }
+            """
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "test.swift")
+        let skeleton = try swiftAPI.finalize()
+        let exported = try #require(skeleton.exported)
+        let exportSwift = ExportSwift(progress: .silent, moduleName: skeleton.moduleName, skeleton: exported)
+        #expect(throws: BridgeJSCoreError.self) {
+            _ = try exportSwift.finalize()
+        }
+    }
+
+    @Test
+    func asyncReturnOfConvertibleTypeSucceeds() throws {
+        let source = """
+            @JS func loadCount() async -> Int {
+                1
+            }
+            """
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "test.swift")
+        let skeleton = try swiftAPI.finalize()
+        let exported = try #require(skeleton.exported)
+        let exportSwift = ExportSwift(progress: .silent, moduleName: skeleton.moduleName, skeleton: exported)
+        #expect(try exportSwift.finalize() != nil)
+    }
+
     @Test
     func omitsNextLineWhenErrorIsOnLastLine() throws {
         let source = """

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Async.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Async.swift
@@ -17,3 +17,66 @@
 @JS func asyncRoundTripJSObject(_ v: JSObject) async -> JSObject {
     return v
 }
+
+@JS struct AsyncPoint {
+    var x: Int
+    var y: Int
+}
+
+@JS func asyncRoundTripStruct(_ v: AsyncPoint) async -> AsyncPoint {
+    return v
+}
+
+@JS func asyncRoundTripStructThrows(_ v: AsyncPoint) async throws(JSException) -> AsyncPoint {
+    return v
+}
+
+@JS func asyncCombineStructs(_ a: AsyncPoint, _ b: AsyncPoint) async -> AsyncPoint {
+    return AsyncPoint(x: a.x + b.x, y: a.y + b.y)
+}
+
+@JS enum AsyncDirection {
+    case north
+    case south
+}
+
+@JS func asyncRoundTripEnum(_ v: AsyncDirection) async -> AsyncDirection {
+    return v
+}
+
+@JS enum AsyncTheme: String {
+    case light
+    case dark
+}
+
+@JS func asyncRoundTripRawEnum(_ v: AsyncTheme) async -> AsyncTheme {
+    return v
+}
+
+@JS func asyncRoundTripOptionalEnum(_ v: AsyncDirection?) async -> AsyncDirection? {
+    return v
+}
+
+@JS func asyncRoundTripOptionalRawEnum(_ v: AsyncTheme?) async -> AsyncTheme? {
+    return v
+}
+
+@JS func asyncRoundTripOptionalStruct(_ v: AsyncPoint?) async -> AsyncPoint? {
+    return v
+}
+
+@JS func asyncRoundTripStructArray(_ v: [AsyncPoint]) async -> [AsyncPoint] {
+    return v
+}
+
+@JS func asyncRoundTripEnumArray(_ v: [AsyncDirection]) async -> [AsyncDirection] {
+    return v
+}
+
+@JS func asyncRoundTripStructDictionary(_ v: [String: AsyncPoint]) async -> [String: AsyncPoint] {
+    return v
+}
+
+@JS func asyncRoundTripEnumDictionary(_ v: [String: AsyncDirection]) async -> [String: AsyncDirection] {
+    return v
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.json
@@ -4,7 +4,59 @@
 
     ],
     "enums" : [
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
 
+            ],
+            "name" : "north"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "south"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "AsyncDirection",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "AsyncDirection",
+        "tsFullPath" : "AsyncDirection"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "light"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "dark"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "AsyncTheme",
+        "rawType" : "String",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "AsyncTheme",
+        "tsFullPath" : "AsyncTheme"
+      }
     ],
     "exposeToGlobal" : false,
     "functions" : [
@@ -180,13 +232,422 @@
 
           }
         }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripStruct",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripStruct",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "AsyncPoint"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "AsyncPoint"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripStructThrows",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "asyncRoundTripStructThrows",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "AsyncPoint"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "AsyncPoint"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncCombineStructs",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncCombineStructs",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "a",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "AsyncPoint"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "b",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "AsyncPoint"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "AsyncPoint"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripEnum",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripEnum",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "caseEnum" : {
+                "_0" : "AsyncDirection"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "caseEnum" : {
+            "_0" : "AsyncDirection"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripRawEnum",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripRawEnum",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "rawValueEnum" : {
+                "_0" : "AsyncTheme",
+                "_1" : "String"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "rawValueEnum" : {
+            "_0" : "AsyncTheme",
+            "_1" : "String"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripOptionalEnum",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripOptionalEnum",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "AsyncDirection"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "AsyncDirection"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripOptionalRawEnum",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripOptionalRawEnum",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "AsyncTheme",
+                    "_1" : "String"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "AsyncTheme",
+                "_1" : "String"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripOptionalStruct",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripOptionalStruct",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "AsyncPoint"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "swiftStruct" : {
+                "_0" : "AsyncPoint"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripStructArray",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripStructArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "AsyncPoint"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "swiftStruct" : {
+                "_0" : "AsyncPoint"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripEnumArray",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripEnumArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "AsyncDirection"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "AsyncDirection"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripStructDictionary",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripStructDictionary",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "dictionary" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "AsyncPoint"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "dictionary" : {
+            "_0" : {
+              "swiftStruct" : {
+                "_0" : "AsyncPoint"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripEnumDictionary",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripEnumDictionary",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "dictionary" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "AsyncDirection"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "dictionary" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "AsyncDirection"
+              }
+            }
+          }
+        }
       }
     ],
     "protocols" : [
 
     ],
     "structs" : [
+      {
+        "methods" : [
 
+        ],
+        "name" : "AsyncPoint",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "x",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "y",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "AsyncPoint"
+      }
     ]
   },
   "moduleName" : "TestModule",

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.swift
@@ -1,11 +1,96 @@
+extension AsyncDirection: _BridgedSwiftCaseEnum {
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
+        return bridgeJSRawValue
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> AsyncDirection {
+        return bridgeJSLiftParameter(value)
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> AsyncDirection {
+        return AsyncDirection(bridgeJSRawValue: value)!
+    }
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
+        return bridgeJSLowerParameter()
+    }
+
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
+        switch bridgeJSRawValue {
+        case 0:
+            self = .north
+        case 1:
+            self = .south
+        default:
+            return nil
+        }
+    }
+
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
+        switch self {
+        case .north:
+            return 0
+        case .south:
+            return 1
+        }
+    }
+}
+
+extension AsyncTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+}
+
+extension AsyncPoint: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> AsyncPoint {
+        let y = Int.bridgeJSStackPop()
+        let x = Int.bridgeJSStackPop()
+        return AsyncPoint(x: x, y: y)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_AsyncPoint(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_AsyncPoint()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_AsyncPoint")
+fileprivate func _bjs_struct_lower_AsyncPoint_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_AsyncPoint_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_AsyncPoint(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_AsyncPoint_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_AsyncPoint")
+fileprivate func _bjs_struct_lift_AsyncPoint_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_AsyncPoint_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_AsyncPoint() -> Int32 {
+    return _bjs_struct_lift_AsyncPoint_extern()
+}
+
 @_expose(wasm, "bjs_asyncReturnVoid")
 @_cdecl("bjs_asyncReturnVoid")
 public func _bjs_asyncReturnVoid() -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
+    return _bjs_makePromise(resolve: Promise_resolve_y, reject: Promise_reject) {
         await asyncReturnVoid()
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -15,10 +100,9 @@ public func _bjs_asyncReturnVoid() -> Int32 {
 @_cdecl("bjs_asyncRoundTripInt")
 public func _bjs_asyncRoundTripInt(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripInt(_: Int.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_Si, reject: Promise_reject) {
+        return await asyncRoundTripInt(_: Int.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -28,10 +112,9 @@ public func _bjs_asyncRoundTripInt(_ v: Int32) -> Int32 {
 @_cdecl("bjs_asyncRoundTripString")
 public func _bjs_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripString(_: String.bridgeJSLiftParameter(vBytes, vLength)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) {
+        return await asyncRoundTripString(_: String.bridgeJSLiftParameter(vBytes, vLength))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -41,10 +124,9 @@ public func _bjs_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int3
 @_cdecl("bjs_asyncRoundTripBool")
 public func _bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripBool(_: Bool.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_Sb, reject: Promise_reject) {
+        return await asyncRoundTripBool(_: Bool.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -54,10 +136,9 @@ public func _bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
 @_cdecl("bjs_asyncRoundTripFloat")
 public func _bjs_asyncRoundTripFloat(_ v: Float32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripFloat(_: Float.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_Sf, reject: Promise_reject) {
+        return await asyncRoundTripFloat(_: Float.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -67,10 +148,9 @@ public func _bjs_asyncRoundTripFloat(_ v: Float32) -> Int32 {
 @_cdecl("bjs_asyncRoundTripDouble")
 public func _bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripDouble(_: Double.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_Sd, reject: Promise_reject) {
+        return await asyncRoundTripDouble(_: Double.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -80,11 +160,543 @@ public func _bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
 @_cdecl("bjs_asyncRoundTripJSObject")
 public func _bjs_asyncRoundTripJSObject(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripJSObject(_: JSObject.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_8JSObjectC, reject: Promise_reject) {
+        return await asyncRoundTripJSObject(_: JSObject.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripStruct")
+@_cdecl("bjs_asyncRoundTripStruct")
+public func _bjs_asyncRoundTripStruct() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = AsyncPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_10AsyncPointV, reject: Promise_reject) {
+        return await asyncRoundTripStruct(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripStructThrows")
+@_cdecl("bjs_asyncRoundTripStructThrows")
+public func _bjs_asyncRoundTripStructThrows() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = AsyncPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_10AsyncPointV, reject: Promise_reject) { () async throws(JSException) -> AsyncPoint in
+        return try await asyncRoundTripStructThrows(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncCombineStructs")
+@_cdecl("bjs_asyncCombineStructs")
+public func _bjs_asyncCombineStructs() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_b = AsyncPoint.bridgeJSLiftParameter()
+    let _tmp_a = AsyncPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_10AsyncPointV, reject: Promise_reject) {
+        return await asyncCombineStructs(_: _tmp_a, _: _tmp_b)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripEnum")
+@_cdecl("bjs_asyncRoundTripEnum")
+public func _bjs_asyncRoundTripEnum(_ v: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_14AsyncDirectionO, reject: Promise_reject) {
+        return await asyncRoundTripEnum(_: AsyncDirection.bridgeJSLiftParameter(v))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripRawEnum")
+@_cdecl("bjs_asyncRoundTripRawEnum")
+public func _bjs_asyncRoundTripRawEnum(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_10AsyncThemeO, reject: Promise_reject) {
+        return await asyncRoundTripRawEnum(_: AsyncTheme.bridgeJSLiftParameter(vBytes, vLength))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripOptionalEnum")
+@_cdecl("bjs_asyncRoundTripOptionalEnum")
+public func _bjs_asyncRoundTripOptionalEnum(_ vIsSome: Int32, _ vValue: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_Sq14AsyncDirectionO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalEnum(_: Optional<AsyncDirection>.bridgeJSLiftParameter(vIsSome, vValue))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripOptionalRawEnum")
+@_cdecl("bjs_asyncRoundTripOptionalRawEnum")
+public func _bjs_asyncRoundTripOptionalRawEnum(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_Sq10AsyncThemeO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalRawEnum(_: Optional<AsyncTheme>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripOptionalStruct")
+@_cdecl("bjs_asyncRoundTripOptionalStruct")
+public func _bjs_asyncRoundTripOptionalStruct() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = Optional<AsyncPoint>.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_Sq10AsyncPointV, reject: Promise_reject) {
+        return await asyncRoundTripOptionalStruct(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripStructArray")
+@_cdecl("bjs_asyncRoundTripStructArray")
+public func _bjs_asyncRoundTripStructArray() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = [AsyncPoint].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa10AsyncPointV, reject: Promise_reject) {
+        return await asyncRoundTripStructArray(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripEnumArray")
+@_cdecl("bjs_asyncRoundTripEnumArray")
+public func _bjs_asyncRoundTripEnumArray() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = [AsyncDirection].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa14AsyncDirectionO, reject: Promise_reject) {
+        return await asyncRoundTripEnumArray(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripStructDictionary")
+@_cdecl("bjs_asyncRoundTripStructDictionary")
+public func _bjs_asyncRoundTripStructDictionary() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = [String: AsyncPoint].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD10AsyncPointV, reject: Promise_reject) {
+        return await asyncRoundTripStructDictionary(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripEnumDictionary")
+@_cdecl("bjs_asyncRoundTripEnumDictionary")
+public func _bjs_asyncRoundTripEnumDictionary() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = [String: AsyncDirection].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD14AsyncDirectionO, reject: Promise_reject) {
+        return await asyncRoundTripEnumDictionary(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@JSFunction func Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_reject_TestModule")
+fileprivate func promise_reject_TestModule_extern(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void
+#else
+fileprivate func promise_reject_TestModule_extern(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_reject_TestModule(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+    return promise_reject_TestModule_extern(promise, valueKind, valuePayload1, valuePayload2)
+}
+
+func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let (valueKind, valuePayload1, valuePayload2) = value.bridgeJSLowerParameter()
+    promise_reject_TestModule(promiseValue, valueKind, valuePayload1, valuePayload2)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_y(_ promise: JSObject) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_y")
+fileprivate func promise_resolve_TestModule_y_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_y_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_y(_ promise: Int32) -> Void {
+    return promise_resolve_TestModule_y_extern(promise)
+}
+
+func _$Promise_resolve_y(_ promise: JSObject) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    promise_resolve_TestModule_y(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Si(_ promise: JSObject, _ value: Int) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Si")
+fileprivate func promise_resolve_TestModule_Si_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_Si_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_Si(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_Si_extern(promise, value)
+}
+
+func _$Promise_resolve_Si(_ promise: JSObject, _ value: Int) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_Si(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_SS")
+fileprivate func promise_resolve_TestModule_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_SS(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_TestModule_SS_extern(promise, valueBytes, valueLength)
+}
+
+func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        promise_resolve_TestModule_SS(promiseValue, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sb(_ promise: JSObject, _ value: Bool) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sb")
+fileprivate func promise_resolve_TestModule_Sb_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_Sb_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_Sb(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_Sb_extern(promise, value)
+}
+
+func _$Promise_resolve_Sb(_ promise: JSObject, _ value: Bool) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_Sb(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sf(_ promise: JSObject, _ value: Float) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sf")
+fileprivate func promise_resolve_TestModule_Sf_extern(_ promise: Int32, _ value: Float32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_Sf_extern(_ promise: Int32, _ value: Float32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_Sf(_ promise: Int32, _ value: Float32) -> Void {
+    return promise_resolve_TestModule_Sf_extern(promise, value)
+}
+
+func _$Promise_resolve_Sf(_ promise: JSObject, _ value: Float) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_Sf(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sd(_ promise: JSObject, _ value: Double) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sd")
+fileprivate func promise_resolve_TestModule_Sd_extern(_ promise: Int32, _ value: Float64) -> Void
+#else
+fileprivate func promise_resolve_TestModule_Sd_extern(_ promise: Int32, _ value: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_Sd(_ promise: Int32, _ value: Float64) -> Void {
+    return promise_resolve_TestModule_Sd_extern(promise, value)
+}
+
+func _$Promise_resolve_Sd(_ promise: JSObject, _ value: Double) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_Sd(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_8JSObjectC(_ promise: JSObject, _ value: JSObject) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_8JSObjectC")
+fileprivate func promise_resolve_TestModule_8JSObjectC_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_8JSObjectC_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_8JSObjectC(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_8JSObjectC_extern(promise, value)
+}
+
+func _$Promise_resolve_8JSObjectC(_ promise: JSObject, _ value: JSObject) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_8JSObjectC(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_10AsyncPointV(_ promise: JSObject, _ value: AsyncPoint) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_10AsyncPointV")
+fileprivate func promise_resolve_TestModule_10AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_10AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_10AsyncPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_10AsyncPointV_extern(promise, value)
+}
+
+func _$Promise_resolve_10AsyncPointV(_ promise: JSObject, _ value: AsyncPoint) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueObjectId = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_10AsyncPointV(promiseValue, valueObjectId)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_14AsyncDirectionO(_ promise: JSObject, _ value: AsyncDirection) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_14AsyncDirectionO")
+fileprivate func promise_resolve_TestModule_14AsyncDirectionO_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_14AsyncDirectionO_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_14AsyncDirectionO(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_14AsyncDirectionO_extern(promise, value)
+}
+
+func _$Promise_resolve_14AsyncDirectionO(_ promise: JSObject, _ value: AsyncDirection) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_14AsyncDirectionO(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_10AsyncThemeO(_ promise: JSObject, _ value: AsyncTheme) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_10AsyncThemeO")
+fileprivate func promise_resolve_TestModule_10AsyncThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_10AsyncThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_10AsyncThemeO(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_TestModule_10AsyncThemeO_extern(promise, valueBytes, valueLength)
+}
+
+func _$Promise_resolve_10AsyncThemeO(_ promise: JSObject, _ value: AsyncTheme) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        promise_resolve_TestModule_10AsyncThemeO(promiseValue, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sq14AsyncDirectionO(_ promise: JSObject, _ value: Optional<AsyncDirection>) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sq14AsyncDirectionO")
+fileprivate func promise_resolve_TestModule_Sq14AsyncDirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_Sq14AsyncDirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_Sq14AsyncDirectionO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    return promise_resolve_TestModule_Sq14AsyncDirectionO_extern(promise, valueIsSome, valueValue)
+}
+
+func _$Promise_resolve_Sq14AsyncDirectionO(_ promise: JSObject, _ value: Optional<AsyncDirection>) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_Sq14AsyncDirectionO(promiseValue, valueIsSome, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sq10AsyncThemeO(_ promise: JSObject, _ value: Optional<AsyncTheme>) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sq10AsyncThemeO")
+fileprivate func promise_resolve_TestModule_Sq10AsyncThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_Sq10AsyncThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_Sq10AsyncThemeO(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_TestModule_Sq10AsyncThemeO_extern(promise, valueIsSome, valueBytes, valueLength)
+}
+
+func _$Promise_resolve_Sq10AsyncThemeO(_ promise: JSObject, _ value: Optional<AsyncTheme>) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    value.bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
+        promise_resolve_TestModule_Sq10AsyncThemeO(promiseValue, valueIsSome, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sq10AsyncPointV(_ promise: JSObject, _ value: Optional<AsyncPoint>) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sq10AsyncPointV")
+fileprivate func promise_resolve_TestModule_Sq10AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_Sq10AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_Sq10AsyncPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_Sq10AsyncPointV_extern(promise, value)
+}
+
+func _$Promise_resolve_Sq10AsyncPointV(_ promise: JSObject, _ value: Optional<AsyncPoint>) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueIsSome = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_Sq10AsyncPointV(promiseValue, valueIsSome)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sa10AsyncPointV(_ promise: JSObject, _ value: [AsyncPoint]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sa10AsyncPointV")
+fileprivate func promise_resolve_TestModule_Sa10AsyncPointV_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_Sa10AsyncPointV_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_Sa10AsyncPointV(_ promise: Int32) -> Void {
+    return promise_resolve_TestModule_Sa10AsyncPointV_extern(promise)
+}
+
+func _$Promise_resolve_Sa10AsyncPointV(_ promise: JSObject, _ value: [AsyncPoint]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_Sa10AsyncPointV(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sa14AsyncDirectionO(_ promise: JSObject, _ value: [AsyncDirection]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sa14AsyncDirectionO")
+fileprivate func promise_resolve_TestModule_Sa14AsyncDirectionO_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_Sa14AsyncDirectionO_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_Sa14AsyncDirectionO(_ promise: Int32) -> Void {
+    return promise_resolve_TestModule_Sa14AsyncDirectionO_extern(promise)
+}
+
+func _$Promise_resolve_Sa14AsyncDirectionO(_ promise: JSObject, _ value: [AsyncDirection]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_Sa14AsyncDirectionO(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SD10AsyncPointV(_ promise: JSObject, _ value: [String: AsyncPoint]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_SD10AsyncPointV")
+fileprivate func promise_resolve_TestModule_SD10AsyncPointV_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_SD10AsyncPointV_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_SD10AsyncPointV(_ promise: Int32) -> Void {
+    return promise_resolve_TestModule_SD10AsyncPointV_extern(promise)
+}
+
+func _$Promise_resolve_SD10AsyncPointV(_ promise: JSObject, _ value: [String: AsyncPoint]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_SD10AsyncPointV(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SD14AsyncDirectionO(_ promise: JSObject, _ value: [String: AsyncDirection]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_SD14AsyncDirectionO")
+fileprivate func promise_resolve_TestModule_SD14AsyncDirectionO_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_SD14AsyncDirectionO_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_SD14AsyncDirectionO(_ promise: Int32) -> Void {
+    return promise_resolve_TestModule_SD14AsyncDirectionO_extern(promise)
+}
+
+func _$Promise_resolve_SD14AsyncDirectionO(_ promise: JSObject, _ value: [String: AsyncDirection]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_SD14AsyncDirectionO(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
@@ -138,6 +138,13 @@ export async function createInstantiator(options, swift) {
                 const value = structHelpers.Point.lift();
                 return swift.memory.retain(value);
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.d.ts
@@ -4,6 +4,26 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
+export const AsyncDirectionValues: {
+    readonly North: 0;
+    readonly South: 1;
+};
+export type AsyncDirectionTag = typeof AsyncDirectionValues[keyof typeof AsyncDirectionValues];
+
+export const AsyncThemeValues: {
+    readonly Light: "light";
+    readonly Dark: "dark";
+};
+export type AsyncThemeTag = typeof AsyncThemeValues[keyof typeof AsyncThemeValues];
+
+export interface AsyncPoint {
+    x: number;
+    y: number;
+}
+export type AsyncDirectionObject = typeof AsyncDirectionValues;
+
+export type AsyncThemeObject = typeof AsyncThemeValues;
+
 export type Exports = {
     asyncReturnVoid(): Promise<void>;
     asyncRoundTripInt(v: number): Promise<number>;
@@ -12,6 +32,20 @@ export type Exports = {
     asyncRoundTripFloat(v: number): Promise<number>;
     asyncRoundTripDouble(v: number): Promise<number>;
     asyncRoundTripJSObject(v: any): Promise<any>;
+    asyncRoundTripStruct(v: AsyncPoint): Promise<AsyncPoint>;
+    asyncRoundTripStructThrows(v: AsyncPoint): Promise<AsyncPoint>;
+    asyncCombineStructs(a: AsyncPoint, b: AsyncPoint): Promise<AsyncPoint>;
+    asyncRoundTripEnum(v: AsyncDirectionTag): Promise<AsyncDirectionTag>;
+    asyncRoundTripRawEnum(v: AsyncThemeTag): Promise<AsyncThemeTag>;
+    asyncRoundTripOptionalEnum(v: AsyncDirectionTag | null): Promise<AsyncDirectionTag | null>;
+    asyncRoundTripOptionalRawEnum(v: AsyncThemeTag | null): Promise<AsyncThemeTag | null>;
+    asyncRoundTripOptionalStruct(v: AsyncPoint | null): Promise<AsyncPoint | null>;
+    asyncRoundTripStructArray(v: AsyncPoint[]): Promise<AsyncPoint[]>;
+    asyncRoundTripEnumArray(v: AsyncDirectionTag[]): Promise<AsyncDirectionTag[]>;
+    asyncRoundTripStructDictionary(v: Record<string, AsyncPoint>): Promise<Record<string, AsyncPoint>>;
+    asyncRoundTripEnumDictionary(v: Record<string, AsyncDirectionTag>): Promise<Record<string, AsyncDirectionTag>>;
+    AsyncDirection: AsyncDirectionObject
+    AsyncTheme: AsyncThemeObject
 }
 export type Imports = {
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
@@ -4,6 +4,16 @@
 // To update this file, just rebuild your project or run
 // `swift package bridge-js`.
 
+export const AsyncDirectionValues = {
+    North: 0,
+    South: 1,
+};
+
+export const AsyncThemeValues = {
+    Light: "light",
+    Dark: "dark",
+};
+
 export async function createInstantiator(options, swift) {
     let instance;
     let memory;
@@ -31,6 +41,106 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
+    function __bjs_jsValueLower(value) {
+        let kind;
+        let payload1;
+        let payload2;
+        if (value === null) {
+            kind = 4;
+            payload1 = 0;
+            payload2 = 0;
+        } else {
+            switch (typeof value) {
+                case "boolean":
+                    kind = 0;
+                    payload1 = value ? 1 : 0;
+                    payload2 = 0;
+                    break;
+                case "number":
+                    kind = 2;
+                    payload1 = 0;
+                    payload2 = value;
+                    break;
+                case "string":
+                    kind = 1;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "undefined":
+                    kind = 5;
+                    payload1 = 0;
+                    payload2 = 0;
+                    break;
+                case "object":
+                    kind = 3;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "function":
+                    kind = 3;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "symbol":
+                    kind = 7;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "bigint":
+                    kind = 8;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                default:
+                    throw new TypeError("Unsupported JSValue type");
+            }
+        }
+        return [kind, payload1, payload2];
+    }
+    function __bjs_jsValueLift(kind, payload1, payload2) {
+        let jsValue;
+        switch (kind) {
+            case 0:
+                jsValue = payload1 !== 0;
+                break;
+            case 1:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 2:
+                jsValue = payload2;
+                break;
+            case 3:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 4:
+                jsValue = null;
+                break;
+            case 5:
+                jsValue = undefined;
+                break;
+            case 7:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 8:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            default:
+                throw new TypeError("Unsupported JSValue kind " + kind);
+        }
+        return jsValue;
+    }
+
+    const __bjs_createAsyncPointHelpers = () => ({
+        lower: (value) => {
+            i32Stack.push((value.x | 0));
+            i32Stack.push((value.y | 0));
+        },
+        lift: () => {
+            const int = i32Stack.pop();
+            const int1 = i32Stack.pop();
+            return { x: int1, y: int };
+        }
+    });
 
     return {
         /**
@@ -105,6 +215,203 @@ export async function createInstantiator(options, swift) {
                 const byteLen = count * Ctor.BYTES_PER_ELEMENT;
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
+            }
+            bjs["swift_js_struct_lower_AsyncPoint"] = function(objectId) {
+                structHelpers.AsyncPoint.lower(swift.memory.getObject(objectId));
+            }
+            bjs["swift_js_struct_lift_AsyncPoint"] = function() {
+                const value = structHelpers.AsyncPoint.lift();
+                return swift.memory.retain(value);
+            }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
+            bjs["promise_resolve_TestModule_y"] = function(promise) {
+                try {
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve();
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_Si"] = function(promise, value) {
+                try {
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(value);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_SS"] = function(promise, valueBytes, valueCount) {
+                try {
+                    const string = decodeString(valueBytes, valueCount);
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(string);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_Sb"] = function(promise, value) {
+                try {
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(value !== 0);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_Sf"] = function(promise, value) {
+                try {
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(value);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_Sd"] = function(promise, value) {
+                try {
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(value);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_8JSObjectC"] = function(promise, value) {
+                try {
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(swift.memory.getObject(value));
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_10AsyncPointV"] = function(promise, value) {
+                try {
+                    const value1 = swift.memory.getObject(value);
+                    swift.memory.release(value);
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(value1);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_14AsyncDirectionO"] = function(promise, value) {
+                try {
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(value);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_10AsyncThemeO"] = function(promise, valueBytes, valueCount) {
+                try {
+                    const string = decodeString(valueBytes, valueCount);
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(string);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_Sq14AsyncDirectionO"] = function(promise, valueIsSome, valueWrappedValue) {
+                try {
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(valueIsSome ? valueWrappedValue : null);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_Sq10AsyncThemeO"] = function(promise, valueIsSome, valueBytes, valueCount) {
+                try {
+                    let optResult;
+                    if (valueIsSome) {
+                        const string = decodeString(valueBytes, valueCount);
+                        optResult = string;
+                    } else {
+                        optResult = null;
+                    }
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(optResult);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_Sq10AsyncPointV"] = function(promise, value) {
+                try {
+                    let optResult;
+                    if (value) {
+                        const struct = structHelpers.AsyncPoint.lift();
+                        optResult = struct;
+                    } else {
+                        optResult = null;
+                    }
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(optResult);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_Sa10AsyncPointV"] = function(promise) {
+                try {
+                    const arrayLen = i32Stack.pop();
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const struct = structHelpers.AsyncPoint.lift();
+                            arrayResult.push(struct);
+                        }
+                        arrayResult.reverse();
+                    }
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(arrayResult);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_Sa14AsyncDirectionO"] = function(promise) {
+                try {
+                    const arrayLen = i32Stack.pop();
+                    let arrayResult;
+                    if (arrayLen === -1) {
+                        arrayResult = taStack.pop();
+                    } else {
+                        arrayResult = [];
+                        for (let i = 0; i < arrayLen; i++) {
+                            const caseId = i32Stack.pop();
+                            arrayResult.push(caseId);
+                        }
+                        arrayResult.reverse();
+                    }
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(arrayResult);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_SD10AsyncPointV"] = function(promise) {
+                try {
+                    const dictLen = i32Stack.pop();
+                    const dictResult = {};
+                    for (let i = 0; i < dictLen; i++) {
+                        const struct = structHelpers.AsyncPoint.lift();
+                        const string = strStack.pop();
+                        dictResult[string] = struct;
+                    }
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(dictResult);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_SD14AsyncDirectionO"] = function(promise) {
+                try {
+                    const dictLen = i32Stack.pop();
+                    const dictResult = {};
+                    for (let i = 0; i < dictLen; i++) {
+                        const caseId = i32Stack.pop();
+                        const string = strStack.pop();
+                        dictResult[string] = caseId;
+                    }
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(dictResult);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_reject_TestModule"] = function(promise, valueKind, valuePayload1, valuePayload2) {
+                try {
+                    const jsValue = __bjs_jsValueLift(valueKind, valuePayload1, valuePayload2);
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].reject(jsValue);
+                } catch (error) {
+                    setException(error);
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -210,6 +517,9 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
+            const AsyncPointHelpers = __bjs_createAsyncPointHelpers();
+            structHelpers.AsyncPoint = AsyncPointHelpers;
+
             const exports = {
                 asyncReturnVoid: function bjs_asyncReturnVoid() {
                     const ret = instance.exports.bjs_asyncReturnVoid();
@@ -255,6 +565,137 @@ export async function createInstantiator(options, swift) {
                     swift.memory.release(ret);
                     return ret1;
                 },
+                asyncRoundTripStruct: function bjs_asyncRoundTripStruct(v) {
+                    structHelpers.AsyncPoint.lower(v);
+                    const ret = instance.exports.bjs_asyncRoundTripStruct();
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                asyncRoundTripStructThrows: function bjs_asyncRoundTripStructThrows(v) {
+                    structHelpers.AsyncPoint.lower(v);
+                    const ret = instance.exports.bjs_asyncRoundTripStructThrows();
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return ret1;
+                },
+                asyncCombineStructs: function bjs_asyncCombineStructs(a, b) {
+                    structHelpers.AsyncPoint.lower(a);
+                    structHelpers.AsyncPoint.lower(b);
+                    const ret = instance.exports.bjs_asyncCombineStructs();
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                asyncRoundTripEnum: function bjs_asyncRoundTripEnum(v) {
+                    const ret = instance.exports.bjs_asyncRoundTripEnum(v);
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                asyncRoundTripRawEnum: function bjs_asyncRoundTripRawEnum(v) {
+                    const vBytes = textEncoder.encode(v);
+                    const vId = swift.memory.retain(vBytes);
+                    const ret = instance.exports.bjs_asyncRoundTripRawEnum(vId, vBytes.length);
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                asyncRoundTripOptionalEnum: function bjs_asyncRoundTripOptionalEnum(v) {
+                    const isSome = v != null;
+                    const ret = instance.exports.bjs_asyncRoundTripOptionalEnum(+isSome, isSome ? v : 0);
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                asyncRoundTripOptionalRawEnum: function bjs_asyncRoundTripOptionalRawEnum(v) {
+                    const isSome = v != null;
+                    let result, result1;
+                    if (isSome) {
+                        const vBytes = textEncoder.encode(v);
+                        const vId = swift.memory.retain(vBytes);
+                        result = vId;
+                        result1 = vBytes.length;
+                    } else {
+                        result = 0;
+                        result1 = 0;
+                    }
+                    const ret = instance.exports.bjs_asyncRoundTripOptionalRawEnum(+isSome, result, result1);
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                asyncRoundTripOptionalStruct: function bjs_asyncRoundTripOptionalStruct(v) {
+                    const isSome = v != null;
+                    if (isSome) {
+                        structHelpers.AsyncPoint.lower(v);
+                    }
+                    i32Stack.push(+isSome);
+                    const ret = instance.exports.bjs_asyncRoundTripOptionalStruct();
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                asyncRoundTripStructArray: function bjs_asyncRoundTripStructArray(v) {
+                    for (const elem of v) {
+                        structHelpers.AsyncPoint.lower(elem);
+                    }
+                    i32Stack.push(v.length);
+                    const ret = instance.exports.bjs_asyncRoundTripStructArray();
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                asyncRoundTripEnumArray: function bjs_asyncRoundTripEnumArray(v) {
+                    for (const elem of v) {
+                        i32Stack.push((elem | 0));
+                    }
+                    i32Stack.push(v.length);
+                    const ret = instance.exports.bjs_asyncRoundTripEnumArray();
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                asyncRoundTripStructDictionary: function bjs_asyncRoundTripStructDictionary(v) {
+                    const entries = Object.entries(v);
+                    for (const entry of entries) {
+                        const [key, value] = entry;
+                        const bytes = textEncoder.encode(key);
+                        const id = swift.memory.retain(bytes);
+                        i32Stack.push(bytes.length);
+                        i32Stack.push(id);
+                        structHelpers.AsyncPoint.lower(value);
+                    }
+                    i32Stack.push(entries.length);
+                    const ret = instance.exports.bjs_asyncRoundTripStructDictionary();
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                asyncRoundTripEnumDictionary: function bjs_asyncRoundTripEnumDictionary(v) {
+                    const entries = Object.entries(v);
+                    for (const entry of entries) {
+                        const [key, value] = entry;
+                        const bytes = textEncoder.encode(key);
+                        const id = swift.memory.retain(bytes);
+                        i32Stack.push(bytes.length);
+                        i32Stack.push(id);
+                        i32Stack.push((value | 0));
+                    }
+                    i32Stack.push(entries.length);
+                    const ret = instance.exports.bjs_asyncRoundTripEnumDictionary();
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                },
+                AsyncDirection: AsyncDirectionValues,
+                AsyncTheme: AsyncThemeValues,
             };
             _exports = exports;
             return exports;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncImport.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncImport.js
@@ -221,6 +221,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncStaticImport.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncStaticImport.js
@@ -220,6 +220,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
@@ -162,6 +162,13 @@ export async function createInstantiator(options, swift) {
                 const value = structHelpers.MathOperations.lift();
                 return swift.memory.retain(value);
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
@@ -154,6 +154,13 @@ export async function createInstantiator(options, swift) {
                 const value = structHelpers.Counters.lift();
                 return swift.memory.retain(value);
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
@@ -856,6 +856,13 @@ export async function createInstantiator(options, swift) {
                 const value = structHelpers.Point.lift();
                 return swift.memory.retain(value);
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
@@ -130,6 +130,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCaseImport.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCaseImport.js
@@ -111,6 +111,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
@@ -150,6 +150,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
@@ -131,6 +131,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
@@ -182,6 +182,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/FixedWidthIntegers.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/FixedWidthIntegers.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.ConfigPointer.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.ConfigPointer.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.PerClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.PerClass.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
@@ -152,6 +152,13 @@ export async function createInstantiator(options, swift) {
                 const value = structHelpers.FooContainer.lift();
                 return swift.memory.retain(value);
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSTypedArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSTypedArrayTypes.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
@@ -196,6 +196,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/NestedType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/NestedType.js
@@ -145,6 +145,13 @@ export async function createInstantiator(options, swift) {
                 const value = structHelpers.Player_Stats.lift();
                 return swift.memory.retain(value);
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
@@ -163,6 +163,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ProtocolInClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ProtocolInClosure.js
@@ -131,6 +131,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
@@ -150,6 +150,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
@@ -150,6 +150,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
@@ -111,6 +111,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
@@ -111,6 +111,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -241,6 +241,13 @@ export async function createInstantiator(options, swift) {
                 const value = structHelpers.Animal.lift();
                 return swift.memory.retain(value);
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
@@ -132,6 +132,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
@@ -375,6 +375,13 @@ export async function createInstantiator(options, swift) {
                 const value = structHelpers.Vector2D.lift();
                 return swift.memory.retain(value);
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
@@ -125,6 +125,13 @@ export async function createInstantiator(options, swift) {
                 const value = structHelpers.Point.lift();
                 return swift.memory.retain(value);
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftTypedClosureAccess.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftTypedClosureAccess.js
@@ -131,6 +131,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
@@ -106,6 +106,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
@@ -130,6 +130,13 @@ export async function createInstantiator(options, swift) {
                 const value = structHelpers.PointerFields.lift();
                 return swift.memory.retain(value);
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
@@ -107,6 +107,13 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;

--- a/Plugins/PackageToJS/Templates/instantiate.js
+++ b/Plugins/PackageToJS/Templates/instantiate.js
@@ -69,6 +69,7 @@ async function createInstantiator(options, swift) {
                 swift_js_pop_i64: unexpectedBjsCall,
                 swift_js_closure_unregister: unexpectedBjsCall,
                 swift_js_push_typed_array: unexpectedBjsCall,
+                swift_js_make_promise: unexpectedBjsCall,
             };
         },
         /** @param {WebAssembly.Instance} instance */

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -2286,3 +2286,67 @@ extension _BridgedAsOptional {
         throw error
     }
 }
+
+// MARK: Async Promise Creation
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_make_promise")
+private func _swift_js_make_promise_extern() -> Int32
+#else
+private func _swift_js_make_promise_extern() -> Int32 { _onlyAvailableOnWasm() }
+#endif
+
+// `@unchecked Sendable` is safe because the Wasm runtime is single-threaded.
+private struct _BridgeJSMakePromiseContext<T>: @unchecked Sendable {
+    let promise: JSObject
+    let resolve: (JSObject, T) throws(JSException) -> Void
+    let reject: (JSObject, JSValue) throws(JSException) -> Void
+    let body: () async throws(JSException) -> T
+}
+
+/// Returns a `Promise` synchronously and settles it from a `Task` via the generated
+/// `resolve` / `reject` thunks, which this library cannot name directly.
+@_spi(BridgeJS) public func _bjs_makePromise<T>(
+    resolve: @escaping (JSObject, T) throws(JSException) -> Void,
+    reject: @escaping (JSObject, JSValue) throws(JSException) -> Void,
+    _ body: @escaping () async throws(JSException) -> T
+) -> Int32 {
+    let promise = JSObject(id: JavaScriptObjectRef(bitPattern: _swift_js_make_promise_extern()))
+    let context = _BridgeJSMakePromiseContext(promise: promise, resolve: resolve, reject: reject, body: body)
+    Task {
+        do throws(JSException) {
+            let value = try await context.body()
+            try context.resolve(context.promise, value)
+        } catch {
+            try? context.reject(context.promise, error.thrownValue)
+        }
+    }
+    return promise.bridgeJSLowerReturn()
+}
+
+private struct _BridgeJSMakeVoidPromiseContext: @unchecked Sendable {
+    let promise: JSObject
+    let resolve: (JSObject) throws(JSException) -> Void
+    let reject: (JSObject, JSValue) throws(JSException) -> Void
+    let body: () async throws(JSException) -> Void
+}
+
+/// `Void`-returning overload: a `Void` value can't cross the bridge as a parameter, so the
+/// generated `resolve` thunk takes only the promise and settles it with `undefined`.
+@_spi(BridgeJS) public func _bjs_makePromise(
+    resolve: @escaping (JSObject) throws(JSException) -> Void,
+    reject: @escaping (JSObject, JSValue) throws(JSException) -> Void,
+    _ body: @escaping () async throws(JSException) -> Void
+) -> Int32 {
+    let promise = JSObject(id: JavaScriptObjectRef(bitPattern: _swift_js_make_promise_extern()))
+    let context = _BridgeJSMakeVoidPromiseContext(promise: promise, resolve: resolve, reject: reject, body: body)
+    Task {
+        do throws(JSException) {
+            try await context.body()
+            try context.resolve(context.promise)
+        } catch {
+            try? context.reject(context.promise, error.thrownValue)
+        }
+    }
+    return promise.bridgeJSLowerReturn()
+}

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -174,6 +174,10 @@ extension Greeter {
         return a + b
     }
 
+    @JS func asyncMakePoint(x: Int, y: Int) async -> PublicPoint {
+        return PublicPoint(x: x, y: y)
+    }
+
     deinit {
         Self.onDeinit()
     }
@@ -301,6 +305,26 @@ extension StaticCalculator {
 @JS func getTheme() -> Theme {
     return .light
 }
+
+@JS func asyncRoundTripTheme(_ v: Theme) async -> Theme { v }
+
+@JS func asyncRoundTripDirection(_ v: Direction) async -> Direction { v }
+
+@JS func asyncRoundTripOptionalTheme(_ v: Theme?) async -> Theme? { v }
+
+@JS func asyncRoundTripOptionalDirection(_ v: Direction?) async -> Direction? { v }
+
+@JS func asyncRoundTripDirectionArray(_ v: [Direction]) async -> [Direction] { v }
+
+@JS func asyncRoundTripDirectionDict(_ v: [String: Direction]) async -> [String: Direction] { v }
+
+@JS func asyncRoundTripThemeArray(_ v: [Theme]) async -> [Theme] { v }
+
+@JS func asyncRoundTripThemeDict(_ v: [String: Theme]) async -> [String: Theme] { v }
+
+@JS func asyncRoundTripFileSize(_ v: FileSize) async -> FileSize { v }
+
+@JS func asyncRoundTripOptionalFileSize(_ v: FileSize?) async -> FileSize? { v }
 
 @JS func setHttpStatus(_ status: HttpStatus) -> HttpStatus {
     return status

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -7182,10 +7182,9 @@ public func _bjs_throwsWithJSObjectResult() -> Int32 {
 @_cdecl("bjs_asyncRoundTripVoid")
 public func _bjs_asyncRoundTripVoid() -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
+    return _bjs_makePromise(resolve: Promise_resolve_y, reject: Promise_reject) {
         await asyncRoundTripVoid()
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7195,10 +7194,9 @@ public func _bjs_asyncRoundTripVoid() -> Int32 {
 @_cdecl("bjs_asyncRoundTripInt")
 public func _bjs_asyncRoundTripInt(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripInt(v: Int.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_Si, reject: Promise_reject) {
+        return await asyncRoundTripInt(v: Int.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7208,10 +7206,9 @@ public func _bjs_asyncRoundTripInt(_ v: Int32) -> Int32 {
 @_cdecl("bjs_asyncRoundTripFloat")
 public func _bjs_asyncRoundTripFloat(_ v: Float32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripFloat(v: Float.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_Sf, reject: Promise_reject) {
+        return await asyncRoundTripFloat(v: Float.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7221,10 +7218,9 @@ public func _bjs_asyncRoundTripFloat(_ v: Float32) -> Int32 {
 @_cdecl("bjs_asyncRoundTripDouble")
 public func _bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripDouble(v: Double.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_Sd, reject: Promise_reject) {
+        return await asyncRoundTripDouble(v: Double.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7234,10 +7230,9 @@ public func _bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
 @_cdecl("bjs_asyncRoundTripBool")
 public func _bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripBool(v: Bool.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_Sb, reject: Promise_reject) {
+        return await asyncRoundTripBool(v: Bool.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7247,10 +7242,9 @@ public func _bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
 @_cdecl("bjs_asyncRoundTripString")
 public func _bjs_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripString(v: String.bridgeJSLiftParameter(vBytes, vLength)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) {
+        return await asyncRoundTripString(v: String.bridgeJSLiftParameter(vBytes, vLength))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7260,10 +7254,9 @@ public func _bjs_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int3
 @_cdecl("bjs_asyncRoundTripSwiftHeapObject")
 public func _bjs_asyncRoundTripSwiftHeapObject(_ v: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripSwiftHeapObject(v: Greeter.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_7GreeterC, reject: Promise_reject) {
+        return await asyncRoundTripSwiftHeapObject(v: Greeter.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7273,10 +7266,9 @@ public func _bjs_asyncRoundTripSwiftHeapObject(_ v: UnsafeMutableRawPointer) -> 
 @_cdecl("bjs_asyncRoundTripJSObject")
 public func _bjs_asyncRoundTripJSObject(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSPromise.async {
-        return await asyncRoundTripJSObject(v: JSObject.bridgeJSLiftParameter(v)).jsValue
-    }.jsObject
-    return ret.bridgeJSLowerReturn()
+    return _bjs_makePromise(resolve: Promise_resolve_8JSObjectC, reject: Promise_reject) {
+        return await asyncRoundTripJSObject(v: JSObject.bridgeJSLiftParameter(v))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -7397,6 +7389,130 @@ public func _bjs_getTheme() -> Void {
     #if arch(wasm32)
     let ret = getTheme()
     return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripTheme")
+@_cdecl("bjs_asyncRoundTripTheme")
+public func _bjs_asyncRoundTripTheme(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_5ThemeO, reject: Promise_reject) {
+        return await asyncRoundTripTheme(_: Theme.bridgeJSLiftParameter(vBytes, vLength))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripDirection")
+@_cdecl("bjs_asyncRoundTripDirection")
+public func _bjs_asyncRoundTripDirection(_ v: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_9DirectionO, reject: Promise_reject) {
+        return await asyncRoundTripDirection(_: Direction.bridgeJSLiftParameter(v))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripOptionalTheme")
+@_cdecl("bjs_asyncRoundTripOptionalTheme")
+public func _bjs_asyncRoundTripOptionalTheme(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_Sq5ThemeO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalTheme(_: Optional<Theme>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripOptionalDirection")
+@_cdecl("bjs_asyncRoundTripOptionalDirection")
+public func _bjs_asyncRoundTripOptionalDirection(_ vIsSome: Int32, _ vValue: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_Sq9DirectionO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalDirection(_: Optional<Direction>.bridgeJSLiftParameter(vIsSome, vValue))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripDirectionArray")
+@_cdecl("bjs_asyncRoundTripDirectionArray")
+public func _bjs_asyncRoundTripDirectionArray() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = [Direction].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa9DirectionO, reject: Promise_reject) {
+        return await asyncRoundTripDirectionArray(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripDirectionDict")
+@_cdecl("bjs_asyncRoundTripDirectionDict")
+public func _bjs_asyncRoundTripDirectionDict() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = [String: Direction].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD9DirectionO, reject: Promise_reject) {
+        return await asyncRoundTripDirectionDict(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripThemeArray")
+@_cdecl("bjs_asyncRoundTripThemeArray")
+public func _bjs_asyncRoundTripThemeArray() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = [Theme].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa5ThemeO, reject: Promise_reject) {
+        return await asyncRoundTripThemeArray(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripThemeDict")
+@_cdecl("bjs_asyncRoundTripThemeDict")
+public func _bjs_asyncRoundTripThemeDict() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_v = [String: Theme].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD5ThemeO, reject: Promise_reject) {
+        return await asyncRoundTripThemeDict(_: _tmp_v)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripFileSize")
+@_cdecl("bjs_asyncRoundTripFileSize")
+public func _bjs_asyncRoundTripFileSize(_ v: Int64) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_8FileSizeO, reject: Promise_reject) {
+        return await asyncRoundTripFileSize(_: FileSize.bridgeJSLiftParameter(v))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripOptionalFileSize")
+@_cdecl("bjs_asyncRoundTripOptionalFileSize")
+public func _bjs_asyncRoundTripOptionalFileSize(_ vIsSome: Int32, _ vValue: Int64) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_Sq8FileSizeO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalFileSize(_: Optional<FileSize>.bridgeJSLiftParameter(vIsSome, vValue))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -8050,6 +8166,110 @@ public func _bjs_roundTripPublicPoint() -> Void {
     #endif
 }
 
+@_expose(wasm, "bjs_asyncRoundTripPublicPoint")
+@_cdecl("bjs_asyncRoundTripPublicPoint")
+public func _bjs_asyncRoundTripPublicPoint() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_point = PublicPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) {
+        return await asyncRoundTripPublicPoint(_: _tmp_point)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripPublicPointThrows")
+@_cdecl("bjs_asyncRoundTripPublicPointThrows")
+public func _bjs_asyncRoundTripPublicPointThrows() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_point = PublicPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) { () async throws(JSException) -> PublicPoint in
+        return try await asyncRoundTripPublicPointThrows(_: _tmp_point)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncStructOrThrow")
+@_cdecl("bjs_asyncStructOrThrow")
+public func _bjs_asyncStructOrThrow(_ shouldThrow: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) { () async throws(JSException) -> PublicPoint in
+        return try await asyncStructOrThrow(_: Bool.bridgeJSLiftParameter(shouldThrow))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncCombinePublicPoints")
+@_cdecl("bjs_asyncCombinePublicPoints")
+public func _bjs_asyncCombinePublicPoints() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_b = PublicPoint.bridgeJSLiftParameter()
+    let _tmp_a = PublicPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) {
+        return await asyncCombinePublicPoints(_: _tmp_a, _: _tmp_b)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripContact")
+@_cdecl("bjs_asyncRoundTripContact")
+public func _bjs_asyncRoundTripContact() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_contact = Contact.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_7ContactV, reject: Promise_reject) {
+        return await asyncRoundTripContact(_: _tmp_contact)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripPublicPointArray")
+@_cdecl("bjs_asyncRoundTripPublicPointArray")
+public func _bjs_asyncRoundTripPublicPointArray() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_points = [PublicPoint].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa11PublicPointV, reject: Promise_reject) {
+        return await asyncRoundTripPublicPointArray(_: _tmp_points)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripOptionalPublicPoint")
+@_cdecl("bjs_asyncRoundTripOptionalPublicPoint")
+public func _bjs_asyncRoundTripOptionalPublicPoint() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_point = Optional<PublicPoint>.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_Sq11PublicPointV, reject: Promise_reject) {
+        return await asyncRoundTripOptionalPublicPoint(_: _tmp_point)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_asyncRoundTripPublicPointDict")
+@_cdecl("bjs_asyncRoundTripPublicPointDict")
+public func _bjs_asyncRoundTripPublicPointDict() -> Int32 {
+    #if arch(wasm32)
+    let _tmp_points = [String: PublicPoint].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD11PublicPointV, reject: Promise_reject) {
+        return await asyncRoundTripPublicPointDict(_: _tmp_points)
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_roundTripContact")
 @_cdecl("bjs_roundTripContact")
 public func _bjs_roundTripContact() -> Void {
@@ -8654,6 +8874,18 @@ public func _bjs_Calculator_add(_ _self: UnsafeMutableRawPointer, _ a: Int32, _ 
     #if arch(wasm32)
     let ret = Calculator.bridgeJSLiftParameter(_self).add(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_Calculator_asyncMakePoint")
+@_cdecl("bjs_Calculator_asyncMakePoint")
+public func _bjs_Calculator_asyncMakePoint(_ _self: UnsafeMutableRawPointer, _ x: Int32, _ y: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) {
+        return await Calculator.bridgeJSLiftParameter(_self).asyncMakePoint(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -11137,6 +11369,512 @@ fileprivate func _bjs_LeakCheck_wrap_extern(_ pointer: UnsafeMutableRawPointer) 
 #endif
 @inline(never) fileprivate func _bjs_LeakCheck_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     return _bjs_LeakCheck_wrap_extern(pointer)
+}
+
+@JSFunction func Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_reject_BridgeJSRuntimeTests")
+fileprivate func promise_reject_BridgeJSRuntimeTests_extern(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void
+#else
+fileprivate func promise_reject_BridgeJSRuntimeTests_extern(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_reject_BridgeJSRuntimeTests(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+    return promise_reject_BridgeJSRuntimeTests_extern(promise, valueKind, valuePayload1, valuePayload2)
+}
+
+func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let (valueKind, valuePayload1, valuePayload2) = value.bridgeJSLowerParameter()
+    promise_reject_BridgeJSRuntimeTests(promiseValue, valueKind, valuePayload1, valuePayload2)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_y(_ promise: JSObject) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_y")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_y_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_y_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_y(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_y_extern(promise)
+}
+
+func _$Promise_resolve_y(_ promise: JSObject) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_y(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Si(_ promise: JSObject, _ value: Int) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Si")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Si_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Si_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Si(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Si_extern(promise, value)
+}
+
+func _$Promise_resolve_Si(_ promise: JSObject, _ value: Int) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Si(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sf(_ promise: JSObject, _ value: Float) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sf")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sf_extern(_ promise: Int32, _ value: Float32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sf_extern(_ promise: Int32, _ value: Float32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sf(_ promise: Int32, _ value: Float32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sf_extern(promise, value)
+}
+
+func _$Promise_resolve_Sf(_ promise: JSObject, _ value: Float) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sf(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sd(_ promise: JSObject, _ value: Double) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sd")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sd_extern(_ promise: Int32, _ value: Float64) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sd_extern(_ promise: Int32, _ value: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sd(_ promise: Int32, _ value: Float64) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sd_extern(promise, value)
+}
+
+func _$Promise_resolve_Sd(_ promise: JSObject, _ value: Double) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sd(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sb(_ promise: JSObject, _ value: Bool) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sb")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sb_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sb_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sb(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sb_extern(promise, value)
+}
+
+func _$Promise_resolve_Sb(_ promise: JSObject, _ value: Bool) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sb(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SS")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SS(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_SS_extern(promise, valueBytes, valueLength)
+}
+
+func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        promise_resolve_BridgeJSRuntimeTests_SS(promiseValue, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_7GreeterC(_ promise: JSObject, _ value: Greeter) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_7GreeterC")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(promise, value)
+}
+
+func _$Promise_resolve_7GreeterC(_ promise: JSObject, _ value: Greeter) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valuePointer = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_7GreeterC(promiseValue, valuePointer)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_8JSObjectC(_ promise: JSObject, _ value: JSObject) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_8JSObjectC")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_8JSObjectC_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_8JSObjectC_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_8JSObjectC(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_8JSObjectC_extern(promise, value)
+}
+
+func _$Promise_resolve_8JSObjectC(_ promise: JSObject, _ value: JSObject) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_8JSObjectC(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_5ThemeO(_ promise: JSObject, _ value: Theme) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_5ThemeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(promise, valueBytes, valueLength)
+}
+
+func _$Promise_resolve_5ThemeO(_ promise: JSObject, _ value: Theme) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        promise_resolve_BridgeJSRuntimeTests_5ThemeO(promiseValue, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_9DirectionO(_ promise: JSObject, _ value: Direction) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_9DirectionO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(promise, value)
+}
+
+func _$Promise_resolve_9DirectionO(_ promise: JSObject, _ value: Direction) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_9DirectionO(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sq5ThemeO(_ promise: JSObject, _ value: Optional<Theme>) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(promise, valueIsSome, valueBytes, valueLength)
+}
+
+func _$Promise_resolve_Sq5ThemeO(_ promise: JSObject, _ value: Optional<Theme>) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    value.bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
+        promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO(promiseValue, valueIsSome, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sq9DirectionO(_ promise: JSObject, _ value: Optional<Direction>) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(promise, valueIsSome, valueValue)
+}
+
+func _$Promise_resolve_Sq9DirectionO(_ promise: JSObject, _ value: Optional<Direction>) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO(promiseValue, valueIsSome, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sa9DirectionO(_ promise: JSObject, _ value: [Direction]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(promise)
+}
+
+func _$Promise_resolve_Sa9DirectionO(_ promise: JSObject, _ value: [Direction]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SD9DirectionO(_ promise: JSObject, _ value: [String: Direction]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD9DirectionO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(promise)
+}
+
+func _$Promise_resolve_SD9DirectionO(_ promise: JSObject, _ value: [String: Direction]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_SD9DirectionO(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sa5ThemeO(_ promise: JSObject, _ value: [Theme]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(promise)
+}
+
+func _$Promise_resolve_Sa5ThemeO(_ promise: JSObject, _ value: [Theme]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SD5ThemeO(_ promise: JSObject, _ value: [String: Theme]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD5ThemeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(promise)
+}
+
+func _$Promise_resolve_SD5ThemeO(_ promise: JSObject, _ value: [String: Theme]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_SD5ThemeO(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_8FileSizeO(_ promise: JSObject, _ value: FileSize) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_8FileSizeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(_ promise: Int32, _ value: Int64) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(_ promise: Int32, _ value: Int64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO(_ promise: Int32, _ value: Int64) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(promise, value)
+}
+
+func _$Promise_resolve_8FileSizeO(_ promise: JSObject, _ value: FileSize) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_8FileSizeO(promiseValue, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sq8FileSizeO(_ promise: JSObject, _ value: Optional<FileSize>) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(promise, valueIsSome, valueValue)
+}
+
+func _$Promise_resolve_Sq8FileSizeO(_ promise: JSObject, _ value: Optional<FileSize>) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO(promiseValue, valueIsSome, valueValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_11PublicPointV(_ promise: JSObject, _ value: PublicPoint) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_11PublicPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(promise, value)
+}
+
+func _$Promise_resolve_11PublicPointV(_ promise: JSObject, _ value: PublicPoint) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueObjectId = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_11PublicPointV(promiseValue, valueObjectId)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_7ContactV(_ promise: JSObject, _ value: Contact) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_7ContactV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(promise, value)
+}
+
+func _$Promise_resolve_7ContactV(_ promise: JSObject, _ value: Contact) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueObjectId = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_7ContactV(promiseValue, valueObjectId)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sa11PublicPointV(_ promise: JSObject, _ value: [PublicPoint]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(promise)
+}
+
+func _$Promise_resolve_Sa11PublicPointV(_ promise: JSObject, _ value: [PublicPoint]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_Sq11PublicPointV(_ promise: JSObject, _ value: Optional<PublicPoint>) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(promise, value)
+}
+
+func _$Promise_resolve_Sq11PublicPointV(_ promise: JSObject, _ value: Optional<PublicPoint>) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueIsSome = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(promiseValue, valueIsSome)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SD11PublicPointV(_ promise: JSObject, _ value: [String: PublicPoint]) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(_ promise: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(_ promise: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(promise)
+}
+
+func _$Promise_resolve_SD11PublicPointV(_ promise: JSObject, _ value: [String: PublicPoint]) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV(promiseValue)
+    if let error = _swift_js_take_exception() { throw error }
 }
 
 #if arch(wasm32)

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -908,6 +908,46 @@
                 }
               }
             }
+          },
+          {
+            "abiName" : "bjs_Calculator_asyncMakePoint",
+            "effects" : {
+              "isAsync" : true,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "asyncMakePoint",
+            "parameters" : [
+              {
+                "label" : "x",
+                "name" : "x",
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              },
+              {
+                "label" : "y",
+                "name" : "y",
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
           }
         ],
         "name" : "Calculator",
@@ -12569,6 +12609,330 @@
         }
       },
       {
+        "abiName" : "bjs_asyncRoundTripTheme",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripTheme",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "rawValueEnum" : {
+                "_0" : "Theme",
+                "_1" : "String"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "rawValueEnum" : {
+            "_0" : "Theme",
+            "_1" : "String"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripDirection",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripDirection",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "caseEnum" : {
+                "_0" : "Direction"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "caseEnum" : {
+            "_0" : "Direction"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripOptionalTheme",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripOptionalTheme",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "Theme",
+                    "_1" : "String"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "Theme",
+                "_1" : "String"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripOptionalDirection",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripOptionalDirection",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Direction"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "Direction"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripDirectionArray",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripDirectionArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Direction"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "Direction"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripDirectionDict",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripDirectionDict",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "dictionary" : {
+                "_0" : {
+                  "caseEnum" : {
+                    "_0" : "Direction"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "dictionary" : {
+            "_0" : {
+              "caseEnum" : {
+                "_0" : "Direction"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripThemeArray",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripThemeArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "Theme",
+                    "_1" : "String"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "Theme",
+                "_1" : "String"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripThemeDict",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripThemeDict",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "dictionary" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "Theme",
+                    "_1" : "String"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "dictionary" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "Theme",
+                "_1" : "String"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripFileSize",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripFileSize",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "rawValueEnum" : {
+                "_0" : "FileSize",
+                "_1" : "Int64"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "rawValueEnum" : {
+            "_0" : "FileSize",
+            "_1" : "Int64"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripOptionalFileSize",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripOptionalFileSize",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "rawValueEnum" : {
+                    "_0" : "FileSize",
+                    "_1" : "Int64"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "rawValueEnum" : {
+                "_0" : "FileSize",
+                "_1" : "Int64"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
         "abiName" : "bjs_setHttpStatus",
         "effects" : {
           "isAsync" : false,
@@ -14357,6 +14721,241 @@
         "returnType" : {
           "swiftStruct" : {
             "_0" : "PublicPoint"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripPublicPoint",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripPublicPoint",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "point",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "PublicPoint"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripPublicPointThrows",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "asyncRoundTripPublicPointThrows",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "point",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "PublicPoint"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncStructOrThrow",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "asyncStructOrThrow",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "shouldThrow",
+            "type" : {
+              "bool" : {
+
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "PublicPoint"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncCombinePublicPoints",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncCombinePublicPoints",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "a",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "b",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "PublicPoint"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripContact",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripContact",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "contact",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "Contact"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "swiftStruct" : {
+            "_0" : "Contact"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripPublicPointArray",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripPublicPointArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "points",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "PublicPoint"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripOptionalPublicPoint",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripOptionalPublicPoint",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "point",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "PublicPoint"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_asyncRoundTripPublicPointDict",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "asyncRoundTripPublicPointDict",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "points",
+            "type" : {
+              "dictionary" : {
+                "_0" : {
+                  "swiftStruct" : {
+                    "_0" : "PublicPoint"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "dictionary" : {
+            "_0" : {
+              "swiftStruct" : {
+                "_0" : "PublicPoint"
+              }
+            }
           }
         }
       },

--- a/Tests/BridgeJSRuntimeTests/JavaScript/AsyncImportTests.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/AsyncImportTests.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 
 import assert from 'node:assert';
+import { ThemeValues, DirectionValues, FileSizeValues } from '../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.js';
 
 /**
  * @returns {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Imports["AsyncImportImports"]}
@@ -43,4 +44,79 @@ export function getImports(importsContext) {
 /** @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports */
 export async function runAsyncWorksTests(exports) {
     await exports.asyncRoundTripVoid();
+
+    const asyncPoint = { x: 7, y: 11 };
+    assert.deepEqual(await exports.asyncRoundTripPublicPoint(asyncPoint), asyncPoint);
+    assert.deepEqual(await exports.asyncRoundTripPublicPointThrows(asyncPoint), asyncPoint);
+
+    const [c1, c2] = await Promise.all([
+        exports.asyncRoundTripPublicPoint({ x: 1, y: 2 }),
+        exports.asyncRoundTripPublicPoint({ x: 3, y: 4 }),
+    ]);
+    assert.deepEqual(c1, { x: 1, y: 2 });
+    assert.deepEqual(c2, { x: 3, y: 4 });
+
+    assert.deepEqual(await exports.asyncCombinePublicPoints({ x: 1, y: 2 }, { x: 10, y: 20 }), { x: 11, y: 22 });
+
+    assert.deepEqual(await exports.asyncStructOrThrow(false), { x: 1, y: 2 });
+    await assert.rejects(
+        () => exports.asyncStructOrThrow(true),
+        (error) => error instanceof Error && error.message === "async struct failure"
+    );
+
+    const richContact = {
+        name: "Alice",
+        age: 30,
+        address: { street: "123 Main St", city: "NYC", zipCode: 10001 },
+        email: "alice@test.com",
+        secondaryAddress: { street: "456 Oak Ave", city: "LA", zipCode: null },
+    };
+    assert.deepEqual(await exports.asyncRoundTripContact(richContact), richContact);
+
+    const calc = exports.createCalculator();
+    assert.deepEqual(await calc.asyncMakePoint(3, 4), { x: 3, y: 4 });
+    calc.release();
+
+    assert.equal(await exports.asyncRoundTripTheme(ThemeValues.Dark), ThemeValues.Dark);
+    assert.equal(await exports.asyncRoundTripDirection(DirectionValues.East), DirectionValues.East);
+
+    assert.deepEqual(
+        await exports.asyncRoundTripPublicPointArray([{ x: 1, y: 2 }, { x: 3, y: 4 }]),
+        [{ x: 1, y: 2 }, { x: 3, y: 4 }]
+    );
+
+    assert.equal(await exports.asyncRoundTripOptionalTheme(ThemeValues.Light), ThemeValues.Light);
+    assert.equal(await exports.asyncRoundTripOptionalTheme(null), null);
+    assert.equal(await exports.asyncRoundTripOptionalDirection(DirectionValues.South), DirectionValues.South);
+    assert.equal(await exports.asyncRoundTripOptionalDirection(null), null);
+
+    assert.deepEqual(await exports.asyncRoundTripOptionalPublicPoint({ x: 5, y: 6 }), { x: 5, y: 6 });
+    assert.equal(await exports.asyncRoundTripOptionalPublicPoint(null), null);
+
+    assert.deepEqual(
+        await exports.asyncRoundTripPublicPointDict({ a: { x: 1, y: 2 }, b: { x: 3, y: 4 } }),
+        { a: { x: 1, y: 2 }, b: { x: 3, y: 4 } }
+    );
+
+    assert.deepEqual(
+        await exports.asyncRoundTripDirectionArray([DirectionValues.North, DirectionValues.East]),
+        [DirectionValues.North, DirectionValues.East]
+    );
+    assert.deepEqual(
+        await exports.asyncRoundTripDirectionDict({ a: DirectionValues.North, b: DirectionValues.South }),
+        { a: DirectionValues.North, b: DirectionValues.South }
+    );
+
+    assert.deepEqual(
+        await exports.asyncRoundTripThemeArray([ThemeValues.Light, ThemeValues.Dark]),
+        [ThemeValues.Light, ThemeValues.Dark]
+    );
+    assert.deepEqual(
+        await exports.asyncRoundTripThemeDict({ a: ThemeValues.Light, b: ThemeValues.Auto }),
+        { a: ThemeValues.Light, b: ThemeValues.Auto }
+    );
+
+    assert.equal(await exports.asyncRoundTripFileSize(FileSizeValues.Large), FileSizeValues.Large);
+    assert.equal(await exports.asyncRoundTripOptionalFileSize(FileSizeValues.Tiny), FileSizeValues.Tiny);
+    assert.equal(await exports.asyncRoundTripOptionalFileSize(null), null);
 }

--- a/Tests/BridgeJSRuntimeTests/StructAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/StructAPIs.swift
@@ -210,6 +210,41 @@ extension Vector2D {
     point
 }
 
+@JS public func asyncRoundTripPublicPoint(_ point: PublicPoint) async -> PublicPoint {
+    point
+}
+
+@JS public func asyncRoundTripPublicPointThrows(_ point: PublicPoint) async throws(JSException) -> PublicPoint {
+    point
+}
+
+@JS public func asyncStructOrThrow(_ shouldThrow: Bool) async throws(JSException) -> PublicPoint {
+    if shouldThrow {
+        throw JSException(JSError(message: "async struct failure").jsValue)
+    }
+    return PublicPoint(x: 1, y: 2)
+}
+
+@JS public func asyncCombinePublicPoints(_ a: PublicPoint, _ b: PublicPoint) async -> PublicPoint {
+    PublicPoint(x: a.x + b.x, y: a.y + b.y)
+}
+
+@JS func asyncRoundTripContact(_ contact: Contact) async -> Contact {
+    contact
+}
+
+@JS public func asyncRoundTripPublicPointArray(_ points: [PublicPoint]) async -> [PublicPoint] {
+    points
+}
+
+@JS public func asyncRoundTripOptionalPublicPoint(_ point: PublicPoint?) async -> PublicPoint? {
+    point
+}
+
+@JS public func asyncRoundTripPublicPointDict(_ points: [String: PublicPoint]) async -> [String: PublicPoint] {
+    points
+}
+
 @JS func roundTripContact(_ contact: Contact) -> Contact {
     return contact
 }


### PR DESCRIPTION
## Overview

Addresses #753. Async exported functions previously required a return type conforming to `ConvertibleToJSValue`. The generated thunk wrapped the body in `JSPromise.async { ... }` and lowered the result with `.jsValue`, so types that have no `.jsValue` representation (`@JS struct`s, raw-value and case enums, and their `Optional`/`Array`/`Dictionary` compositions) could not be returned from an `async @JS func`:

```swift
@JS struct Point { var x: Int; var y: Int }
@JS func getPoint() async -> Point { ... }   // did not compile: Point has no `.jsValue`
```

This PR settles every `async` exported return through a single new mechanism that lowers the value via the regular imported-parameter ABI, so all bridged types and their nested compositions can be returned.

## Approach

**1. Create the Promise eagerly, settle it from a `Task`.**
An exported async function must hand a value back to JavaScript synchronously (the Wasm export returns an `i32` object id), while the work itself is asynchronous. The thunk therefore creates a JS `Promise` immediately via a new `_bjs_makePromise` intrinsic, returns its retained object id, and resolves or rejects it later from a `Task`:

```swift
// generated thunk (struct return)
public func _bjs_getPoint() -> Int32 {
    return _bjs_makePromise(resolve: Promise_resolve_5PointV, reject: Promise_reject) {
        return await getPoint()
    }
}
```

The `resolve`/`reject` settlers are stashed on the `Promise` under a `Symbol` (rather than plain string fields) so they cannot clash with anything else on the object.

**2. Settle through generated `@JSFunction` thunks rather than ad-hoc lowering.**
`_bjs_makePromise` lives in the JavaScriptKit library and cannot name the per-module, per-type lowering that the generator produces. So the generator emits a `Promise_resolve_<mangled>` thunk per distinct return type (deduplicated by mangled name) and a single shared `Promise_reject`, and injects them into `_bjs_makePromise`. Each resolve thunk lowers its value through the **standard imported-parameter ABI**:

```swift
@JSFunction func Promise_resolve_5PointV(_ promise: JSObject, _ value: Point) throws(JSException)
@JSFunction func Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException)
```

The benefit of reusing the imported-parameter ABI is that **every existing per-type lowering is inherited for free**: struct fields pushed on the stack, enum tags, optional `isSome` discriminators, arrays, and dictionaries all round-trip with no new marshaling code. `reject` uses the full `JSValue` ABI so any thrown error is forwarded faithfully.

**3. One path for all async returns.**
Rather than branch between `JSPromise.async` + `.jsValue` for `ConvertibleToJSValue` returns and `_bjs_makePromise` for the rest, every async return now settles through `_bjs_makePromise`. This removes the dual codegen path and the type predicate that used to select between them. `Void` is the one special case: a `Void` value can't cross the bridge as a parameter, so its `resolve` thunk takes only the promise (via a small `_bjs_makePromise` overload) and settles with `undefined`.

**4. Drain stack parameters synchronously before the deferred `Task`.**
Complex parameters travel via a single shared, mutable bridge stack. Because the async body runs later on a `Task`, any stack-using parameter must be lifted into a local **in the thunk** before the `Task` is scheduled, otherwise an interleaved bridge call would corrupt the shared stack. The thunk hoists these lifts in reverse (LIFO) order to preserve the stack discipline:

```swift
public func _bjs_combine() -> Int32 {
    let _tmp_b = AsyncPoint.bridgeJSLiftParameter()
    let _tmp_a = AsyncPoint.bridgeJSLiftParameter()
    return _bjs_makePromise(resolve: ..., reject: ...) {
        return await combine(_: _tmp_a, _: _tmp_b)
    }
}
```

**5. Annotate the throwing async closure explicitly.**
A throwing async body needs an explicit `() async throws(JSException) -> T in` closure type; without it Swift infers `throws(any Error)` instead of `throws(JSException)`. Non-throwing bodies infer correctly and are left unannotated.

**6. Diagnose, rather than miscompile, the unsupported cases.**
The few types that cannot be lowered through the imported-parameter ABI (associated-value enums, protocols, namespace enums, including those nested in `Optional`/`Array`/`Dictionary`) are rejected with a clear BridgeJS diagnostic instead of producing uncompilable Swift.

## Tests

End-to-end runtime round-trips plus codegen snapshots cover the matrix: `@JS struct`, case enum, and raw-value enum, each as a bare value, `Optional`, `Array`, and `Dictionary`; an `Int64`-backed enum (base and optional, exercising the `i64` resolve-helper signature); `Void` and `ConvertibleToJSValue` returns; the throwing variant, the reject path (asserted via `assert.rejects`), multi-parameter stack hoisting, a rich nested struct, an async class method, and concurrent calls via `Promise.all` (the regression guard for shared-stack corruption). Unsupported types are covered by the diagnostic path.
