### PR TITLE
Fix error descriptions Embedded Swift compatibility

### DIFF
--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.swift
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.swift
@@ -188,7 +188,7 @@ public func _bjs_PlayBridgeJS_updateDetailed(_ _self: UnsafeMutableRawPointer, _
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -453,7 +453,7 @@ public class ExportSwift {
                                 _swift_js_throw(Int32(bitPattern: $0.id))
                             }
                         } else {
-                            let jsError = JSError(message: String(describing: error))
+                            let jsError = JSError(message: error.description)
                             withExtendedLifetime(jsError.jsObject) {
                                 _swift_js_throw(Int32(bitPattern: $0.id))
                             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.Global.swift
@@ -117,7 +117,7 @@ public func _bjs_Services_Graph_GraphOperations_static_validate(_ graphId: Int32
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.swift
@@ -117,7 +117,7 @@ public func _bjs_Services_Graph_GraphOperations_static_validate(_ graphId: Int32
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.swift
@@ -59,7 +59,7 @@ public func _bjs_makeFoo() -> Int32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Throws.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Throws.swift
@@ -10,7 +10,7 @@ public func _bjs_throwsSomething() -> Void {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -6967,7 +6967,7 @@ public func _bjs_makeImportedFoo(_ valueBytes: Int32, _ valueLength: Int32) -> I
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7002,7 +7002,7 @@ public func _bjs_throwsSwiftError(_ shouldThrow: Int32) -> Void {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7027,7 +7027,7 @@ public func _bjs_throwsWithIntResult() -> Int32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7052,7 +7052,7 @@ public func _bjs_throwsWithStringResult() -> Void {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7077,7 +7077,7 @@ public func _bjs_throwsWithBoolResult() -> Int32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7102,7 +7102,7 @@ public func _bjs_throwsWithFloatResult() -> Float32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7127,7 +7127,7 @@ public func _bjs_throwsWithDoubleResult() -> Float64 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7152,7 +7152,7 @@ public func _bjs_throwsWithSwiftHeapObjectResult() -> UnsafeMutableRawPointer {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
@@ -7177,7 +7177,7 @@ public func _bjs_throwsWithJSObjectResult() -> Int32 {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }
         } else {
-            let jsError = JSError(message: String(describing: error))
+            let jsError = JSError(message: error.description)
             withExtendedLifetime(jsError.jsObject) {
                 _swift_js_throw(Int32(bitPattern: $0.id))
             }


### PR DESCRIPTION
The BridgeJS generator emits `JSError(message: String(describing: error))` for throwing `@JS` exports, but `String.init(describing:)` is unavailable in Embedded Swift, so embedded Wasm builds of any package with a throwing export fail. The caught error is statically a `JSException` with a stored `description`, so the generated glue now uses `error.description` for identical output. Snapshots regenerated.