### PR TITLE
BridgeJS: Fix reject path of zero-parameter async throwing exports

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -426,21 +426,45 @@ public class ExportSwift {
         /// A throwing async body needs an explicit closure type, otherwise Swift infers
         /// `throws(any Error)` instead of `throws(JSException)`.
         /// See: https://github.com/swiftlang/swift/issues/76165
-        private func asyncThrowsClosureHead(returnSpelling: String?) -> String {
+        private func asyncThrowsClosureHead(returnSpelling: String?, forcesCapture: Bool) -> String {
             guard effects.isThrows else { return "" }
             let returns = returnSpelling.map { " -> \($0)" } ?? ""
-            return " () async throws(JSException)\(returns) in"
+            let capture = forcesCapture ? "[__bjs_capture] " : ""
+            return " \(capture)() async throws(JSException)\(returns) in"
+        }
+
+        /// A captureless throwing async body closure lowers via `thin_to_thick_function`,
+        /// which miscompiles typed-error calls on wasm32. Forcing a capture that the body
+        /// reads turns the closure into a partial apply with a context, avoiding the
+        /// broken convention. An unread capture list entry is dropped by capture analysis,
+        /// so the body must also read the captured value.
+        /// See: https://github.com/swiftlang/swift/issues/89320
+        private var asyncThrowsBodyForcesCapture: Bool {
+            effects.isThrows && abiParameterSignatures.isEmpty && asyncHoistedBindings.isEmpty
         }
 
         func render(abiName: String) -> DeclSyntax {
             let body: CodeBlockItemListSyntax
             if effects.isAsync, let resolveType = asyncResolveReturnType {
                 let resolveName = "Promise_resolve_\(resolveType.mangleTypeName)"
-                let closureHead = asyncThrowsClosureHead(returnSpelling: resolveType.swiftType)
+                let forcesCapture = asyncThrowsBodyForcesCapture
+                let closureHead = asyncThrowsClosureHead(
+                    returnSpelling: resolveType.swiftType,
+                    forcesCapture: forcesCapture
+                )
+                var hoistedBindings = asyncHoistedBindings
+                var bodyItems = self.body
+                if forcesCapture {
+                    hoistedBindings.append("let __bjs_capture = 0")
+                    if !bodyItems.isEmpty {
+                        bodyItems[0] = bodyItems[0].with(\.leadingTrivia, .newline)
+                    }
+                    bodyItems.insert("_ = __bjs_capture", at: 0)
+                }
                 body = """
-                    \(CodeBlockItemListSyntax(asyncHoistedBindings))
+                    \(CodeBlockItemListSyntax(hoistedBindings))
                     return _bjs_makePromise(resolve: \(raw: resolveName), reject: Promise_reject) {\(raw: closureHead)
-                        \(CodeBlockItemListSyntax(self.body))
+                        \(CodeBlockItemListSyntax(bodyItems))
                     }
                     """
             } else if effects.isThrows {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Async.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/Async.swift
@@ -31,6 +31,10 @@
     return v
 }
 
+@JS func asyncThrowsZeroArg() async throws(JSException) -> String {
+    return "ok"
+}
+
 @JS func asyncCombineStructs(_ a: AsyncPoint, _ b: AsyncPoint) async -> AsyncPoint {
     return AsyncPoint(x: a.x + b.x, y: a.y + b.y)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.json
@@ -284,6 +284,23 @@
         }
       },
       {
+        "abiName" : "bjs_asyncThrowsZeroArg",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "asyncThrowsZeroArg",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
         "abiName" : "bjs_asyncCombineStructs",
         "effects" : {
           "isAsync" : true,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.swift
@@ -194,6 +194,20 @@ public func _bjs_asyncRoundTripStructThrows() -> Int32 {
     #endif
 }
 
+@_expose(wasm, "bjs_asyncThrowsZeroArg")
+@_cdecl("bjs_asyncThrowsZeroArg")
+public func _bjs_asyncThrowsZeroArg() -> Int32 {
+    #if arch(wasm32)
+    let __bjs_capture = 0
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { [__bjs_capture] () async throws(JSException) -> String in
+        _ = __bjs_capture
+        return try await asyncThrowsZeroArg()
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_asyncCombineStructs")
 @_cdecl("bjs_asyncCombineStructs")
 public func _bjs_asyncCombineStructs() -> Int32 {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.d.ts
@@ -34,6 +34,7 @@ export type Exports = {
     asyncRoundTripJSObject(v: any): Promise<any>;
     asyncRoundTripStruct(v: AsyncPoint): Promise<AsyncPoint>;
     asyncRoundTripStructThrows(v: AsyncPoint): Promise<AsyncPoint>;
+    asyncThrowsZeroArg(): Promise<string>;
     asyncCombineStructs(a: AsyncPoint, b: AsyncPoint): Promise<AsyncPoint>;
     asyncRoundTripEnum(v: AsyncDirectionTag): Promise<AsyncDirectionTag>;
     asyncRoundTripRawEnum(v: AsyncThemeTag): Promise<AsyncThemeTag>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
@@ -585,6 +585,18 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret1;
                 },
+                asyncThrowsZeroArg: function bjs_asyncThrowsZeroArg() {
+                    const ret = instance.exports.bjs_asyncThrowsZeroArg();
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return ret1;
+                },
                 asyncCombineStructs: function bjs_asyncCombineStructs(a, b) {
                     structHelpers.AsyncPoint.lower(a);
                     structHelpers.AsyncPoint.lower(b);

--- a/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportAPITests.swift
@@ -96,6 +96,10 @@ struct TestError: Error {
 @JS func throwsWithSwiftHeapObjectResult() throws(JSException) -> Greeter { return Greeter(name: "Test") }
 @JS func throwsWithJSObjectResult() throws(JSException) -> JSObject { return JSObject() }
 
+@JS func zeroArgAsyncThrows() async throws(JSException) -> String {
+    throw JSException(JSError(message: "ZeroArgAsyncThrowsError").jsValue)
+}
+
 @JS func asyncRoundTripVoid() async -> Void { return }
 @JS func asyncRoundTripInt(v: Int) async -> Int { return v }
 @JS func asyncRoundTripFloat(v: Float) async -> Float { return v }

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -7189,6 +7189,20 @@ public func _bjs_throwsWithJSObjectResult() -> Int32 {
     #endif
 }
 
+@_expose(wasm, "bjs_zeroArgAsyncThrows")
+@_cdecl("bjs_zeroArgAsyncThrows")
+public func _bjs_zeroArgAsyncThrows() -> Int32 {
+    #if arch(wasm32)
+    let __bjs_capture = 0
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { [__bjs_capture] () async throws(JSException) -> String in
+        _ = __bjs_capture
+        return try await zeroArgAsyncThrows()
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_asyncRoundTripVoid")
 @_cdecl("bjs_asyncRoundTripVoid")
 public func _bjs_asyncRoundTripVoid() -> Int32 {
@@ -11403,6 +11417,28 @@ func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException)
     if let error = _swift_js_take_exception() { throw error }
 }
 
+@JSFunction func Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SS")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SS(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_SS_extern(promise, valueBytes, valueLength)
+}
+
+func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        promise_resolve_BridgeJSRuntimeTests_SS(promiseValue, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() { throw error }
+}
+
 @JSFunction func Promise_resolve_y(_ promise: JSObject) throws(JSException)
 
 #if arch(wasm32)
@@ -11504,28 +11540,6 @@ func _$Promise_resolve_Sb(_ promise: JSObject, _ value: Bool) throws(JSException
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_Sb(promiseValue, valueValue)
-    if let error = _swift_js_take_exception() { throw error }
-}
-
-@JSFunction func Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException)
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SS")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
-#else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SS(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_SS_extern(promise, valueBytes, valueLength)
-}
-
-func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
-    value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
-        promise_resolve_BridgeJSRuntimeTests_SS(promiseValue, valueBytes, valueLength)
-    }
     if let error = _swift_js_take_exception() { throw error }
 }
 

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -12172,6 +12172,23 @@
         }
       },
       {
+        "abiName" : "bjs_zeroArgAsyncThrows",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "zeroArgAsyncThrows",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
         "abiName" : "bjs_asyncRoundTripVoid",
         "effects" : {
           "isAsync" : true,

--- a/Tests/BridgeJSRuntimeTests/JavaScript/AsyncImportTests.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/AsyncImportTests.mjs
@@ -64,6 +64,11 @@ export async function runAsyncWorksTests(exports) {
         (error) => error instanceof Error && error.message === "async struct failure"
     );
 
+    await assert.rejects(
+        () => exports.zeroArgAsyncThrows(),
+        (error) => error instanceof Error && error.message === "ZeroArgAsyncThrowsError"
+    );
+
     const richContact = {
         name: "Alice",
         age: 30,


### PR DESCRIPTION
## Overview

A zero-parameter `async throws(JSException)` export traps the Wasm instance when it throws. The generated thunk wraps the call in a `_bjs_makePromise` body closure; with no parameters there is nothing to capture, so the closure lowers via `thin_to_thick_function`, and invoking that value with an indirect typed error miscompiles on Wasm (swiftlang/swift#89320): the thrown `JSException` arrives corrupted in `Promise_reject` and lowering it traps with `RuntimeError: table index is out of bounds` (or the promise rejects with a garbage value). Exports with parameters are unaffected because their hoisted parameter locals are captured, which makes the body closure a partial apply with a matching call signature.

```swift
@JS func ping() async throws(JSException) -> String {
    throw JSException(JSError(message: "failure").jsValue)
}
```

Generated thunk before:

```swift
return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
    return try await ping()
}
```

After:

```swift
let __bjs_capture = 0
return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { [__bjs_capture] () async throws(JSException) -> String in
    _ = __bjs_capture
    return try await ping()
}
```

**1. Force a capture in captureless async throwing thunk bodies.** When the body closure would otherwise capture nothing (zero-parameter top-level functions, static methods, and constructors share this shape), the generator emits a dummy local captured by the closure. The body must also read the captured value: an unread capture list entry is dropped by capture analysis, leaving the closure thin and the bug in place. The read is what produces a real `partial_apply`.

**2. Tests.** A codegen snapshot covers the zero-parameter shape, and an end-to-end regression test asserts the rejection arrives with the thrown message instead of trapping. Existing thunks are emitted byte-identically.

This is a codegen-level workaround for swiftlang/swift#89320; once the IRGen fix in swiftlang/swift#89715 lands in a release toolchain, the forced capture can be removed.
