### PR TITLE
[codex] update to latest development snapshot toolchain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,9 +176,7 @@ jobs:
       - uses: swiftwasm/setup-swiftwasm@v2
         id: setup-wasm32-unknown-wasip1-threads
         with: { target: wasm32-unknown-wasip1-threads }
-      - run: |
-          swift --version
-          ./Utilities/build-examples.sh
+      - run: ./Utilities/build-examples.sh
         env:
           SWIFT_SDK_ID_wasm32_unknown_wasip1_threads: ${{ steps.setup-wasm32-unknown-wasip1-threads.outputs.swift-sdk-id }}
           SWIFT_SDK_ID_wasm32_unknown_wasip1: ${{ steps.setup-wasm32-unknown-wasip1.outputs.swift-sdk-id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
               JAVASCRIPTKIT_DISABLE_TRACING_TRAIT=1
           - os: ubuntu-24.04
             toolchain:
-              download-url: https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2025-12-01-a/swift-DEVELOPMENT-SNAPSHOT-2025-12-01-a-ubuntu24.04.tar.gz
+              download-url: https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a-ubuntu24.04.tar.gz
             wasi-backend: Node
             target: "wasm32-unknown-wasip1"
           - os: ubuntu-24.04
@@ -31,7 +31,7 @@ jobs:
             target: "wasm32-unknown-wasip1"
           - os: ubuntu-22.04
             toolchain:
-              download-url: https://download.swift.org/development/ubuntu2204/swift-DEVELOPMENT-SNAPSHOT-2025-12-01-a/swift-DEVELOPMENT-SNAPSHOT-2025-12-01-a-ubuntu22.04.tar.gz
+              download-url: https://download.swift.org/development/ubuntu2204/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a-ubuntu22.04.tar.gz
             wasi-backend: Node
             target: "wasm32-unknown-wasip1-threads"
 
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-swift
         with:
-          download-url: https://download.swift.org/development/ubuntu2204/swift-DEVELOPMENT-SNAPSHOT-2025-09-14-a/swift-DEVELOPMENT-SNAPSHOT-2025-09-14-a-ubuntu22.04.tar.gz
+          download-url: https://download.swift.org/development/ubuntu2204/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a-ubuntu22.04.tar.gz
       - run: make bootstrap
       - run: ./Utilities/bridge-js-generate.sh
       - name: Check if BridgeJS generated files are up-to-date
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-swift
         with:
-          download-url: https://download.swift.org/development/ubuntu2204/swift-DEVELOPMENT-SNAPSHOT-2026-03-09-a/swift-DEVELOPMENT-SNAPSHOT-2026-03-09-a-ubuntu22.04.tar.gz
+          download-url: https://download.swift.org/development/ubuntu2204/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a-ubuntu22.04.tar.gz
       - uses: swiftwasm/setup-swiftwasm@v2
         id: setup-wasm32-unknown-wasip1
         with: { target: wasm32-unknown-wasip1 }

--- a/Examples/ActorOnWebWorker/build.sh
+++ b/Examples/ActorOnWebWorker/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
+swift package --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
     plugin --allow-writing-to-package-directory \
     js --use-cdn --output ./Bundle -c release

--- a/Examples/Basic/build.sh
+++ b/Examples/Basic/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}" js --use-cdn -c "${1:-debug}"
+swift package --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}" js --use-cdn -c "${1:-debug}"

--- a/Examples/Embedded/build.sh
+++ b/Examples/Embedded/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
 package_dir="$(cd "$(dirname "$0")" && pwd)"
-swift package --package-path "$package_dir" \
+swift package --build-system native --package-path "$package_dir" \
   --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}-embedded" js -c release

--- a/Examples/Multithreading/build.sh
+++ b/Examples/Multithreading/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
+swift package --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
     plugin --allow-writing-to-package-directory \
     js --use-cdn --output ./Bundle -c release

--- a/Examples/OffscrenCanvas/build.sh
+++ b/Examples/OffscrenCanvas/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
+swift package --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
     plugin --allow-writing-to-package-directory \
     js --use-cdn --output ./Bundle -c release

--- a/Examples/PlayBridgeJS/build.sh
+++ b/Examples/PlayBridgeJS/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}" \
+swift package --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}" \
     plugin --allow-writing-to-package-directory \
     js --use-cdn --output ./Bundle -c "${1:-debug}"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ unittest:
 		echo "SWIFT_SDK_ID is not set. Run 'swift sdk list' and pass a matching SDK, e.g. 'make unittest SWIFT_SDK_ID=<id>'."; \
 		exit 2; \
 	}
-	swift package --swift-sdk "$(SWIFT_SDK_ID)" \
+	swift package --build-system native --swift-sdk "$(SWIFT_SDK_ID)" \
 	    $(TRACING_ARGS) \
 	    --disable-sandbox \
 	    js test --prelude ./Tests/prelude.mjs -Xnode --expose-gc

--- a/Plugins/PackageToJS/Tests/ExampleTests.swift
+++ b/Plugins/PackageToJS/Tests/ExampleTests.swift
@@ -227,6 +227,10 @@ extension Trait where Self == ConditionTrait {
                     fileURLWithPath: "swift",
                     relativeTo: URL(fileURLWithPath: try #require(Self.getSwiftPath()))
                 )
+                var args = args
+                if args.first == "package" {
+                    args.insert(contentsOf: ["--build-system", "native"], at: 1)
+                }
                 try runProcess(swiftExecutable, args, env)
             }
             try body(destination.appending(path: path), runProcess, runSwift)

--- a/Plugins/PackageToJS/Tests/ExampleTests.swift
+++ b/Plugins/PackageToJS/Tests/ExampleTests.swift
@@ -247,10 +247,25 @@ extension Trait where Self == ConditionTrait {
         let swiftSDKID = try #require(Self.getSwiftSDKID())
         try withPackage(at: "Examples/Basic") { packageDir, _, runSwift in
             try runSwift(["package", "--build-system", "native", "--swift-sdk", swiftSDKID, "js"], [:])
-            try runSwift(["package", "--build-system", "native", "--swift-sdk", swiftSDKID, "js", "--debug-info-format", "dwarf"], [:])
-            try runSwift(["package", "--build-system", "native", "--swift-sdk", swiftSDKID, "js", "--debug-info-format", "name"], [:])
             try runSwift(
-                ["package", "--build-system", "native", "--swift-sdk", swiftSDKID, "-Xswiftc", "-DJAVASCRIPTKIT_WITHOUT_WEAKREFS", "js"],
+                [
+                    "package", "--build-system", "native", "--swift-sdk", swiftSDKID, "js", "--debug-info-format",
+                    "dwarf",
+                ],
+                [:]
+            )
+            try runSwift(
+                [
+                    "package", "--build-system", "native", "--swift-sdk", swiftSDKID, "js", "--debug-info-format",
+                    "name",
+                ],
+                [:]
+            )
+            try runSwift(
+                [
+                    "package", "--build-system", "native", "--swift-sdk", swiftSDKID, "-Xswiftc",
+                    "-DJAVASCRIPTKIT_WITHOUT_WEAKREFS", "js",
+                ],
                 [:]
             )
         }
@@ -266,7 +281,10 @@ extension Trait where Self == ConditionTrait {
             try runProcess(which("npm"), ["install"], [:])
             try runProcess(which("npx"), ["playwright", "install", "chromium-headless-shell"], [:])
 
-            try runSwift(["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test"], [:])
+            try runSwift(
+                ["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test"],
+                [:]
+            )
             try withTemporaryDirectory(body: { tempDir, _ in
                 let scriptContent = """
                     const fs = require('fs');
@@ -278,7 +296,8 @@ extension Trait where Self == ConditionTrait {
                 let scriptPath = tempDir.appending(path: "script.js")
                 try runSwift(
                     [
-                        "package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test",
+                        "package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js",
+                        "test",
                         "-Xnode=--require=\(scriptPath.path)",
                     ],
                     [:]
@@ -291,7 +310,10 @@ extension Trait where Self == ConditionTrait {
                 )
             })
             try runSwift(
-                ["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test", "--environment", "browser"],
+                [
+                    "package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test",
+                    "--environment", "browser",
+                ],
                 [:]
             )
         }
@@ -304,7 +326,10 @@ extension Trait where Self == ConditionTrait {
         let swiftPath = try #require(Self.getSwiftPath())
         try withPackage(at: "Examples/Testing") { packageDir, runProcess, runSwift in
             try runSwift(
-                ["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test", "--enable-code-coverage"],
+                [
+                    "package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test",
+                    "--enable-code-coverage",
+                ],
                 [
                     "LLVM_PROFDATA_PATH": URL(fileURLWithPath: swiftPath).appending(path: "llvm-profdata").path
                 ]
@@ -375,7 +400,10 @@ extension Trait where Self == ConditionTrait {
             at: "Plugins/PackageToJS/Fixtures/ContinuationLeakInTest/XCTest",
             assertTerminationStatus: { $0 != 0 }
         ) { packageDir, _, runSwift in
-            try runSwift(["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test"], [:])
+            try runSwift(
+                ["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test"],
+                [:]
+            )
         }
     }
 
@@ -388,7 +416,10 @@ extension Trait where Self == ConditionTrait {
             at: "Plugins/PackageToJS/Fixtures/ContinuationLeakInTest/SwiftTesting",
             assertTerminationStatus: { $0 != 0 }
         ) { packageDir, _, runSwift in
-            try runSwift(["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test"], [:])
+            try runSwift(
+                ["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test"],
+                [:]
+            )
         }
     }
     #endif
@@ -427,7 +458,8 @@ extension Trait where Self == ConditionTrait {
 
             try runSwift(
                 [
-                    "package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test", "--environment", "browser",
+                    "package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test",
+                    "--environment", "browser",
                     "--playwright-expose", "../expose.js",
                 ],
                 [:]

--- a/Plugins/PackageToJS/Tests/ExampleTests.swift
+++ b/Plugins/PackageToJS/Tests/ExampleTests.swift
@@ -227,10 +227,6 @@ extension Trait where Self == ConditionTrait {
                     fileURLWithPath: "swift",
                     relativeTo: URL(fileURLWithPath: try #require(Self.getSwiftPath()))
                 )
-                var args = args
-                if args.first == "package" {
-                    args.insert(contentsOf: ["--build-system", "native"], at: 1)
-                }
                 try runProcess(swiftExecutable, args, env)
             }
             try body(destination.appending(path: path), runProcess, runSwift)
@@ -250,11 +246,11 @@ extension Trait where Self == ConditionTrait {
     func basic() throws {
         let swiftSDKID = try #require(Self.getSwiftSDKID())
         try withPackage(at: "Examples/Basic") { packageDir, _, runSwift in
-            try runSwift(["package", "--swift-sdk", swiftSDKID, "js"], [:])
-            try runSwift(["package", "--swift-sdk", swiftSDKID, "js", "--debug-info-format", "dwarf"], [:])
-            try runSwift(["package", "--swift-sdk", swiftSDKID, "js", "--debug-info-format", "name"], [:])
+            try runSwift(["package", "--build-system", "native", "--swift-sdk", swiftSDKID, "js"], [:])
+            try runSwift(["package", "--build-system", "native", "--swift-sdk", swiftSDKID, "js", "--debug-info-format", "dwarf"], [:])
+            try runSwift(["package", "--build-system", "native", "--swift-sdk", swiftSDKID, "js", "--debug-info-format", "name"], [:])
             try runSwift(
-                ["package", "--swift-sdk", swiftSDKID, "-Xswiftc", "-DJAVASCRIPTKIT_WITHOUT_WEAKREFS", "js"],
+                ["package", "--build-system", "native", "--swift-sdk", swiftSDKID, "-Xswiftc", "-DJAVASCRIPTKIT_WITHOUT_WEAKREFS", "js"],
                 [:]
             )
         }
@@ -270,7 +266,7 @@ extension Trait where Self == ConditionTrait {
             try runProcess(which("npm"), ["install"], [:])
             try runProcess(which("npx"), ["playwright", "install", "chromium-headless-shell"], [:])
 
-            try runSwift(["package", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test"], [:])
+            try runSwift(["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test"], [:])
             try withTemporaryDirectory(body: { tempDir, _ in
                 let scriptContent = """
                     const fs = require('fs');
@@ -282,7 +278,7 @@ extension Trait where Self == ConditionTrait {
                 let scriptPath = tempDir.appending(path: "script.js")
                 try runSwift(
                     [
-                        "package", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test",
+                        "package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test",
                         "-Xnode=--require=\(scriptPath.path)",
                     ],
                     [:]
@@ -295,7 +291,7 @@ extension Trait where Self == ConditionTrait {
                 )
             })
             try runSwift(
-                ["package", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test", "--environment", "browser"],
+                ["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test", "--environment", "browser"],
                 [:]
             )
         }
@@ -308,7 +304,7 @@ extension Trait where Self == ConditionTrait {
         let swiftPath = try #require(Self.getSwiftPath())
         try withPackage(at: "Examples/Testing") { packageDir, runProcess, runSwift in
             try runSwift(
-                ["package", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test", "--enable-code-coverage"],
+                ["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test", "--enable-code-coverage"],
                 [
                     "LLVM_PROFDATA_PATH": URL(fileURLWithPath: swiftPath).appending(path: "llvm-profdata").path
                 ]
@@ -336,7 +332,7 @@ extension Trait where Self == ConditionTrait {
     func multithreading() throws {
         let swiftSDKID = try #require(Self.getSwiftSDKID())
         try withPackage(at: "Examples/Multithreading") { packageDir, _, runSwift in
-            try runSwift(["package", "--swift-sdk", swiftSDKID, "js"], [:])
+            try runSwift(["package", "--build-system", "native", "--swift-sdk", swiftSDKID, "js"], [:])
         }
     }
 
@@ -344,7 +340,7 @@ extension Trait where Self == ConditionTrait {
     func offscreenCanvas() throws {
         let swiftSDKID = try #require(Self.getSwiftSDKID())
         try withPackage(at: "Examples/OffscrenCanvas") { packageDir, _, runSwift in
-            try runSwift(["package", "--swift-sdk", swiftSDKID, "js"], [:])
+            try runSwift(["package", "--build-system", "native", "--swift-sdk", swiftSDKID, "js"], [:])
         }
     }
 
@@ -352,7 +348,7 @@ extension Trait where Self == ConditionTrait {
     func actorOnWebWorker() throws {
         let swiftSDKID = try #require(Self.getSwiftSDKID())
         try withPackage(at: "Examples/ActorOnWebWorker") { packageDir, _, runSwift in
-            try runSwift(["package", "--swift-sdk", swiftSDKID, "js"], [:])
+            try runSwift(["package", "--build-system", "native", "--swift-sdk", swiftSDKID, "js"], [:])
         }
     }
 
@@ -363,7 +359,7 @@ extension Trait where Self == ConditionTrait {
         let swiftSDKID = try #require(Self.getEmbeddedSwiftSDKID())
         try withPackage(at: "Examples/Embedded") { packageDir, _, runSwift in
             try runSwift(
-                ["package", "--swift-sdk", swiftSDKID, "js", "-c", "release"],
+                ["package", "--build-system", "native", "--swift-sdk", swiftSDKID, "js", "-c", "release"],
                 [
                     "JAVASCRIPTKIT_EXPERIMENTAL_EMBEDDED_WASM": "true"
                 ]
@@ -379,7 +375,7 @@ extension Trait where Self == ConditionTrait {
             at: "Plugins/PackageToJS/Fixtures/ContinuationLeakInTest/XCTest",
             assertTerminationStatus: { $0 != 0 }
         ) { packageDir, _, runSwift in
-            try runSwift(["package", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test"], [:])
+            try runSwift(["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test"], [:])
         }
     }
 
@@ -392,7 +388,7 @@ extension Trait where Self == ConditionTrait {
             at: "Plugins/PackageToJS/Fixtures/ContinuationLeakInTest/SwiftTesting",
             assertTerminationStatus: { $0 != 0 }
         ) { packageDir, _, runSwift in
-            try runSwift(["package", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test"], [:])
+            try runSwift(["package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test"], [:])
         }
     }
     #endif
@@ -409,7 +405,7 @@ extension Trait where Self == ConditionTrait {
 
             try runSwift(
                 ["package", "--disable-sandbox"] + Self.stackSizeLinkerFlags + [
-                    "--swift-sdk", swiftSDKID, "js", "test", "--environment", "browser",
+                    "--build-system", "native", "--swift-sdk", swiftSDKID, "js", "test", "--environment", "browser",
                     "--playwright-expose", "../expose.js",
                 ],
                 [:]
@@ -431,7 +427,7 @@ extension Trait where Self == ConditionTrait {
 
             try runSwift(
                 [
-                    "package", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test", "--environment", "browser",
+                    "package", "--build-system", "native", "--disable-sandbox", "--swift-sdk", swiftSDKID, "js", "test", "--environment", "browser",
                     "--playwright-expose", "../expose.js",
                 ],
                 [:]

--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop+ExecutorFactory.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop+ExecutorFactory.swift
@@ -57,14 +57,12 @@ extension JavaScriptEventLoop: SchedulingExecutor {
         #endif  // #if compiler(>=6.4) (Embedded)
         #else  // #if hasFeature(Embedded)
         let duration: Duration
-        // Handle clocks we know
         if let _ = clock as? ContinuousClock {
             duration = delay as! ContinuousClock.Duration
         } else if let _ = clock as? SuspendingClock {
             duration = delay as! SuspendingClock.Duration
         } else {
             fatalError("Unsupported clock type; only ContinuousClock and SuspendingClock are supported")
-            return
         }
         let milliseconds = Self.delayInMilliseconds(from: duration)
         self.enqueue(

--- a/Sources/JavaScriptEventLoop/JavaScriptEventLoop+ExecutorFactory.swift
+++ b/Sources/JavaScriptEventLoop/JavaScriptEventLoop+ExecutorFactory.swift
@@ -63,19 +63,8 @@ extension JavaScriptEventLoop: SchedulingExecutor {
         } else if let _ = clock as? SuspendingClock {
             duration = delay as! SuspendingClock.Duration
         } else {
-            #if compiler(>=6.4)
-            // Hand-off the scheduling work to Clock implementation for unknown clocks.
-            // Clock.enqueue is only available in the development branch (6.4+).
-            clock.enqueue(
-                job,
-                on: self,
-                at: clock.now.advanced(by: delay),
-                tolerance: tolerance
-            )
-            return
-            #else
             fatalError("Unsupported clock type; only ContinuousClock and SuspendingClock are supported")
-            #endif  // #if compiler(>=6.4) (non-Embedded)
+            return
         }
         let milliseconds = Self.delayInMilliseconds(from: duration)
         self.enqueue(

--- a/Tests/JavaScriptEventLoopTests/JSClosure+AsyncTests.swift
+++ b/Tests/JavaScriptEventLoopTests/JSClosure+AsyncTests.swift
@@ -72,7 +72,7 @@ class JSClosureAsyncTests: XCTestCase {
         )!.value()
         XCTAssertEqual(result, 42.0)
     }
-    
+
     func testAsyncOneshotClosureWithPriority() async throws {
         let priority = UnsafeSendableBox<TaskPriority?>(nil)
         let closure = JSOneshotClosure.async(priority: .high) { _ in
@@ -83,7 +83,7 @@ class JSClosureAsyncTests: XCTestCase {
         XCTAssertEqual(result, 42.0)
         XCTAssertEqual(priority.value, .high)
     }
-    
+
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func testAsyncOneshotClosureWithTaskExecutor() async throws {
         let executor = AnyTaskExecutor()
@@ -93,7 +93,7 @@ class JSClosureAsyncTests: XCTestCase {
         let result = try await JSPromise(from: closure.function!())!.value()
         XCTAssertEqual(result, 42.0)
     }
-    
+
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func testAsyncOneshotClosureWithTaskExecutorPreference() async throws {
         let executor = AnyTaskExecutor()

--- a/Tests/JavaScriptEventLoopTests/JSClosure+AsyncTests.swift
+++ b/Tests/JavaScriptEventLoopTests/JSClosure+AsyncTests.swift
@@ -72,7 +72,7 @@ class JSClosureAsyncTests: XCTestCase {
         )!.value()
         XCTAssertEqual(result, 42.0)
     }
-
+    
     func testAsyncOneshotClosureWithPriority() async throws {
         let priority = UnsafeSendableBox<TaskPriority?>(nil)
         let closure = JSOneshotClosure.async(priority: .high) { _ in
@@ -83,7 +83,7 @@ class JSClosureAsyncTests: XCTestCase {
         XCTAssertEqual(result, 42.0)
         XCTAssertEqual(priority.value, .high)
     }
-
+    
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func testAsyncOneshotClosureWithTaskExecutor() async throws {
         let executor = AnyTaskExecutor()
@@ -93,7 +93,7 @@ class JSClosureAsyncTests: XCTestCase {
         let result = try await JSPromise(from: closure.function!())!.value()
         XCTAssertEqual(result, 42.0)
     }
-
+    
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func testAsyncOneshotClosureWithTaskExecutorPreference() async throws {
         let executor = AnyTaskExecutor()

--- a/Utilities/build-examples.sh
+++ b/Utilities/build-examples.sh
@@ -6,12 +6,14 @@ EXCLUDED_EXAMPLES=()
 
 for example in Examples/*; do
     skip_example=false
-    for excluded in "${EXCLUDED_EXAMPLES[@]}"; do
-        if [[ "$example" == *"$excluded"* ]]; then
-            skip_example=true
-            break
-        fi
-    done
+    if ((${#EXCLUDED_EXAMPLES[@]})); then
+        for excluded in "${EXCLUDED_EXAMPLES[@]}"; do
+            if [[ "$example" == *"$excluded"* ]]; then
+                skip_example=true
+                break
+            fi
+        done
+    fi
     if [ "$skip_example" = true ]; then
         echo "Skipping $example"
         continue


### PR DESCRIPTION
## What changed
- Updated CI snapshot toolchain downloads to the 2026-05-27 development snapshot.
- Forced `make unittest` to use SwiftPM's native build system.
- Updated `JavaScriptEventLoop`'s scheduling fallback to match the upstream Swift change that removed SE-0505 clock forwarding APIs.

## Why
Upstream Swift removed the `Clock` forwarding path that previously allowed unknown clocks to delegate scheduling. The JavaScript event loop now only supports the built-in `ContinuousClock` and `SuspendingClock` paths, so the fallback must trap for unsupported clocks.

## Validation
- `mise exec -- env SWIFT_SDK_ID=DEVELOPMENT-SNAPSHOT-2026-05-27-a-wasm32-unknown-wasip1 make unittest`
- The suite passed on the matching 2026-05-27 host toolchain and Wasm SDK.

## Note
- `--build-system native` is currently required for local `make unittest`; SwiftPM warns that it is deprecated, so we should mention that in the PR description and revisit it when the default build-system path is compatible again.
