### PR TITLE
Use SwiftSyntax prebuilt action in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,14 +96,14 @@ jobs:
           node-version: '20'
       - name: Install TypeScript
         run: npm install
-      - uses: swiftwasm/setup-swift-syntax-prebuilts@v1
-        id: swiftsyntax-prebuilts
-        with:
-          swift-syntax-version: ${{ matrix.entry.swift-syntax-version }}
       - name: Validate BridgeJS TypeScript declarations
         run: npm run check:bridgejs-dts
       - name: Run BridgeJS tests
-        run: swift test ${{ steps.swiftsyntax-prebuilts.outputs.swift-flags }} --package-path ./Plugins/BridgeJS
+        # NOTE: This job runs in the swift Docker image, whose compiler tag is
+        # swift-6.3.2-RELEASE. No matching release asset is currently published
+        # for the setup action, so using it falls back to a local SwiftSyntax
+        # prebuild and makes the job slower than building normally.
+        run: swift test --disable-experimental-prebuilts --package-path ./Plugins/BridgeJS
         env:
           BRIDGEJS_OVERRIDE_SWIFT_SYNTAX_VERSION: ${{ matrix.entry.swift-syntax-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.event_name, 'pull') }}
 jobs:
   test:
+    if: false # TEMP: narrow CI while debugging SwiftSyntax prebuilt consumption.
     name: Build and Test
     strategy:
       matrix:
@@ -79,6 +80,7 @@ jobs:
         run: npm run check:bridgejs-dts
 
   test-bridgejs-against-swift-versions:
+    if: false # TEMP: narrow CI while debugging SwiftSyntax prebuilt consumption.
     name: Test BridgeJS against Swift versions
     strategy:
       matrix:
@@ -108,6 +110,7 @@ jobs:
           BRIDGEJS_OVERRIDE_SWIFT_SYNTAX_VERSION: ${{ matrix.entry.swift-syntax-version }}
 
   native-build:
+    if: false # TEMP: narrow CI while debugging SwiftSyntax prebuilt consumption.
     # Check native build to make it easy to develop applications by Xcode
     name: Build for native target
     strategy:
@@ -126,6 +129,7 @@ jobs:
           DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer/
 
   prettier:
+    if: false # TEMP: narrow CI while debugging SwiftSyntax prebuilt consumption.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -136,6 +140,7 @@ jobs:
       - run: npx prettier --check Runtime/src
 
   format:
+    if: false # TEMP: narrow CI while debugging SwiftSyntax prebuilt consumption.
     runs-on: ubuntu-latest
     container:
       image: swift:6.3
@@ -151,6 +156,7 @@ jobs:
           }
 
   check-bridgejs-generated:
+    if: false # TEMP: narrow CI while debugging SwiftSyntax prebuilt consumption.
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
@@ -175,6 +181,7 @@ jobs:
 
   build-examples:
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-swift
@@ -192,20 +199,27 @@ jobs:
           swift-syntax-version: "603.0.2"
       - run: |
           swift --version
-          ./Utilities/build-examples.sh
+          echo "SwiftSyntax restore source: ${{ steps.swiftsyntax-prebuilts.outputs.restore-source }}"
+          echo "SwiftSyntax cache hit: ${{ steps.swiftsyntax-prebuilts.outputs.cache-hit }}"
+          echo "SwiftSyntax prebuilts path: ${{ steps.swiftsyntax-prebuilts.outputs.prebuilts-path }}"
+          find "${{ steps.swiftsyntax-prebuilts.outputs.prebuilts-path }}" -maxdepth 3 -type f | sort
+          cd Examples/ActorOnWebWorker
+          ./build.sh release
         env:
           SWIFT_SDK_ID_wasm32_unknown_wasip1_threads: ${{ steps.setup-wasm32-unknown-wasip1-threads.outputs.swift-sdk-id }}
           SWIFT_SDK_ID_wasm32_unknown_wasip1: ${{ steps.setup-wasm32-unknown-wasip1.outputs.swift-sdk-id }}
           SWIFT_PACKAGE_FLAGS: ${{ steps.swiftsyntax-prebuilts.outputs.swift-flags }}
-      - run: ./Utilities/prepare-gh-pages.sh
+      - if: false # TEMP: skip pages packaging while debugging one example.
+        run: ./Utilities/prepare-gh-pages.sh
       - name: Upload static files as artifact
+        if: false # TEMP: skip pages artifact upload while debugging one example.
         id: deployment
         uses: actions/upload-pages-artifact@v5
         with:
           path: ./_site
   deploy-examples:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: false # TEMP: narrow CI while debugging SwiftSyntax prebuilt consumption.
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,6 +203,9 @@ jobs:
           echo "SwiftSyntax cache hit: ${{ steps.swiftsyntax-prebuilts.outputs.cache-hit }}"
           echo "SwiftSyntax prebuilts path: ${{ steps.swiftsyntax-prebuilts.outputs.prebuilts-path }}"
           find "${{ steps.swiftsyntax-prebuilts.outputs.prebuilts-path }}" -maxdepth 3 -type f | sort
+          swift package --verbose ${SWIFT_PACKAGE_FLAGS} --package-path Examples/ActorOnWebWorker resolve
+          find Examples/ActorOnWebWorker/.build/prebuilts -maxdepth 5 -print 2>/dev/null | sort || true
+          find Examples/ActorOnWebWorker/.build -name workspace-state.json -print -exec sed -n '1,240p' {} \; || true
           cd Examples/ActorOnWebWorker
           ./build.sh release
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,24 +204,80 @@ jobs:
           echo "SwiftSyntax cache hit: ${{ steps.swiftsyntax-prebuilts.outputs.cache-hit }}"
           echo "SwiftSyntax prebuilts path: ${{ steps.swiftsyntax-prebuilts.outputs.prebuilts-path }}"
           find "${{ steps.swiftsyntax-prebuilts.outputs.prebuilts-path }}" -maxdepth 3 -type f | sort
-          swift package --verbose ${SWIFT_PACKAGE_FLAGS} --package-path Examples/ActorOnWebWorker resolve
-          find Examples/ActorOnWebWorker/.build/prebuilts -maxdepth 5 -print 2>/dev/null | sort || true
-          find Examples/ActorOnWebWorker/.build -name workspace-state.json -print -exec sed -n '1,240p' {} \; || true
-          cd Examples/ActorOnWebWorker
 
-          swift build --verbose ${SWIFT_PACKAGE_FLAGS} --build-system native \
-            --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
-            --product MyApp -c release \
-            -Xswiftc -static-stdlib \
-            -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor \
-            -Xlinker --export-if-defined=__main_argc_argv 2>&1 | tee prebuilt-warmup.log
+          runtime_view="$RUNNER_TEMP/JavaScriptKitRuntimeOnly"
+          rm -rf "$runtime_view"
+          cp -R "$GITHUB_WORKSPACE" "$runtime_view"
+          rm -rf "$runtime_view/.git"
 
-          swift package --verbose ${SWIFT_PACKAGE_FLAGS} --build-system native \
+          cat > "$runtime_view/Package.swift" <<'EOF'
+          // swift-tools-version:6.2
+
+          import CompilerPluginSupport
+          import PackageDescription
+
+          let package = Package(
+              name: "JavaScriptKit",
+              platforms: [
+                  .macOS(.v13),
+                  .iOS(.v13),
+                  .tvOS(.v13),
+                  .watchOS(.v6),
+                  .macCatalyst(.v13),
+              ],
+              products: [
+                  .library(name: "JavaScriptKit", targets: ["JavaScriptKit"]),
+                  .library(name: "JavaScriptEventLoop", targets: ["JavaScriptEventLoop"]),
+                  .plugin(name: "PackageToJS", targets: ["PackageToJS"]),
+              ],
+              dependencies: [
+                  .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"604.0.0")
+              ],
+              targets: [
+                  .target(
+                      name: "JavaScriptKit",
+                      dependencies: ["_CJavaScriptKit", "BridgeJSMacros"],
+                      exclude: ["Runtime"],
+                      swiftSettings: [
+                          .enableExperimentalFeature("Extern"),
+                      ]
+                  ),
+                  .target(name: "_CJavaScriptKit"),
+                  .macro(
+                      name: "BridgeJSMacros",
+                      dependencies: [
+                          .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                          .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+                      ]
+                  ),
+                  .target(
+                      name: "JavaScriptEventLoop",
+                      dependencies: ["JavaScriptKit", "_CJavaScriptEventLoop"]
+                  ),
+                  .target(name: "_CJavaScriptEventLoop"),
+                  .plugin(
+                      name: "PackageToJS",
+                      capability: .command(
+                          intent: .custom(verb: "js", description: "Convert a Swift package to a JavaScript package")
+                      ),
+                      path: "Plugins/PackageToJS/Sources"
+                  ),
+              ]
+          )
+          EOF
+
+          swift package --verbose ${SWIFT_PACKAGE_FLAGS} --package-path "$runtime_view/Examples/ActorOnWebWorker" resolve
+          find "$runtime_view/Examples/ActorOnWebWorker/.build/prebuilts" -maxdepth 5 -print 2>/dev/null | sort || true
+          find "$runtime_view/Examples/ActorOnWebWorker/.build" -name workspace-state.json -print -exec sed -n '1,240p' {} \; || true
+
+          cd "$runtime_view/Examples/ActorOnWebWorker"
+
+          swift package --verbose ${SWIFT_PACKAGE_FLAGS} --build-system native --package JavaScriptKit \
             --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
             plugin --allow-writing-to-package-directory \
             js --use-cdn --output ./Bundle -c release 2>&1 | tee plugin-build.log
 
-          if grep -E "Compiling (SwiftSyntax|SwiftBasicFormat|SwiftDiagnostics|SwiftParser|SwiftOperators|SwiftIfConfig|SwiftCompilerPlugin|SwiftSyntaxMacros|SwiftSyntaxMacroExpansion|SwiftCompilerPluginMessageHandling)" prebuilt-warmup.log plugin-build.log; then
+          if grep -E "Compiling (SwiftSyntax|SwiftBasicFormat|SwiftDiagnostics|SwiftParser|SwiftOperators|SwiftIfConfig|SwiftCompilerPlugin|SwiftSyntaxMacros|SwiftSyntaxMacroExpansion|SwiftCompilerPluginMessageHandling)|SwiftSyntax-tool\.build|SwiftCompilerPlugin-tool\.build|SwiftSyntaxMacros-tool\.build" plugin-build.log; then
             echo "::error::SwiftSyntax was built from source instead of using prebuilts"
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,7 +207,10 @@ jobs:
           find Examples/ActorOnWebWorker/.build/prebuilts -maxdepth 5 -print 2>/dev/null | sort || true
           find Examples/ActorOnWebWorker/.build -name workspace-state.json -print -exec sed -n '1,240p' {} \; || true
           cd Examples/ActorOnWebWorker
-          ./build.sh release
+          swift package --verbose ${SWIFT_PACKAGE_FLAGS} \
+            --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
+            plugin --allow-writing-to-package-directory \
+            js --use-cdn --output ./Bundle -c release
         env:
           SWIFT_SDK_ID_wasm32_unknown_wasip1_threads: ${{ steps.setup-wasm32-unknown-wasip1-threads.outputs.swift-sdk-id }}
           SWIFT_SDK_ID_wasm32_unknown_wasip1: ${{ steps.setup-wasm32-unknown-wasip1.outputs.swift-sdk-id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - os: ubuntu-24.04
             toolchain:
               download-url: https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a-ubuntu24.04.tar.gz
+            swift-syntax-version: "603.0.2"
             wasi-backend: Node
             target: "wasm32-unknown-wasip1"
             env: |
@@ -22,11 +23,13 @@ jobs:
           - os: ubuntu-24.04
             toolchain:
               download-url: https://download.swift.org/swift-6.3-branch/ubuntu2404/swift-6.3-DEVELOPMENT-SNAPSHOT-2026-03-05-a/swift-6.3-DEVELOPMENT-SNAPSHOT-2026-03-05-a-ubuntu24.04.tar.gz
+            swift-syntax-version: "603.0.2"
             wasi-backend: Node
             target: "wasm32-unknown-wasip1"
           - os: ubuntu-22.04
             toolchain:
               download-url: https://download.swift.org/development/ubuntu2204/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a-ubuntu22.04.tar.gz
+            swift-syntax-version: "603.0.2"
             wasi-backend: Node
             target: "wasm32-unknown-wasip1-threads"
 
@@ -53,17 +56,25 @@ jobs:
         run: |
           echo "SWIFT_SDK_ID=${{ steps.setup-swiftwasm.outputs.swift-sdk-id }}" >> $GITHUB_ENV
           echo "SWIFT_BIN_PATH=$(dirname $(which swiftc))" >> $GITHUB_ENV
+      - uses: swiftwasm/setup-swift-syntax-prebuilts@v1
+        id: swiftsyntax-prebuilts
+        with:
+          swift-syntax-version: ${{ matrix.entry.swift-syntax-version }}
       - run: make bootstrap
       - run: make unittest
         # Skip unit tests with uwasi because its proc_exit throws
         # unhandled promise rejection.
         if: ${{ matrix.entry.wasi-backend != 'MicroWASI' }}
+        env:
+          SWIFT_PACKAGE_FLAGS: ${{ steps.swiftsyntax-prebuilts.outputs.swift-flags }}
       - name: Check if SwiftPM resources are stale
         run: |
           make regenerate_swiftpm_resources
           git diff --exit-code Sources/JavaScriptKit/Runtime
-      - run: swift test --package-path ./Plugins/PackageToJS
-      - run: swift test --package-path ./Plugins/BridgeJS
+      - run: swift test ${{ steps.swiftsyntax-prebuilts.outputs.swift-flags }} --package-path ./Plugins/PackageToJS
+      - run: swift test ${{ steps.swiftsyntax-prebuilts.outputs.swift-flags }} --package-path ./Plugins/BridgeJS
+        env:
+          BRIDGEJS_OVERRIDE_SWIFT_SYNTAX_VERSION: ${{ matrix.entry.swift-syntax-version }}
       - name: Validate BridgeJS TypeScript declarations
         run: npm run check:bridgejs-dts
 
@@ -73,7 +84,7 @@ jobs:
       matrix:
         entry:
           - image: "swift:6.3"
-            swift-syntax-version: "603.0.0"
+            swift-syntax-version: "603.0.2"
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.entry.image }}
@@ -85,12 +96,14 @@ jobs:
           node-version: '20'
       - name: Install TypeScript
         run: npm install
+      - uses: swiftwasm/setup-swift-syntax-prebuilts@v1
+        id: swiftsyntax-prebuilts
+        with:
+          swift-syntax-version: ${{ matrix.entry.swift-syntax-version }}
       - name: Validate BridgeJS TypeScript declarations
         run: npm run check:bridgejs-dts
       - name: Run BridgeJS tests
-        # NOTE: Seems like the prebuilt SwiftSyntax binaries are not compatible with
-        # non-macro dependents, so disable experimental prebuilts for now.
-        run: swift test --disable-experimental-prebuilts --package-path ./Plugins/BridgeJS
+        run: swift test ${{ steps.swiftsyntax-prebuilts.outputs.swift-flags }} --package-path ./Plugins/BridgeJS
         env:
           BRIDGEJS_OVERRIDE_SWIFT_SYNTAX_VERSION: ${{ matrix.entry.swift-syntax-version }}
 
@@ -144,8 +157,14 @@ jobs:
       - uses: ./.github/actions/install-swift
         with:
           download-url: https://download.swift.org/development/ubuntu2204/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a-ubuntu22.04.tar.gz
+      - uses: swiftwasm/setup-swift-syntax-prebuilts@v1
+        id: swiftsyntax-prebuilts
+        with:
+          swift-syntax-version: "600.0.1"
       - run: make bootstrap
       - run: ./Utilities/bridge-js-generate.sh
+        env:
+          SWIFT_PACKAGE_FLAGS: ${{ steps.swiftsyntax-prebuilts.outputs.swift-flags }}
       - name: Check if BridgeJS generated files are up-to-date
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -167,10 +186,17 @@ jobs:
       - uses: swiftwasm/setup-swiftwasm@v2
         id: setup-wasm32-unknown-wasip1-threads
         with: { target: wasm32-unknown-wasip1-threads }
-      - run: ./Utilities/build-examples.sh
+      - uses: swiftwasm/setup-swift-syntax-prebuilts@v1
+        id: swiftsyntax-prebuilts
+        with:
+          swift-syntax-version: "603.0.2"
+      - run: |
+          swift --version
+          ./Utilities/build-examples.sh
         env:
           SWIFT_SDK_ID_wasm32_unknown_wasip1_threads: ${{ steps.setup-wasm32-unknown-wasip1-threads.outputs.swift-sdk-id }}
           SWIFT_SDK_ID_wasm32_unknown_wasip1: ${{ steps.setup-wasm32-unknown-wasip1.outputs.swift-sdk-id }}
+          SWIFT_PACKAGE_FLAGS: ${{ steps.swiftsyntax-prebuilts.outputs.swift-flags }}
       - run: ./Utilities/prepare-gh-pages.sh
       - name: Upload static files as artifact
         id: deployment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,7 +174,7 @@ jobs:
           }
 
   build-examples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-swift

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -272,7 +272,7 @@ jobs:
 
           cd "$runtime_view/Examples/ActorOnWebWorker"
 
-          swift package --verbose ${SWIFT_PACKAGE_FLAGS} --build-system native --package JavaScriptKit \
+          swift package --verbose ${SWIFT_PACKAGE_FLAGS} --build-system native \
             --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
             plugin --allow-writing-to-package-directory \
             js --use-cdn --output ./Bundle -c release 2>&1 | tee plugin-build.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,7 +207,7 @@ jobs:
           find Examples/ActorOnWebWorker/.build/prebuilts -maxdepth 5 -print 2>/dev/null | sort || true
           find Examples/ActorOnWebWorker/.build -name workspace-state.json -print -exec sed -n '1,240p' {} \; || true
           cd Examples/ActorOnWebWorker
-          swift package --verbose ${SWIFT_PACKAGE_FLAGS} \
+          swift package --verbose ${SWIFT_PACKAGE_FLAGS} --build-system swiftbuild \
             --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
             plugin --allow-writing-to-package-directory \
             js --use-cdn --output ./Bundle -c release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "SWIFT_SDK_ID=${{ steps.setup-swiftwasm.outputs.swift-sdk-id }}" >> $GITHUB_ENV
           echo "SWIFT_BIN_PATH=$(dirname $(which swiftc))" >> $GITHUB_ENV
-      - uses: swiftwasm/setup-swift-syntax-prebuilts@v1
+      - uses: swiftwasm/setup-swift-syntax-prebuilts@yt/support-swiftpm-triple-build-dir
         id: swiftsyntax-prebuilts
         with:
           swift-syntax-version: ${{ matrix.entry.swift-syntax-version }}
@@ -157,7 +157,7 @@ jobs:
       - uses: ./.github/actions/install-swift
         with:
           download-url: https://download.swift.org/development/ubuntu2204/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a-ubuntu22.04.tar.gz
-      - uses: swiftwasm/setup-swift-syntax-prebuilts@v1
+      - uses: swiftwasm/setup-swift-syntax-prebuilts@yt/support-swiftpm-triple-build-dir
         id: swiftsyntax-prebuilts
         with:
           swift-syntax-version: "600.0.1"
@@ -186,7 +186,7 @@ jobs:
       - uses: swiftwasm/setup-swiftwasm@v2
         id: setup-wasm32-unknown-wasip1-threads
         with: { target: wasm32-unknown-wasip1-threads }
-      - uses: swiftwasm/setup-swift-syntax-prebuilts@v1
+      - uses: swiftwasm/setup-swift-syntax-prebuilts@yt/support-swiftpm-triple-build-dir
         id: swiftsyntax-prebuilts
         with:
           swift-syntax-version: "603.0.2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,6 +198,7 @@ jobs:
         with:
           swift-syntax-version: "603.0.2"
       - run: |
+          set -o pipefail
           swift --version
           echo "SwiftSyntax restore source: ${{ steps.swiftsyntax-prebuilts.outputs.restore-source }}"
           echo "SwiftSyntax cache hit: ${{ steps.swiftsyntax-prebuilts.outputs.cache-hit }}"
@@ -207,10 +208,23 @@ jobs:
           find Examples/ActorOnWebWorker/.build/prebuilts -maxdepth 5 -print 2>/dev/null | sort || true
           find Examples/ActorOnWebWorker/.build -name workspace-state.json -print -exec sed -n '1,240p' {} \; || true
           cd Examples/ActorOnWebWorker
-          swift package --verbose ${SWIFT_PACKAGE_FLAGS} --build-system swiftbuild \
+
+          swift build --verbose ${SWIFT_PACKAGE_FLAGS} --build-system native \
+            --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
+            --product MyApp -c release \
+            -Xswiftc -static-stdlib \
+            -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor \
+            -Xlinker --export-if-defined=__main_argc_argv 2>&1 | tee prebuilt-warmup.log
+
+          swift package --verbose ${SWIFT_PACKAGE_FLAGS} --build-system native \
             --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
             plugin --allow-writing-to-package-directory \
-            js --use-cdn --output ./Bundle -c release
+            js --use-cdn --output ./Bundle -c release 2>&1 | tee plugin-build.log
+
+          if grep -E "Compiling (SwiftSyntax|SwiftBasicFormat|SwiftDiagnostics|SwiftParser|SwiftOperators|SwiftIfConfig|SwiftCompilerPlugin|SwiftSyntaxMacros|SwiftSyntaxMacroExpansion|SwiftCompilerPluginMessageHandling)" prebuilt-warmup.log plugin-build.log; then
+            echo "::error::SwiftSyntax was built from source instead of using prebuilts"
+            exit 1
+          fi
         env:
           SWIFT_SDK_ID_wasm32_unknown_wasip1_threads: ${{ steps.setup-wasm32-unknown-wasip1-threads.outputs.swift-sdk-id }}
           SWIFT_SDK_ID_wasm32_unknown_wasip1: ${{ steps.setup-wasm32-unknown-wasip1.outputs.swift-sdk-id }}

--- a/Examples/ActorOnWebWorker/build.sh
+++ b/Examples/ActorOnWebWorker/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
+swift package ${SWIFT_PACKAGE_FLAGS:-} --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
     plugin --allow-writing-to-package-directory \
     js --use-cdn --output ./Bundle -c release

--- a/Examples/Basic/build.sh
+++ b/Examples/Basic/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}" js --use-cdn -c "${1:-debug}"
+swift package ${SWIFT_PACKAGE_FLAGS:-} --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}" js --use-cdn -c "${1:-debug}"

--- a/Examples/Embedded/build.sh
+++ b/Examples/Embedded/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
 package_dir="$(cd "$(dirname "$0")" && pwd)"
-swift package --build-system native --package-path "$package_dir" \
+swift package ${SWIFT_PACKAGE_FLAGS:-} --build-system native --package-path "$package_dir" \
   --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}-embedded" js -c release

--- a/Examples/Multithreading/build.sh
+++ b/Examples/Multithreading/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
+swift package ${SWIFT_PACKAGE_FLAGS:-} --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
     plugin --allow-writing-to-package-directory \
     js --use-cdn --output ./Bundle -c release

--- a/Examples/OffscrenCanvas/build.sh
+++ b/Examples/OffscrenCanvas/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
+swift package ${SWIFT_PACKAGE_FLAGS:-} --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1_threads:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1-threads}}" \
     plugin --allow-writing-to-package-directory \
     js --use-cdn --output ./Bundle -c release

--- a/Examples/PlayBridgeJS/build.sh
+++ b/Examples/PlayBridgeJS/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
-swift package --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}" \
+swift package ${SWIFT_PACKAGE_FLAGS:-} --build-system native --swift-sdk "${SWIFT_SDK_ID_wasm32_unknown_wasip1:-${SWIFT_SDK_ID:-wasm32-unknown-wasip1}}" \
     plugin --allow-writing-to-package-directory \
     js --use-cdn --output ./Bundle -c "${1:-debug}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SWIFT_SDK_ID ?=
+SWIFT_PACKAGE_FLAGS ?=
 ifeq ($(JAVASCRIPTKIT_DISABLE_TRACING_TRAIT),1)
 	TRACING_ARGS :=
 else
@@ -16,7 +17,9 @@ unittest:
 		echo "SWIFT_SDK_ID is not set. Run 'swift sdk list' and pass a matching SDK, e.g. 'make unittest SWIFT_SDK_ID=<id>'."; \
 		exit 2; \
 	}
-	swift package --build-system native --swift-sdk "$(SWIFT_SDK_ID)" \
+	swift package $(SWIFT_PACKAGE_FLAGS) \
+	    --build-system native \
+	    --swift-sdk "$(SWIFT_SDK_ID)" \
 	    $(TRACING_ARGS) \
 	    --disable-sandbox \
 	    js test --prelude ./Tests/prelude.mjs -Xnode --expose-gc

--- a/Utilities/bridge-js-generate.sh
+++ b/Utilities/bridge-js-generate.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-swift build --package-path ./Plugins/BridgeJS --product BridgeJSTool
+swift build ${SWIFT_PACKAGE_FLAGS:-} --package-path ./Plugins/BridgeJS --product BridgeJSTool
 
 ./Plugins/BridgeJS/.build/debug/BridgeJSTool generate --project ./tsconfig.json --module-name BridgeJSRuntimeTests --target-dir ./Tests/BridgeJSRuntimeTests --output-dir ./Tests/BridgeJSRuntimeTests/Generated
 ./Plugins/BridgeJS/.build/debug/BridgeJSTool generate --project ./tsconfig.json --module-name BridgeJSGlobalTests --target-dir ./Tests/BridgeJSGlobalTests --output-dir ./Tests/BridgeJSGlobalTests/Generated


### PR DESCRIPTION
Wires `swiftwasm/setup-swift-syntax-prebuilts@v1` into the Linux SwiftSyntax-heavy CI jobs and passes the action's SwiftPM flags into the relevant `swift`/Makefile/script invocations.

This deliberately does **not** cache SwiftPM `.build/` directories. SwiftPM build products are not guaranteed to be cross-machine portable, so the PR only relies on the action's toolchain/platform-scoped SwiftSyntax prebuilt artifacts.

Action-side prerequisites are now in place:

- `swiftwasm/setup-swift-syntax-prebuilts@v1` points at the merged Node 24 action runtime.
- Published release assets now exist for JavaScriptKit's current development snapshot:
  - `prebuilt-603.0.2-swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a` with Ubuntu 22.04 and Ubuntu 24.04 assets.
  - `prebuilt-600.0.1-swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a` with the Ubuntu 22.04 asset used by `check-bridgejs-generated`.
- The action repo also has a follow-up branch (`yt/support-swiftpm-triple-build-dir`) that fixes build-artifact discovery for SwiftPM's newer triple-qualified build output layout; that was needed to publish the May 2026 assets.

Current timing evidence:

| Job | Latest main | PR evidence | Notes |
| --- | ---: | ---: | --- |
| Ubuntu 24.04 development | 15m00s | 14m33s in run `27335043949` | Prebuilts restored from GitHub Release, but `make unittest` still compiles SwiftSyntax as a normal package dependency. |
| Ubuntu 24.04 Swift 6.3 branch | 12m29s | 13m38s in run `27335043949` | Same limitation; small regression likely from action overhead plus run variance. |
| Ubuntu 22.04 development | 20m57s | 20m48s in run `27335043949` | Essentially flat; `PackageToJS` and BridgeJS integration tests dominate. |
| `check-bridgejs-generated` | 3m31s | 3m36s in run `27335043949` | Flat; action restore adds a few seconds. |
| `build-examples` | 56m56s | 57m45s in run `27335043949` | Flat/slower; example builds dominate and `.build/` is intentionally not cached. |
| `swift:6.3` BridgeJS matrix | 3m12s | 3m14s in run `27338274284` | The action is disabled for this job because the Docker image reports compiler tag `swift-6.3.2-RELEASE`, which has no matching release asset and previously caused a slow local prebuild fallback. |

Why the speedup is small:

- The action does restore assets (`Restore source: github-release`) for the May 2026 Linux jobs.
- SwiftPM still compiles SwiftSyntax libraries when JavaScriptKit/BridgeJS depend on them directly (`SwiftSyntax`, `SwiftParser`, `SwiftSyntaxBuilder`, `SwiftSyntaxMacros`, test-support targets, etc.). The prebuilt action does not replace those normal library dependency builds in the observed CI logs.
- The longest steps are integration/example paths: `PackageToJS`'s package build finished in ~17s, but its `ExampleTests.basic()` took ~7.5m; `build-examples` remains ~58m.
- We are intentionally not caching `.build/`, so those package/example builds are cold each run.

Expected CI signal:

- Covered setup steps should report `Restore source: github-release` or `github-cache`.
- They should not fall back to `local-build` for the covered SwiftSyntax/toolchain/platform combinations.
- There is no `actions/cache` usage for SwiftPM `.build/` directories in this PR.