### PR TITLE
BridgeJS: Normalize wasm pointer offsets in JS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
           echo "SWIFT_SDK_ID=${{ steps.setup-swiftwasm.outputs.swift-sdk-id }}" >> $GITHUB_ENV
           echo "SWIFT_BIN_PATH=$(dirname $(which swiftc))" >> $GITHUB_ENV
       - run: make bootstrap
+      - run: npm run test:runtime
       - run: make unittest
         # Skip unit tests with uwasi because its proc_exit throws
         # unhandled promise rejection.

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -107,6 +107,7 @@ public struct BridgeJSLink {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };
@@ -428,7 +429,7 @@ public struct BridgeJSLink {
                         "\(JSGlueVariableScope.reservedSwift).\(JSGlueVariableScope.reservedMemory).release(sourceId);"
                     )
                     printer.write(
-                        "const bytes = new Uint8Array(\(JSGlueVariableScope.reservedMemory).buffer, bytesPtr);"
+                        "const bytes = new Uint8Array(\(JSGlueVariableScope.reservedMemory).buffer, bytesPtr >>> 0);"
                     )
                     printer.write("bytes.set(source);")
                 }
@@ -443,7 +444,7 @@ public struct BridgeJSLink {
                 printer.write("bjs[\"swift_js_init_memory_with_result\"] = function(ptr, len) {")
                 printer.indent {
                     printer.write(
-                        "const target = new Uint8Array(\(JSGlueVariableScope.reservedMemory).buffer, ptr, len);"
+                        "const target = new Uint8Array(\(JSGlueVariableScope.reservedMemory).buffer, ptr >>> 0, len >>> 0);"
                     )
                     printer.write("target.set(\(JSGlueVariableScope.reservedStorageToReturnBytes));")
                     printer.write("\(JSGlueVariableScope.reservedStorageToReturnBytes) = undefined;")
@@ -789,7 +790,7 @@ public struct BridgeJSLink {
                                 helperPrinter.write("if (state.unregistered) {")
                                 helperPrinter.indent {
                                     helperPrinter.write(
-                                        "const bytes = new Uint8Array(\(JSGlueVariableScope.reservedMemory).buffer, state.file);"
+                                        "const bytes = new Uint8Array(\(JSGlueVariableScope.reservedMemory).buffer, state.file >>> 0);"
                                     )
                                     helperPrinter.write("let length = 0;")
                                     helperPrinter.write("while (bytes[length] !== 0) { length += 1; }")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
@@ -70,14 +70,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -390,6 +390,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
@@ -155,14 +155,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncAssociatedValueEnum.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncAssociatedValueEnum.js
@@ -178,14 +178,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncImport.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncImport.js
@@ -128,7 +128,7 @@ export async function createInstantiator(options, swift) {
         const state = { pointer, file, line, unregistered: false };
         const real = (...args) => {
             if (state.unregistered) {
-                const bytes = new Uint8Array(memory.buffer, state.file);
+                const bytes = new Uint8Array(memory.buffer, state.file >>> 0);
                 let length = 0;
                 while (bytes[length] !== 0) { length += 1; }
                 const fileID = decodeString(state.file, length);
@@ -160,14 +160,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncStaticImport.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncStaticImport.js
@@ -128,7 +128,7 @@ export async function createInstantiator(options, swift) {
         const state = { pointer, file, line, unregistered: false };
         const real = (...args) => {
             if (state.unregistered) {
-                const bytes = new Uint8Array(memory.buffer, state.file);
+                const bytes = new Uint8Array(memory.buffer, state.file >>> 0);
                 let length = 0;
                 while (bytes[length] !== 0) { length += 1; }
                 const fileID = decodeString(state.file, length);
@@ -159,14 +159,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
@@ -87,14 +87,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -301,6 +301,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
@@ -86,14 +86,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -310,6 +310,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
@@ -788,14 +788,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -987,6 +987,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValueImport.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValueImport.js
@@ -89,14 +89,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
@@ -69,14 +69,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCaseImport.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCaseImport.js
@@ -50,14 +50,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
@@ -89,14 +89,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -293,6 +293,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
@@ -70,14 +70,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -274,6 +274,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
@@ -121,14 +121,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/FixedWidthIntegers.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/FixedWidthIntegers.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalGetter.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GlobalThisImports.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.ConfigPointer.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.ConfigPointer.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -245,6 +245,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.PerClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.PerClass.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -245,6 +245,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -245,6 +245,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
@@ -84,14 +84,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/InvalidPropertyNames.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClass.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSClassStaticFunctions.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSTypedArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSTypedArrayTypes.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
@@ -135,14 +135,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -369,6 +369,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -237,6 +237,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -245,6 +245,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -237,6 +237,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -249,6 +249,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -249,6 +249,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/NestedType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/NestedType.js
@@ -70,14 +70,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -280,6 +280,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -526,6 +526,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -237,6 +237,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
@@ -102,14 +102,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -597,6 +597,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ProtocolInClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ProtocolInClosure.js
@@ -39,7 +39,7 @@ export async function createInstantiator(options, swift) {
         const state = { pointer, file, line, unregistered: false };
         const real = (...args) => {
             if (state.unregistered) {
-                const bytes = new Uint8Array(memory.buffer, state.file);
+                const bytes = new Uint8Array(memory.buffer, state.file >>> 0);
                 let length = 0;
                 while (bytes[length] !== 0) { length += 1; }
                 const fileID = decodeString(state.file, length);
@@ -70,14 +70,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -383,6 +383,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
@@ -89,14 +89,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -281,6 +281,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
@@ -89,14 +89,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -281,6 +281,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
@@ -50,14 +50,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -242,6 +242,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
@@ -50,14 +50,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -242,6 +242,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -265,6 +265,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -158,7 +158,7 @@ export async function createInstantiator(options, swift) {
         const state = { pointer, file, line, unregistered: false };
         const real = (...args) => {
             if (state.unregistered) {
-                const bytes = new Uint8Array(memory.buffer, state.file);
+                const bytes = new Uint8Array(memory.buffer, state.file >>> 0);
                 let length = 0;
                 while (bytes[length] !== 0) { length += 1; }
                 const fileID = decodeString(state.file, length);
@@ -262,14 +262,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -1352,6 +1352,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
@@ -128,7 +128,7 @@ export async function createInstantiator(options, swift) {
         const state = { pointer, file, line, unregistered: false };
         const real = (...args) => {
             if (state.unregistered) {
-                const bytes = new Uint8Array(memory.buffer, state.file);
+                const bytes = new Uint8Array(memory.buffer, state.file >>> 0);
                 let length = 0;
                 while (bytes[length] !== 0) { length += 1; }
                 const fileID = decodeString(state.file, length);
@@ -160,14 +160,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
@@ -258,14 +258,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }
@@ -506,6 +506,7 @@ export async function createInstantiator(options, swift) {
             /// Represents a Swift heap object like a class instance or an actor instance.
             class SwiftHeapObject {
                 static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
                     const makeFresh = (identityMap) => {
                         const obj = Object.create(prototype);
                         const state = { pointer, deinit, hasReleased: false, identityMap };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
@@ -57,14 +57,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftTypedClosureAccess.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftTypedClosureAccess.js
@@ -39,7 +39,7 @@ export async function createInstantiator(options, swift) {
         const state = { pointer, file, line, unregistered: false };
         const real = (...args) => {
             if (state.unregistered) {
-                const bytes = new Uint8Array(memory.buffer, state.file);
+                const bytes = new Uint8Array(memory.buffer, state.file >>> 0);
                 let length = 0;
                 while (bytes[length] !== 0) { length += 1; }
                 const fileID = decodeString(state.file, length);
@@ -70,14 +70,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
@@ -45,14 +45,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
@@ -62,14 +62,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
@@ -46,14 +46,14 @@ export async function createInstantiator(options, swift) {
             bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
                 const source = swift.memory.getObject(sourceId);
                 swift.memory.release(sourceId);
-                const bytes = new Uint8Array(memory.buffer, bytesPtr);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
                 bytes.set(source);
             }
             bjs["swift_js_make_js_string"] = function(ptr, len) {
                 return swift.memory.retain(decodeString(ptr, len));
             }
             bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
-                const target = new Uint8Array(memory.buffer, ptr, len);
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
                 target.set(tmpRetBytes);
                 tmpRetBytes = undefined;
             }

--- a/Runtime/src/index.ts
+++ b/Runtime/src/index.ts
@@ -450,31 +450,39 @@ export class SwiftRuntime {
                 const memory = this.memory;
                 const bytes = this.textEncoder.encode(memory.getObject(ref));
                 const bytes_ptr = memory.retain(bytes);
-                this.getDataView().setUint32(bytes_ptr_result, bytes_ptr, true);
+                this.getDataView().setUint32(
+                    bytes_ptr_result >>> 0,
+                    bytes_ptr,
+                    true,
+                );
                 return bytes.length;
             },
             swjs_decode_string:
                 // NOTE: TextDecoder can't decode typed arrays backed by SharedArrayBuffer
                 this.options.sharedMemory == true
                     ? (bytes_ptr: pointer, length: number) => {
+                          const bytesOffset = bytes_ptr >>> 0;
+                          const byteLength = length >>> 0;
                           const bytes = this.getUint8Array().slice(
-                              bytes_ptr,
-                              bytes_ptr + length,
+                              bytesOffset,
+                              bytesOffset + byteLength,
                           );
                           const string = this.textDecoder.decode(bytes);
                           return this.memory.retain(string);
                       }
                     : (bytes_ptr: pointer, length: number) => {
+                          const bytesOffset = bytes_ptr >>> 0;
+                          const byteLength = length >>> 0;
                           const bytes = this.getUint8Array().subarray(
-                              bytes_ptr,
-                              bytes_ptr + length,
+                              bytesOffset,
+                              bytesOffset + byteLength,
                           );
                           const string = this.textDecoder.decode(bytes);
                           return this.memory.retain(string);
                       },
             swjs_load_string: (ref: ref, buffer: pointer) => {
                 const bytes = this.memory.getObject(ref);
-                this.getUint8Array().set(bytes, buffer);
+                this.getUint8Array().set(bytes, buffer >>> 0);
             },
 
             swjs_call_function: (
@@ -741,8 +749,8 @@ export class SwiftRuntime {
                 }
                 const array = new ArrayType(
                     this.wasmMemory!.buffer,
-                    elementsPtr,
-                    length,
+                    elementsPtr >>> 0,
+                    length >>> 0,
                 );
                 // Call `.slice()` to copy the memory
                 return this.memory.retain(array.slice());
@@ -756,7 +764,7 @@ export class SwiftRuntime {
                 const memory = this.memory;
                 const typedArray = memory.getObject(ref);
                 const bytes = new Uint8Array(typedArray.buffer);
-                this.getUint8Array().set(bytes, buffer);
+                this.getUint8Array().set(bytes, buffer >>> 0);
             },
 
             swjs_release: (ref: ref) => {

--- a/Runtime/src/js-value.ts
+++ b/Runtime/src/js-value.ts
@@ -60,14 +60,16 @@ export const decodeArray = (
     memory: DataView,
     objectSpace: JSObjectSpace,
 ) => {
+    const basePtr = ptr >>> 0;
+    const count = length >>> 0;
     // fast path for empty array
-    if (length === 0) {
+    if (count === 0) {
         return [];
     }
 
     let result = [];
-    for (let index = 0; index < length; index++) {
-        const base = ptr + 16 * index;
+    for (let index = 0; index < count; index++) {
+        const base = basePtr + 16 * index;
         const kind = memory.getUint32(base, true);
         const payload1 = memory.getUint32(base + 4, true);
         const payload2 = memory.getFloat64(base + 8, true);
@@ -97,7 +99,7 @@ export const write = (
         memory,
         objectSpace,
     );
-    memory.setUint32(kind_ptr, kind, true);
+    memory.setUint32(kind_ptr >>> 0, kind, true);
 };
 
 export const writeAndReturnKindBits = (
@@ -109,23 +111,25 @@ export const writeAndReturnKindBits = (
     objectSpace: JSObjectSpace,
 ): JavaScriptValueKindAndFlags => {
     const exceptionBit = (is_exception ? 1 : 0) << 31;
+    const payload1Offset = payload1_ptr >>> 0;
+    const payload2Offset = payload2_ptr >>> 0;
     if (value === null) {
         return exceptionBit | Kind.Null;
     }
 
     const writeRef = (kind: Kind) => {
-        memory.setUint32(payload1_ptr, objectSpace.retain(value), true);
+        memory.setUint32(payload1Offset, objectSpace.retain(value), true);
         return exceptionBit | kind;
     };
 
     const type = typeof value;
     switch (type) {
         case "boolean": {
-            memory.setUint32(payload1_ptr, value ? 1 : 0, true);
+            memory.setUint32(payload1Offset, value ? 1 : 0, true);
             return exceptionBit | Kind.Boolean;
         }
         case "number": {
-            memory.setFloat64(payload2_ptr, value, true);
+            memory.setFloat64(payload2Offset, value, true);
             return exceptionBit | Kind.Number;
         }
         case "string": {
@@ -157,9 +161,11 @@ export function decodeObjectRefs(
     length: number,
     memory: DataView,
 ): ref[] {
-    const result: ref[] = new Array(length);
-    for (let i = 0; i < length; i++) {
-        result[i] = memory.getUint32(ptr + 4 * i, true);
+    const basePtr = ptr >>> 0;
+    const count = length >>> 0;
+    const result: ref[] = new Array(count);
+    for (let i = 0; i < count; i++) {
+        result[i] = memory.getUint32(basePtr + 4 * i, true);
     }
     return result;
 }

--- a/Runtime/test/pointer-normalization.test.ts
+++ b/Runtime/test/pointer-normalization.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "vitest";
+import { SwiftRuntime } from "../src/index.js";
+import { decodeArray, decodeObjectRefs, Kind, write } from "../src/js-value.js";
+
+// A Wasm pointer is an `i32`. Once the linear memory grows past 2 GiB, valid
+// addresses set the high bit and the guest passes them to JavaScript as *negative*
+// numbers, which must be normalized with `>>> 0` before being used as memory
+// offsets. These tests use a real >2 GiB `WebAssembly.Memory` and a real
+// `SwiftRuntime`, exercising the actual code paths at such an address; without the
+// normalization each one throws a `RangeError` on the negative offset.
+const PAGE_SIZE = 64 * 1024;
+const HIGH_OFFSET = 0x8000_0000; // 2 GiB, the first address with the high bit set
+const SIGNED_POINTER = HIGH_OFFSET | 0; // how the guest passes that pointer: -2_147_483_648
+const MEMORY_PAGES = HIGH_OFFSET / PAGE_SIZE + 4; // a few pages past the offset
+
+function makeRuntime(): { runtime: SwiftRuntime; memory: WebAssembly.Memory } {
+    const memory = new WebAssembly.Memory({ initial: MEMORY_PAGES });
+    const runtime = new SwiftRuntime();
+    runtime.setInstance({
+        exports: {
+            memory,
+            swjs_library_version: () => 708,
+        },
+    } as unknown as WebAssembly.Instance);
+    return { runtime, memory };
+}
+
+describe("pointer normalization at >2 GiB addresses", () => {
+    test("swjs_decode_string reads from a high-bit pointer", () => {
+        const { runtime, memory } = makeRuntime();
+        const bytes = new TextEncoder().encode("hello, 🌍");
+        new Uint8Array(memory.buffer).set(bytes, HIGH_OFFSET);
+
+        const imports = runtime.wasmImports as any;
+        const ref = imports.swjs_decode_string(SIGNED_POINTER, bytes.length);
+
+        expect((runtime as any).memory.getObject(ref)).toBe("hello, 🌍");
+    });
+
+    test("swjs_load_string writes to a high-bit pointer", () => {
+        const { runtime, memory } = makeRuntime();
+        const bytes = new TextEncoder().encode("world");
+        const ref = (runtime as any).memory.retain(bytes);
+
+        const imports = runtime.wasmImports as any;
+        imports.swjs_load_string(ref, SIGNED_POINTER);
+
+        const written = new Uint8Array(memory.buffer).slice(
+            HIGH_OFFSET,
+            HIGH_OFFSET + bytes.length,
+        );
+        expect(new TextDecoder().decode(written)).toBe("world");
+    });
+
+    test("swjs_create_typed_array copies from a high-bit pointer", () => {
+        const { runtime, memory } = makeRuntime();
+        new Uint8Array(memory.buffer).set([1, 2, 3, 4], HIGH_OFFSET);
+
+        const space = (runtime as any).memory;
+        const constructorRef = space.retain(Uint8Array);
+        const imports = runtime.wasmImports as any;
+        const ref = imports.swjs_create_typed_array(
+            constructorRef,
+            SIGNED_POINTER,
+            4,
+        );
+
+        expect(Array.from(space.getObject(ref))).toEqual([1, 2, 3, 4]);
+    });
+
+    test("decodeArray reads JSValue elements from a high-bit pointer", () => {
+        const { runtime, memory } = makeRuntime();
+        const dataView = new DataView(memory.buffer);
+        dataView.setUint32(HIGH_OFFSET, Kind.Number, true);
+        dataView.setUint32(HIGH_OFFSET + 4, 0, true);
+        dataView.setFloat64(HIGH_OFFSET + 8, 42.5, true);
+
+        const values = decodeArray(
+            SIGNED_POINTER,
+            1,
+            dataView,
+            (runtime as any).memory,
+        );
+
+        expect(values).toEqual([42.5]);
+    });
+
+    test("decodeObjectRefs reads refs from a high-bit pointer", () => {
+        const { memory } = makeRuntime();
+        const dataView = new DataView(memory.buffer);
+        dataView.setUint32(HIGH_OFFSET, 11, true);
+        dataView.setUint32(HIGH_OFFSET + 4, 22, true);
+
+        expect(decodeObjectRefs(SIGNED_POINTER, 2, dataView)).toEqual([11, 22]);
+    });
+
+    test("write stores a JSValue at high-bit pointers", () => {
+        const { runtime, memory } = makeRuntime();
+        const dataView = new DataView(memory.buffer);
+
+        write(
+            42.5,
+            SIGNED_POINTER,
+            SIGNED_POINTER + 4,
+            SIGNED_POINTER + 8,
+            false,
+            dataView,
+            (runtime as any).memory,
+        );
+
+        expect(dataView.getUint32(HIGH_OFFSET, true)).toBe(Kind.Number);
+        expect(dataView.getFloat64(HIGH_OFFSET + 8, true)).toBe(42.5);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:ts": "cd Runtime; rollup -c",
     "prepublishOnly": "npm run build",
     "format": "prettier --write Runtime/src",
+    "test:runtime": "vitest run Runtime/test",
     "check:bridgejs-dts": "tsc --project Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/tsconfig.json"
   },
   "keywords": [


### PR DESCRIPTION
## Overview

This PR fixes signed `i32` pointer handling at the Swift-to-JavaScript boundary. WebAssembly pointers can legally point above the 2 GiB line, but the JS API exposes `i32` values as signed numbers. When generated BridgeJS glue or runtime helpers used those signed values directly as typed-array or `DataView` offsets, pointers above `0x7fff_ffff` could become negative and fail with an out-of-bounds `RangeError`.

The change normalizes pointer offsets with `>>> 0` before using them to index WebAssembly linear memory. It also canonicalizes Swift heap object wrapper identity keys so signed and unsigned representations of the same pointer do not miss the identity cache.

**1. BridgeJS generated glue**

Generated `swift_js_init_memory`, `swift_js_init_memory_with_result`, and released-closure debug paths now unsigned-normalize pointer inputs before creating `Uint8Array` views. Swift heap object wrappers normalize pointers before storing or looking up identity-cache entries.

**2. Runtime helpers**

Runtime `DataView` and typed-array helper paths now unsigned-normalize pointer offsets before reading or writing memory. This covers JSValue array decoding, object-ref decoding, result payload writes, string loading/decoding, and typed-array creation/loading.