### PR TITLE
BridgeJS: Emit static members in declare global class declarations

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -3143,17 +3143,19 @@ extension BridgeJSLink {
 
                                 let sortedMethods = klass.methods.sorted { $0.name < $1.name }
                                 for method in sortedMethods {
+                                    let staticKeyword = method.effects.isStatic ? "static " : ""
                                     let methodSignature =
-                                        "\(method.name)\(renderTSSignatureCallback(method.parameters, method.returnType, method.effects));"
+                                        "\(staticKeyword)\(method.name)\(renderTSSignatureCallback(method.parameters, method.returnType, method.effects));"
                                     printer.write(methodSignature)
                                 }
 
-                                let sortedProperties = klass.properties.filter { !$0.isStatic }.sorted {
-                                    $0.name < $1.name
-                                }
+                                let sortedProperties = klass.properties.sorted { $0.name < $1.name }
                                 for property in sortedProperties {
+                                    let staticKeyword = property.isStatic ? "static " : ""
                                     let readonly = property.isReadonly ? "readonly " : ""
-                                    printer.write("\(readonly)\(property.name): \(property.type.tsType);")
+                                    printer.write(
+                                        "\(staticKeyword)\(readonly)\(property.name): \(property.type.tsType);"
+                                    )
                                 }
 
                                 printer.write("release(): void;")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.d.ts
@@ -34,7 +34,8 @@ declare global {
             class Greeter {
                 constructor(name: string);
                 greet(): string;
-                makeDefault(): Greeter;
+                static makeDefault(): Greeter;
+                static readonly defaultGreeting: string;
                 release(): void;
             }
             class UUID {


### PR DESCRIPTION
## Overview

Static members of a globally-exposed `@JS(namespace:)` class were rendered incorrectly in the generated `declare global { namespace ... }` TypeScript declarations: every method was emitted without `static`, and properties were filtered to instance-only. As a result a `@JS static func` was typed as an instance method and a `@JS static var` was dropped from the `.d.ts` entirely.

This is a type-only defect. The emitted JavaScript already exposes these members statically (and the class's namespace export entry types them correctly), so the runtime behavior is unaffected and only TypeScript consumers were impacted: static access such as `MyNamespace.MyClass.makeDefault()` would not type-check even though the call works at runtime. We found it now, as we have `tsc --noEmit` check over consumer code.

The fix splits static and instance members in this path, emitting static methods with `static` and including static properties (with `static`/`readonly` as appropriate).

### Before / after

```ts
// before
class Greeter {
    constructor(name: string);
    greet(): string;
    makeDefault(): Greeter;   // wrongly typed as instance, defaultGreeting missing
    release(): void;
}

// after
class Greeter {
    constructor(name: string);
    greet(): string;
    static makeDefault(): Greeter;
    static readonly defaultGreeting: string;
    release(): void;
}
```