### PR TITLE
CI: Build examples in parallel on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,44 @@ jobs:
             exit 1
           }
 
+  # Pull requests: compile every example in parallel just to catch breakage.
+  # One job per example avoids rebuilding JavaScriptKit + swift-syntax 6x in series,
+  # which collapses the wall-clock time from ~1h to that of the slowest single example.
   build-examples:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - ActorOnWebWorker
+          - Basic
+          - Embedded
+          - Multithreading
+          - OffscrenCanvas
+          - PlayBridgeJS
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/install-swift
+        with:
+          download-url: https://download.swift.org/development/ubuntu2204/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a/swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a-ubuntu22.04.tar.gz
+      - uses: swiftwasm/setup-swiftwasm@v2
+        id: setup-wasm32-unknown-wasip1
+        with: { target: wasm32-unknown-wasip1 }
+      - uses: swiftwasm/setup-swiftwasm@v2
+        id: setup-wasm32-unknown-wasip1-threads
+        with: { target: wasm32-unknown-wasip1-threads }
+      # build.sh resolves the package relative to the working directory, so run it
+      # from the example directory (mirroring Utilities/build-examples.sh's `cd`).
+      - run: ./build.sh release
+        working-directory: Examples/${{ matrix.example }}
+        env:
+          SWIFT_SDK_ID_wasm32_unknown_wasip1_threads: ${{ steps.setup-wasm32-unknown-wasip1-threads.outputs.swift-sdk-id }}
+          SWIFT_SDK_ID_wasm32_unknown_wasip1: ${{ steps.setup-wasm32-unknown-wasip1.outputs.swift-sdk-id }}
+
+  # main: build all examples in release and publish them to GitHub Pages.
+  build-examples-deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -184,7 +221,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    needs: build-examples
+    needs: build-examples-deploy
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Overview

`build-examples` builds every example sequentially in a single job and takes ~57 minutes. Each example is its own SwiftPM package that recompiles JavaScriptKit and swift-syntax from scratch, so the cost is dominated by repeating that swift-syntax compile back-to-back.

This turns the pull-request `build-examples` job into a matrix - one job per example, running concurrently - so the wall-clock time drops to that of the slowest single example. `main` keeps the single `build-examples-deploy` job (full release build) plus the GitHub Pages deploy, so published artifacts are identical. Examples are built in `release` to match the deploy path, and each matrix step runs `build.sh` from the example directory via `working-directory` (mirroring `Utilities/build-examples.sh`).

## Timing

| setup | examples wall-clock |
|---|---|
| today (single sequential job) | ~57 min |
| parallel matrix | ~10 min |

Each example still takes ~10 min on its own (dominated by compiling swift-syntax from scratch), but they now run in parallel. The `main` deploy job is unchanged.

## Branch protection: required checks need updating

Because `build-examples` is now a matrix, the single `build-examples` status check is replaced by one per example. An admin needs to update the branch protection required checks for `main`: drop `build-examples` and add the six matrix contexts:

- `build-examples (ActorOnWebWorker)`
- `build-examples (Basic)`
- `build-examples (Embedded)`
- `build-examples (Multithreading)`
- `build-examples (OffscrenCanvas)`
- `build-examples (PlayBridgeJS)`

Use the job + matrix name exactly as above. The `Run unit tests /` prefix and the `(pull_request)` suffix shown in the PR merge box are display-only and are not part of the required-context string. Until this is done, the old `build-examples` context sits in "Expected — Waiting for status to be reported" and blocks merge.
