### PR TITLE
BridgeJS: Support generic functions at the Swift and JavaScript boundary

### DIFF
--- a/Examples/Embedded/Package.swift
+++ b/Examples/Embedded/Package.swift
@@ -16,6 +16,9 @@ let package = Package(
             swiftSettings: [
                 .enableExperimentalFeature("Extern")
             ],
+            plugins: [
+                .plugin(name: "BridgeJS", package: "JavaScriptKit")
+            ]
         )
     ],
     swiftLanguageModes: [.v5]

--- a/Examples/Embedded/Sources/EmbeddedApp/main.swift
+++ b/Examples/Embedded/Sources/EmbeddedApp/main.swift
@@ -1,5 +1,15 @@
 import JavaScriptKit
 
+// BridgeJS generic imports work under Embedded Swift: `echoValue` is
+// implemented in JavaScript (see index.html) and a single piece of generated
+// glue serves every conforming type, selected by a runtime type ID.
+@JS struct CounterLabel {
+    var count: Int
+    var text: String
+}
+
+@JSFunction func echoValue<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+
 let alert = JSObject.global.alert.object!
 let document = JSObject.global.document
 
@@ -45,6 +55,17 @@ let encoderContainer = document.createElement("div")
 _ = encoderContainer.appendChild(textInputElement)
 _ = encoderContainer.appendChild(encodeResultElement)
 _ = document.body.appendChild(encoderContainer)
+
+let genericResultElement = document.createElement("pre")
+do {
+    let number = try echoValue(42)
+    let text = try echoValue("hello")
+    let label = try echoValue(CounterLabel(count: number, text: text))
+    genericResultElement.innerText = .string("Generic import round-trip: \(label.text) \(label.count)")
+} catch {
+    genericResultElement.innerText = "Generic import round-trip failed"
+}
+_ = document.body.appendChild(genericResultElement)
 
 func print(_ message: String) {
     _ = JSObject.global.console.log(message)

--- a/Examples/Embedded/index.html
+++ b/Examples/Embedded/index.html
@@ -8,7 +8,14 @@
 <body>
   <script type="module">
     import { init } from "./.build/plugins/PackageToJS/outputs/Package/index.js";
-    init();
+    init({
+      getImports() {
+        return {
+          // Implements the generic `echoValue` imported by main.swift.
+          echoValue: (value) => value,
+        };
+      },
+    });
   </script>
 </body>
 

--- a/Plugins/BridgeJS/README.md
+++ b/Plugins/BridgeJS/README.md
@@ -98,7 +98,7 @@ graph LR
 | `Dictionary<K, V>` | `Record<K, V>` | - | [#495](https://github.com/swiftwasm/JavaScriptKit/issues/495) |
 | `Set<T>` | `Set<T>` | - | [#397](https://github.com/swiftwasm/JavaScriptKit/issues/397) |
 | `Foundation.URL` | `string` | - | [#496](https://github.com/swiftwasm/JavaScriptKit/issues/496) |
-| Generics | - | - | [#398](https://github.com/swiftwasm/JavaScriptKit/issues/398) |
+| Generic function or method (`T`, `[T]`, `T?`, `[String: T]`) | `<T>(value: T, type: BridgeType<T>)` | Depends on `T` | ✅ |
 
 ### Import-specific (TypeScript -> Swift)
 

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -24,11 +24,21 @@ public class ExportSwift {
     private var skeleton: ExportedSkeleton
     private var sourceFiles: [(sourceFile: SourceFileSyntax, inputFilePath: String)] = []
 
-    public init(progress: ProgressReporting, moduleName: String, skeleton: ExportedSkeleton) {
+    private let hasGenericExports: Bool
+    private let hasGenerics: Bool
+
+    public init(
+        progress: ProgressReporting,
+        moduleName: String,
+        skeleton: ExportedSkeleton,
+        imported: ImportedModuleSkeleton? = nil
+    ) {
         self.progress = progress
         self.moduleName = moduleName
         self.exposeToGlobal = skeleton.exposeToGlobal
         self.skeleton = skeleton
+        self.hasGenericExports = skeleton.hasGenericDeclarations
+        self.hasGenerics = hasGenericExports || (imported?.hasGenericDeclarations ?? false)
     }
 
     /// Finalizes the export process and generates the bridge code
@@ -46,6 +56,7 @@ public class ExportSwift {
 
     func renderSwiftGlue() throws -> String? {
         var decls: [DeclSyntax] = []
+        let genericExportCodegen = GenericExportCodegen()
 
         try withSpan("Render Protocols") { [self] in
             let protocolCodegen = ProtocolCodegen()
@@ -59,6 +70,14 @@ public class ExportSwift {
             for enumDef in skeleton.enums {
                 if let enumHelpers = enumCodegen.renderEnumHelpers(enumDef) {
                     decls.append(enumHelpers)
+                }
+                if hasGenerics, enumDef.enumType != .namespace {
+                    decls.append(
+                        contentsOf: genericExportCodegen.renderConformance(
+                            typeName: enumDef.swiftCallName,
+                            abiName: enumDef.abiName
+                        )
+                    )
                 }
 
                 for staticMethod in enumDef.staticMethods {
@@ -80,11 +99,24 @@ public class ExportSwift {
             let structCodegen = StructCodegen()
             for structDef in skeleton.structs {
                 decls.append(contentsOf: structCodegen.renderStructHelpers(structDef))
+                if hasGenerics {
+                    decls.append(
+                        contentsOf: genericExportCodegen.renderConformance(
+                            typeName: structDef.swiftCallName,
+                            abiName: structDef.abiName
+                        )
+                    )
+                }
                 decls.append(contentsOf: try renderSingleExportedStruct(struct: structDef))
             }
 
             for function in skeleton.functions {
                 decls.append(try renderSingleExportedFunction(function: function))
+            }
+            if hasGenericExports {
+                decls.append(
+                    contentsOf: genericExportCodegen.renderTypeRegistry(skeleton: skeleton)
+                )
             }
             for klass in skeleton.classes {
                 decls.append(contentsOf: try renderSingleExportedClass(klass: klass))
@@ -639,6 +671,15 @@ public class ExportSwift {
     }
 
     func renderSingleExportedFunction(function: ExportedFunction) throws -> DeclSyntax {
+        if function.isGeneric {
+            if function.effects.isStatic, let staticContext = function.staticContext {
+                return try GenericExportCodegen().renderExportedFunction(
+                    function,
+                    selfKind: .staticMember(staticContextBaseName(staticContext))
+                )
+            }
+            return try GenericExportCodegen().renderExportedFunction(function)
+        }
         let builder = try ExportedThunkBuilder(effects: function.effects, returnType: function.returnType)
         for param in function.parameters {
             try builder.liftParameter(param: param)
@@ -682,6 +723,13 @@ public class ExportSwift {
         ownerTypeName: String,
         instanceSelfType: BridgeType
     ) throws -> DeclSyntax {
+        if method.isGeneric {
+            let selfKind: GenericExportCodegen.SelfKind =
+                method.effects.isStatic
+                ? .staticMember(ownerTypeName)
+                : .instance(instanceSelfType)
+            return try GenericExportCodegen().renderExportedFunction(method, selfKind: selfKind)
+        }
         let builder = try ExportedThunkBuilder(effects: method.effects, returnType: method.returnType)
         if !method.effects.isStatic {
             try builder.liftParameter(param: Parameter(label: nil, name: "_self", type: instanceSelfType))
@@ -826,6 +874,15 @@ public class ExportSwift {
         // Generate ConvertibleToJSValue extension
         decls.append(contentsOf: renderConvertibleToJSValueExtension(klass: klass))
 
+        if hasGenerics, klass.isFinal == true {
+            decls.append(
+                contentsOf: GenericExportCodegen().renderConformance(
+                    typeName: klass.swiftCallName,
+                    abiName: klass.abiName
+                )
+            )
+        }
+
         return decls
     }
 
@@ -875,6 +932,257 @@ public class ExportSwift {
     }
 }
 
+// MARK: - GenericExportCodegen
+
+/// Renders Swift glue for generic `@JS` exported functions.
+struct GenericExportCodegen {
+    enum SelfKind {
+        case free
+        case instance(BridgeType)
+        case staticMember(String)
+    }
+
+    func renderConformance(typeName: String, abiName: String) -> [DeclSyntax] {
+        let printer = CodeFragmentPrinter()
+        printer.write("extension \(typeName): _BridgedSwiftGenericBridgeable {")
+        printer.indent {
+            printer.write(
+                "@_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id(\"\(abiName)\")"
+            )
+        }
+        printer.write("}")
+        return ["\(raw: printer.lines.joined(separator: "\n"))"]
+    }
+
+    func renderTypeRegistry(skeleton: ExportedSkeleton) -> [DeclSyntax] {
+        let printer = CodeFragmentPrinter()
+        printer.write("#if !hasFeature(Embedded)")
+        printer.write(
+            "private let _bridgeJSExportTypeRegistry: [Int32: any _BridgedSwiftGenericBridgeable.Type] = {"
+        )
+        printer.indent {
+            printer.write("var registry: [Int32: any _BridgedSwiftGenericBridgeable.Type] = [:]")
+            printer.write("func register<T: _BridgedSwiftGenericBridgeable>(_ type: T.Type) {")
+            printer.indent {
+                printer.write("registry[T.bridgeJSTypeID] = type")
+            }
+            printer.write("}")
+            for primitive in BridgeType.genericBridgeablePrimitives {
+                printer.write("register(\(primitive.token).self)")
+            }
+            for structDef in skeleton.structs {
+                printer.write("register(\(structDef.swiftCallName).self)")
+            }
+            for klass in skeleton.classes where klass.isFinal == true {
+                printer.write("register(\(klass.swiftCallName).self)")
+            }
+            for enumDef in skeleton.enums where enumDef.enumType != .namespace {
+                printer.write("register(\(enumDef.swiftCallName).self)")
+            }
+            printer.write("return registry")
+        }
+        printer.write("}()")
+        printer.write("#endif")
+        return ["\(raw: printer.lines.joined(separator: "\n"))"]
+    }
+
+    func renderExportedFunction(
+        _ function: ExportedFunction,
+        selfKind: SelfKind = .free
+    ) throws -> DeclSyntax {
+        let genericNames = function.genericParameterNames
+        let count = genericNames.count
+
+        let genericValueParameters = function.genericValueParameters
+        let concreteParameters = function.concreteParameters
+        guard !genericValueParameters.isEmpty else {
+            throw BridgeJSCoreError(
+                "Generic @JS exports must use a generic parameter in at least one parameter"
+            )
+        }
+        let returnPushStatement: String?
+        if case .void = function.returnType {
+            returnPushStatement = nil
+        } else if let statement = function.returnType.genericStackPushStatement(value: "ret") {
+            returnPushStatement = statement
+        } else {
+            throw BridgeJSCoreError("Generic @JS exports must return the generic type or Void in this version")
+        }
+
+        let selfParameter: Parameter?
+        switch selfKind {
+        case .instance(let instanceSelfType):
+            selfParameter = Parameter(label: nil, name: "_self", type: instanceSelfType)
+        case .free, .staticMember:
+            selfParameter = nil
+        }
+
+        let builder = try ExportSwift.ExportedThunkBuilder(
+            effects: Effects(isAsync: false, isThrows: false, isStatic: false),
+            returnType: .void
+        )
+        if let selfParameter {
+            try builder.liftParameter(param: selfParameter)
+        }
+        for concreteParameter in concreteParameters {
+            try builder.liftParameter(param: concreteParameter)
+        }
+        let concreteABIParameters = builder.abiParameterSignatures
+        let concreteLiftedExprs = builder.liftedParameterExprs
+        let concreteABINames = concreteABIParameters.map { $0.name }
+
+        func genericIndex(_ genericName: String) -> Int { genericNames.firstIndex(of: genericName)! }
+        func metatypeName(_ genericName: String) -> String { "_generic\(genericIndex(genericName))Type" }
+        func typeIdName(_ genericName: String) -> String {
+            ABINameGenerator.genericTypeIdParameterName(index: genericIndex(genericName))
+        }
+
+        func argument(label: String?, expression: String) -> String {
+            if let label, label != "_" {
+                return "\(label): \(expression)"
+            }
+            return expression
+        }
+
+        let abiName = function.abiName
+
+        let thunkSignature = SwiftSignatureBuilder.buildABIFunctionSignature(
+            abiParameters: concreteABIParameters + genericNames.map { (name: typeIdName($0), type: .i32) },
+            returnType: nil
+        )
+
+        var valueStackBindings: [(name: String, expr: String)] = []
+        var wasmArgBindings: [(name: String, expr: String)] = []
+        var bindingNameByParameter: [String: String] = [:]
+        let allConcreteParameters = (selfParameter.map { [$0] } ?? []) + concreteParameters
+        for (concreteParameter, liftedExpr) in zip(allConcreteParameters, concreteLiftedExprs) {
+            if concreteParameter.type.isStackUsingParameter {
+                let bindingName = "_tmp_\(concreteParameter.name)"
+                valueStackBindings.append((bindingName, liftedExpr.description))
+                bindingNameByParameter[concreteParameter.name] = bindingName
+            } else {
+                let bindingName = "_val_\(concreteParameter.name)"
+                wasmArgBindings.append((bindingName, liftedExpr.description))
+                bindingNameByParameter[concreteParameter.name] = bindingName
+            }
+        }
+
+        var userCallArguments: [String] = []
+        for param in function.parameters {
+            if param.type.usesGenericParameter {
+                userCallArguments.append(argument(label: param.label, expression: param.name))
+            } else {
+                let bindingName = bindingNameByParameter[param.name] ?? param.name
+                userCallArguments.append(argument(label: param.label, expression: bindingName))
+            }
+        }
+
+        let printer = CodeFragmentPrinter()
+        printer.write("#if hasFeature(Embedded)")
+        printer.write(SwiftCodePattern.buildExposeAttributes(abiName: abiName))
+        printer.write("public func _\(abiName)\(thunkSignature) {")
+        printer.indent {
+            printer.write(
+                "fatalError(\"Generic @JS exported functions are not supported in Embedded Swift\")"
+            )
+        }
+        printer.write("}")
+        printer.write("#else")
+        let entryDecl = SwiftCodePattern.buildExposedFunctionDecl(
+            abiName: abiName,
+            signature: thunkSignature
+        ) { printer in
+            for genericName in genericNames {
+                printer.write(
+                    "guard let \(metatypeName(genericName)) = _bridgeJSExportTypeRegistry[\(typeIdName(genericName))] else {"
+                )
+                printer.indent {
+                    printer.write(
+                        "fatalError(\"BridgeJS: unknown generic type id \\(\(typeIdName(genericName)))\")"
+                    )
+                }
+                printer.write("}")
+            }
+            let open1Arguments = genericNames.map { metatypeName($0) } + concreteABINames
+            printer.write("_\(abiName)_open1(\(open1Arguments.joined(separator: ", ")))")
+        }
+        printer.write(multilineString: entryDecl.description)
+
+        for k in 1...count {
+            let openName = "_\(abiName)_open\(k)"
+            let openedName = genericNames[k - 1]
+            let alreadyOpened = Array(genericNames[0..<(k - 1)])
+            let remaining = Array(genericNames[k..<count])
+
+            let genericClauseNames = [openedName] + alreadyOpened
+            let genericClause =
+                "<\(genericClauseNames.map { "\($0): _BridgedSwiftGenericBridgeable" }.joined(separator: ", "))>"
+
+            var params: [String] = []
+            params.append("_ \(metatypeName(openedName)): \(openedName).Type")
+            for openedAlready in alreadyOpened {
+                params.append("as\(openedAlready) \(metatypeName(openedAlready)): \(openedAlready).Type")
+            }
+            for remainingName in remaining {
+                params.append("_ \(metatypeName(remainingName)): any _BridgedSwiftGenericBridgeable.Type")
+            }
+            for abiParam in concreteABIParameters {
+                params.append("_ \(abiParam.name): \(abiParam.type.swiftType)")
+            }
+            let openSignature = "\(genericClause)(\(params.joined(separator: ", ")))"
+
+            printer.write("private func \(openName)\(openSignature) {")
+            printer.indent {
+                if k < count {
+                    let nextOpenedName = genericNames[k]
+                    var callArguments: [String] = []
+                    callArguments.append(metatypeName(nextOpenedName))
+                    for threadedName in genericNames[0..<k] {
+                        callArguments.append("as\(threadedName): \(threadedName).self")
+                    }
+                    for remainingName in genericNames[(k + 1)..<count] {
+                        callArguments.append(metatypeName(remainingName))
+                    }
+                    callArguments.append(contentsOf: concreteABINames)
+                    printer.write("_\(abiName)_open\(k + 1)(\(callArguments.joined(separator: ", ")))")
+                } else {
+                    for genericValueParameter in genericValueParameters.reversed() {
+                        let popExpr = genericValueParameter.type.genericStackPopExpression ?? ""
+                        printer.write("let \(genericValueParameter.name) = \(popExpr)")
+                    }
+                    for binding in valueStackBindings.reversed() {
+                        printer.write("let \(binding.name) = \(binding.expr)")
+                    }
+                    for binding in wasmArgBindings {
+                        printer.write("let \(binding.name) = \(binding.expr)")
+                    }
+                    let callee: String
+                    switch selfKind {
+                    case .free:
+                        callee = function.name
+                    case .instance:
+                        let selfBinding = bindingNameByParameter["_self"]!
+                        callee = "\(selfBinding).\(function.name)"
+                    case .staticMember(let ownerTypeName):
+                        callee = "\(ownerTypeName).\(function.name)"
+                    }
+                    if let returnPushStatement {
+                        printer.write(
+                            "let ret = \(callee)(\(userCallArguments.joined(separator: ", ")))"
+                        )
+                        printer.write(returnPushStatement)
+                    } else {
+                        printer.write("\(callee)(\(userCallArguments.joined(separator: ", ")))")
+                    }
+                }
+            }
+            printer.write("}")
+        }
+        printer.write("#endif")
+        return "\(raw: printer.lines.joined(separator: "\n"))"
+    }
+}
+
 // MARK: - StackCodegen
 
 /// Helper for stack-based lifting and lowering operations.
@@ -896,6 +1204,8 @@ struct StackCodegen {
             return "JSObject.bridgeJSStackPop()"
         case .void, .namespaceEnum:
             return "()"
+        case .generic:
+            fatalError("Generic parameters are handled by the generic export thunk, not concrete-type codegen")
         }
     }
 
@@ -908,7 +1218,7 @@ struct StackCodegen {
             return "\(raw: typeName)<\(raw: wrappedType.swiftType)>.bridgeJSStackPop()"
         case .jsObject(let className?):
             return "\(raw: typeName)<JSObject>.bridgeJSStackPop().map { \(raw: className)(unsafelyWrapping: $0) }"
-        case .nullable, .void, .namespaceEnum, .closure, .unsafePointer, .swiftProtocol:
+        case .nullable, .void, .namespaceEnum, .closure, .unsafePointer, .swiftProtocol, .generic:
             fatalError("Invalid nullable wrapped type: \(wrappedType)")
         }
     }
@@ -941,6 +1251,8 @@ struct StackCodegen {
             return lowerArrayStatements(elementType: elementType, accessor: accessor, varPrefix: varPrefix)
         case .dictionary(let valueType):
             return lowerDictionaryStatements(valueType: valueType, accessor: accessor, varPrefix: varPrefix)
+        case .generic:
+            fatalError("Generic parameters are handled by the generic export thunk, not concrete-type codegen")
         }
     }
 
@@ -1596,9 +1908,29 @@ extension BridgeType {
         case .associatedValueEnum:
             return ["_BridgedSwiftAssociatedValueEnum"]
         case .rawValueEnum, .void, .unsafePointer, .namespaceEnum,
-            .swiftProtocol, .closure, .nullable, .array, .dictionary, .alias:
+            .swiftProtocol, .closure, .nullable, .array, .dictionary, .alias, .generic:
             // Not supported yet.
             return nil
+        }
+    }
+
+    /// Wrapped generic values bridge through the same `Array`/`Optional`/`Dictionary`
+    /// conditional conformances that concrete types use.
+    var genericStackPopExpression: String? {
+        switch self {
+        case .generic(let name): return "\(name).bridgeJSStackPop()"
+        case .array(.generic(let name)): return "Array<\(name)>.bridgeJSStackPop()"
+        case .nullable(.generic(let name), _): return "Optional<\(name)>.bridgeJSStackPop()"
+        case .dictionary(.generic(let name)): return "Dictionary<String, \(name)>.bridgeJSStackPop()"
+        default: return nil
+        }
+    }
+
+    func genericStackPushStatement(value: String) -> String? {
+        switch self {
+        case .generic, .array(.generic), .nullable(.generic, _), .dictionary(.generic):
+            return "\(value).bridgeJSStackPush()"
+        default: return nil
         }
     }
 
@@ -1631,6 +1963,7 @@ extension BridgeType {
             let closureType = "(\(paramTypes))\(effectsStr) -> \(signature.returnType.swiftType)"
             return useJSTypedClosure ? "JSTypedClosure<\(closureType)>" : closureType
         case .alias(let name, _): return name
+        case .generic(let name): return name
         }
     }
 
@@ -1717,6 +2050,10 @@ extension BridgeType {
             return LiftingIntrinsicInfo(parameters: [])
         case .alias(_, let underlying):
             return try underlying.liftParameterInfo()
+        case .generic:
+            throw BridgeJSCoreError(
+                "Generic parameters are handled by the generic export thunk, not concrete-type codegen"
+            )
         }
     }
 
@@ -1770,6 +2107,10 @@ extension BridgeType {
             return .array
         case .alias(_, let underlying):
             return try underlying.loweringReturnInfo()
+        case .generic:
+            throw BridgeJSCoreError(
+                "Generic parameters are handled by the generic export thunk, not concrete-type codegen"
+            )
         }
     }
 }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -944,7 +944,7 @@ struct GenericExportCodegen {
 
     func renderConformance(typeName: String, abiName: String) -> [DeclSyntax] {
         let printer = CodeFragmentPrinter()
-        printer.write("extension \(typeName): _BridgedSwiftGenericBridgeable {")
+        printer.write("extension \(typeName): BridgedSwiftGenericBridgeable {")
         printer.indent {
             printer.write(
                 "@_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id(\"\(abiName)\")"
@@ -958,11 +958,11 @@ struct GenericExportCodegen {
         let printer = CodeFragmentPrinter()
         printer.write("#if !hasFeature(Embedded)")
         printer.write(
-            "private let _bridgeJSExportTypeRegistry: [Int32: any _BridgedSwiftGenericBridgeable.Type] = {"
+            "private let _bridgeJSExportTypeRegistry: [Int32: any BridgedSwiftGenericBridgeable.Type] = {"
         )
         printer.indent {
-            printer.write("var registry: [Int32: any _BridgedSwiftGenericBridgeable.Type] = [:]")
-            printer.write("func register<T: _BridgedSwiftGenericBridgeable>(_ type: T.Type) {")
+            printer.write("var registry: [Int32: any BridgedSwiftGenericBridgeable.Type] = [:]")
+            printer.write("func register<T: BridgedSwiftGenericBridgeable>(_ type: T.Type) {")
             printer.indent {
                 printer.write("registry[T.bridgeJSTypeID] = type")
             }
@@ -1116,7 +1116,7 @@ struct GenericExportCodegen {
 
             let genericClauseNames = [openedName] + alreadyOpened
             let genericClause =
-                "<\(genericClauseNames.map { "\($0): _BridgedSwiftGenericBridgeable" }.joined(separator: ", "))>"
+                "<\(genericClauseNames.map { "\($0): BridgedSwiftGenericBridgeable" }.joined(separator: ", "))>"
 
             var params: [String] = []
             params.append("_ \(metatypeName(openedName)): \(openedName).Type")
@@ -1124,7 +1124,7 @@ struct GenericExportCodegen {
                 params.append("as\(openedAlready) \(metatypeName(openedAlready)): \(openedAlready).Type")
             }
             for remainingName in remaining {
-                params.append("_ \(metatypeName(remainingName)): any _BridgedSwiftGenericBridgeable.Type")
+                params.append("_ \(metatypeName(remainingName)): any BridgedSwiftGenericBridgeable.Type")
             }
             for abiParam in concreteABIParameters {
                 params.append("_ \(abiParam.name): \(abiParam.type.swiftType)")

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -143,6 +143,11 @@ public struct ImportTS {
         }
 
         func lowerParameter(param: Parameter) throws {
+            if let genericPush = param.type.genericStackPushStatement(value: param.name) {
+                stackLoweringStmts.insert(genericPush, at: 0)
+                return
+            }
+
             let loweringInfo = try param.type.loweringParameterInfo(context: context)
 
             switch param.type {
@@ -241,6 +246,18 @@ public struct ImportTS {
             abiParameterForwardings.insert(contentsOf: ["resolveRef", "rejectRef"], at: 0)
         }
 
+        private func appendTypeIDParameter(index: Int, genericParameterName: String) {
+            let abiParamName = ABINameGenerator.genericTypeIdParameterName(index: index)
+            abiParameterSignatures.append((abiParamName, .i32))
+            abiParameterForwardings.append("\(genericParameterName).bridgeJSTypeID")
+        }
+
+        func appendTypeIDParameters(_ genericParameterNames: [String]) {
+            for (index, name) in genericParameterNames.enumerated() {
+                appendTypeIDParameter(index: index, genericParameterName: name)
+            }
+        }
+
         func call() throws {
             for stmt in stackLoweringStmts {
                 body.write(stmt.description)
@@ -297,14 +314,18 @@ public struct ImportTS {
                 body.write("return \(returnType.swiftType).bridgeJSLiftReturnFromSideChannel()")
             } else {
                 let liftExpr: String
-                switch returnType {
-                case .closure(let signature, _):
-                    liftExpr = "_BJS_Closure_\(signature.mangleName).bridgeJSLift(ret)"
-                default:
-                    if liftingInfo.valueToLift != nil {
-                        liftExpr = "\(returnType.swiftType).bridgeJSLiftReturn(ret)"
-                    } else {
-                        liftExpr = "\(returnType.swiftType).bridgeJSLiftReturn()"
+                if let genericPop = returnType.genericStackPopExpression {
+                    liftExpr = genericPop
+                } else {
+                    switch returnType {
+                    case .closure(let signature, _):
+                        liftExpr = "_BJS_Closure_\(signature.mangleName).bridgeJSLift(ret)"
+                    default:
+                        if liftingInfo.valueToLift != nil {
+                            liftExpr = "\(returnType.swiftType).bridgeJSLiftReturn(ret)"
+                        } else {
+                            liftExpr = "\(returnType.swiftType).bridgeJSLiftReturn()"
+                        }
                     }
                 }
                 body.write("return \(liftExpr)")
@@ -363,7 +384,8 @@ public struct ImportTS {
             name: String,
             parameters: [Parameter],
             returnType: BridgeType,
-            effects: Effects
+            effects: Effects,
+            genericParameters: [String] = []
         ) -> DeclSyntax {
             let printer = CodeFragmentPrinter()
             let signature = SwiftSignatureBuilder.buildFunctionSignature(
@@ -372,7 +394,12 @@ public struct ImportTS {
                 effects: effects,
                 useWildcardLabels: true
             )
-            printer.write("func \(name.backtickIfNeeded())\(signature) {")
+            let genericClause =
+                genericParameters.isEmpty
+                ? ""
+                : "<" + genericParameters.map { "\($0): _BridgedSwiftGenericBridgeable" }.joined(separator: ", ")
+                    + ">"
+            printer.write("func \(name.backtickIfNeeded())\(genericClause)\(signature) {")
             printer.indent {
                 printer.write(lines: body.lines)
             }
@@ -432,6 +459,7 @@ public struct ImportTS {
         for param in function.parameters {
             try builder.lowerParameter(param: param)
         }
+        builder.appendTypeIDParameters(function.genericParameterNames)
         try builder.call()
         try builder.liftReturnValue()
         topLevelDecls.append(builder.renderImportDecl())
@@ -440,7 +468,8 @@ public struct ImportTS {
                 name: Self.thunkName(function: function),
                 parameters: function.parameters,
                 returnType: function.returnType,
-                effects: function.effects
+                effects: function.effects,
+                genericParameters: function.genericParameterNames
             )
             .with(\.leadingTrivia, Self.renderDocumentation(documentation: function.documentation))
         ]
@@ -461,6 +490,7 @@ public struct ImportTS {
             for param in method.parameters {
                 try builder.lowerParameter(param: param)
             }
+            builder.appendTypeIDParameters(method.genericParameterNames)
             try builder.call()
             try builder.liftReturnValue()
             topLevelDecls.append(builder.renderImportDecl())
@@ -469,7 +499,8 @@ public struct ImportTS {
                     name: Self.thunkName(type: type, method: method),
                     parameters: [selfParameter] + method.parameters,
                     returnType: method.returnType,
-                    effects: method.effects
+                    effects: method.effects,
+                    genericParameters: method.genericParameterNames
                 )
             ]
         }
@@ -485,6 +516,7 @@ public struct ImportTS {
             for param in method.parameters {
                 try builder.lowerParameter(param: param)
             }
+            builder.appendTypeIDParameters(method.genericParameterNames)
             try builder.call()
             try builder.liftReturnValue()
             topLevelDecls.append(builder.renderImportDecl())
@@ -493,7 +525,8 @@ public struct ImportTS {
                     name: Self.thunkName(type: type, method: method),
                     parameters: method.parameters,
                     returnType: method.returnType,
-                    effects: method.effects
+                    effects: method.effects,
+                    genericParameters: method.genericParameterNames
                 )
             ]
         }
@@ -959,6 +992,8 @@ extension BridgeType {
             return LoweringParameterInfo(loweredParameters: [])
         case .alias:
             preconditionFailure("`.alias` must be resolved by `.unaliased` before reaching loweringParameterInfo")
+        case .generic:
+            return LoweringParameterInfo(loweredParameters: [])
         }
     }
 
@@ -1033,6 +1068,8 @@ extension BridgeType {
             return LiftingReturnInfo(valueToLift: nil)
         case .alias:
             preconditionFailure("`.alias` must be resolved by `.unaliased` before reaching liftingReturnInfo")
+        case .generic:
+            return LiftingReturnInfo(valueToLift: nil)
         }
     }
 }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -397,7 +397,7 @@ public struct ImportTS {
             let genericClause =
                 genericParameters.isEmpty
                 ? ""
-                : "<" + genericParameters.map { "\($0): _BridgedSwiftGenericBridgeable" }.joined(separator: ", ")
+                : "<" + genericParameters.map { "\($0): BridgedSwiftGenericBridgeable" }.joined(separator: ", ")
                     + ">"
             printer.write("func \(name.backtickIfNeeded())\(genericClause)\(signature) {")
             printer.indent {

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -746,8 +746,8 @@ public final class SwiftToSkeleton {
     }
 
     fileprivate static func isBridgeableGenericConstraint(_ constraint: String?) -> Bool {
-        constraint == "_BridgedSwiftGenericBridgeable"
-            || constraint == "JavaScriptKit._BridgedSwiftGenericBridgeable"
+        constraint == "BridgedSwiftGenericBridgeable"
+            || constraint == "JavaScriptKit.BridgedSwiftGenericBridgeable"
     }
 
 }
@@ -1337,7 +1337,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
                     diagnose(
                         node: node,
                         message:
-                            "Generic parameter '\(genericParam.name.text)' must be constrained to '_BridgedSwiftGenericBridgeable' to be used with @JS."
+                            "Generic parameter '\(genericParam.name.text)' must be constrained to 'BridgedSwiftGenericBridgeable' to be used with @JS."
                     )
                     return nil
                 }
@@ -3100,7 +3100,7 @@ private final class ImportSwiftMacrosAPICollector: SyntaxAnyVisitor {
                         DiagnosticError(
                             node: Syntax(genericParam),
                             message:
-                                "Generic parameter '\(paramName)' must be constrained to '_BridgedSwiftGenericBridgeable' to be used with @JSFunction."
+                                "Generic parameter '\(paramName)' must be constrained to 'BridgedSwiftGenericBridgeable' to be used with @JSFunction."
                         )
                     )
                     return nil

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -7,6 +7,79 @@ import BridgeJSUtilities
 import BridgeJSSkeleton
 #endif
 
+/// Outcome of attempting to resolve a type as a reference to a generic parameter.
+enum GenericParameterResolution {
+    case resolved(BridgeType)
+    /// A non-nil message is a hard diagnostic; `nil` means the type isn't generic
+    /// and the caller should fall back to normal type resolution.
+    case rejected(String?)
+}
+
+func resolveGenericTypeReference(
+    for type: TypeSyntax,
+    genericParameterNames: [String]
+) -> GenericParameterResolution {
+    if let identifier = type.as(IdentifierTypeSyntax.self),
+        identifier.genericArgumentClause == nil,
+        genericParameterNames.contains(identifier.name.text)
+    {
+        return .resolved(.generic(identifier.name.text))
+    }
+    if let wrapped = wrappedGenericBridgeType(for: type, genericParameterNames: genericParameterNames) {
+        return .resolved(wrapped)
+    }
+    if !genericParameterNames.isEmpty,
+        let wrapped = wrappedGenericParameter(in: type, genericParameterNames: genericParameterNames)
+    {
+        return .rejected(
+            "Generic parameter '\(wrapped)' may only be used as a bare type; wrapping it beyond 'T?', '[T]' and '[String: T]' is not supported."
+        )
+    }
+    return .rejected(nil)
+}
+
+private func wrappedGenericParameter(
+    in type: TypeSyntax,
+    genericParameterNames: [String]
+) -> String? {
+    for token in type.tokens(viewMode: .sourceAccurate) {
+        if case .identifier(let text) = token.tokenKind, genericParameterNames.contains(text) {
+            return text
+        }
+    }
+    return nil
+}
+
+private func wrappedGenericBridgeType(
+    for type: TypeSyntax,
+    genericParameterNames: [String]
+) -> BridgeType? {
+    func bareGenericName(_ inner: TypeSyntax) -> String? {
+        guard let identifier = inner.as(IdentifierTypeSyntax.self),
+            identifier.genericArgumentClause == nil,
+            genericParameterNames.contains(identifier.name.text)
+        else {
+            return nil
+        }
+        return identifier.name.text
+    }
+    if let arrayType = type.as(ArrayTypeSyntax.self), let name = bareGenericName(arrayType.element) {
+        return .array(.generic(name))
+    }
+    if let optionalType = type.as(OptionalTypeSyntax.self), let name = bareGenericName(optionalType.wrappedType) {
+        return .nullable(.generic(name), .null)
+    }
+    if let dictType = type.as(DictionaryTypeSyntax.self),
+        let keyIdentifier = dictType.key.as(IdentifierTypeSyntax.self),
+        keyIdentifier.genericArgumentClause == nil,
+        keyIdentifier.name.text == "String",
+        let name = bareGenericName(dictType.value)
+    {
+        return .dictionary(.generic(name))
+    }
+    return nil
+}
+
 /// Builds BridgeJS skeletons from Swift source files using SwiftSyntax walk for API collection.
 ///
 /// This is a shared entry point for producing:
@@ -672,6 +745,11 @@ public final class SwiftToSkeleton {
         return String(name.dropFirst().dropLast())
     }
 
+    fileprivate static func isBridgeableGenericConstraint(_ constraint: String?) -> Bool {
+        constraint == "_BridgedSwiftGenericBridgeable"
+            || constraint == "JavaScriptKit._BridgedSwiftGenericBridgeable"
+    }
+
 }
 
 private enum ExportSwiftConstants {
@@ -1128,20 +1206,40 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
     }
 
     /// Shared parameter parsing logic used by functions, initializers, and protocol methods
+    private func lookupTypeWithGenerics(
+        for type: TypeSyntax,
+        genericParameterNames: [String],
+        errors: inout [DiagnosticError]
+    ) -> BridgeType? {
+        switch resolveGenericTypeReference(for: type, genericParameterNames: genericParameterNames) {
+        case .resolved(let bridgeType):
+            return bridgeType
+        case .rejected(let message):
+            if let message {
+                errors.append(DiagnosticError(node: Syntax(type), message: message))
+                return nil
+            }
+            return parent.lookupType(for: type, errors: &errors)
+        }
+    }
+
     private func parseParameters(
         from parameterClause: FunctionParameterClauseSyntax,
-        allowDefaults: Bool = true
+        allowDefaults: Bool = true,
+        genericParameterNames: [String] = []
     ) -> [Parameter] {
         var parameters: [Parameter] = []
 
         for param in parameterClause.parameters {
-            let resolvedType = withLookupErrors { self.parent.lookupType(for: param.type, errors: &$0) }
+            let resolvedType = withLookupErrors {
+                self.lookupTypeWithGenerics(
+                    for: param.type,
+                    genericParameterNames: genericParameterNames,
+                    errors: &$0
+                )
+            }
             guard let type = resolvedType else {
                 continue  // Skip unsupported types
-            }
-            if case .nullable(let wrappedType, _) = type, wrappedType.isOptional {
-                diagnoseNestedOptional(node: param.type, type: param.type.trimmedDescription)
-                continue
             }
             if case .nullable(let wrappedType, _) = type, wrappedType.isOptional {
                 diagnoseNestedOptional(node: param.type, type: param.type.trimmedDescription)
@@ -1231,6 +1329,43 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             return nil
         }
 
+        var genericParameterNames: [String] = []
+        if let genericClause = node.genericParameterClause {
+            for genericParam in genericClause.parameters {
+                let constraint = genericParam.inheritedType?.trimmedDescription
+                guard SwiftToSkeleton.isBridgeableGenericConstraint(constraint) else {
+                    diagnose(
+                        node: node,
+                        message:
+                            "Generic parameter '\(genericParam.name.text)' must be constrained to '_BridgedSwiftGenericBridgeable' to be used with @JS."
+                    )
+                    return nil
+                }
+                genericParameterNames.append(genericParam.name.text)
+            }
+            if node.genericWhereClause != nil {
+                diagnose(
+                    node: node,
+                    message: "'where' clauses are not supported on generic @JS functions."
+                )
+                return nil
+            }
+            if node.signature.effectSpecifiers?.asyncSpecifier != nil {
+                diagnose(
+                    node: node,
+                    message: "Generic @JS functions cannot be 'async' yet."
+                )
+                return nil
+            }
+            if node.signature.effectSpecifiers?.throwsClause != nil {
+                diagnose(
+                    node: node,
+                    message: "Generic @JS functions cannot be 'throws' yet."
+                )
+                return nil
+            }
+        }
+
         let name = node.name.text
 
         let attributeNamespace = extractNamespace(from: jsAttribute)
@@ -1260,10 +1395,20 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             )
         }
 
-        let parameters = parseParameters(from: node.signature.parameterClause, allowDefaults: true)
+        let parameters = parseParameters(
+            from: node.signature.parameterClause,
+            allowDefaults: true,
+            genericParameterNames: genericParameterNames
+        )
         let returnType: BridgeType
         if let returnClause = node.signature.returnClause {
-            let resolvedType = withLookupErrors { self.parent.lookupType(for: returnClause.type, errors: &$0) }
+            let resolvedType = withLookupErrors {
+                self.lookupTypeWithGenerics(
+                    for: returnClause.type,
+                    genericParameterNames: genericParameterNames,
+                    errors: &$0
+                )
+            }
 
             if let type = resolvedType, case .nullable(let wrappedType, _) = type, wrappedType.isOptional {
                 diagnoseNestedOptional(node: returnClause.type, type: returnClause.type.trimmedDescription)
@@ -1274,6 +1419,34 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             returnType = type
         } else {
             returnType = .void
+        }
+
+        if !genericParameterNames.isEmpty {
+            for genericName in genericParameterNames {
+                if !parameters.contains(where: { $0.type.referencedGenericName == genericName }) {
+                    diagnose(
+                        node: node,
+                        message:
+                            "The generic parameter '\(genericName)' must be used in at least one parameter of a generic @JS function."
+                    )
+                    return nil
+                }
+            }
+            switch returnType {
+            case .void:
+                break
+            default:
+                guard let returnName = returnType.referencedGenericName,
+                    genericParameterNames.contains(returnName)
+                else {
+                    diagnose(
+                        node: node,
+                        message:
+                            "A generic @JS function must return the generic type (optionally wrapped in '[T]', 'T?' or '[String: T]') or Void."
+                    )
+                    return nil
+                }
+            }
         }
 
         let abiName: String
@@ -1337,7 +1510,8 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             effects: effects,
             namespace: finalNamespace,
             staticContext: staticContext,
-            documentation: extractDocumentation(from: node)
+            documentation: extractDocumentation(from: node),
+            genericParameters: genericParameterNames.isEmpty ? nil : genericParameterNames
         )
     }
 
@@ -1653,6 +1827,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             message: "Class visibility must be at least internal"
         )
         let classIdentityMode = extractIdentityMode(from: jsAttribute)
+        let isFinal = node.modifiers.contains { $0.name.tokenKind == .keyword(.final) } ? true : nil
         let exportedClass = ExportedClass(
             name: name,
             swiftCallName: swiftCallName,
@@ -1662,7 +1837,8 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             properties: [],
             namespace: effectiveNamespace,
             identityMode: classIdentityMode,
-            documentation: extractDocumentation(from: node)
+            documentation: extractDocumentation(from: node),
+            isFinal: isFinal
         )
         let uniqueKey = makeKey(name: name, namespace: effectiveNamespace)
 
@@ -2914,21 +3090,84 @@ private final class ImportSwiftMacrosAPICollector: SyntaxAnyVisitor {
             return nil
         }
 
+        var genericParameterNames: [String] = []
+        if let genericClause = node.genericParameterClause {
+            for genericParam in genericClause.parameters {
+                let paramName = genericParam.name.text
+                let constraintText = genericParam.inheritedType?.trimmedDescription
+                guard SwiftToSkeleton.isBridgeableGenericConstraint(constraintText) else {
+                    errors.append(
+                        DiagnosticError(
+                            node: Syntax(genericParam),
+                            message:
+                                "Generic parameter '\(paramName)' must be constrained to '_BridgedSwiftGenericBridgeable' to be used with @JSFunction."
+                        )
+                    )
+                    return nil
+                }
+                genericParameterNames.append(paramName)
+            }
+        }
+        if node.genericWhereClause != nil {
+            errors.append(
+                DiagnosticError(
+                    node: node,
+                    message: "'where' clauses are not supported on @JSFunction declarations."
+                )
+            )
+            return nil
+        }
+
         let baseName = SwiftToSkeleton.normalizeIdentifier(node.name.text)
         let jsName = AttributeChecker.extractJSName(from: jsFunction)
         let from = AttributeChecker.extractJSImportFrom(from: jsFunction)
         let name = baseName
 
-        let parameters = parseParameters(from: node.signature.parameterClause)
+        let parameters = parseParameters(
+            from: node.signature.parameterClause,
+            genericParameterNames: genericParameterNames
+        )
         let returnType: BridgeType
         if let returnTypeSyntax = node.signature.returnClause?.type {
-            guard let resolved = withLookupErrors({ parent.lookupType(for: returnTypeSyntax, errors: &$0) }) else {
+            guard
+                let resolved = lookupTypeWithGenerics(
+                    for: returnTypeSyntax,
+                    genericParameterNames: genericParameterNames
+                )
+            else {
                 return nil
             }
             returnType = resolved
         } else {
             returnType = .void
         }
+
+        if !genericParameterNames.isEmpty {
+            if effects.isAsync {
+                errors.append(
+                    DiagnosticError(
+                        node: node,
+                        message: "Generic @JSFunction declarations cannot be 'async' yet."
+                    )
+                )
+                return nil
+            }
+            for genericName in genericParameterNames {
+                let usedInParameter = parameters.contains { $0.type.referencedGenericName == genericName }
+                let usedInReturn = returnType.referencedGenericName == genericName
+                if !usedInParameter && !usedInReturn {
+                    errors.append(
+                        DiagnosticError(
+                            node: node,
+                            message:
+                                "The generic parameter '\(genericName)' must be used in a parameter or return type of a generic @JSFunction declaration."
+                        )
+                    )
+                    return nil
+                }
+            }
+        }
+
         let accessLevel = Self.bridgeAccessLevel(from: node.modifiers)
         return ImportedFunctionSkeleton(
             name: name,
@@ -2938,7 +3177,8 @@ private final class ImportSwiftMacrosAPICollector: SyntaxAnyVisitor {
             returnType: returnType,
             effects: effects,
             documentation: nil,
-            accessLevel: accessLevel
+            accessLevel: accessLevel,
+            genericParameters: genericParameterNames.isEmpty ? nil : genericParameterNames
         )
     }
 
@@ -3014,7 +3254,26 @@ private final class ImportSwiftMacrosAPICollector: SyntaxAnyVisitor {
 
     // MARK: - Type and Parameter Parsing
 
-    private func parseParameters(from clause: FunctionParameterClauseSyntax) -> [Parameter] {
+    private func lookupTypeWithGenerics(
+        for type: TypeSyntax,
+        genericParameterNames: [String]
+    ) -> BridgeType? {
+        switch resolveGenericTypeReference(for: type, genericParameterNames: genericParameterNames) {
+        case .resolved(let bridgeType):
+            return bridgeType
+        case .rejected(let message):
+            if let message {
+                errors.append(DiagnosticError(node: Syntax(type), message: message))
+                return nil
+            }
+            return withLookupErrors { parent.lookupType(for: type, errors: &$0) }
+        }
+    }
+
+    private func parseParameters(
+        from clause: FunctionParameterClauseSyntax,
+        genericParameterNames: [String] = []
+    ) -> [Parameter] {
         clause.parameters.compactMap { param in
             let type = param.type
             if type.is(MissingTypeSyntax.self) {
@@ -3026,7 +3285,8 @@ private final class ImportSwiftMacrosAPICollector: SyntaxAnyVisitor {
                 )
                 return nil
             }
-            guard let bridgeType = withLookupErrors({ parent.lookupType(for: type, errors: &$0) }) else {
+            guard let bridgeType = lookupTypeWithGenerics(for: type, genericParameterNames: genericParameterNames)
+            else {
                 return nil
             }
             let nameToken = param.secondName ?? param.firstName

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -30,6 +30,14 @@ public struct BridgeJSLink {
         skeletons.compactMap(\.exported).compactMap(\.identityMode).first ?? "none"
     }
 
+    var hasGenericExports: Bool {
+        skeletons.contains { $0.exported?.hasGenericDeclarations ?? false }
+    }
+
+    var hasGenerics: Bool {
+        hasGenericExports || skeletons.contains { $0.imported?.hasGenericDeclarations ?? false }
+    }
+
     /// Whether a class should use identity caching based on its annotation and the config default.
     private func shouldUseIdentityCache(for klass: ExportedClass) -> Bool {
         // Per-class annotation takes priority
@@ -245,6 +253,12 @@ public struct BridgeJSLink {
             }
         }
 
+        if hasGenericExports {
+            let tokens = try generateBridgeTypeTokens()
+            data.topLevelTypeLines.append(contentsOf: tokens.js)
+            data.topLevelDtsTypeLines.append(contentsOf: tokens.dts)
+        }
+
         // Process imported skeletons
         for unified in skeletons {
             guard let imported = unified.imported else { continue }
@@ -308,7 +322,7 @@ public struct BridgeJSLink {
     }
 
     private func generateVariableDeclarations() -> [String] {
-        return [
+        var declarations: [String] = [
             "let \(JSGlueVariableScope.reservedInstance);",
             "let \(JSGlueVariableScope.reservedMemory);",
             "let \(JSGlueVariableScope.reservedSetException);",
@@ -332,10 +346,18 @@ public struct BridgeJSLink {
             "let \(JSGlueVariableScope.reservedTaStack) = [];",
             "const \(JSGlueVariableScope.reservedEnumHelpers) = {};",
             "const \(JSGlueVariableScope.reservedStructHelpers) = {};",
+        ]
+        if hasGenerics {
+            declarations.append("let \(JSGlueVariableScope.reservedCodecs);")
+            declarations.append("let \(JSGlueVariableScope.reservedCodecsById) = [];")
+            declarations.append(contentsOf: GenericJSCodegen.runtimeHelperDeclarations())
+        }
+        declarations.append(contentsOf: [
             "",
             "let _exports = null;",
             "let bjs = null;",
-        ]
+        ])
+        return declarations
     }
 
     /// JS const (in the import glue scope) holding the `Symbol` under which a promise's
@@ -370,6 +392,137 @@ public struct BridgeJSLink {
         var lines = builder.renderFunction(name: nil)
         lines[0] = "bjs[\"\(externName)\"] = \(lines[0])"
         printer.write(lines: lines)
+    }
+
+    private func genericEnumBridgeType(_ enumDef: ExportedEnum) -> BridgeType? {
+        switch enumDef.enumType {
+        case .simple:
+            return .caseEnum(enumDef.name)
+        case .rawValue:
+            guard let rawType = enumDef.rawType else { return nil }
+            return .rawValueEnum(enumDef.name, rawType)
+        case .associatedValue:
+            return .associatedValueEnum(enumDef.name)
+        case .namespace:
+            return nil
+        }
+    }
+
+    /// One entry per bridgeable type across all linked modules. Tokens are unqualified
+    /// type names, so a name shared by two modules must fail the build.
+    private func genericTypeEntries() throws -> [(token: String, type: BridgeType, tsType: String)] {
+        var entries: [(token: String, type: BridgeType, tsType: String)] = BridgeType.genericBridgeablePrimitives.map {
+            (token: $0.token, type: $0.type, tsType: $0.type.tsType)
+        }
+        var definingModuleByToken: [String: String] = Dictionary(
+            uniqueKeysWithValues: BridgeType.genericBridgeablePrimitives.map { ($0.token, "JavaScriptKit") }
+        )
+        func claim(_ token: String, module: String) throws {
+            if let existing = definingModuleByToken[token] {
+                throw BridgeJSLinkError(
+                    message:
+                        "Generic bridge token '\(token)' is defined by both '\(existing)' and '\(module)'. @JS type names used with generic functions must be unique across linked modules."
+                )
+            }
+            definingModuleByToken[token] = module
+        }
+        func tsQualifiedName(name: String, namespace: [String]?) -> String {
+            ((namespace ?? []) + [name]).joined(separator: ".")
+        }
+        for unified in skeletons {
+            guard let exported = unified.exported else { continue }
+            let module = unified.moduleName
+            for structDef in exported.structs {
+                try claim(structDef.abiName, module: module)
+                entries.append(
+                    (
+                        token: structDef.abiName,
+                        type: .swiftStruct(structDef.abiName),
+                        tsType: tsQualifiedName(name: structDef.name, namespace: structDef.namespace)
+                    )
+                )
+            }
+            for klass in exported.classes where klass.isFinal == true {
+                try claim(klass.abiName, module: module)
+                entries.append(
+                    (
+                        token: klass.abiName,
+                        type: .swiftHeapObject(klass.name),
+                        tsType: tsQualifiedName(name: klass.name, namespace: klass.namespace)
+                    )
+                )
+            }
+            for enumDef in exported.enums {
+                guard let bridgeType = genericEnumBridgeType(enumDef) else { continue }
+                try claim(enumDef.abiName, module: module)
+                let enumTypeName = enumDef.emitStyle == .tsEnum ? enumDef.tsFullPath : "\(enumDef.tsFullPath)Tag"
+                entries.append(
+                    (token: enumDef.abiName, type: bridgeType, tsType: enumTypeName)
+                )
+            }
+        }
+        return entries
+    }
+
+    private func appendGenericCodec(token: String, type: BridgeType, into printer: CodeFragmentPrinter) throws {
+        func context() -> IntrinsicJSFragment.PrintCodeContext {
+            IntrinsicJSFragment.PrintCodeContext(
+                scope: JSGlueVariableScope(intrinsicRegistry: intrinsicRegistry),
+                printer: printer,
+                hasDirectAccessToSwiftClass: false,
+                classNamespaces: intrinsicRegistry.classNamespaces
+            )
+        }
+        let lowerFragment = try IntrinsicJSFragment.stackLowerFragment(elementType: type)
+        let liftFragment = try IntrinsicJSFragment.stackLiftFragment(elementType: type)
+        printer.write("\"\(token)\": {")
+        try printer.indent {
+            printer.write("lower: (v) => {")
+            try printer.indent {
+                _ = try lowerFragment.printCode(["v"], context())
+            }
+            printer.write("},")
+            printer.write("lift: () => {")
+            try printer.indent {
+                let results = try liftFragment.printCode([], context())
+                printer.write("return \(results[0]);")
+            }
+            printer.write("},")
+        }
+        printer.write("},")
+    }
+
+    private func generateGenericCodecTable(into printer: CodeFragmentPrinter) throws {
+        let decodeString = JSGlueVariableScope.reservedDecodeString
+        let entries = try genericTypeEntries()
+        printer.write("\(JSGlueVariableScope.reservedCodecs) = {")
+        try printer.indent {
+            for entry in entries {
+                try appendGenericCodec(token: entry.token, type: entry.type, into: printer)
+            }
+        }
+        printer.write("};")
+        printer.write("bjs[\"swift_js_resolve_type_id\"] = function(ptr, len) {")
+        printer.indent {
+            printer.write("return __bjs_resolveGenericType(\(decodeString)(ptr, len));")
+        }
+        printer.write("}")
+    }
+
+    private func generateBridgeTypeTokens() throws -> (js: [String], dts: [String]) {
+        let entries = try genericTypeEntries()
+
+        let jsEntries = entries.map { "\($0.token): \"\($0.token)\"" }
+        let jsLines = ["export const BridgeTypes = { \(jsEntries.joined(separator: ", ")) };"]
+
+        var dtsLines: [String] = []
+        dtsLines.append(
+            "export type BridgeType<T> = string & { readonly __bridgeType?: (value: T) => void };"
+        )
+        let dtsEntries = entries.map { "\($0.token): BridgeType<\($0.tsType)>;" }
+        dtsLines.append("export const BridgeTypes: { \(dtsEntries.joined(separator: " ")) };")
+
+        return (js: jsLines, dts: dtsLines)
     }
 
     private func generateAddImports(needsImportsObject: Bool) throws -> CodeFragmentPrinter {
@@ -540,6 +693,9 @@ public struct BridgeJSLink {
                         }
                         printer.write("}")
                     }
+                }
+                if hasGenerics {
+                    try generateGenericCodecTable(into: printer)
                 }
 
                 // Always provided: the runtime's `_bjs_makePromise` imports it unconditionally.
@@ -963,6 +1119,10 @@ public struct BridgeJSLink {
                     printer.write("export type \(enumObjectName) = typeof \(fullEnumValuesPath) & {")
                     printer.indent {
                         for function in enumDefinition.staticMethods {
+                            if function.isGeneric {
+                                printer.write("\(renderGenericExportMethodTSSignature(function: function));")
+                                continue
+                            }
                             printer.write(
                                 lines: renderJSDoc(
                                     documentation: function.documentation,
@@ -1020,7 +1180,10 @@ public struct BridgeJSLink {
                 self.renderExportedStructExportEntry(structDef)
             },
             renderFunctionEntry: { function in
-                self.renderJSDoc(documentation: function.documentation, parameters: function.parameters)
+                if function.isGeneric {
+                    return [self.renderGenericExportMethodTSSignature(function: function) + ";"]
+                }
+                return self.renderJSDoc(documentation: function.documentation, parameters: function.parameters)
                     + [
                         "\(function.name)\(self.renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
                     ]
@@ -1362,8 +1525,9 @@ public struct BridgeJSLink {
                     // Add methods
                     for method in type.methods {
                         let methodName = method.jsName ?? method.name
+                        let genericClause = renderGenericClause(method.genericParameterNames)
                         let methodSignature =
-                            "\(renderTSPropertyName(methodName))\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
+                            "\(renderTSPropertyName(methodName))\(genericClause)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
                         printer.write(methodSignature)
                     }
 
@@ -1578,6 +1742,29 @@ public struct BridgeJSLink {
         return "(\(parameterSignatures.joined(separator: ", "))): \(returnTypeWithEffect)"
     }
 
+    private func renderGenericExportMethodTSSignature(function: ExportedFunction) -> String {
+        let genericNames = function.genericParameterNames
+        let nameScope = JSGlueVariableScope(intrinsicRegistry: intrinsicRegistry)
+        let naming = GenericJSCodegen.makeGenericMethodNaming(
+            scope: nameScope,
+            parameters: function.parameters,
+            genericNames: genericNames
+        )
+        let genericClause = renderGenericClause(genericNames)
+        var parameterSignatures = function.parameters.map { param in
+            "\(param.name): \(resolveTypeScriptType(param.type))"
+        }
+        for genericName in genericNames {
+            parameterSignatures.append("\(naming.tokenName(genericName)): BridgeType<\(genericName)>")
+        }
+        let returnSignature = resolveTypeScriptType(function.returnType)
+        return "\(function.name)\(genericClause)(\(parameterSignatures.joined(separator: ", "))): \(returnSignature)"
+    }
+
+    private func renderGenericClause(_ genericParameterNames: [String]) -> String {
+        genericParameterNames.isEmpty ? "" : "<\(genericParameterNames.joined(separator: ", "))>"
+    }
+
     private func renderTSPropertyName(_ name: String) -> String {
         // TypeScript allows quoted property names for keys that aren't valid identifiers.
         if name.range(of: #"^[$A-Z_][0-9A-Z_$]*$"#, options: [.regularExpression, .caseInsensitive]) != nil {
@@ -1609,6 +1796,10 @@ public struct BridgeJSLink {
                 dtsTypePrinter.write("\(property.name): \(tsType);")
             }
             for method in structDefinition.methods where !method.effects.isStatic {
+                if method.isGeneric {
+                    dtsTypePrinter.write("\(renderGenericExportMethodTSSignature(function: method));")
+                    continue
+                }
                 let jsDocLines = renderJSDoc(
                     documentation: method.documentation,
                     parameters: method.parameters
@@ -1643,6 +1834,10 @@ public struct BridgeJSLink {
             dtsExportEntryPrinter.write("\(readonly)\(property.name): \(resolveTypeScriptType(property.type));")
         }
         for method in structDefinition.methods where method.effects.isStatic {
+            if method.isGeneric {
+                dtsExportEntryPrinter.write("\(renderGenericExportMethodTSSignature(function: method));")
+                continue
+            }
             let jsDocLines = renderJSDoc(documentation: method.documentation, parameters: method.parameters)
             dtsExportEntryPrinter.write(lines: jsDocLines)
             dtsExportEntryPrinter.write(
@@ -1690,6 +1885,14 @@ public struct BridgeJSLink {
         }
 
         for method in structDefinition.methods where method.effects.isStatic {
+            if method.isGeneric {
+                let (js, _) = try renderGenericExportedFunctionThunk(
+                    function: method,
+                    selfKind: .staticObjectMember
+                )
+                jsPrinter.write(lines: js)
+                continue
+            }
             let methodLines = try renderStaticMethodForExportObject(method: method)
             jsPrinter.write(lines: methodLines)
         }
@@ -1744,6 +1947,14 @@ public struct BridgeJSLink {
         {
             var enumMethodLines: [String] = []
             for function in enumDefinition.staticMethods {
+                if function.isGeneric {
+                    let (js, _) = try renderGenericExportedFunctionThunk(
+                        function: function,
+                        selfKind: .staticObjectMember
+                    )
+                    enumMethodLines.append(contentsOf: js)
+                    continue
+                }
                 let methodLines = try renderStaticMethodForExportObject(method: function)
                 enumMethodLines.append(contentsOf: methodLines)
             }
@@ -1886,6 +2097,10 @@ extension BridgeJSLink {
             return try renderStaticFunction(function: function, staticContext: staticContext)
         }
 
+        if function.isGeneric {
+            return try renderGenericExportedFunction(function: function)
+        }
+
         let thunkBuilder = ExportedThunkBuilder(
             effects: function.effects,
             intrinsicRegistry: intrinsicRegistry
@@ -1909,6 +2124,95 @@ extension BridgeJSLink {
         )
 
         return (funcLines, dtsLines)
+    }
+
+    private func renderGenericExportedFunction(
+        function: ExportedFunction
+    ) throws -> (js: [String], dts: [String]) {
+        guard function.isGeneric else {
+            throw BridgeJSLinkError(
+                message: "Generic exported function '\(function.name)' has no generic parameters"
+            )
+        }
+        return try renderGenericExportedFunctionThunk(function: function)
+    }
+
+    enum GenericJSSelf {
+        case free
+        case instance
+        case staticMember
+        case staticObjectMember
+    }
+
+    private func renderGenericExportedFunctionThunk(
+        function: ExportedFunction,
+        selfKind: GenericJSSelf = .free
+    ) throws -> (js: [String], dts: [String]) {
+        let genericNames = function.genericParameterNames
+
+        let genericValueParameters = function.genericValueParameters
+        guard !genericValueParameters.isEmpty else {
+            throw BridgeJSLinkError(
+                message: "Generic exported function '\(function.name)' has no generic value parameter"
+            )
+        }
+        let concreteParameters = function.concreteParameters
+
+        let thunkBuilder = ExportedThunkBuilder(
+            effects: function.effects,
+            intrinsicRegistry: intrinsicRegistry
+        )
+        for param in concreteParameters {
+            try thunkBuilder.lowerParameter(param: param)
+        }
+        let selfForwardings: [String] = selfKind == .instance ? ["this.pointer"] : []
+
+        let nameScope = JSGlueVariableScope(intrinsicRegistry: intrinsicRegistry)
+        let naming = GenericJSCodegen.makeGenericMethodNaming(
+            scope: nameScope,
+            parameters: function.parameters,
+            genericNames: genericNames
+        )
+        let tokenName = naming.tokenName
+
+        let printer = CodeFragmentPrinter()
+        let userParameterNames = function.parameters.map { $0.name } + genericNames.map { tokenName($0) }
+        let header: String
+        let footer: String
+        switch selfKind {
+        case .free:
+            header = "function \(function.abiName)(\(userParameterNames.joined(separator: ", "))) {"
+            footer = "}"
+        case .instance:
+            header = "\(function.name)(\(userParameterNames.joined(separator: ", "))) {"
+            footer = "}"
+        case .staticMember:
+            header = "static \(function.name)(\(userParameterNames.joined(separator: ", "))) {"
+            footer = "}"
+        case .staticObjectMember:
+            header = "\(function.name): function(\(userParameterNames.joined(separator: ", "))) {"
+            footer = "},"
+        }
+        printer.write(header)
+        printer.indent {
+            GenericJSCodegen.emitGenericExportCallBody(
+                into: printer,
+                abiName: function.abiName,
+                naming: naming,
+                genericNames: genericNames,
+                selfStatements: [],
+                selfForwardings: selfForwardings,
+                concreteStatements: thunkBuilder.body.lines,
+                concreteForwardings: thunkBuilder.parameterForwardings,
+                genericValueParameters: genericValueParameters,
+                returnType: function.returnType
+            )
+        }
+        printer.write(footer)
+
+        let dtsLine = renderGenericExportMethodTSSignature(function: function) + ";"
+
+        return (printer.lines, [dtsLine])
     }
 
     private func renderStaticFunction(
@@ -1998,6 +2302,10 @@ extension BridgeJSLink {
         function: ExportedFunction,
         namespace: String
     ) throws -> (js: [String], dts: [String]) {
+        if function.isGeneric {
+            return try renderGenericExportedFunctionThunk(function: function, selfKind: .free)
+        }
+
         let thunkBuilder = ExportedThunkBuilder(
             effects: function.effects,
             intrinsicRegistry: intrinsicRegistry
@@ -2155,6 +2463,17 @@ extension BridgeJSLink {
         }
 
         for method in klass.methods {
+            if method.isGeneric {
+                let (js, dts) = try renderGenericExportedFunctionThunk(
+                    function: method,
+                    selfKind: method.effects.isStatic ? .staticMember : .instance
+                )
+                jsPrinter.indent { jsPrinter.write(lines: js) }
+                if !method.effects.isStatic {
+                    dtsTypePrinter.indent { dtsTypePrinter.write(lines: dts) }
+                }
+                continue
+            }
             if method.effects.isStatic {
                 let thunkBuilder = ExportedThunkBuilder(
                     effects: method.effects,
@@ -2241,6 +2560,10 @@ extension BridgeJSLink {
             )
         }
         for method in klass.methods where method.effects.isStatic {
+            if method.isGeneric {
+                printer.write("\(renderGenericExportMethodTSSignature(function: method));")
+                continue
+            }
             printer.write(lines: renderJSDoc(documentation: method.documentation, parameters: method.parameters))
             printer.write(
                 "\(method.name)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
@@ -2273,6 +2596,10 @@ extension BridgeJSLink {
             }
             for method in klass.methods.sorted(by: { $0.name < $1.name }) {
                 let staticKeyword = method.effects.isStatic ? "static " : ""
+                if method.isGeneric {
+                    printer.write("\(staticKeyword)\(renderGenericExportMethodTSSignature(function: method));")
+                    continue
+                }
                 printer.write(lines: renderJSDoc(documentation: method.documentation, parameters: method.parameters))
                 printer.write(
                     "\(staticKeyword)\(method.name)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
@@ -2370,6 +2697,8 @@ extension BridgeJSLink {
         var parameterNames: [String] = []
         var parameterForwardings: [String] = []
         var returnExpr: String?
+        var genericCodecVariables: [String: String] = [:]
+        var genericTypeIdParameters: [String: String] = [:]
         let printContext: IntrinsicJSFragment.PrintCodeContext
 
         init(
@@ -2395,7 +2724,31 @@ extension BridgeJSLink {
             parameterNames.append("self")
         }
 
+        func declareGenericCodecs(genericParameters: [String]) {
+            for genericParam in genericParameters {
+                let typeIdParam = scope.variable("\(genericParam.lowercased())TypeId")
+                let codecVar = scope.variable("codec\(genericParam)")
+                body.write("const \(codecVar) = \(JSGlueVariableScope.reservedCodecsById)[\(typeIdParam)];")
+                genericCodecVariables[genericParam] = codecVar
+                genericTypeIdParameters[genericParam] = typeIdParam
+            }
+        }
+
         func liftParameter(param: Parameter) throws {
+            if let name = param.type.referencedGenericName {
+                guard let codecVar = genericCodecVariables[name] else {
+                    throw BridgeJSLinkError(
+                        message: "Generic codec for '\(name)' was not declared before lifting parameter '\(param.name)'"
+                    )
+                }
+                let valueVar = scope.variable(param.name)
+                let liftExpr =
+                    GenericJSCodegen.genericCodecLiftExpression(type: param.type, codec: codecVar)
+                    ?? "\(codecVar).lift()"
+                body.write("const \(valueVar) = \(liftExpr);")
+                parameterForwardings.append(valueVar)
+                return
+            }
             let liftingFragment = try IntrinsicJSFragment.liftParameter(type: param.type, context: context)
             let valuesToLift: [String]
             if liftingFragment.parameters.count == 0 {
@@ -2410,6 +2763,16 @@ extension BridgeJSLink {
             let liftedValues = try liftingFragment.printCode(valuesToLift, printContext)
             assert(liftedValues.count == 1, "Lifting fragment should produce exactly one value")
             parameterForwardings.append(contentsOf: liftedValues)
+        }
+
+        func liftParametersAndGenericTypeIds(_ parameters: [Parameter], genericParameters: [String]) throws {
+            declareGenericCodecs(genericParameters: genericParameters)
+            for param in parameters {
+                try liftParameter(param: param)
+            }
+            for genericParam in genericParameters {
+                parameterNames.append(genericTypeIdParameters[genericParam] ?? genericParam)
+            }
         }
 
         func renderFunction(name: String?) -> [String] {
@@ -2486,6 +2849,25 @@ extension BridgeJSLink {
         private func call(callExpr: String) throws {
             if effects.isAsync {
                 body.write("\(callExpr).then(resolve, reject);")
+                return
+            }
+            if let name = returnType.referencedGenericName {
+                guard let codecVar = genericCodecVariables[name] else {
+                    throw BridgeJSLinkError(
+                        message: "Generic codec for return type '\(name)' was not declared before the call"
+                    )
+                }
+                let resultVariable = scope.variable("ret")
+                body.write("let \(resultVariable) = \(callExpr);")
+                let lowerStmt =
+                    GenericJSCodegen.genericCodecLowerStatement(
+                        type: returnType,
+                        codec: codecVar,
+                        value: resultVariable
+                    )
+                    ?? "\(codecVar).lower(\(resultVariable));"
+                body.write(lowerStmt)
+                self.returnExpr = nil
                 return
             }
             let loweringFragment = try IntrinsicJSFragment.lowerReturn(type: returnType, context: context)
@@ -3456,18 +3838,21 @@ extension BridgeJSLink {
             returnType: function.returnType,
             intrinsicRegistry: intrinsicRegistry
         )
-        for param in function.parameters {
-            try thunkBuilder.liftParameter(param: param)
-        }
+        let genericParameters = function.genericParameterNames
+        try thunkBuilder.liftParametersAndGenericTypeIds(
+            function.parameters,
+            genericParameters: genericParameters
+        )
         let jsName = function.jsName ?? function.name
         let importRootExpr = function.from == .global ? "globalThis" : "imports"
 
         try thunkBuilder.call(name: jsName, fromObjectExpr: importRootExpr)
         let funcLines = thunkBuilder.renderFunction(name: function.abiName(context: nil))
         if function.from == nil {
+            let genericClause = renderGenericClause(genericParameters)
             importObjectBuilder.appendDts(
                 [
-                    "\(renderTSPropertyName(jsName))\(renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
+                    "\(renderTSPropertyName(jsName))\(genericClause)\(renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
                 ]
             )
         }
@@ -3555,8 +3940,9 @@ extension BridgeJSLink {
                 }
                 for method in type.staticMethods {
                     let methodName = method.jsName ?? method.name
+                    let genericClause = renderGenericClause(method.genericParameterNames)
                     let signature =
-                        "\(renderTSPropertyName(methodName))\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
+                        "\(renderTSPropertyName(methodName))\(genericClause)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
                     dtsPrinter.write(signature)
                 }
             }
@@ -3635,9 +4021,11 @@ extension BridgeJSLink {
             returnType: method.returnType,
             intrinsicRegistry: intrinsicRegistry
         )
-        for param in method.parameters {
-            try thunkBuilder.liftParameter(param: param)
-        }
+        let genericParameters = method.genericParameters ?? []
+        try thunkBuilder.liftParametersAndGenericTypeIds(
+            method.parameters,
+            genericParameters: genericParameters
+        )
         let importRootExpr = context.from == .global ? "globalThis" : "imports"
         let constructorExpr = ImportedThunkBuilder.propertyAccessExpr(
             objectExpr: importRootExpr,
@@ -3659,9 +4047,11 @@ extension BridgeJSLink {
             intrinsicRegistry: intrinsicRegistry
         )
         thunkBuilder.liftSelf()
-        for param in method.parameters {
-            try thunkBuilder.liftParameter(param: param)
-        }
+        let genericParameters = method.genericParameters ?? []
+        try thunkBuilder.liftParametersAndGenericTypeIds(
+            method.parameters,
+            genericParameters: genericParameters
+        )
 
         try thunkBuilder.callMethod(name: method.jsName ?? method.name)
         let funcLines = thunkBuilder.renderFunction(name: method.abiName(context: context))
@@ -4005,6 +4395,8 @@ extension BridgeType {
             return "Record<string, \(valueType.tsType)>"
         case .alias(_, let underlying):
             return underlying.tsType
+        case .generic(let name):
+            return name
         }
     }
 

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -35,6 +35,8 @@ final class JSGlueVariableScope {
     static let reservedSwiftClosureRegistry = "swiftClosureRegistry"
     static let reservedMakeSwiftClosure = "makeClosure"
     static let reservedTaStack = "taStack"
+    static let reservedCodecs = "__bjs_codecs"
+    static let reservedCodecsById = "__bjs_codecsById"
 
     private let intrinsicRegistry: JSIntrinsicRegistry
 
@@ -65,6 +67,8 @@ final class JSGlueVariableScope {
         reservedSwiftClosureRegistry,
         reservedMakeSwiftClosure,
         reservedTaStack,
+        reservedCodecs,
+        reservedCodecsById,
     ]
 
     init(intrinsicRegistry: JSIntrinsicRegistry) {
@@ -135,6 +139,193 @@ extension JSGlueVariableScope {
     }
     func popPointer() -> String {
         return "\(JSGlueVariableScope.reservedPointerStack).pop()"
+    }
+}
+
+enum GenericJSCodegen {
+    static func genericCodecLowerStatement(type: BridgeType, codec: String, value: String) -> String? {
+        switch type {
+        case .generic: return "\(codec).lower(\(value));"
+        case .array(.generic): return "__bjs_lowerArrayGeneric(\(value), \(codec));"
+        case .nullable(.generic, _): return "__bjs_lowerOptionalGeneric(\(value), \(codec));"
+        case .dictionary(.generic): return "__bjs_lowerDictGeneric(\(value), \(codec));"
+        default: return nil
+        }
+    }
+
+    static func genericCodecLiftExpression(type: BridgeType, codec: String) -> String? {
+        switch type {
+        case .generic: return "\(codec).lift()"
+        case .array(.generic): return "__bjs_liftArrayGeneric(\(codec))"
+        case .nullable(.generic, _): return "__bjs_liftOptionalGeneric(\(codec))"
+        case .dictionary(.generic): return "__bjs_liftDictGeneric(\(codec))"
+        default: return nil
+        }
+    }
+
+    struct GenericMethodNaming {
+        let tokenNames: [String: String]
+        let codecNames: [String: String]
+        let typeIdNames: [String: String]
+
+        func tokenName(_ genericName: String) -> String {
+            guard let name = tokenNames[genericName] else {
+                preconditionFailure("No token name registered for generic '\(genericName)'")
+            }
+            return name
+        }
+
+        func codecVariable(_ genericName: String) -> String {
+            guard let name = codecNames[genericName] else {
+                preconditionFailure("No codec variable registered for generic '\(genericName)'")
+            }
+            return name
+        }
+
+        func typeIdVariable(_ genericName: String) -> String {
+            guard let name = typeIdNames[genericName] else {
+                preconditionFailure("No type-id variable registered for generic '\(genericName)'")
+            }
+            return name
+        }
+
+        func genericName(of param: Parameter) -> String {
+            guard let name = param.type.referencedGenericName else {
+                preconditionFailure("Generic value parameter '\(param.name)' has no referenced generic name")
+            }
+            return name
+        }
+    }
+
+    static func makeGenericMethodNaming(
+        scope: JSGlueVariableScope,
+        parameters: [Parameter],
+        genericNames: [String]
+    ) -> GenericMethodNaming {
+        for parameter in parameters {
+            _ = scope.variable(parameter.name)
+        }
+        let tokenNames = Dictionary(uniqueKeysWithValues: genericNames.map { ($0, scope.variable("type\($0)")) })
+        let codecNames = Dictionary(uniqueKeysWithValues: genericNames.map { ($0, scope.variable("codec\($0)")) })
+        let typeIdNames = Dictionary(
+            uniqueKeysWithValues: genericNames.map { ($0, scope.variable("\($0.lowercased())TypeId")) }
+        )
+        return GenericMethodNaming(
+            tokenNames: tokenNames,
+            codecNames: codecNames,
+            typeIdNames: typeIdNames
+        )
+    }
+
+    static func emitGenericExportCallBody(
+        into printer: CodeFragmentPrinter,
+        abiName: String,
+        naming: GenericMethodNaming,
+        genericNames: [String],
+        selfStatements: [String],
+        selfForwardings: [String],
+        concreteStatements: [String],
+        concreteForwardings: [String],
+        genericValueParameters: [Parameter],
+        returnType: BridgeType
+    ) {
+        for genericName in genericNames {
+            printer.write(
+                "const \(naming.typeIdVariable(genericName)) = __bjs_resolveGenericType(\(naming.tokenName(genericName)));"
+            )
+            printer.write(
+                "const \(naming.codecVariable(genericName)) = \(JSGlueVariableScope.reservedCodecsById)[\(naming.typeIdVariable(genericName))];"
+            )
+        }
+        printer.write(lines: selfStatements)
+        printer.write(lines: concreteStatements)
+        for parameter in genericValueParameters {
+            if let statement = genericCodecLowerStatement(
+                type: parameter.type,
+                codec: naming.codecVariable(naming.genericName(of: parameter)),
+                value: parameter.name
+            ) {
+                printer.write(statement)
+            }
+        }
+        let callArguments = selfForwardings + concreteForwardings + genericNames.map { naming.typeIdVariable($0) }
+        printer.write("instance.exports.\(abiName)(\(callArguments.joined(separator: ", ")));")
+        if let returnGenericName = returnType.referencedGenericName,
+            let liftExpression = genericCodecLiftExpression(
+                type: returnType,
+                codec: naming.codecVariable(returnGenericName)
+            )
+        {
+            printer.write("return \(liftExpression);")
+        }
+    }
+
+    static func runtimeHelperDeclarations() -> [String] {
+        let i32 = JSGlueVariableScope.reservedI32Stack
+        let codecs = JSGlueVariableScope.reservedCodecs
+        let codecsById = JSGlueVariableScope.reservedCodecsById
+        return [
+            "function __bjs_resolveGenericType(token) {",
+            "    const codec = \(codecs)[token];",
+            "    if (!codec) {",
+            "        throw new Error(\"BridgeJS: no generic codec registered for type '\" + token + \"'\");",
+            "    }",
+            "    let id = \(codecsById).indexOf(codec);",
+            "    if (id === -1) {",
+            "        id = \(codecsById).push(codec) - 1;",
+            "    }",
+            "    return id;",
+            "}",
+            "function __bjs_lowerArrayGeneric(value, codec) {",
+            "    for (let i = 0; i < value.length; i++) {",
+            "        codec.lower(value[i]);",
+            "    }",
+            "    \(i32).push(value.length);",
+            "}",
+            "function __bjs_liftArrayGeneric(codec) {",
+            "    const count = \(i32).pop();",
+            "    if (count === -1) {",
+            "        return \(JSGlueVariableScope.reservedTaStack).pop();",
+            "    }",
+            "    const result = new Array(count);",
+            "    for (let i = count - 1; i >= 0; i--) {",
+            "        result[i] = codec.lift();",
+            "    }",
+            "    return result;",
+            "}",
+            "function __bjs_lowerOptionalGeneric(value, codec) {",
+            "    if (value === null || value === undefined) {",
+            "        \(i32).push(0);",
+            "    } else {",
+            "        codec.lower(value);",
+            "        \(i32).push(1);",
+            "    }",
+            "}",
+            "function __bjs_liftOptionalGeneric(codec) {",
+            "    if (\(i32).pop() === 0) {",
+            "        return null;",
+            "    }",
+            "    return codec.lift();",
+            "}",
+            "function __bjs_lowerDictGeneric(value, codec) {",
+            "    const keys = Object.keys(value);",
+            "    for (let i = 0; i < keys.length; i++) {",
+            "        \(codecs)[\"String\"].lower(keys[i]);",
+            "        codec.lower(value[keys[i]]);",
+            "    }",
+            "    \(i32).push(keys.length);",
+            "}",
+            "function __bjs_liftDictGeneric(codec) {",
+            "    const count = \(i32).pop();",
+            "    const result = {};",
+            "    for (let i = 0; i < count; i++) {",
+            "        const value = codec.lift();",
+            "        const key = \(codecs)[\"String\"].lift();",
+            "        result[key] = value;",
+            "    }",
+            "    return result;",
+            "}",
+        ]
     }
 }
 
@@ -1943,7 +2134,7 @@ struct IntrinsicJSFragment: Sendable {
         )
     }
 
-    private static func stackLiftFragment(elementType: BridgeType) throws -> IntrinsicJSFragment {
+    static func stackLiftFragment(elementType: BridgeType) throws -> IntrinsicJSFragment {
         if case .nullable(let wrappedType, let kind) = elementType {
             return try optionalElementRaiseFragment(wrappedType: wrappedType, kind: kind)
         }
@@ -2070,7 +2261,7 @@ struct IntrinsicJSFragment: Sendable {
         }
     }
 
-    private static func stackLowerFragment(elementType: BridgeType) throws -> IntrinsicJSFragment {
+    static func stackLowerFragment(elementType: BridgeType) throws -> IntrinsicJSFragment {
         if case .nullable(let wrappedType, let kind) = elementType {
             return try optionalElementLowerFragment(wrappedType: wrappedType, kind: kind)
         }
@@ -2361,6 +2552,44 @@ struct IntrinsicJSFragment: Sendable {
 
             // Attach instance methods to the struct instance
             for method in structDef.methods where !method.effects.isStatic {
+                if method.isGeneric {
+                    let genericNames = method.genericParameterNames
+                    let methodScope = liftScope.makeChildScope()
+                    let naming = GenericJSCodegen.makeGenericMethodNaming(
+                        scope: methodScope,
+                        parameters: method.parameters,
+                        genericNames: genericNames
+                    )
+                    let tokenName = naming.tokenName
+                    let genericParamList = (method.parameters.map { $0.name } + genericNames.map { tokenName($0) })
+                        .joined(separator: ", ")
+                    printer.write("\(instanceVar).\(method.name) = function(\(genericParamList)) {")
+                    let concretePrinter = CodeFragmentPrinter()
+                    var concreteForwardings: [String] = []
+                    for param in method.concreteParameters {
+                        let fragment = try IntrinsicJSFragment.lowerParameter(type: param.type)
+                        let lowered = try fragment.printCode([param.name], context.with(\.printer, concretePrinter))
+                        concreteForwardings.append(contentsOf: lowered)
+                    }
+                    printer.indent {
+                        GenericJSCodegen.emitGenericExportCallBody(
+                            into: printer,
+                            abiName: method.abiName,
+                            naming: naming,
+                            genericNames: genericNames,
+                            selfStatements: [
+                                "\(JSGlueVariableScope.reservedStructHelpers).\(structDef.abiName).lower(this);"
+                            ],
+                            selfForwardings: [],
+                            concreteStatements: concretePrinter.lines,
+                            concreteForwardings: concreteForwardings,
+                            genericValueParameters: method.genericValueParameters,
+                            returnType: method.returnType
+                        )
+                    }
+                    printer.write("}.bind(\(instanceVar));")
+                    continue
+                }
                 let paramList = DefaultValueUtils.formatParameterList(method.parameters)
                 printer.write(
                     "\(instanceVar).\(method.name) = function(\(paramList)) {"
@@ -2622,7 +2851,7 @@ private extension BridgeType {
             return .inlineFlag
         case .closure:
             return .inlineFlag
-        case .swiftStruct, .array, .dictionary, .void, .namespaceEnum:
+        case .swiftStruct, .array, .dictionary, .void, .namespaceEnum, .generic:
             return .stackABI
         case .nullable(let wrapped, _):
             return wrapped.optionalConvention
@@ -2720,7 +2949,7 @@ private extension BridgeType {
             return [("caseId", .i32)]
         case .closure:
             return [("funcRef", .i32)]
-        case .void, .namespaceEnum, .swiftStruct, .array, .dictionary:
+        case .void, .namespaceEnum, .swiftStruct, .array, .dictionary, .generic:
             return []
         case .nullable(let wrapped, _):
             return wrapped.wasmParams

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -22,6 +22,9 @@ extension NamespacedExportedType {
 public struct ABINameGenerator {
     static let prefixComponent = "bjs"
 
+    /// ABI parameter name carrying the runtime type ID for the generic parameter at `index`.
+    public static func genericTypeIdParameterName(index: Int) -> String { "_generic\(index)TypeId" }
+
     /// Generates ABI name using standardized namespace + context pattern
     public static func generateABIName(
         baseName: String,
@@ -273,8 +276,42 @@ public enum BridgeType: Codable, Equatable, Hashable, Sendable {
     case namespaceEnum(String)
     case swiftProtocol(String)
     case swiftStruct(String)
+    case generic(String)
     indirect case closure(ClosureSignature, useJSTypedClosure: Bool)
     indirect case alias(name: String, underlying: BridgeType)
+}
+
+extension BridgeType {
+    public var referencedGenericName: String? {
+        switch self {
+        case .generic(let name): return name
+        case .array(.generic(let name)): return name
+        case .nullable(.generic(let name), _): return name
+        case .dictionary(.generic(let name)): return name
+        default: return nil
+        }
+    }
+
+    public var usesGenericParameter: Bool { referencedGenericName != nil }
+
+    public static let genericBridgeablePrimitives: [(token: String, type: BridgeType)] = [
+        ("Bool", .bool),
+        ("Int", .integer(.int)),
+        ("Int8", .integer(.int8)),
+        ("UInt8", .integer(.uint8)),
+        ("Int16", .integer(.int16)),
+        ("UInt16", .integer(.uint16)),
+        ("Int32", .integer(.int32)),
+        ("UInt32", .integer(.uint32)),
+        ("UInt", .integer(.uint)),
+        ("Int64", .integer(.int64)),
+        ("UInt64", .integer(.uint64)),
+        ("Float", .float),
+        ("Double", .double),
+        ("String", .string),
+        ("JSValue", .jsValue),
+    ]
+
 }
 
 public enum WasmCoreType: String, Codable, Sendable {
@@ -868,6 +905,11 @@ public struct ExportedFunction: Codable, Equatable, Sendable {
     public var namespace: [String]?
     public var staticContext: StaticContext?
     public var documentation: String?
+    public var genericParameters: [String]?
+    public var genericParameterNames: [String] { genericParameters ?? [] }
+    public var isGeneric: Bool { !genericParameterNames.isEmpty }
+    public var genericValueParameters: [Parameter] { parameters.filter { $0.type.usesGenericParameter } }
+    public var concreteParameters: [Parameter] { parameters.filter { !$0.type.usesGenericParameter } }
 
     public init(
         name: String,
@@ -877,7 +919,8 @@ public struct ExportedFunction: Codable, Equatable, Sendable {
         effects: Effects,
         namespace: [String]? = nil,
         staticContext: StaticContext? = nil,
-        documentation: String? = nil
+        documentation: String? = nil,
+        genericParameters: [String]? = nil
     ) {
         self.name = name
         self.abiName = abiName
@@ -887,6 +930,7 @@ public struct ExportedFunction: Codable, Equatable, Sendable {
         self.namespace = namespace
         self.staticContext = staticContext
         self.documentation = documentation
+        self.genericParameters = genericParameters
     }
 }
 
@@ -900,6 +944,7 @@ public struct ExportedClass: Codable, NamespacedExportedType {
     public var namespace: [String]?
     public var identityMode: Bool?  // nil = use config default, true/false = override
     public var documentation: String?
+    public var isFinal: Bool?
 
     public init(
         name: String,
@@ -910,7 +955,8 @@ public struct ExportedClass: Codable, NamespacedExportedType {
         properties: [ExportedProperty] = [],
         namespace: [String]? = nil,
         identityMode: Bool? = nil,
-        documentation: String? = nil
+        documentation: String? = nil,
+        isFinal: Bool? = nil
     ) {
         self.name = name
         self.swiftCallName = swiftCallName
@@ -921,6 +967,7 @@ public struct ExportedClass: Codable, NamespacedExportedType {
         self.namespace = namespace
         self.identityMode = identityMode
         self.documentation = documentation
+        self.isFinal = isFinal
     }
 }
 
@@ -1101,10 +1148,19 @@ public struct ExportedSkeleton: Codable {
     }
 
     private var asyncClosureResolveReturnTypes: [BridgeType] {
-        var collector = AsyncClosureReturnTypeCollector()
+        let collector = AsyncClosureReturnTypeCollector()
         var walker = BridgeSkeletonWalker(visitor: collector)
         walker.walk(self)
         return walker.visitor.returnTypes
+    }
+}
+
+extension ExportedSkeleton {
+    public var hasGenericDeclarations: Bool {
+        functions.contains(where: \.isGeneric)
+            || classes.contains { $0.methods.contains(where: \.isGeneric) }
+            || structs.contains { $0.methods.contains(where: \.isGeneric) }
+            || enums.contains { $0.staticMethods.contains(where: \.isGeneric) }
     }
 }
 
@@ -1144,6 +1200,9 @@ public struct ImportedFunctionSkeleton: Codable {
     /// determine the access level of bridge-generated helpers (e.g. typed
     /// closure inits) that surface through this function's signature.
     public let accessLevel: BridgeJSAccessLevel
+    public let genericParameters: [String]?
+    public var genericParameterNames: [String] { genericParameters ?? [] }
+    public var isGeneric: Bool { !genericParameterNames.isEmpty }
 
     public init(
         name: String,
@@ -1153,7 +1212,8 @@ public struct ImportedFunctionSkeleton: Codable {
         returnType: BridgeType,
         effects: Effects = Effects(isAsync: false, isThrows: true),
         documentation: String? = nil,
-        accessLevel: BridgeJSAccessLevel = .internal
+        accessLevel: BridgeJSAccessLevel = .internal,
+        genericParameters: [String]? = nil
     ) {
         self.name = name
         self.jsName = jsName
@@ -1163,10 +1223,11 @@ public struct ImportedFunctionSkeleton: Codable {
         self.effects = effects
         self.documentation = documentation
         self.accessLevel = accessLevel
+        self.genericParameters = genericParameters
     }
 
     private enum CodingKeys: String, CodingKey {
-        case name, jsName, from, parameters, returnType, effects, documentation, accessLevel
+        case name, jsName, from, parameters, returnType, effects, documentation, accessLevel, genericParameters
     }
 
     public init(from decoder: any Decoder) throws {
@@ -1179,6 +1240,7 @@ public struct ImportedFunctionSkeleton: Codable {
         self.effects = try container.decode(Effects.self, forKey: .effects)
         self.documentation = try container.decodeIfPresent(String.self, forKey: .documentation)
         self.accessLevel = try container.decodeIfPresent(BridgeJSAccessLevel.self, forKey: .accessLevel) ?? .internal
+        self.genericParameters = try container.decodeIfPresent([String].self, forKey: .genericParameters)
     }
 
     public func abiName(context: ImportedTypeSkeleton?) -> String {
@@ -1453,11 +1515,27 @@ public struct ImportedFileSkeleton: Codable {
     }
 }
 
+extension ImportedFileSkeleton {
+    public var hasGenericDeclarations: Bool {
+        functions.contains(where: \.isGeneric)
+            || types.contains {
+                $0.methods.contains(where: \.isGeneric)
+                    || $0.staticMethods.contains(where: \.isGeneric)
+            }
+    }
+}
+
 public struct ImportedModuleSkeleton: Codable {
     public var children: [ImportedFileSkeleton]
 
     public init(children: [ImportedFileSkeleton]) {
         self.children = children
+    }
+}
+
+extension ImportedModuleSkeleton {
+    public var hasGenericDeclarations: Bool {
+        children.contains { $0.hasGenericDeclarations }
     }
 }
 
@@ -1635,7 +1713,7 @@ extension BridgeType {
         case .bool, .integer, .float, .double, .string, .jsValue, .jsObject,
             .swiftHeapObject, .unsafePointer, .swiftProtocol, .void,
             .caseEnum, .rawValueEnum, .associatedValueEnum, .swiftStruct,
-            .namespaceEnum, .closure:
+            .namespaceEnum, .closure, .generic:
             return self
         }
     }
@@ -1682,6 +1760,8 @@ extension BridgeType {
             return nil
         case .alias(_, let underlying):
             return underlying.abiReturnType
+        case .generic:
+            return nil
         }
     }
 
@@ -1773,6 +1853,8 @@ extension BridgeType {
             // `name` is the namespace-qualified swiftCallName (unique), so the underlying
             // representation isn't mangled in - aliases bridge via their JS type's ABI.
             return "Al\(name.count)\(name)"
+        case .generic(let name):
+            return "\(name.count)\(name)T"
         }
     }
 

--- a/Plugins/BridgeJS/Sources/BridgeJSTool/BridgeJSTool.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSTool/BridgeJSTool.swift
@@ -205,12 +205,14 @@ import BridgeJSUtilities
                 printStderr(diagnostic.formattedDescription(fileName: file))
             }
 
+            let importedSkeleton = skeleton.imported
             var exporter: ExportSwift?
             if let skeleton = skeleton.exported {
                 exporter = ExportSwift(
                     progress: progress,
                     moduleName: moduleName,
-                    skeleton: skeleton
+                    skeleton: skeleton,
+                    imported: importedSkeleton
                 )
             }
             var importer: ImportTS?

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/BridgeJSCodegenTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/BridgeJSCodegenTests.swift
@@ -28,7 +28,8 @@ import Testing
             let exportSwift = ExportSwift(
                 progress: .silent,
                 moduleName: skeleton.moduleName,
-                skeleton: exported
+                skeleton: exported,
+                imported: skeleton.imported
             )
             if let s = try exportSwift.finalize() {
                 swiftParts.append(s)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/BridgeJSLinkTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/BridgeJSLinkTests.swift
@@ -179,7 +179,7 @@ import Testing
             moduleName: "FirstModule",
             source: structSource + """
 
-                @JS public func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
+                @JS public func identity<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
                 """
         )
         let second = try makeSkeleton(moduleName: "SecondModule", source: structSource)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/BridgeJSLinkTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/BridgeJSLinkTests.swift
@@ -126,6 +126,74 @@ import Testing
         try snapshot(bridgeJSLink: bridgeJSLink, name: "MixedModules")
     }
 
+    private func linkedJS(forFixture input: String) throws -> String {
+        let url = Self.inputsDirectory.appendingPathComponent(input)
+        let name = url.deletingPathExtension().lastPathComponent
+        let sourceFile = Parser.parse(source: try String(contentsOf: url, encoding: .utf8))
+        let importSwift = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "TestModule",
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        importSwift.addSourceFile(sourceFile, inputFilePath: "\(name).swift")
+        let importResult = try importSwift.finalize()
+        var bridgeJSLink = BridgeJSLink(sharedMemory: false)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let unifiedData = try encoder.encode(importResult)
+        try bridgeJSLink.addSkeletonFile(data: unifiedData)
+        return try bridgeJSLink.link().0
+    }
+
+    @Test
+    func genericResolverIsGatedToGenericModules() throws {
+        let genericJS = try linkedJS(forFixture: "GenericImports.swift")
+        #expect(genericJS.contains("swift_js_resolve_type_id"))
+        #expect(genericJS.contains("__bjs_codecs"))
+
+        let nonGenericJS = try linkedJS(forFixture: "SwiftStructImports.swift")
+        #expect(!nonGenericJS.contains("swift_js_resolve_type_id"))
+        #expect(!nonGenericJS.contains("__bjs_codecs"))
+    }
+
+    @Test
+    func duplicateGenericTokenAcrossModulesFailsLinking() throws {
+        func makeSkeleton(moduleName: String, source: String) throws -> BridgeJSSkeleton {
+            let swiftAPI = SwiftToSkeleton(
+                progress: .silent,
+                moduleName: moduleName,
+                exposeToGlobal: false,
+                externalModuleIndex: .empty
+            )
+            swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "\(moduleName).swift")
+            return try swiftAPI.finalize()
+        }
+        let structSource = """
+            @JS public struct Point {
+                public var x: Int
+                @JS public init(x: Int) { self.x = x }
+            }
+            """
+        let first = try makeSkeleton(
+            moduleName: "FirstModule",
+            source: structSource + """
+
+                @JS public func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
+                """
+        )
+        let second = try makeSkeleton(moduleName: "SecondModule", source: structSource)
+        let bridgeJSLink = BridgeJSLink(skeletons: [first, second], sharedMemory: false)
+        #expect {
+            _ = try bridgeJSLink.link()
+        } throws: { error in
+            guard let linkError = error as? BridgeJSLinkError else { return false }
+            return linkError.message.contains("Generic bridge token 'Point'")
+                && linkError.message.contains("FirstModule")
+                && linkError.message.contains("SecondModule")
+        }
+    }
+
     @Test
     func perClassIdentityModeFromAnnotation() throws {
         let url = Self.inputsDirectory.appendingPathComponent("IdentityModeClass.swift")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/CodegenTestSupport.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/CodegenTestSupport.swift
@@ -1,0 +1,73 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+@testable import BridgeJSLink
+@testable import BridgeJSCore
+@testable import BridgeJSSkeleton
+
+func makeSkeleton(
+    _ source: String,
+    moduleName: String = "TestModule",
+    dependencies: [(moduleName: String, skeleton: BridgeJSSkeleton)] = []
+) throws -> BridgeJSSkeleton {
+    let swiftAPI = SwiftToSkeleton(
+        progress: .silent,
+        moduleName: moduleName,
+        exposeToGlobal: false,
+        externalModuleIndex: ExternalModuleIndex(dependencies: dependencies)
+    )
+    swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: "\(moduleName).swift")
+    return try swiftAPI.finalize()
+}
+
+func renderExportGlue(
+    _ source: String,
+    moduleName: String = "TestModule"
+) throws -> String {
+    let skeleton = try makeSkeleton(source, moduleName: moduleName)
+    let exported = try #require(skeleton.exported)
+    let exportSwift = ExportSwift(
+        progress: .silent,
+        moduleName: skeleton.moduleName,
+        skeleton: exported,
+        imported: skeleton.imported
+    )
+    return try #require(try exportSwift.finalize())
+}
+
+func renderImportGlue(_ source: String, moduleName: String = "TestModule") throws -> String {
+    let skeleton = try makeSkeleton(source, moduleName: moduleName)
+    let imported = try #require(skeleton.imported)
+    let importTS = ImportTS(progress: .silent, moduleName: skeleton.moduleName, skeleton: imported)
+    return try #require(try importTS.finalize())
+}
+
+func expectDiagnostic(
+    source: String,
+    moduleName: String = "App",
+    contains message: String,
+    sourceLocation: Testing.SourceLocation = #_sourceLocation
+) {
+    do {
+        _ = try makeSkeleton(source, moduleName: moduleName)
+        Issue.record("Expected diagnostic but resolution succeeded", sourceLocation: sourceLocation)
+    } catch let error as BridgeJSCoreDiagnosticError {
+        let combined = error.diagnostics.map(\.diagnostic.message).joined(separator: "\n")
+        #expect(combined.contains(message), sourceLocation: sourceLocation)
+    } catch {
+        Issue.record("Unexpected error: \(error)", sourceLocation: sourceLocation)
+    }
+}
+
+func linkSource(_ source: String, moduleName: String = "TestModule") throws -> (js: String, dts: String) {
+    let skeleton = try makeSkeleton(source, moduleName: moduleName)
+    var bridgeJSLink = BridgeJSLink(sharedMemory: false)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let unifiedData = try encoder.encode(skeleton)
+    try bridgeJSLink.addSkeletonFile(data: unifiedData)
+    let result = try bridgeJSLink.link()
+    return (result.outputJs, result.outputDts)
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/GenericExportDiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/GenericExportDiagnosticsTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+@testable import BridgeJSCore
+@testable import BridgeJSSkeleton
+
+@Suite struct GenericExportDiagnosticsTests {
+
+    @Test
+    func genericParameterRequiresBridgeableConstraint() {
+        expectDiagnostic(
+            source: """
+                @JS public func identity<T>(_ value: T) -> T { value }
+                """,
+            contains: "Generic parameter 'T' must be constrained to '_BridgedSwiftGenericBridgeable'"
+        )
+    }
+
+    @Test
+    func genericWhereClauseUnsupported() {
+        expectDiagnostic(
+            source: """
+                @JS public func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T where T: Sendable { value }
+                """,
+            contains: "'where' clauses are not supported"
+        )
+    }
+
+    @Test
+    func asyncGenericExportUnsupported() {
+        expectDiagnostic(
+            source: """
+                @JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) async -> T { v }
+                """,
+            contains: "Generic @JS functions cannot be 'async' yet."
+        )
+    }
+
+    @Test
+    func throwsGenericExportUnsupported() {
+        expectDiagnostic(
+            source: """
+                @JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> T { v }
+                """,
+            contains: "Generic @JS functions cannot be 'throws' yet."
+        )
+    }
+
+    @Test(arguments: [
+        ("[[T]]", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: [[T]]) {}"),
+        ("[T?]", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: [T?]) {}"),
+        ("T??", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T??) {}"),
+        ("[Int: T]", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: [Int: T]) {}"),
+    ])
+    func unsupportedGenericWrapperFormsInParameter(label: String, source: String) {
+        expectDiagnostic(
+            source: source,
+            contains: "may only be used as a bare type"
+        )
+    }
+
+    @Test(arguments: [
+        ("[[T]]", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> [[T]] { [[v]] }"),
+        ("[T?]", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> [T?] { [v] }"),
+        ("T??", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> T?? { v }"),
+        ("[Int: T]", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> [Int: T] { [0: v] }"),
+    ])
+    func unsupportedGenericWrapperFormsInReturn(label: String, source: String) {
+        expectDiagnostic(
+            source: source,
+            contains: "may only be used as a bare type"
+        )
+    }
+
+    @Test
+    func fullyUnusedGenericParameterRejected() {
+        expectDiagnostic(
+            source: """
+                @JS public func combine<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(_ a: T) -> T { a }
+                """,
+            contains: "must be used in at least one parameter"
+        )
+    }
+
+    @Test
+    func genericParameterMustBeUsedAsParameter() {
+        expectDiagnostic(
+            source: """
+                @JS public func f<T: _BridgedSwiftGenericBridgeable>() -> T { fatalError() }
+                """,
+            contains: "must be used in at least one parameter"
+        )
+    }
+
+    @Test
+    func genericConcreteReturnUnsupported() {
+        expectDiagnostic(
+            source: """
+                @JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> String { "" }
+                """,
+            contains: "must return the generic type"
+        )
+    }
+
+    @Test
+    func genericInstanceMethodAsyncIsRejected() {
+        expectDiagnostic(
+            source: """
+                @JS class Box {
+                    @JS init() {}
+                    @JS func wrap<T: _BridgedSwiftGenericBridgeable>(_ v: T) async -> T { v }
+                }
+                """,
+            contains: "Generic @JS functions cannot be 'async' yet."
+        )
+    }
+
+    @Test
+    func genericInstanceMethodThrowsIsRejected() {
+        expectDiagnostic(
+            source: """
+                @JS class Box {
+                    @JS init() {}
+                    @JS func wrap<T: _BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> T { v }
+                }
+                """,
+            contains: "Generic @JS functions cannot be 'throws' yet."
+        )
+    }
+
+    @Test
+    func genericMethodWhereClauseIsRejected() {
+        expectDiagnostic(
+            source: """
+                @JS class Box {
+                    @JS init() {}
+                    @JS func wrap<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> T where T: Sendable { v }
+                }
+                """,
+            contains: "'where' clauses are not supported on generic @JS functions."
+        )
+    }
+
+    @Test
+    func genericMethodUnconstrainedParamIsRejected() {
+        expectDiagnostic(
+            source: """
+                @JS class Box {
+                    @JS init() {}
+                    @JS func f<T>(_ v: T) -> T { v }
+                }
+                """,
+            contains:
+                "Generic parameter 'T' must be constrained to '_BridgedSwiftGenericBridgeable' to be used with @JS."
+        )
+    }
+
+    @Test
+    func genericMethodConcreteReturnIsRejected() {
+        expectDiagnostic(
+            source: """
+                @JS class Box {
+                    @JS init() {}
+                    @JS func count<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> Int { 0 }
+                }
+                """,
+            contains: "must return the generic type"
+        )
+    }
+
+    @Test
+    func genericEnumInstanceMethodIsRejected() {
+        expectDiagnostic(
+            source: """
+                @JS enum E {
+                    case a
+                    @JS func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> T { v }
+                }
+                """,
+            contains: "Only static functions are supported in enums"
+        )
+    }
+
+    @Test
+    func genericTypedPropertyIsRejectedAsUnsupportedType() {
+        expectDiagnostic(
+            source: """
+                @JS final class Box {
+                    @JS init() {}
+                    @JS var value: T
+                }
+                """,
+            contains: "Unsupported type 'T'."
+        )
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/GenericExportDiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/GenericExportDiagnosticsTests.swift
@@ -14,7 +14,7 @@ import Testing
             source: """
                 @JS public func identity<T>(_ value: T) -> T { value }
                 """,
-            contains: "Generic parameter 'T' must be constrained to '_BridgedSwiftGenericBridgeable'"
+            contains: "Generic parameter 'T' must be constrained to 'BridgedSwiftGenericBridgeable'"
         )
     }
 
@@ -22,7 +22,7 @@ import Testing
     func genericWhereClauseUnsupported() {
         expectDiagnostic(
             source: """
-                @JS public func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T where T: Sendable { value }
+                @JS public func identity<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T where T: Sendable { value }
                 """,
             contains: "'where' clauses are not supported"
         )
@@ -32,7 +32,7 @@ import Testing
     func asyncGenericExportUnsupported() {
         expectDiagnostic(
             source: """
-                @JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) async -> T { v }
+                @JS public func f<T: BridgedSwiftGenericBridgeable>(_ v: T) async -> T { v }
                 """,
             contains: "Generic @JS functions cannot be 'async' yet."
         )
@@ -42,17 +42,17 @@ import Testing
     func throwsGenericExportUnsupported() {
         expectDiagnostic(
             source: """
-                @JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> T { v }
+                @JS public func f<T: BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> T { v }
                 """,
             contains: "Generic @JS functions cannot be 'throws' yet."
         )
     }
 
     @Test(arguments: [
-        ("[[T]]", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: [[T]]) {}"),
-        ("[T?]", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: [T?]) {}"),
-        ("T??", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T??) {}"),
-        ("[Int: T]", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: [Int: T]) {}"),
+        ("[[T]]", "@JS public func f<T: BridgedSwiftGenericBridgeable>(_ v: [[T]]) {}"),
+        ("[T?]", "@JS public func f<T: BridgedSwiftGenericBridgeable>(_ v: [T?]) {}"),
+        ("T??", "@JS public func f<T: BridgedSwiftGenericBridgeable>(_ v: T??) {}"),
+        ("[Int: T]", "@JS public func f<T: BridgedSwiftGenericBridgeable>(_ v: [Int: T]) {}"),
     ])
     func unsupportedGenericWrapperFormsInParameter(label: String, source: String) {
         expectDiagnostic(
@@ -62,10 +62,10 @@ import Testing
     }
 
     @Test(arguments: [
-        ("[[T]]", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> [[T]] { [[v]] }"),
-        ("[T?]", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> [T?] { [v] }"),
-        ("T??", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> T?? { v }"),
-        ("[Int: T]", "@JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> [Int: T] { [0: v] }"),
+        ("[[T]]", "@JS public func f<T: BridgedSwiftGenericBridgeable>(_ v: T) -> [[T]] { [[v]] }"),
+        ("[T?]", "@JS public func f<T: BridgedSwiftGenericBridgeable>(_ v: T) -> [T?] { [v] }"),
+        ("T??", "@JS public func f<T: BridgedSwiftGenericBridgeable>(_ v: T) -> T?? { v }"),
+        ("[Int: T]", "@JS public func f<T: BridgedSwiftGenericBridgeable>(_ v: T) -> [Int: T] { [0: v] }"),
     ])
     func unsupportedGenericWrapperFormsInReturn(label: String, source: String) {
         expectDiagnostic(
@@ -78,7 +78,7 @@ import Testing
     func fullyUnusedGenericParameterRejected() {
         expectDiagnostic(
             source: """
-                @JS public func combine<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(_ a: T) -> T { a }
+                @JS public func combine<T: BridgedSwiftGenericBridgeable, U: BridgedSwiftGenericBridgeable>(_ a: T) -> T { a }
                 """,
             contains: "must be used in at least one parameter"
         )
@@ -88,7 +88,7 @@ import Testing
     func genericParameterMustBeUsedAsParameter() {
         expectDiagnostic(
             source: """
-                @JS public func f<T: _BridgedSwiftGenericBridgeable>() -> T { fatalError() }
+                @JS public func f<T: BridgedSwiftGenericBridgeable>() -> T { fatalError() }
                 """,
             contains: "must be used in at least one parameter"
         )
@@ -98,7 +98,7 @@ import Testing
     func genericConcreteReturnUnsupported() {
         expectDiagnostic(
             source: """
-                @JS public func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> String { "" }
+                @JS public func f<T: BridgedSwiftGenericBridgeable>(_ v: T) -> String { "" }
                 """,
             contains: "must return the generic type"
         )
@@ -110,7 +110,7 @@ import Testing
             source: """
                 @JS class Box {
                     @JS init() {}
-                    @JS func wrap<T: _BridgedSwiftGenericBridgeable>(_ v: T) async -> T { v }
+                    @JS func wrap<T: BridgedSwiftGenericBridgeable>(_ v: T) async -> T { v }
                 }
                 """,
             contains: "Generic @JS functions cannot be 'async' yet."
@@ -123,7 +123,7 @@ import Testing
             source: """
                 @JS class Box {
                     @JS init() {}
-                    @JS func wrap<T: _BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> T { v }
+                    @JS func wrap<T: BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> T { v }
                 }
                 """,
             contains: "Generic @JS functions cannot be 'throws' yet."
@@ -136,7 +136,7 @@ import Testing
             source: """
                 @JS class Box {
                     @JS init() {}
-                    @JS func wrap<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> T where T: Sendable { v }
+                    @JS func wrap<T: BridgedSwiftGenericBridgeable>(_ v: T) -> T where T: Sendable { v }
                 }
                 """,
             contains: "'where' clauses are not supported on generic @JS functions."
@@ -153,7 +153,7 @@ import Testing
                 }
                 """,
             contains:
-                "Generic parameter 'T' must be constrained to '_BridgedSwiftGenericBridgeable' to be used with @JS."
+                "Generic parameter 'T' must be constrained to 'BridgedSwiftGenericBridgeable' to be used with @JS."
         )
     }
 
@@ -163,7 +163,7 @@ import Testing
             source: """
                 @JS class Box {
                     @JS init() {}
-                    @JS func count<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> Int { 0 }
+                    @JS func count<T: BridgedSwiftGenericBridgeable>(_ v: T) -> Int { 0 }
                 }
                 """,
             contains: "must return the generic type"
@@ -176,7 +176,7 @@ import Testing
             source: """
                 @JS enum E {
                     case a
-                    @JS func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) -> T { v }
+                    @JS func f<T: BridgedSwiftGenericBridgeable>(_ v: T) -> T { v }
                 }
                 """,
             contains: "Only static functions are supported in enums"

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/GenericImportDiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/GenericImportDiagnosticsTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+@testable import BridgeJSCore
+@testable import BridgeJSSkeleton
+
+@Suite struct GenericImportDiagnosticsTests {
+
+    @Test
+    func genericParameterRequiresBridgeableConstraint() {
+        expectDiagnostic(
+            source: """
+                @JSFunction func identity<T>(_ value: T) throws(JSException) -> T
+                """,
+            contains: "Generic parameter 'T' must be constrained to '_BridgedSwiftGenericBridgeable'"
+        )
+    }
+
+    @Test
+    func genericWhereClauseUnsupported() {
+        expectDiagnostic(
+            source: """
+                @JSFunction func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T where T: Sendable
+                """,
+            contains: "'where' clauses are not supported on @JSFunction"
+        )
+    }
+
+    @Test
+    func asyncGenericImportUnsupported() {
+        expectDiagnostic(
+            source: """
+                @JSFunction func identityAsync<T: _BridgedSwiftGenericBridgeable>(_ value: T) async throws(JSException) -> T
+                """,
+            contains: "Generic @JSFunction declarations cannot be 'async' yet."
+        )
+    }
+
+    @Test
+    func genericImportedMethodIsParsed() throws {
+        let skeleton = try makeSkeleton(
+            """
+            @JSClass struct Box {
+                @JSFunction func member<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+            }
+            """,
+            moduleName: "App"
+        )
+        let imported = try #require(skeleton.imported)
+        let types = imported.children.flatMap { $0.types }
+        let box = try #require(types.first { $0.name == "Box" })
+        let method = try #require(box.methods.first { $0.name == "member" })
+        #expect(method.genericParameters == ["T"])
+    }
+
+    @Test(arguments: [
+        ("[[T]]", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: [[T]]) throws(JSException)"),
+        ("[T?]", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: [T?]) throws(JSException)"),
+        ("T??", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: T??) throws(JSException)"),
+        ("[Int: T]", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: [Int: T]) throws(JSException)"),
+    ])
+    func unsupportedGenericWrapperFormsInParameter(label: String, source: String) {
+        expectDiagnostic(
+            source: source,
+            contains: "may only be used as a bare type"
+        )
+    }
+
+    @Test(arguments: [
+        ("[[T]]", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> [[T]]"),
+        ("[T?]", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> [T?]"),
+        ("T??", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> T??"),
+        ("[Int: T]", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> [Int: T]"),
+    ])
+    func unsupportedGenericWrapperFormsInReturn(label: String, source: String) {
+        expectDiagnostic(
+            source: source,
+            contains: "may only be used as a bare type"
+        )
+    }
+
+    @Test
+    func genericImportedMethodAsyncIsRejected() {
+        expectDiagnostic(
+            source: """
+                @JSClass struct Box {
+                    @JSFunction func member<T: _BridgedSwiftGenericBridgeable>(_ value: T) async throws(JSException) -> T
+                }
+                """,
+            contains: "Generic @JSFunction declarations cannot be 'async' yet."
+        )
+    }
+
+    @Test
+    func genericImportedMethodUnconstrainedParamIsRejected() {
+        expectDiagnostic(
+            source: """
+                @JSClass struct Box {
+                    @JSFunction func member<T>(_ value: T) throws(JSException) -> T
+                }
+                """,
+            contains:
+                "Generic parameter 'T' must be constrained to '_BridgedSwiftGenericBridgeable' to be used with @JSFunction."
+        )
+    }
+
+    @Test
+    func genericImportedFunctionUnusedTypeParamIsRejected() {
+        expectDiagnostic(
+            source: """
+                @JSFunction func unused<T: _BridgedSwiftGenericBridgeable>() throws(JSException) -> Int
+                """,
+            contains:
+                "The generic parameter 'T' must be used in a parameter or return type of a generic @JSFunction declaration."
+        )
+    }
+
+    @Test
+    func genericImportedMethodUnusedTypeParamIsRejected() {
+        expectDiagnostic(
+            source: """
+                @JSClass struct Box {
+                    @JSFunction func member<T: _BridgedSwiftGenericBridgeable>() throws(JSException) -> Int
+                }
+                """,
+            contains:
+                "The generic parameter 'T' must be used in a parameter or return type of a generic @JSFunction declaration."
+        )
+    }
+
+    @Test
+    func genericImportedReturnOnlyTypeParamIsAllowed() throws {
+        let skeleton = try makeSkeleton(
+            """
+            @JSFunction func make<T: _BridgedSwiftGenericBridgeable>() throws(JSException) -> T
+            """,
+            moduleName: "App"
+        )
+        let imported = try #require(skeleton.imported)
+        let functions = imported.children.flatMap { $0.functions }
+        let function = try #require(functions.first { $0.name == "make" })
+        #expect(function.genericParameters == ["T"])
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/GenericImportDiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/GenericImportDiagnosticsTests.swift
@@ -14,7 +14,7 @@ import Testing
             source: """
                 @JSFunction func identity<T>(_ value: T) throws(JSException) -> T
                 """,
-            contains: "Generic parameter 'T' must be constrained to '_BridgedSwiftGenericBridgeable'"
+            contains: "Generic parameter 'T' must be constrained to 'BridgedSwiftGenericBridgeable'"
         )
     }
 
@@ -22,7 +22,7 @@ import Testing
     func genericWhereClauseUnsupported() {
         expectDiagnostic(
             source: """
-                @JSFunction func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T where T: Sendable
+                @JSFunction func identity<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T where T: Sendable
                 """,
             contains: "'where' clauses are not supported on @JSFunction"
         )
@@ -32,7 +32,7 @@ import Testing
     func asyncGenericImportUnsupported() {
         expectDiagnostic(
             source: """
-                @JSFunction func identityAsync<T: _BridgedSwiftGenericBridgeable>(_ value: T) async throws(JSException) -> T
+                @JSFunction func identityAsync<T: BridgedSwiftGenericBridgeable>(_ value: T) async throws(JSException) -> T
                 """,
             contains: "Generic @JSFunction declarations cannot be 'async' yet."
         )
@@ -43,7 +43,7 @@ import Testing
         let skeleton = try makeSkeleton(
             """
             @JSClass struct Box {
-                @JSFunction func member<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+                @JSFunction func member<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
             }
             """,
             moduleName: "App"
@@ -56,10 +56,10 @@ import Testing
     }
 
     @Test(arguments: [
-        ("[[T]]", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: [[T]]) throws(JSException)"),
-        ("[T?]", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: [T?]) throws(JSException)"),
-        ("T??", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: T??) throws(JSException)"),
-        ("[Int: T]", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: [Int: T]) throws(JSException)"),
+        ("[[T]]", "@JSFunction func f<T: BridgedSwiftGenericBridgeable>(_ v: [[T]]) throws(JSException)"),
+        ("[T?]", "@JSFunction func f<T: BridgedSwiftGenericBridgeable>(_ v: [T?]) throws(JSException)"),
+        ("T??", "@JSFunction func f<T: BridgedSwiftGenericBridgeable>(_ v: T??) throws(JSException)"),
+        ("[Int: T]", "@JSFunction func f<T: BridgedSwiftGenericBridgeable>(_ v: [Int: T]) throws(JSException)"),
     ])
     func unsupportedGenericWrapperFormsInParameter(label: String, source: String) {
         expectDiagnostic(
@@ -69,10 +69,10 @@ import Testing
     }
 
     @Test(arguments: [
-        ("[[T]]", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> [[T]]"),
-        ("[T?]", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> [T?]"),
-        ("T??", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> T??"),
-        ("[Int: T]", "@JSFunction func f<T: _BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> [Int: T]"),
+        ("[[T]]", "@JSFunction func f<T: BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> [[T]]"),
+        ("[T?]", "@JSFunction func f<T: BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> [T?]"),
+        ("T??", "@JSFunction func f<T: BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> T??"),
+        ("[Int: T]", "@JSFunction func f<T: BridgedSwiftGenericBridgeable>(_ v: T) throws(JSException) -> [Int: T]"),
     ])
     func unsupportedGenericWrapperFormsInReturn(label: String, source: String) {
         expectDiagnostic(
@@ -86,7 +86,7 @@ import Testing
         expectDiagnostic(
             source: """
                 @JSClass struct Box {
-                    @JSFunction func member<T: _BridgedSwiftGenericBridgeable>(_ value: T) async throws(JSException) -> T
+                    @JSFunction func member<T: BridgedSwiftGenericBridgeable>(_ value: T) async throws(JSException) -> T
                 }
                 """,
             contains: "Generic @JSFunction declarations cannot be 'async' yet."
@@ -102,7 +102,7 @@ import Testing
                 }
                 """,
             contains:
-                "Generic parameter 'T' must be constrained to '_BridgedSwiftGenericBridgeable' to be used with @JSFunction."
+                "Generic parameter 'T' must be constrained to 'BridgedSwiftGenericBridgeable' to be used with @JSFunction."
         )
     }
 
@@ -110,7 +110,7 @@ import Testing
     func genericImportedFunctionUnusedTypeParamIsRejected() {
         expectDiagnostic(
             source: """
-                @JSFunction func unused<T: _BridgedSwiftGenericBridgeable>() throws(JSException) -> Int
+                @JSFunction func unused<T: BridgedSwiftGenericBridgeable>() throws(JSException) -> Int
                 """,
             contains:
                 "The generic parameter 'T' must be used in a parameter or return type of a generic @JSFunction declaration."
@@ -122,7 +122,7 @@ import Testing
         expectDiagnostic(
             source: """
                 @JSClass struct Box {
-                    @JSFunction func member<T: _BridgedSwiftGenericBridgeable>() throws(JSException) -> Int
+                    @JSFunction func member<T: BridgedSwiftGenericBridgeable>() throws(JSException) -> Int
                 }
                 """,
             contains:
@@ -134,7 +134,7 @@ import Testing
     func genericImportedReturnOnlyTypeParamIsAllowed() throws {
         let skeleton = try makeSkeleton(
             """
-            @JSFunction func make<T: _BridgedSwiftGenericBridgeable>() throws(JSException) -> T
+            @JSFunction func make<T: BridgedSwiftGenericBridgeable>() throws(JSException) -> T
             """,
             moduleName: "App"
         )

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/GenericMethodOnlyModuleCodegenTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/GenericMethodOnlyModuleCodegenTests.swift
@@ -7,7 +7,7 @@ import Testing
             """
             @JS final class OnlyBox {
                 @JS init() {}
-                @JS func wrap<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
+                @JS func wrap<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
             }
             """
         ).js
@@ -21,7 +21,7 @@ import Testing
             """
             @JS final class OnlyBox {
                 @JS init() {}
-                @JS func wrap<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
+                @JS func wrap<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
             }
             """,
             "OnlyBox"
@@ -30,7 +30,7 @@ import Testing
             """
             @JS struct OnlyPair {
                 @JS init() {}
-                @JS func first<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
+                @JS func first<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
             }
             """,
             "OnlyPair"
@@ -39,7 +39,7 @@ import Testing
             """
             @JS enum OnlyFactory {
                 case primary
-                @JS static func one<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
+                @JS static func one<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
             }
             """,
             "OnlyFactory"
@@ -48,7 +48,7 @@ import Testing
     func exportMethodOnlyEmitsSwiftRuntimeInfrastructure(source: String, typeName: String) throws {
         let swift = try renderExportGlue(source)
         #expect(swift.contains("_bridgeJSExportTypeRegistry"))
-        #expect(swift.contains("extension \(typeName): _BridgedSwiftGenericBridgeable {"))
+        #expect(swift.contains("extension \(typeName): BridgedSwiftGenericBridgeable {"))
         #expect(swift.contains("register(\(typeName).self)"))
     }
 
@@ -57,7 +57,7 @@ import Testing
         let js = try linkSource(
             """
             @JSClass struct OnlyConsumer {
-                @JSFunction func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+                @JSFunction func identity<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
             }
             """
         ).js

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/GenericMethodOnlyModuleCodegenTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/GenericMethodOnlyModuleCodegenTests.swift
@@ -1,0 +1,68 @@
+import Testing
+
+@Suite struct GenericMethodOnlyModuleCodegenTests {
+    @Test
+    func exportClassMethodOnlyEmitsJSRuntimeInfrastructure() throws {
+        let js = try linkSource(
+            """
+            @JS final class OnlyBox {
+                @JS init() {}
+                @JS func wrap<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
+            }
+            """
+        ).js
+        #expect(js.contains("let __bjs_codecsById = [];"))
+        #expect(js.contains("function __bjs_resolveGenericType(token) {"))
+        #expect(js.contains("export const BridgeTypes = {"))
+    }
+
+    @Test(arguments: [
+        (
+            """
+            @JS final class OnlyBox {
+                @JS init() {}
+                @JS func wrap<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
+            }
+            """,
+            "OnlyBox"
+        ),
+        (
+            """
+            @JS struct OnlyPair {
+                @JS init() {}
+                @JS func first<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
+            }
+            """,
+            "OnlyPair"
+        ),
+        (
+            """
+            @JS enum OnlyFactory {
+                case primary
+                @JS static func one<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
+            }
+            """,
+            "OnlyFactory"
+        ),
+    ])
+    func exportMethodOnlyEmitsSwiftRuntimeInfrastructure(source: String, typeName: String) throws {
+        let swift = try renderExportGlue(source)
+        #expect(swift.contains("_bridgeJSExportTypeRegistry"))
+        #expect(swift.contains("extension \(typeName): _BridgedSwiftGenericBridgeable {"))
+        #expect(swift.contains("register(\(typeName).self)"))
+    }
+
+    @Test
+    func importMethodOnlyEmitsJSRuntimeInfrastructure() throws {
+        let js = try linkSource(
+            """
+            @JSClass struct OnlyConsumer {
+                @JSFunction func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+            }
+            """
+        ).js
+        #expect(js.contains("let __bjs_codecsById = [];"))
+        #expect(js.contains("function __bjs_resolveGenericType(token) {"))
+        #expect(js.contains("__bjs_codecsById["))
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/GenericExports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/GenericExports.swift
@@ -40,47 +40,47 @@
     }
 }
 
-@JS public func genericExportIdentity<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+@JS public func genericExportIdentity<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T {
     return value
 }
 
-@JS public func genericExportArray<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) -> [T] {
+@JS public func genericExportArray<T: BridgedSwiftGenericBridgeable>(_ values: [T]) -> [T] {
     return values
 }
 
-@JS public func genericExportOptional<T: _BridgedSwiftGenericBridgeable>(_ value: T?) -> T? {
+@JS public func genericExportOptional<T: BridgedSwiftGenericBridgeable>(_ value: T?) -> T? {
     return value
 }
 
-@JS public func genericExportDictionary<T: _BridgedSwiftGenericBridgeable>(_ values: [String: T]) -> [String: T] {
+@JS public func genericExportDictionary<T: BridgedSwiftGenericBridgeable>(_ values: [String: T]) -> [String: T] {
     return values
 }
 
-@JS public func genericExportEcho<T: _BridgedSwiftGenericBridgeable>(_ value: T, tag: Int) -> T {
+@JS public func genericExportEcho<T: BridgedSwiftGenericBridgeable>(_ value: T, tag: Int) -> T {
     return value
 }
 
-@JS public func genericExportStructConcreteLeading<T: _BridgedSwiftGenericBridgeable>(_ v: T, _ p: ExportPoint) -> T {
+@JS public func genericExportStructConcreteLeading<T: BridgedSwiftGenericBridgeable>(_ v: T, _ p: ExportPoint) -> T {
     return v
 }
 
-@JS public func genericExportStructAndScalar<T: _BridgedSwiftGenericBridgeable>(_ p: ExportPoint, tag: Int, _ v: T) -> T
+@JS public func genericExportStructAndScalar<T: BridgedSwiftGenericBridgeable>(_ p: ExportPoint, tag: Int, _ v: T) -> T
 {
     return v
 }
 
-@JS public func genericExportPair<T: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) -> T {
+@JS public func genericExportPair<T: BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) -> T {
     return a
 }
 
-@JS public func genericExportCombine<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(
+@JS public func genericExportCombine<T: BridgedSwiftGenericBridgeable, U: BridgedSwiftGenericBridgeable>(
     _ a: T,
     _ b: U
 ) -> T {
     return a
 }
 
-@JS public func genericExportCombineReturnU<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(
+@JS public func genericExportCombineReturnU<T: BridgedSwiftGenericBridgeable, U: BridgedSwiftGenericBridgeable>(
     _ a: T,
     _ b: U
 ) -> U {
@@ -89,8 +89,8 @@
 
 @JS
 public func genericExportCaseDistinct<
-    T: _BridgedSwiftGenericBridgeable,
-    t: _BridgedSwiftGenericBridgeable
+    T: BridgedSwiftGenericBridgeable,
+    t: BridgedSwiftGenericBridgeable
 >(_ a: T, _ b: t) -> T {
     return a
 }
@@ -98,15 +98,15 @@ public func genericExportCaseDistinct<
 @JS final class GenericBox {
     @JS init() {}
 
-    @JS func wrap<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+    @JS func wrap<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T {
         return value
     }
 
-    @JS func combine<T: _BridgedSwiftGenericBridgeable, t: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: t) -> T {
+    @JS func combine<T: BridgedSwiftGenericBridgeable, t: BridgedSwiftGenericBridgeable>(_ a: T, _ b: t) -> T {
         return a
     }
 
-    @JS static func makeArray<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> [T] {
+    @JS static func makeArray<T: BridgedSwiftGenericBridgeable>(_ value: T) -> [T] {
         return [value]
     }
 }
@@ -114,23 +114,23 @@ public func genericExportCaseDistinct<
 @JS struct GenericPair {
     @JS init() {}
 
-    @JS func first<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+    @JS func first<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T {
         return value
     }
 
-    @JS func combine<T: _BridgedSwiftGenericBridgeable, t: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: t) -> T {
+    @JS func combine<T: BridgedSwiftGenericBridgeable, t: BridgedSwiftGenericBridgeable>(_ a: T, _ b: t) -> T {
         return a
     }
 
-    @JS func maybe<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T? {
+    @JS func maybe<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T? {
         return value
     }
 
-    @JS func dict<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> [String: T] {
+    @JS func dict<T: BridgedSwiftGenericBridgeable>(_ value: T) -> [String: T] {
         return ["value": value]
     }
 
-    @JS static func wrap<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> [T] {
+    @JS static func wrap<T: BridgedSwiftGenericBridgeable>(_ value: T) -> [T] {
         return [value]
     }
 }
@@ -138,13 +138,13 @@ public func genericExportCaseDistinct<
 @JS enum GenericFactory {
     case primary
 
-    @JS static func one<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+    @JS static func one<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T {
         return value
     }
 }
 
 @JS enum GenericNamespace {
-    @JS static func make<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+    @JS static func make<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T {
         return value
     }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/GenericExports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/GenericExports.swift
@@ -1,0 +1,150 @@
+@JS struct ExportPoint {
+    var x: Int
+    var y: Int
+}
+
+@JS enum ExportNamespace {
+    @JS struct Metadata {
+        var label: String
+        var count: Int
+    }
+
+    @JS enum Level: Int {
+        case low = 1
+        case high = 9
+    }
+}
+
+@JS enum ExportMode: String {
+    case on
+    case off
+}
+
+@JS enum ExportColor {
+    case red
+    case green
+}
+
+@JS enum ExportTagged {
+    case number(value: Int)
+    case text(value: String)
+}
+
+@JS final class ExportBox {
+    @JS var value: Int
+    @JS init(value: Int) {
+        self.value = value
+    }
+    @JS func get() -> Int {
+        value
+    }
+}
+
+@JS public func genericExportIdentity<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+    return value
+}
+
+@JS public func genericExportArray<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) -> [T] {
+    return values
+}
+
+@JS public func genericExportOptional<T: _BridgedSwiftGenericBridgeable>(_ value: T?) -> T? {
+    return value
+}
+
+@JS public func genericExportDictionary<T: _BridgedSwiftGenericBridgeable>(_ values: [String: T]) -> [String: T] {
+    return values
+}
+
+@JS public func genericExportEcho<T: _BridgedSwiftGenericBridgeable>(_ value: T, tag: Int) -> T {
+    return value
+}
+
+@JS public func genericExportStructConcreteLeading<T: _BridgedSwiftGenericBridgeable>(_ v: T, _ p: ExportPoint) -> T {
+    return v
+}
+
+@JS public func genericExportStructAndScalar<T: _BridgedSwiftGenericBridgeable>(_ p: ExportPoint, tag: Int, _ v: T) -> T
+{
+    return v
+}
+
+@JS public func genericExportPair<T: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) -> T {
+    return a
+}
+
+@JS public func genericExportCombine<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(
+    _ a: T,
+    _ b: U
+) -> T {
+    return a
+}
+
+@JS public func genericExportCombineReturnU<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(
+    _ a: T,
+    _ b: U
+) -> U {
+    return b
+}
+
+@JS
+public func genericExportCaseDistinct<
+    T: _BridgedSwiftGenericBridgeable,
+    t: _BridgedSwiftGenericBridgeable
+>(_ a: T, _ b: t) -> T {
+    return a
+}
+
+@JS final class GenericBox {
+    @JS init() {}
+
+    @JS func wrap<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+        return value
+    }
+
+    @JS func combine<T: _BridgedSwiftGenericBridgeable, t: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: t) -> T {
+        return a
+    }
+
+    @JS static func makeArray<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> [T] {
+        return [value]
+    }
+}
+
+@JS struct GenericPair {
+    @JS init() {}
+
+    @JS func first<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+        return value
+    }
+
+    @JS func combine<T: _BridgedSwiftGenericBridgeable, t: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: t) -> T {
+        return a
+    }
+
+    @JS func maybe<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T? {
+        return value
+    }
+
+    @JS func dict<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> [String: T] {
+        return ["value": value]
+    }
+
+    @JS static func wrap<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> [T] {
+        return [value]
+    }
+}
+
+@JS enum GenericFactory {
+    case primary
+
+    @JS static func one<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+        return value
+    }
+}
+
+@JS enum GenericNamespace {
+    @JS static func make<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+        return value
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/GenericImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/GenericImports.swift
@@ -1,0 +1,58 @@
+@JS
+struct GenericPoint {
+    var x: Int
+    var y: Int
+}
+
+@JS enum GenericColor {
+    case red
+    case green
+}
+
+@JS enum GenericMode: String {
+    case light
+    case dark
+}
+
+@JS enum GenericTagged {
+    case number(value: Int)
+    case text(value: String)
+}
+
+@JS final class GenericImportBox {
+    @JS var value: Int
+    @JS init(value: Int) {
+        self.value = value
+    }
+    @JS func get() -> Int {
+        value
+    }
+}
+
+@JSFunction func genericRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+
+@JSFunction func genericParse<T: _BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T
+
+@JSFunction func importGenericCombine<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(
+    _ a: T,
+    _ b: U
+) throws(JSException) -> U
+
+@JSFunction func importGenericCaseDistinct<T: _BridgedSwiftGenericBridgeable, t: _BridgedSwiftGenericBridgeable>(
+    _ a: T,
+    _ b: t
+) throws(JSException) -> T
+
+@JSFunction func importGenericArray<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T]
+
+@JSFunction func importGenericOptional<T: _BridgedSwiftGenericBridgeable>(_ value: T?) throws(JSException) -> T?
+
+@JSFunction func importGenericDictionary<T: _BridgedSwiftGenericBridgeable>(
+    _ values: [String: T]
+) throws(JSException) -> [String: T]
+
+@JSClass struct GenericConsumer {
+    @JSFunction func accept<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException)
+    @JSFunction func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+    @JSFunction static func box<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/GenericImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/GenericImports.swift
@@ -29,30 +29,30 @@ struct GenericPoint {
     }
 }
 
-@JSFunction func genericRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+@JSFunction func genericRoundTrip<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
 
-@JSFunction func genericParse<T: _BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T
+@JSFunction func genericParse<T: BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T
 
-@JSFunction func importGenericCombine<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(
+@JSFunction func importGenericCombine<T: BridgedSwiftGenericBridgeable, U: BridgedSwiftGenericBridgeable>(
     _ a: T,
     _ b: U
 ) throws(JSException) -> U
 
-@JSFunction func importGenericCaseDistinct<T: _BridgedSwiftGenericBridgeable, t: _BridgedSwiftGenericBridgeable>(
+@JSFunction func importGenericCaseDistinct<T: BridgedSwiftGenericBridgeable, t: BridgedSwiftGenericBridgeable>(
     _ a: T,
     _ b: t
 ) throws(JSException) -> T
 
-@JSFunction func importGenericArray<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T]
+@JSFunction func importGenericArray<T: BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T]
 
-@JSFunction func importGenericOptional<T: _BridgedSwiftGenericBridgeable>(_ value: T?) throws(JSException) -> T?
+@JSFunction func importGenericOptional<T: BridgedSwiftGenericBridgeable>(_ value: T?) throws(JSException) -> T?
 
-@JSFunction func importGenericDictionary<T: _BridgedSwiftGenericBridgeable>(
+@JSFunction func importGenericDictionary<T: BridgedSwiftGenericBridgeable>(
     _ values: [String: T]
 ) throws(JSException) -> [String: T]
 
 @JSClass struct GenericConsumer {
-    @JSFunction func accept<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException)
-    @JSFunction func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
-    @JSFunction static func box<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+    @JSFunction func accept<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException)
+    @JSFunction func identity<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+    @JSFunction static func box<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Alias.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Alias.json
@@ -79,6 +79,7 @@
             }
           ]
         },
+        "isFinal" : true,
         "methods" : [
           {
             "abiName" : "bjs_PolygonReference_snapshot",
@@ -196,6 +197,7 @@
             }
           ]
         },
+        "isFinal" : true,
         "methods" : [
 
         ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.json
@@ -34,6 +34,7 @@
             }
           ]
         },
+        "isFinal" : true,
         "methods" : [
 
         ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAlias.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAlias.json
@@ -31,6 +31,7 @@
             }
           ]
         },
+        "isFinal" : true,
         "methods" : [
 
         ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericExports.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericExports.json
@@ -1,0 +1,1135 @@
+{
+  "exported" : {
+    "aliases" : [
+
+    ],
+    "classes" : [
+      {
+        "constructor" : {
+          "abiName" : "bjs_ExportBox_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "value",
+              "name" : "value",
+              "type" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "isFinal" : true,
+        "methods" : [
+          {
+            "abiName" : "bjs_ExportBox_get",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "get",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "name" : "ExportBox",
+        "properties" : [
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "name" : "value",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "ExportBox"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_GenericBox_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+
+          ]
+        },
+        "isFinal" : true,
+        "methods" : [
+          {
+            "abiName" : "bjs_GenericBox_wrap",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "wrap",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_GenericBox_combine",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T",
+              "t"
+            ],
+            "name" : "combine",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "a",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              },
+              {
+                "label" : "_",
+                "name" : "b",
+                "type" : {
+                  "generic" : {
+                    "_0" : "t"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_GenericBox_static_makeArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "makeArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            },
+            "staticContext" : {
+              "className" : {
+                "_0" : "GenericBox"
+              }
+            }
+          }
+        ],
+        "name" : "GenericBox",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "GenericBox"
+      }
+    ],
+    "enums" : [
+      {
+        "cases" : [
+
+        ],
+        "emitStyle" : "const",
+        "name" : "ExportNamespace",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "ExportNamespace",
+        "tsFullPath" : "ExportNamespace"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "low",
+            "rawValue" : "1"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "high",
+            "rawValue" : "9"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "Level",
+        "namespace" : [
+          "ExportNamespace"
+        ],
+        "rawType" : "Int",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "ExportNamespace.Level",
+        "tsFullPath" : "ExportNamespace.Level"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "on"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "off"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "ExportMode",
+        "rawType" : "String",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "ExportMode",
+        "tsFullPath" : "ExportMode"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "red"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "green"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "ExportColor",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "ExportColor",
+        "tsFullPath" : "ExportColor"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+              {
+                "label" : "value",
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "name" : "number"
+          },
+          {
+            "associatedValues" : [
+              {
+                "label" : "value",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "name" : "text"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "ExportTagged",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "ExportTagged",
+        "tsFullPath" : "ExportTagged"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "primary"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "GenericFactory",
+        "staticMethods" : [
+          {
+            "abiName" : "bjs_GenericFactory_static_one",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "one",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            },
+            "staticContext" : {
+              "enumName" : {
+                "_0" : "GenericFactory"
+              }
+            }
+          }
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "GenericFactory",
+        "tsFullPath" : "GenericFactory"
+      },
+      {
+        "cases" : [
+
+        ],
+        "emitStyle" : "const",
+        "name" : "GenericNamespace",
+        "staticMethods" : [
+          {
+            "abiName" : "bjs_GenericNamespace_static_make",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "make",
+            "namespace" : [
+              "GenericNamespace"
+            ],
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            },
+            "staticContext" : {
+              "namespaceEnum" : {
+                "_0" : "GenericNamespace"
+              }
+            }
+          }
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "GenericNamespace",
+        "tsFullPath" : "GenericNamespace"
+      }
+    ],
+    "exposeToGlobal" : false,
+    "functions" : [
+      {
+        "abiName" : "bjs_genericExportIdentity",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "genericExportIdentity",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_genericExportArray",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "genericExportArray",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_genericExportOptional",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "genericExportOptional",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_genericExportDictionary",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "genericExportDictionary",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "dictionary" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "dictionary" : {
+            "_0" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_genericExportEcho",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "genericExportEcho",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "label" : "tag",
+            "name" : "tag",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_genericExportStructConcreteLeading",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "genericExportStructConcreteLeading",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "p",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "ExportPoint"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_genericExportStructAndScalar",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "genericExportStructAndScalar",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "p",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "ExportPoint"
+              }
+            }
+          },
+          {
+            "label" : "tag",
+            "name" : "tag",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "v",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_genericExportPair",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "genericExportPair",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "a",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "b",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_genericExportCombine",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T",
+          "U"
+        ],
+        "name" : "genericExportCombine",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "a",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "b",
+            "type" : {
+              "generic" : {
+                "_0" : "U"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_genericExportCombineReturnU",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T",
+          "U"
+        ],
+        "name" : "genericExportCombineReturnU",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "a",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "b",
+            "type" : {
+              "generic" : {
+                "_0" : "U"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "U"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_genericExportCaseDistinct",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T",
+          "t"
+        ],
+        "name" : "genericExportCaseDistinct",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "a",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "b",
+            "type" : {
+              "generic" : {
+                "_0" : "t"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      }
+    ],
+    "protocols" : [
+
+    ],
+    "structs" : [
+      {
+        "methods" : [
+
+        ],
+        "name" : "ExportPoint",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "x",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "y",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "ExportPoint"
+      },
+      {
+        "methods" : [
+
+        ],
+        "name" : "Metadata",
+        "namespace" : [
+          "ExportNamespace"
+        ],
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "label",
+            "namespace" : [
+              "ExportNamespace"
+            ],
+            "type" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "count",
+            "namespace" : [
+              "ExportNamespace"
+            ],
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "ExportNamespace.Metadata"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_GenericPair_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+
+          ]
+        },
+        "methods" : [
+          {
+            "abiName" : "bjs_GenericPair_first",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "first",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_GenericPair_combine",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T",
+              "t"
+            ],
+            "name" : "combine",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "a",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              },
+              {
+                "label" : "_",
+                "name" : "b",
+                "type" : {
+                  "generic" : {
+                    "_0" : "t"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_GenericPair_maybe",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "maybe",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_GenericPair_dict",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "dict",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "dictionary" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_GenericPair_static_wrap",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "wrap",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            },
+            "staticContext" : {
+              "structName" : {
+                "_0" : "GenericPair"
+              }
+            }
+          }
+        ],
+        "name" : "GenericPair",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "GenericPair"
+      }
+    ]
+  },
+  "moduleName" : "TestModule",
+  "usedExternalModules" : [
+
+  ]
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericExports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericExports.swift
@@ -1,0 +1,1029 @@
+extension ExportNamespace.Level: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+}
+
+extension ExportNamespace.Level: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportNamespace_Level")
+}
+
+extension ExportMode: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+}
+
+extension ExportMode: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportMode")
+}
+
+extension ExportColor: _BridgedSwiftCaseEnum {
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
+        return bridgeJSRawValue
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> ExportColor {
+        return bridgeJSLiftParameter(value)
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> ExportColor {
+        return ExportColor(bridgeJSRawValue: value)!
+    }
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
+        return bridgeJSLowerParameter()
+    }
+
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
+        switch bridgeJSRawValue {
+        case 0:
+            self = .red
+        case 1:
+            self = .green
+        default:
+            return nil
+        }
+    }
+
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
+        switch self {
+        case .red:
+            return 0
+        case .green:
+            return 1
+        }
+    }
+}
+
+extension ExportColor: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportColor")
+}
+
+extension ExportTagged: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> ExportTagged {
+        switch caseId {
+        case 0:
+            return .number(value: Int.bridgeJSStackPop())
+        case 1:
+            return .text(value: String.bridgeJSStackPop())
+        default:
+            fatalError("Unknown ExportTagged case ID: \(caseId)")
+        }
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
+        switch self {
+        case .number(let value):
+            value.bridgeJSStackPush()
+            return Int32(0)
+        case .text(let value):
+            value.bridgeJSStackPush()
+            return Int32(1)
+        }
+    }
+}
+
+extension ExportTagged: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportTagged")
+}
+
+extension GenericFactory: _BridgedSwiftCaseEnum {
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
+        return bridgeJSRawValue
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> GenericFactory {
+        return bridgeJSLiftParameter(value)
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> GenericFactory {
+        return GenericFactory(bridgeJSRawValue: value)!
+    }
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
+        return bridgeJSLowerParameter()
+    }
+
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
+        switch bridgeJSRawValue {
+        case 0:
+            self = .primary
+        default:
+            return nil
+        }
+    }
+
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
+        switch self {
+        case .primary:
+            return 0
+        }
+    }
+}
+
+extension GenericFactory: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericFactory")
+}
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_GenericFactory_static_one")
+@_cdecl("bjs_GenericFactory_static_one")
+public func _bjs_GenericFactory_static_one(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_GenericFactory_static_one")
+@_cdecl("bjs_GenericFactory_static_one")
+public func _bjs_GenericFactory_static_one(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_GenericFactory_static_one_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_GenericFactory_static_one_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let ret = GenericFactory.one(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_GenericNamespace_static_make")
+@_cdecl("bjs_GenericNamespace_static_make")
+public func _bjs_GenericNamespace_static_make(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_GenericNamespace_static_make")
+@_cdecl("bjs_GenericNamespace_static_make")
+public func _bjs_GenericNamespace_static_make(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_GenericNamespace_static_make_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_GenericNamespace_static_make_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let ret = GenericNamespace.make(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+extension ExportPoint: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ExportPoint {
+        let y = Int.bridgeJSStackPop()
+        let x = Int.bridgeJSStackPop()
+        return ExportPoint(x: x, y: y)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_ExportPoint(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ExportPoint()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ExportPoint")
+fileprivate func _bjs_struct_lower_ExportPoint_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_ExportPoint_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_ExportPoint(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_ExportPoint_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ExportPoint")
+fileprivate func _bjs_struct_lift_ExportPoint_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_ExportPoint_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_ExportPoint() -> Int32 {
+    return _bjs_struct_lift_ExportPoint_extern()
+}
+
+extension ExportPoint: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportPoint")
+}
+
+extension ExportNamespace.Metadata: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ExportNamespace.Metadata {
+        let count = Int.bridgeJSStackPop()
+        let label = String.bridgeJSStackPop()
+        return ExportNamespace.Metadata(label: label, count: count)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.label.bridgeJSStackPush()
+        self.count.bridgeJSStackPush()
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_ExportNamespace_Metadata(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ExportNamespace_Metadata()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ExportNamespace_Metadata")
+fileprivate func _bjs_struct_lower_ExportNamespace_Metadata_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_ExportNamespace_Metadata_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_ExportNamespace_Metadata(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_ExportNamespace_Metadata_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ExportNamespace_Metadata")
+fileprivate func _bjs_struct_lift_ExportNamespace_Metadata_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_ExportNamespace_Metadata_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_ExportNamespace_Metadata() -> Int32 {
+    return _bjs_struct_lift_ExportNamespace_Metadata_extern()
+}
+
+extension ExportNamespace.Metadata: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportNamespace_Metadata")
+}
+
+extension GenericPair: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> GenericPair {
+        return GenericPair()
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_GenericPair(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_GenericPair()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_GenericPair")
+fileprivate func _bjs_struct_lower_GenericPair_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_GenericPair_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_GenericPair(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_GenericPair_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_GenericPair")
+fileprivate func _bjs_struct_lift_GenericPair_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_GenericPair_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_GenericPair() -> Int32 {
+    return _bjs_struct_lift_GenericPair_extern()
+}
+
+extension GenericPair: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericPair")
+}
+
+@_expose(wasm, "bjs_GenericPair_init")
+@_cdecl("bjs_GenericPair_init")
+public func _bjs_GenericPair_init() -> Void {
+    #if arch(wasm32)
+    let ret = GenericPair()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_GenericPair_first")
+@_cdecl("bjs_GenericPair_first")
+public func _bjs_GenericPair_first(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_GenericPair_first")
+@_cdecl("bjs_GenericPair_first")
+public func _bjs_GenericPair_first(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_GenericPair_first_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_GenericPair_first_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let _tmp__self = GenericPair.bridgeJSLiftParameter()
+    let ret = _tmp__self.first(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_GenericPair_combine")
+@_cdecl("bjs_GenericPair_combine")
+public func _bjs_GenericPair_combine(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_GenericPair_combine")
+@_cdecl("bjs_GenericPair_combine")
+public func _bjs_GenericPair_combine(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    guard let _generic1Type = _bridgeJSExportTypeRegistry[_generic1TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic1TypeId)")
+    }
+    _bjs_GenericPair_combine_open1(_generic0Type, _generic1Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_GenericPair_combine_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type) {
+    _bjs_GenericPair_combine_open2(_generic1Type, asT: T.self)
+}
+private func _bjs_GenericPair_combine_open2<t: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: t.Type, asT _generic0Type: T.Type) {
+    let b = t.bridgeJSStackPop()
+    let a = T.bridgeJSStackPop()
+    let _tmp__self = GenericPair.bridgeJSLiftParameter()
+    let ret = _tmp__self.combine(a, b)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_GenericPair_maybe")
+@_cdecl("bjs_GenericPair_maybe")
+public func _bjs_GenericPair_maybe(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_GenericPair_maybe")
+@_cdecl("bjs_GenericPair_maybe")
+public func _bjs_GenericPair_maybe(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_GenericPair_maybe_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_GenericPair_maybe_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let _tmp__self = GenericPair.bridgeJSLiftParameter()
+    let ret = _tmp__self.maybe(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_GenericPair_dict")
+@_cdecl("bjs_GenericPair_dict")
+public func _bjs_GenericPair_dict(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_GenericPair_dict")
+@_cdecl("bjs_GenericPair_dict")
+public func _bjs_GenericPair_dict(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_GenericPair_dict_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_GenericPair_dict_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let _tmp__self = GenericPair.bridgeJSLiftParameter()
+    let ret = _tmp__self.dict(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_GenericPair_static_wrap")
+@_cdecl("bjs_GenericPair_static_wrap")
+public func _bjs_GenericPair_static_wrap(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_GenericPair_static_wrap")
+@_cdecl("bjs_GenericPair_static_wrap")
+public func _bjs_GenericPair_static_wrap(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_GenericPair_static_wrap_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_GenericPair_static_wrap_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let ret = GenericPair.wrap(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_genericExportIdentity")
+@_cdecl("bjs_genericExportIdentity")
+public func _bjs_genericExportIdentity(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_genericExportIdentity")
+@_cdecl("bjs_genericExportIdentity")
+public func _bjs_genericExportIdentity(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_genericExportIdentity_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_genericExportIdentity_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let ret = genericExportIdentity(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_genericExportArray")
+@_cdecl("bjs_genericExportArray")
+public func _bjs_genericExportArray(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_genericExportArray")
+@_cdecl("bjs_genericExportArray")
+public func _bjs_genericExportArray(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_genericExportArray_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_genericExportArray_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let values = Array<T>.bridgeJSStackPop()
+    let ret = genericExportArray(values)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_genericExportOptional")
+@_cdecl("bjs_genericExportOptional")
+public func _bjs_genericExportOptional(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_genericExportOptional")
+@_cdecl("bjs_genericExportOptional")
+public func _bjs_genericExportOptional(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_genericExportOptional_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_genericExportOptional_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = Optional<T>.bridgeJSStackPop()
+    let ret = genericExportOptional(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_genericExportDictionary")
+@_cdecl("bjs_genericExportDictionary")
+public func _bjs_genericExportDictionary(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_genericExportDictionary")
+@_cdecl("bjs_genericExportDictionary")
+public func _bjs_genericExportDictionary(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_genericExportDictionary_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_genericExportDictionary_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let values = Dictionary<String, T>.bridgeJSStackPop()
+    let ret = genericExportDictionary(values)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_genericExportEcho")
+@_cdecl("bjs_genericExportEcho")
+public func _bjs_genericExportEcho(_ tag: Int32, _ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_genericExportEcho")
+@_cdecl("bjs_genericExportEcho")
+public func _bjs_genericExportEcho(_ tag: Int32, _ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_genericExportEcho_open1(_generic0Type, tag)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_genericExportEcho_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ tag: Int32) {
+    let value = T.bridgeJSStackPop()
+    let _val_tag = Int.bridgeJSLiftParameter(tag)
+    let ret = genericExportEcho(value, tag: _val_tag)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_genericExportStructConcreteLeading")
+@_cdecl("bjs_genericExportStructConcreteLeading")
+public func _bjs_genericExportStructConcreteLeading(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_genericExportStructConcreteLeading")
+@_cdecl("bjs_genericExportStructConcreteLeading")
+public func _bjs_genericExportStructConcreteLeading(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_genericExportStructConcreteLeading_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_genericExportStructConcreteLeading_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let v = T.bridgeJSStackPop()
+    let _tmp_p = ExportPoint.bridgeJSLiftParameter()
+    let ret = genericExportStructConcreteLeading(v, _tmp_p)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_genericExportStructAndScalar")
+@_cdecl("bjs_genericExportStructAndScalar")
+public func _bjs_genericExportStructAndScalar(_ tag: Int32, _ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_genericExportStructAndScalar")
+@_cdecl("bjs_genericExportStructAndScalar")
+public func _bjs_genericExportStructAndScalar(_ tag: Int32, _ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_genericExportStructAndScalar_open1(_generic0Type, tag)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_genericExportStructAndScalar_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ tag: Int32) {
+    let v = T.bridgeJSStackPop()
+    let _tmp_p = ExportPoint.bridgeJSLiftParameter()
+    let _val_tag = Int.bridgeJSLiftParameter(tag)
+    let ret = genericExportStructAndScalar(_tmp_p, tag: _val_tag, v)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_genericExportPair")
+@_cdecl("bjs_genericExportPair")
+public func _bjs_genericExportPair(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_genericExportPair")
+@_cdecl("bjs_genericExportPair")
+public func _bjs_genericExportPair(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_genericExportPair_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_genericExportPair_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let b = T.bridgeJSStackPop()
+    let a = T.bridgeJSStackPop()
+    let ret = genericExportPair(a, b)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_genericExportCombine")
+@_cdecl("bjs_genericExportCombine")
+public func _bjs_genericExportCombine(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_genericExportCombine")
+@_cdecl("bjs_genericExportCombine")
+public func _bjs_genericExportCombine(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    guard let _generic1Type = _bridgeJSExportTypeRegistry[_generic1TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic1TypeId)")
+    }
+    _bjs_genericExportCombine_open1(_generic0Type, _generic1Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_genericExportCombine_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type) {
+    _bjs_genericExportCombine_open2(_generic1Type, asT: T.self)
+}
+private func _bjs_genericExportCombine_open2<U: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type) {
+    let b = U.bridgeJSStackPop()
+    let a = T.bridgeJSStackPop()
+    let ret = genericExportCombine(a, b)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_genericExportCombineReturnU")
+@_cdecl("bjs_genericExportCombineReturnU")
+public func _bjs_genericExportCombineReturnU(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_genericExportCombineReturnU")
+@_cdecl("bjs_genericExportCombineReturnU")
+public func _bjs_genericExportCombineReturnU(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    guard let _generic1Type = _bridgeJSExportTypeRegistry[_generic1TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic1TypeId)")
+    }
+    _bjs_genericExportCombineReturnU_open1(_generic0Type, _generic1Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_genericExportCombineReturnU_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type) {
+    _bjs_genericExportCombineReturnU_open2(_generic1Type, asT: T.self)
+}
+private func _bjs_genericExportCombineReturnU_open2<U: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type) {
+    let b = U.bridgeJSStackPop()
+    let a = T.bridgeJSStackPop()
+    let ret = genericExportCombineReturnU(a, b)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_genericExportCaseDistinct")
+@_cdecl("bjs_genericExportCaseDistinct")
+public func _bjs_genericExportCaseDistinct(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_genericExportCaseDistinct")
+@_cdecl("bjs_genericExportCaseDistinct")
+public func _bjs_genericExportCaseDistinct(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    guard let _generic1Type = _bridgeJSExportTypeRegistry[_generic1TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic1TypeId)")
+    }
+    _bjs_genericExportCaseDistinct_open1(_generic0Type, _generic1Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_genericExportCaseDistinct_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type) {
+    _bjs_genericExportCaseDistinct_open2(_generic1Type, asT: T.self)
+}
+private func _bjs_genericExportCaseDistinct_open2<t: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: t.Type, asT _generic0Type: T.Type) {
+    let b = t.bridgeJSStackPop()
+    let a = T.bridgeJSStackPop()
+    let ret = genericExportCaseDistinct(a, b)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if !hasFeature(Embedded)
+private let _bridgeJSExportTypeRegistry: [Int32: any _BridgedSwiftGenericBridgeable.Type] = {
+    var registry: [Int32: any _BridgedSwiftGenericBridgeable.Type] = [:]
+    func register<T: _BridgedSwiftGenericBridgeable>(_ type: T.Type) {
+        registry[T.bridgeJSTypeID] = type
+    }
+    register(Bool.self)
+    register(Int.self)
+    register(Int8.self)
+    register(UInt8.self)
+    register(Int16.self)
+    register(UInt16.self)
+    register(Int32.self)
+    register(UInt32.self)
+    register(UInt.self)
+    register(Int64.self)
+    register(UInt64.self)
+    register(Float.self)
+    register(Double.self)
+    register(String.self)
+    register(JSValue.self)
+    register(ExportPoint.self)
+    register(ExportNamespace.Metadata.self)
+    register(GenericPair.self)
+    register(ExportBox.self)
+    register(GenericBox.self)
+    register(ExportNamespace.Level.self)
+    register(ExportMode.self)
+    register(ExportColor.self)
+    register(ExportTagged.self)
+    register(GenericFactory.self)
+    return registry
+}()
+#endif
+
+@_expose(wasm, "bjs_ExportBox_init")
+@_cdecl("bjs_ExportBox_init")
+public func _bjs_ExportBox_init(_ value: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = ExportBox(value: Int.bridgeJSLiftParameter(value))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ExportBox_get")
+@_cdecl("bjs_ExportBox_get")
+public func _bjs_ExportBox_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = ExportBox.bridgeJSLiftParameter(_self).get()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ExportBox_value_get")
+@_cdecl("bjs_ExportBox_value_get")
+public func _bjs_ExportBox_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = ExportBox.bridgeJSLiftParameter(_self).value
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ExportBox_value_set")
+@_cdecl("bjs_ExportBox_value_set")
+public func _bjs_ExportBox_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+    #if arch(wasm32)
+    ExportBox.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ExportBox_deinit")
+@_cdecl("bjs_ExportBox_deinit")
+public func _bjs_ExportBox_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<ExportBox>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension ExportBox: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_ExportBox_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_ExportBox_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_ExportBox_wrap")
+fileprivate func _bjs_ExportBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_ExportBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_ExportBox_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_ExportBox_wrap_extern(pointer)
+}
+
+extension ExportBox: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportBox")
+}
+
+@_expose(wasm, "bjs_GenericBox_init")
+@_cdecl("bjs_GenericBox_init")
+public func _bjs_GenericBox_init() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = GenericBox()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_GenericBox_wrap")
+@_cdecl("bjs_GenericBox_wrap")
+public func _bjs_GenericBox_wrap(_ _self: UnsafeMutableRawPointer, _ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_GenericBox_wrap")
+@_cdecl("bjs_GenericBox_wrap")
+public func _bjs_GenericBox_wrap(_ _self: UnsafeMutableRawPointer, _ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_GenericBox_wrap_open1(_generic0Type, _self)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_GenericBox_wrap_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _self: UnsafeMutableRawPointer) {
+    let value = T.bridgeJSStackPop()
+    let _val__self = GenericBox.bridgeJSLiftParameter(_self)
+    let ret = _val__self.wrap(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_GenericBox_combine")
+@_cdecl("bjs_GenericBox_combine")
+public func _bjs_GenericBox_combine(_ _self: UnsafeMutableRawPointer, _ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_GenericBox_combine")
+@_cdecl("bjs_GenericBox_combine")
+public func _bjs_GenericBox_combine(_ _self: UnsafeMutableRawPointer, _ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    guard let _generic1Type = _bridgeJSExportTypeRegistry[_generic1TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic1TypeId)")
+    }
+    _bjs_GenericBox_combine_open1(_generic0Type, _generic1Type, _self)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_GenericBox_combine_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type, _ _self: UnsafeMutableRawPointer) {
+    _bjs_GenericBox_combine_open2(_generic1Type, asT: T.self, _self)
+}
+private func _bjs_GenericBox_combine_open2<t: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: t.Type, asT _generic0Type: T.Type, _ _self: UnsafeMutableRawPointer) {
+    let b = t.bridgeJSStackPop()
+    let a = T.bridgeJSStackPop()
+    let _val__self = GenericBox.bridgeJSLiftParameter(_self)
+    let ret = _val__self.combine(a, b)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_GenericBox_static_makeArray")
+@_cdecl("bjs_GenericBox_static_makeArray")
+public func _bjs_GenericBox_static_makeArray(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_GenericBox_static_makeArray")
+@_cdecl("bjs_GenericBox_static_makeArray")
+public func _bjs_GenericBox_static_makeArray(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_GenericBox_static_makeArray_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_GenericBox_static_makeArray_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let ret = GenericBox.makeArray(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+@_expose(wasm, "bjs_GenericBox_deinit")
+@_cdecl("bjs_GenericBox_deinit")
+public func _bjs_GenericBox_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<GenericBox>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension GenericBox: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_GenericBox_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_GenericBox_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_GenericBox_wrap")
+fileprivate func _bjs_GenericBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_GenericBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_GenericBox_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_GenericBox_wrap_extern(pointer)
+}
+
+extension GenericBox: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericBox")
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericExports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericExports.swift
@@ -1,14 +1,14 @@
 extension ExportNamespace.Level: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension ExportNamespace.Level: _BridgedSwiftGenericBridgeable {
+extension ExportNamespace.Level: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportNamespace_Level")
 }
 
 extension ExportMode: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension ExportMode: _BridgedSwiftGenericBridgeable {
+extension ExportMode: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportMode")
 }
 
@@ -47,7 +47,7 @@ extension ExportColor: _BridgedSwiftCaseEnum {
     }
 }
 
-extension ExportColor: _BridgedSwiftGenericBridgeable {
+extension ExportColor: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportColor")
 }
 
@@ -75,7 +75,7 @@ extension ExportTagged: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension ExportTagged: _BridgedSwiftGenericBridgeable {
+extension ExportTagged: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportTagged")
 }
 
@@ -110,7 +110,7 @@ extension GenericFactory: _BridgedSwiftCaseEnum {
     }
 }
 
-extension GenericFactory: _BridgedSwiftGenericBridgeable {
+extension GenericFactory: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericFactory")
 }
 
@@ -133,7 +133,7 @@ public func _bjs_GenericFactory_static_one(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_GenericFactory_static_one_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_GenericFactory_static_one_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let ret = GenericFactory.one(value)
     ret.bridgeJSStackPush()
@@ -159,7 +159,7 @@ public func _bjs_GenericNamespace_static_make(_ _generic0TypeId: Int32) -> Void 
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_GenericNamespace_static_make_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_GenericNamespace_static_make_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let ret = GenericNamespace.make(value)
     ret.bridgeJSStackPush()
@@ -214,7 +214,7 @@ fileprivate func _bjs_struct_lift_ExportPoint_extern() -> Int32 {
     return _bjs_struct_lift_ExportPoint_extern()
 }
 
-extension ExportPoint: _BridgedSwiftGenericBridgeable {
+extension ExportPoint: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportPoint")
 }
 
@@ -266,7 +266,7 @@ fileprivate func _bjs_struct_lift_ExportNamespace_Metadata_extern() -> Int32 {
     return _bjs_struct_lift_ExportNamespace_Metadata_extern()
 }
 
-extension ExportNamespace.Metadata: _BridgedSwiftGenericBridgeable {
+extension ExportNamespace.Metadata: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportNamespace_Metadata")
 }
 
@@ -314,7 +314,7 @@ fileprivate func _bjs_struct_lift_GenericPair_extern() -> Int32 {
     return _bjs_struct_lift_GenericPair_extern()
 }
 
-extension GenericPair: _BridgedSwiftGenericBridgeable {
+extension GenericPair: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericPair")
 }
 
@@ -348,7 +348,7 @@ public func _bjs_GenericPair_first(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_GenericPair_first_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_GenericPair_first_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let _tmp__self = GenericPair.bridgeJSLiftParameter()
     let ret = _tmp__self.first(value)
@@ -378,10 +378,10 @@ public func _bjs_GenericPair_combine(_ _generic0TypeId: Int32, _ _generic1TypeId
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_GenericPair_combine_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type) {
+private func _bjs_GenericPair_combine_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any BridgedSwiftGenericBridgeable.Type) {
     _bjs_GenericPair_combine_open2(_generic1Type, asT: T.self)
 }
-private func _bjs_GenericPair_combine_open2<t: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: t.Type, asT _generic0Type: T.Type) {
+private func _bjs_GenericPair_combine_open2<t: BridgedSwiftGenericBridgeable, T: BridgedSwiftGenericBridgeable>(_ _generic1Type: t.Type, asT _generic0Type: T.Type) {
     let b = t.bridgeJSStackPop()
     let a = T.bridgeJSStackPop()
     let _tmp__self = GenericPair.bridgeJSLiftParameter()
@@ -409,7 +409,7 @@ public func _bjs_GenericPair_maybe(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_GenericPair_maybe_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_GenericPair_maybe_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let _tmp__self = GenericPair.bridgeJSLiftParameter()
     let ret = _tmp__self.maybe(value)
@@ -436,7 +436,7 @@ public func _bjs_GenericPair_dict(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_GenericPair_dict_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_GenericPair_dict_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let _tmp__self = GenericPair.bridgeJSLiftParameter()
     let ret = _tmp__self.dict(value)
@@ -463,7 +463,7 @@ public func _bjs_GenericPair_static_wrap(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_GenericPair_static_wrap_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_GenericPair_static_wrap_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let ret = GenericPair.wrap(value)
     ret.bridgeJSStackPush()
@@ -489,7 +489,7 @@ public func _bjs_genericExportIdentity(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_genericExportIdentity_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_genericExportIdentity_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let ret = genericExportIdentity(value)
     ret.bridgeJSStackPush()
@@ -515,7 +515,7 @@ public func _bjs_genericExportArray(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_genericExportArray_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_genericExportArray_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let values = Array<T>.bridgeJSStackPop()
     let ret = genericExportArray(values)
     ret.bridgeJSStackPush()
@@ -541,7 +541,7 @@ public func _bjs_genericExportOptional(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_genericExportOptional_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_genericExportOptional_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = Optional<T>.bridgeJSStackPop()
     let ret = genericExportOptional(value)
     ret.bridgeJSStackPush()
@@ -567,7 +567,7 @@ public func _bjs_genericExportDictionary(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_genericExportDictionary_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_genericExportDictionary_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let values = Dictionary<String, T>.bridgeJSStackPop()
     let ret = genericExportDictionary(values)
     ret.bridgeJSStackPush()
@@ -593,7 +593,7 @@ public func _bjs_genericExportEcho(_ tag: Int32, _ _generic0TypeId: Int32) -> Vo
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_genericExportEcho_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ tag: Int32) {
+private func _bjs_genericExportEcho_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ tag: Int32) {
     let value = T.bridgeJSStackPop()
     let _val_tag = Int.bridgeJSLiftParameter(tag)
     let ret = genericExportEcho(value, tag: _val_tag)
@@ -620,7 +620,7 @@ public func _bjs_genericExportStructConcreteLeading(_ _generic0TypeId: Int32) ->
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_genericExportStructConcreteLeading_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_genericExportStructConcreteLeading_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let v = T.bridgeJSStackPop()
     let _tmp_p = ExportPoint.bridgeJSLiftParameter()
     let ret = genericExportStructConcreteLeading(v, _tmp_p)
@@ -647,7 +647,7 @@ public func _bjs_genericExportStructAndScalar(_ tag: Int32, _ _generic0TypeId: I
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_genericExportStructAndScalar_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ tag: Int32) {
+private func _bjs_genericExportStructAndScalar_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ tag: Int32) {
     let v = T.bridgeJSStackPop()
     let _tmp_p = ExportPoint.bridgeJSLiftParameter()
     let _val_tag = Int.bridgeJSLiftParameter(tag)
@@ -675,7 +675,7 @@ public func _bjs_genericExportPair(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_genericExportPair_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_genericExportPair_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let b = T.bridgeJSStackPop()
     let a = T.bridgeJSStackPop()
     let ret = genericExportPair(a, b)
@@ -705,10 +705,10 @@ public func _bjs_genericExportCombine(_ _generic0TypeId: Int32, _ _generic1TypeI
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_genericExportCombine_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type) {
+private func _bjs_genericExportCombine_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any BridgedSwiftGenericBridgeable.Type) {
     _bjs_genericExportCombine_open2(_generic1Type, asT: T.self)
 }
-private func _bjs_genericExportCombine_open2<U: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type) {
+private func _bjs_genericExportCombine_open2<U: BridgedSwiftGenericBridgeable, T: BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type) {
     let b = U.bridgeJSStackPop()
     let a = T.bridgeJSStackPop()
     let ret = genericExportCombine(a, b)
@@ -738,10 +738,10 @@ public func _bjs_genericExportCombineReturnU(_ _generic0TypeId: Int32, _ _generi
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_genericExportCombineReturnU_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type) {
+private func _bjs_genericExportCombineReturnU_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any BridgedSwiftGenericBridgeable.Type) {
     _bjs_genericExportCombineReturnU_open2(_generic1Type, asT: T.self)
 }
-private func _bjs_genericExportCombineReturnU_open2<U: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type) {
+private func _bjs_genericExportCombineReturnU_open2<U: BridgedSwiftGenericBridgeable, T: BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type) {
     let b = U.bridgeJSStackPop()
     let a = T.bridgeJSStackPop()
     let ret = genericExportCombineReturnU(a, b)
@@ -771,10 +771,10 @@ public func _bjs_genericExportCaseDistinct(_ _generic0TypeId: Int32, _ _generic1
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_genericExportCaseDistinct_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type) {
+private func _bjs_genericExportCaseDistinct_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any BridgedSwiftGenericBridgeable.Type) {
     _bjs_genericExportCaseDistinct_open2(_generic1Type, asT: T.self)
 }
-private func _bjs_genericExportCaseDistinct_open2<t: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: t.Type, asT _generic0Type: T.Type) {
+private func _bjs_genericExportCaseDistinct_open2<t: BridgedSwiftGenericBridgeable, T: BridgedSwiftGenericBridgeable>(_ _generic1Type: t.Type, asT _generic0Type: T.Type) {
     let b = t.bridgeJSStackPop()
     let a = T.bridgeJSStackPop()
     let ret = genericExportCaseDistinct(a, b)
@@ -783,9 +783,9 @@ private func _bjs_genericExportCaseDistinct_open2<t: _BridgedSwiftGenericBridgea
 #endif
 
 #if !hasFeature(Embedded)
-private let _bridgeJSExportTypeRegistry: [Int32: any _BridgedSwiftGenericBridgeable.Type] = {
-    var registry: [Int32: any _BridgedSwiftGenericBridgeable.Type] = [:]
-    func register<T: _BridgedSwiftGenericBridgeable>(_ type: T.Type) {
+private let _bridgeJSExportTypeRegistry: [Int32: any BridgedSwiftGenericBridgeable.Type] = {
+    var registry: [Int32: any BridgedSwiftGenericBridgeable.Type] = [:]
+    func register<T: BridgedSwiftGenericBridgeable>(_ type: T.Type) {
         registry[T.bridgeJSTypeID] = type
     }
     register(Bool.self)
@@ -891,7 +891,7 @@ fileprivate func _bjs_ExportBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) 
     return _bjs_ExportBox_wrap_extern(pointer)
 }
 
-extension ExportBox: _BridgedSwiftGenericBridgeable {
+extension ExportBox: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportBox")
 }
 
@@ -925,7 +925,7 @@ public func _bjs_GenericBox_wrap(_ _self: UnsafeMutableRawPointer, _ _generic0Ty
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_GenericBox_wrap_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _self: UnsafeMutableRawPointer) {
+private func _bjs_GenericBox_wrap_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _self: UnsafeMutableRawPointer) {
     let value = T.bridgeJSStackPop()
     let _val__self = GenericBox.bridgeJSLiftParameter(_self)
     let ret = _val__self.wrap(value)
@@ -955,10 +955,10 @@ public func _bjs_GenericBox_combine(_ _self: UnsafeMutableRawPointer, _ _generic
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_GenericBox_combine_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type, _ _self: UnsafeMutableRawPointer) {
+private func _bjs_GenericBox_combine_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any BridgedSwiftGenericBridgeable.Type, _ _self: UnsafeMutableRawPointer) {
     _bjs_GenericBox_combine_open2(_generic1Type, asT: T.self, _self)
 }
-private func _bjs_GenericBox_combine_open2<t: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: t.Type, asT _generic0Type: T.Type, _ _self: UnsafeMutableRawPointer) {
+private func _bjs_GenericBox_combine_open2<t: BridgedSwiftGenericBridgeable, T: BridgedSwiftGenericBridgeable>(_ _generic1Type: t.Type, asT _generic0Type: T.Type, _ _self: UnsafeMutableRawPointer) {
     let b = t.bridgeJSStackPop()
     let a = T.bridgeJSStackPop()
     let _val__self = GenericBox.bridgeJSLiftParameter(_self)
@@ -986,7 +986,7 @@ public func _bjs_GenericBox_static_makeArray(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_GenericBox_static_makeArray_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_GenericBox_static_makeArray_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let ret = GenericBox.makeArray(value)
     ret.bridgeJSStackPush()
@@ -1024,6 +1024,6 @@ fileprivate func _bjs_GenericBox_wrap_extern(_ pointer: UnsafeMutableRawPointer)
     return _bjs_GenericBox_wrap_extern(pointer)
 }
 
-extension GenericBox: _BridgedSwiftGenericBridgeable {
+extension GenericBox: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericBox")
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericImports.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericImports.json
@@ -1,0 +1,557 @@
+{
+  "exported" : {
+    "aliases" : [
+
+    ],
+    "classes" : [
+      {
+        "constructor" : {
+          "abiName" : "bjs_GenericImportBox_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "value",
+              "name" : "value",
+              "type" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "isFinal" : true,
+        "methods" : [
+          {
+            "abiName" : "bjs_GenericImportBox_get",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "get",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "name" : "GenericImportBox",
+        "properties" : [
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "name" : "value",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "GenericImportBox"
+      }
+    ],
+    "enums" : [
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "red"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "green"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "GenericColor",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "GenericColor",
+        "tsFullPath" : "GenericColor"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "light"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "dark"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "GenericMode",
+        "rawType" : "String",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "GenericMode",
+        "tsFullPath" : "GenericMode"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+              {
+                "label" : "value",
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "name" : "number"
+          },
+          {
+            "associatedValues" : [
+              {
+                "label" : "value",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "name" : "text"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "GenericTagged",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "GenericTagged",
+        "tsFullPath" : "GenericTagged"
+      }
+    ],
+    "exposeToGlobal" : false,
+    "functions" : [
+
+    ],
+    "protocols" : [
+
+    ],
+    "structs" : [
+      {
+        "methods" : [
+
+        ],
+        "name" : "GenericPoint",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "x",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "y",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "GenericPoint"
+      }
+    ]
+  },
+  "imported" : {
+    "children" : [
+      {
+        "functions" : [
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "genericRoundTrip",
+            "parameters" : [
+              {
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "genericParse",
+            "parameters" : [
+              {
+                "name" : "json",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T",
+              "U"
+            ],
+            "name" : "importGenericCombine",
+            "parameters" : [
+              {
+                "name" : "a",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              },
+              {
+                "name" : "b",
+                "type" : {
+                  "generic" : {
+                    "_0" : "U"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "U"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T",
+              "t"
+            ],
+            "name" : "importGenericCaseDistinct",
+            "parameters" : [
+              {
+                "name" : "a",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              },
+              {
+                "name" : "b",
+                "type" : {
+                  "generic" : {
+                    "_0" : "t"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "importGenericArray",
+            "parameters" : [
+              {
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "generic" : {
+                        "_0" : "T"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "importGenericOptional",
+            "parameters" : [
+              {
+                "name" : "value",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "generic" : {
+                        "_0" : "T"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "importGenericDictionary",
+            "parameters" : [
+              {
+                "name" : "values",
+                "type" : {
+                  "dictionary" : {
+                    "_0" : {
+                      "generic" : {
+                        "_0" : "T"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "dictionary" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "types" : [
+          {
+            "accessLevel" : "internal",
+            "getters" : [
+
+            ],
+            "methods" : [
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "genericParameters" : [
+                  "T"
+                ],
+                "name" : "accept",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "generic" : {
+                        "_0" : "T"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "void" : {
+
+                  }
+                }
+              },
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "genericParameters" : [
+                  "T"
+                ],
+                "name" : "identity",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "generic" : {
+                        "_0" : "T"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "name" : "GenericConsumer",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "genericParameters" : [
+                  "T"
+                ],
+                "name" : "box",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "generic" : {
+                        "_0" : "T"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "moduleName" : "TestModule",
+  "usedExternalModules" : [
+
+  ]
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericImports.swift
@@ -33,14 +33,14 @@ extension GenericColor: _BridgedSwiftCaseEnum {
     }
 }
 
-extension GenericColor: _BridgedSwiftGenericBridgeable {
+extension GenericColor: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericColor")
 }
 
 extension GenericMode: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension GenericMode: _BridgedSwiftGenericBridgeable {
+extension GenericMode: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericMode")
 }
 
@@ -68,7 +68,7 @@ extension GenericTagged: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension GenericTagged: _BridgedSwiftGenericBridgeable {
+extension GenericTagged: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericTagged")
 }
 
@@ -120,7 +120,7 @@ fileprivate func _bjs_struct_lift_GenericPoint_extern() -> Int32 {
     return _bjs_struct_lift_GenericPoint_extern()
 }
 
-extension GenericPoint: _BridgedSwiftGenericBridgeable {
+extension GenericPoint: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericPoint")
 }
 
@@ -198,7 +198,7 @@ fileprivate func _bjs_GenericImportBox_wrap_extern(_ pointer: UnsafeMutableRawPo
     return _bjs_GenericImportBox_wrap_extern(pointer)
 }
 
-extension GenericImportBox: _BridgedSwiftGenericBridgeable {
+extension GenericImportBox: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericImportBox")
 }
 
@@ -214,7 +214,7 @@ fileprivate func bjs_genericRoundTrip_extern(_ _generic0TypeId: Int32) -> Void {
     return bjs_genericRoundTrip_extern(_generic0TypeId)
 }
 
-func _$genericRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
+func _$genericRoundTrip<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
     value.bridgeJSStackPush()
     bjs_genericRoundTrip(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
@@ -235,7 +235,7 @@ fileprivate func bjs_genericParse_extern(_ jsonBytes: Int32, _ jsonLength: Int32
     return bjs_genericParse_extern(jsonBytes, jsonLength, _generic0TypeId)
 }
 
-func _$genericParse<T: _BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T {
+func _$genericParse<T: BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T {
     json.bridgeJSWithLoweredParameter { (jsonBytes, jsonLength) in
         bjs_genericParse(jsonBytes, jsonLength, T.bridgeJSTypeID)
     }
@@ -257,7 +257,7 @@ fileprivate func bjs_importGenericCombine_extern(_ _generic0TypeId: Int32, _ _ge
     return bjs_importGenericCombine_extern(_generic0TypeId, _generic1TypeId)
 }
 
-func _$importGenericCombine<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: U) throws(JSException) -> U {
+func _$importGenericCombine<T: BridgedSwiftGenericBridgeable, U: BridgedSwiftGenericBridgeable>(_ a: T, _ b: U) throws(JSException) -> U {
     b.bridgeJSStackPush()
     a.bridgeJSStackPush()
     bjs_importGenericCombine(T.bridgeJSTypeID, U.bridgeJSTypeID)
@@ -279,7 +279,7 @@ fileprivate func bjs_importGenericCaseDistinct_extern(_ _generic0TypeId: Int32, 
     return bjs_importGenericCaseDistinct_extern(_generic0TypeId, _generic1TypeId)
 }
 
-func _$importGenericCaseDistinct<T: _BridgedSwiftGenericBridgeable, t: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: t) throws(JSException) -> T {
+func _$importGenericCaseDistinct<T: BridgedSwiftGenericBridgeable, t: BridgedSwiftGenericBridgeable>(_ a: T, _ b: t) throws(JSException) -> T {
     b.bridgeJSStackPush()
     a.bridgeJSStackPush()
     bjs_importGenericCaseDistinct(T.bridgeJSTypeID, t.bridgeJSTypeID)
@@ -301,7 +301,7 @@ fileprivate func bjs_importGenericArray_extern(_ _generic0TypeId: Int32) -> Void
     return bjs_importGenericArray_extern(_generic0TypeId)
 }
 
-func _$importGenericArray<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T] {
+func _$importGenericArray<T: BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T] {
     values.bridgeJSStackPush()
     bjs_importGenericArray(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
@@ -322,7 +322,7 @@ fileprivate func bjs_importGenericOptional_extern(_ _generic0TypeId: Int32) -> V
     return bjs_importGenericOptional_extern(_generic0TypeId)
 }
 
-func _$importGenericOptional<T: _BridgedSwiftGenericBridgeable>(_ value: Optional<T>) throws(JSException) -> Optional<T> {
+func _$importGenericOptional<T: BridgedSwiftGenericBridgeable>(_ value: Optional<T>) throws(JSException) -> Optional<T> {
     value.bridgeJSStackPush()
     bjs_importGenericOptional(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
@@ -343,7 +343,7 @@ fileprivate func bjs_importGenericDictionary_extern(_ _generic0TypeId: Int32) ->
     return bjs_importGenericDictionary_extern(_generic0TypeId)
 }
 
-func _$importGenericDictionary<T: _BridgedSwiftGenericBridgeable>(_ values: [String: T]) throws(JSException) -> [String: T] {
+func _$importGenericDictionary<T: BridgedSwiftGenericBridgeable>(_ values: [String: T]) throws(JSException) -> [String: T] {
     values.bridgeJSStackPush()
     bjs_importGenericDictionary(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
@@ -388,7 +388,7 @@ fileprivate func bjs_GenericConsumer_identity_extern(_ self: Int32, _ _generic0T
     return bjs_GenericConsumer_identity_extern(self, _generic0TypeId)
 }
 
-func _$GenericConsumer_box<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
+func _$GenericConsumer_box<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
     value.bridgeJSStackPush()
     bjs_GenericConsumer_box_static(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
@@ -397,7 +397,7 @@ func _$GenericConsumer_box<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws
     return T.bridgeJSStackPop()
 }
 
-func _$GenericConsumer_accept<T: _BridgedSwiftGenericBridgeable>(_ self: JSObject, _ value: T) throws(JSException) -> Void {
+func _$GenericConsumer_accept<T: BridgedSwiftGenericBridgeable>(_ self: JSObject, _ value: T) throws(JSException) -> Void {
     let selfValue = self.bridgeJSLowerParameter()
     value.bridgeJSStackPush()
     bjs_GenericConsumer_accept(selfValue, T.bridgeJSTypeID)
@@ -406,7 +406,7 @@ func _$GenericConsumer_accept<T: _BridgedSwiftGenericBridgeable>(_ self: JSObjec
     }
 }
 
-func _$GenericConsumer_identity<T: _BridgedSwiftGenericBridgeable>(_ self: JSObject, _ value: T) throws(JSException) -> T {
+func _$GenericConsumer_identity<T: BridgedSwiftGenericBridgeable>(_ self: JSObject, _ value: T) throws(JSException) -> T {
     let selfValue = self.bridgeJSLowerParameter()
     value.bridgeJSStackPush()
     bjs_GenericConsumer_identity(selfValue, T.bridgeJSTypeID)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericImports.swift
@@ -1,0 +1,417 @@
+extension GenericColor: _BridgedSwiftCaseEnum {
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
+        return bridgeJSRawValue
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> GenericColor {
+        return bridgeJSLiftParameter(value)
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> GenericColor {
+        return GenericColor(bridgeJSRawValue: value)!
+    }
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
+        return bridgeJSLowerParameter()
+    }
+
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
+        switch bridgeJSRawValue {
+        case 0:
+            self = .red
+        case 1:
+            self = .green
+        default:
+            return nil
+        }
+    }
+
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
+        switch self {
+        case .red:
+            return 0
+        case .green:
+            return 1
+        }
+    }
+}
+
+extension GenericColor: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericColor")
+}
+
+extension GenericMode: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+}
+
+extension GenericMode: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericMode")
+}
+
+extension GenericTagged: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> GenericTagged {
+        switch caseId {
+        case 0:
+            return .number(value: Int.bridgeJSStackPop())
+        case 1:
+            return .text(value: String.bridgeJSStackPop())
+        default:
+            fatalError("Unknown GenericTagged case ID: \(caseId)")
+        }
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
+        switch self {
+        case .number(let value):
+            value.bridgeJSStackPush()
+            return Int32(0)
+        case .text(let value):
+            value.bridgeJSStackPush()
+            return Int32(1)
+        }
+    }
+}
+
+extension GenericTagged: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericTagged")
+}
+
+extension GenericPoint: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> GenericPoint {
+        let y = Int.bridgeJSStackPop()
+        let x = Int.bridgeJSStackPop()
+        return GenericPoint(x: x, y: y)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_GenericPoint(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_GenericPoint()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_GenericPoint")
+fileprivate func _bjs_struct_lower_GenericPoint_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_GenericPoint_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_GenericPoint(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_GenericPoint_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_GenericPoint")
+fileprivate func _bjs_struct_lift_GenericPoint_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_GenericPoint_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_GenericPoint() -> Int32 {
+    return _bjs_struct_lift_GenericPoint_extern()
+}
+
+extension GenericPoint: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericPoint")
+}
+
+@_expose(wasm, "bjs_GenericImportBox_init")
+@_cdecl("bjs_GenericImportBox_init")
+public func _bjs_GenericImportBox_init(_ value: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = GenericImportBox(value: Int.bridgeJSLiftParameter(value))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_GenericImportBox_get")
+@_cdecl("bjs_GenericImportBox_get")
+public func _bjs_GenericImportBox_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = GenericImportBox.bridgeJSLiftParameter(_self).get()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_GenericImportBox_value_get")
+@_cdecl("bjs_GenericImportBox_value_get")
+public func _bjs_GenericImportBox_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = GenericImportBox.bridgeJSLiftParameter(_self).value
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_GenericImportBox_value_set")
+@_cdecl("bjs_GenericImportBox_value_set")
+public func _bjs_GenericImportBox_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+    #if arch(wasm32)
+    GenericImportBox.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_GenericImportBox_deinit")
+@_cdecl("bjs_GenericImportBox_deinit")
+public func _bjs_GenericImportBox_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<GenericImportBox>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension GenericImportBox: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_GenericImportBox_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_GenericImportBox_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_GenericImportBox_wrap")
+fileprivate func _bjs_GenericImportBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_GenericImportBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_GenericImportBox_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_GenericImportBox_wrap_extern(pointer)
+}
+
+extension GenericImportBox: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericImportBox")
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_genericRoundTrip")
+fileprivate func bjs_genericRoundTrip_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_genericRoundTrip_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_genericRoundTrip(_ _generic0TypeId: Int32) -> Void {
+    return bjs_genericRoundTrip_extern(_generic0TypeId)
+}
+
+func _$genericRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
+    value.bridgeJSStackPush()
+    bjs_genericRoundTrip(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return T.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_genericParse")
+fileprivate func bjs_genericParse_extern(_ jsonBytes: Int32, _ jsonLength: Int32, _ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_genericParse_extern(_ jsonBytes: Int32, _ jsonLength: Int32, _ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_genericParse(_ jsonBytes: Int32, _ jsonLength: Int32, _ _generic0TypeId: Int32) -> Void {
+    return bjs_genericParse_extern(jsonBytes, jsonLength, _generic0TypeId)
+}
+
+func _$genericParse<T: _BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T {
+    json.bridgeJSWithLoweredParameter { (jsonBytes, jsonLength) in
+        bjs_genericParse(jsonBytes, jsonLength, T.bridgeJSTypeID)
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return T.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_importGenericCombine")
+fileprivate func bjs_importGenericCombine_extern(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void
+#else
+fileprivate func bjs_importGenericCombine_extern(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_importGenericCombine(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    return bjs_importGenericCombine_extern(_generic0TypeId, _generic1TypeId)
+}
+
+func _$importGenericCombine<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: U) throws(JSException) -> U {
+    b.bridgeJSStackPush()
+    a.bridgeJSStackPush()
+    bjs_importGenericCombine(T.bridgeJSTypeID, U.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return U.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_importGenericCaseDistinct")
+fileprivate func bjs_importGenericCaseDistinct_extern(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void
+#else
+fileprivate func bjs_importGenericCaseDistinct_extern(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_importGenericCaseDistinct(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    return bjs_importGenericCaseDistinct_extern(_generic0TypeId, _generic1TypeId)
+}
+
+func _$importGenericCaseDistinct<T: _BridgedSwiftGenericBridgeable, t: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: t) throws(JSException) -> T {
+    b.bridgeJSStackPush()
+    a.bridgeJSStackPush()
+    bjs_importGenericCaseDistinct(T.bridgeJSTypeID, t.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return T.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_importGenericArray")
+fileprivate func bjs_importGenericArray_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_importGenericArray_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_importGenericArray(_ _generic0TypeId: Int32) -> Void {
+    return bjs_importGenericArray_extern(_generic0TypeId)
+}
+
+func _$importGenericArray<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T] {
+    values.bridgeJSStackPush()
+    bjs_importGenericArray(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Array<T>.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_importGenericOptional")
+fileprivate func bjs_importGenericOptional_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_importGenericOptional_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_importGenericOptional(_ _generic0TypeId: Int32) -> Void {
+    return bjs_importGenericOptional_extern(_generic0TypeId)
+}
+
+func _$importGenericOptional<T: _BridgedSwiftGenericBridgeable>(_ value: Optional<T>) throws(JSException) -> Optional<T> {
+    value.bridgeJSStackPush()
+    bjs_importGenericOptional(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<T>.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_importGenericDictionary")
+fileprivate func bjs_importGenericDictionary_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_importGenericDictionary_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_importGenericDictionary(_ _generic0TypeId: Int32) -> Void {
+    return bjs_importGenericDictionary_extern(_generic0TypeId)
+}
+
+func _$importGenericDictionary<T: _BridgedSwiftGenericBridgeable>(_ values: [String: T]) throws(JSException) -> [String: T] {
+    values.bridgeJSStackPush()
+    bjs_importGenericDictionary(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Dictionary<String, T>.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_GenericConsumer_box_static")
+fileprivate func bjs_GenericConsumer_box_static_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_GenericConsumer_box_static_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_GenericConsumer_box_static(_ _generic0TypeId: Int32) -> Void {
+    return bjs_GenericConsumer_box_static_extern(_generic0TypeId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_GenericConsumer_accept")
+fileprivate func bjs_GenericConsumer_accept_extern(_ self: Int32, _ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_GenericConsumer_accept_extern(_ self: Int32, _ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_GenericConsumer_accept(_ self: Int32, _ _generic0TypeId: Int32) -> Void {
+    return bjs_GenericConsumer_accept_extern(self, _generic0TypeId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_GenericConsumer_identity")
+fileprivate func bjs_GenericConsumer_identity_extern(_ self: Int32, _ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_GenericConsumer_identity_extern(_ self: Int32, _ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_GenericConsumer_identity(_ self: Int32, _ _generic0TypeId: Int32) -> Void {
+    return bjs_GenericConsumer_identity_extern(self, _generic0TypeId)
+}
+
+func _$GenericConsumer_box<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
+    value.bridgeJSStackPush()
+    bjs_GenericConsumer_box_static(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return T.bridgeJSStackPop()
+}
+
+func _$GenericConsumer_accept<T: _BridgedSwiftGenericBridgeable>(_ self: JSObject, _ value: T) throws(JSException) -> Void {
+    let selfValue = self.bridgeJSLowerParameter()
+    value.bridgeJSStackPush()
+    bjs_GenericConsumer_accept(selfValue, T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+func _$GenericConsumer_identity<T: _BridgedSwiftGenericBridgeable>(_ self: JSObject, _ value: T) throws(JSException) -> T {
+    let selfValue = self.bridgeJSLowerParameter()
+    value.bridgeJSStackPush()
+    bjs_GenericConsumer_identity(selfValue, T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return T.bridgeJSStackPop()
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GenericExports.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GenericExports.d.ts
@@ -1,0 +1,126 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export const ExportModeValues: {
+    readonly On: "on";
+    readonly Off: "off";
+};
+export type ExportModeTag = typeof ExportModeValues[keyof typeof ExportModeValues];
+
+export const ExportColorValues: {
+    readonly Red: 0;
+    readonly Green: 1;
+};
+export type ExportColorTag = typeof ExportColorValues[keyof typeof ExportColorValues];
+
+export const ExportTaggedValues: {
+    readonly Tag: {
+        readonly Number: 0;
+        readonly Text: 1;
+    };
+};
+
+export type ExportTaggedTag =
+  { tag: typeof ExportTaggedValues.Tag.Number; value: number } | { tag: typeof ExportTaggedValues.Tag.Text; value: string }
+
+export const GenericFactoryValues: {
+    readonly Primary: 0;
+};
+export type GenericFactoryTag = typeof GenericFactoryValues[keyof typeof GenericFactoryValues];
+
+export interface ExportPoint {
+    x: number;
+    y: number;
+}
+export interface GenericPair {
+    first<T>(value: T, typeT: BridgeType<T>): T;
+    combine<T, t>(a: T, b: t, typeT: BridgeType<T>, typet: BridgeType<t>): T;
+    maybe<T>(value: T, typeT: BridgeType<T>): T | null;
+    dict<T>(value: T, typeT: BridgeType<T>): Record<string, T>;
+}
+export type BridgeType<T> = string & { readonly __bridgeType?: (value: T) => void };
+export const BridgeTypes: { Bool: BridgeType<boolean>; Int: BridgeType<number>; Int8: BridgeType<number>; UInt8: BridgeType<number>; Int16: BridgeType<number>; UInt16: BridgeType<number>; Int32: BridgeType<number>; UInt32: BridgeType<number>; UInt: BridgeType<number>; Int64: BridgeType<bigint>; UInt64: BridgeType<bigint>; Float: BridgeType<number>; Double: BridgeType<number>; String: BridgeType<string>; JSValue: BridgeType<any>; ExportPoint: BridgeType<ExportPoint>; ExportNamespace_Metadata: BridgeType<ExportNamespace.Metadata>; GenericPair: BridgeType<GenericPair>; ExportBox: BridgeType<ExportBox>; GenericBox: BridgeType<GenericBox>; ExportNamespace_Level: BridgeType<ExportNamespace.LevelTag>; ExportMode: BridgeType<ExportModeTag>; ExportColor: BridgeType<ExportColorTag>; ExportTagged: BridgeType<ExportTaggedTag>; GenericFactory: BridgeType<GenericFactoryTag>; };
+export type LevelObject = typeof ExportNamespace.LevelValues;
+
+export type ExportModeObject = typeof ExportModeValues;
+
+export type ExportColorObject = typeof ExportColorValues;
+
+export type ExportTaggedObject = typeof ExportTaggedValues;
+
+export type GenericFactoryObject = typeof GenericFactoryValues & {
+    one<T>(value: T, typeT: BridgeType<T>): T;
+};
+
+export namespace ExportNamespace {
+    const LevelValues: {
+        readonly Low: 1;
+        readonly High: 9;
+    };
+    type LevelTag = typeof LevelValues[keyof typeof LevelValues];
+    export interface Metadata {
+        label: string;
+        count: number;
+    }
+}
+/// Represents a Swift heap object like a class instance or an actor instance.
+export interface SwiftHeapObject {
+    /// Release the heap object.
+    ///
+    /// Note: Calling this method will release the heap object and it will no longer be accessible.
+    release(): void;
+}
+export interface ExportBox extends SwiftHeapObject {
+    get(): number;
+    value: number;
+}
+export interface GenericBox extends SwiftHeapObject {
+    wrap<T>(value: T, typeT: BridgeType<T>): T;
+    combine<T, t>(a: T, b: t, typeT: BridgeType<T>, typet: BridgeType<t>): T;
+}
+export type Exports = {
+    genericExportIdentity<T>(value: T, typeT: BridgeType<T>): T;
+    genericExportArray<T>(values: T[], typeT: BridgeType<T>): T[];
+    genericExportOptional<T>(value: T | null, typeT: BridgeType<T>): T | null;
+    genericExportDictionary<T>(values: Record<string, T>, typeT: BridgeType<T>): Record<string, T>;
+    genericExportEcho<T>(value: T, tag: number, typeT: BridgeType<T>): T;
+    genericExportStructConcreteLeading<T>(v: T, p: ExportPoint, typeT: BridgeType<T>): T;
+    genericExportStructAndScalar<T>(p: ExportPoint, tag: number, v: T, typeT: BridgeType<T>): T;
+    genericExportPair<T>(a: T, b: T, typeT: BridgeType<T>): T;
+    genericExportCombine<T, U>(a: T, b: U, typeT: BridgeType<T>, typeU: BridgeType<U>): T;
+    genericExportCombineReturnU<T, U>(a: T, b: U, typeT: BridgeType<T>, typeU: BridgeType<U>): U;
+    genericExportCaseDistinct<T, t>(a: T, b: t, typeT: BridgeType<T>, typet: BridgeType<t>): T;
+    ExportMode: ExportModeObject
+    ExportColor: ExportColorObject
+    ExportTagged: ExportTaggedObject
+    GenericFactory: GenericFactoryObject
+    ExportBox: {
+        new(value: number): ExportBox;
+    },
+    ExportNamespace: {
+        Level: LevelObject
+    },
+    GenericBox: {
+        new(): GenericBox;
+        makeArray<T>(value: T, typeT: BridgeType<T>): T[];
+    },
+    GenericNamespace: {
+        make<T>(value: T, typeT: BridgeType<T>): T;
+    },
+    GenericPair: {
+        init(): GenericPair;
+        wrap<T>(value: T, typeT: BridgeType<T>): T[];
+    },
+}
+export type Imports = {
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GenericExports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GenericExports.js
@@ -1,0 +1,1031 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export const LevelValues = {
+    Low: 1,
+    High: 9,
+};
+
+export const ExportModeValues = {
+    On: "on",
+    Off: "off",
+};
+
+export const ExportColorValues = {
+    Red: 0,
+    Green: 1,
+};
+
+export const ExportTaggedValues = {
+    Tag: {
+        Number: 0,
+        Text: 1,
+    },
+};
+export const GenericFactoryValues = {
+    Primary: 0,
+};
+
+export const BridgeTypes = { Bool: "Bool", Int: "Int", Int8: "Int8", UInt8: "UInt8", Int16: "Int16", UInt16: "UInt16", Int32: "Int32", UInt32: "UInt32", UInt: "UInt", Int64: "Int64", UInt64: "UInt64", Float: "Float", Double: "Double", String: "String", JSValue: "JSValue", ExportPoint: "ExportPoint", ExportNamespace_Metadata: "ExportNamespace_Metadata", GenericPair: "GenericPair", ExportBox: "ExportBox", GenericBox: "GenericBox", ExportNamespace_Level: "ExportNamespace_Level", ExportMode: "ExportMode", ExportColor: "ExportColor", ExportTagged: "ExportTagged", GenericFactory: "GenericFactory" };
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    let decodeString;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let strStack = [];
+    let i32Stack = [];
+    let i64Stack = [];
+    let f32Stack = [];
+    let f64Stack = [];
+    let ptrStack = [];
+    let taStack = [];
+    const enumHelpers = {};
+    const structHelpers = {};
+    let __bjs_codecs;
+    let __bjs_codecsById = [];
+    function __bjs_resolveGenericType(token) {
+        const codec = __bjs_codecs[token];
+        if (!codec) {
+            throw new Error("BridgeJS: no generic codec registered for type '" + token + "'");
+        }
+        let id = __bjs_codecsById.indexOf(codec);
+        if (id === -1) {
+            id = __bjs_codecsById.push(codec) - 1;
+        }
+        return id;
+    }
+    function __bjs_lowerArrayGeneric(value, codec) {
+        for (let i = 0; i < value.length; i++) {
+            codec.lower(value[i]);
+        }
+        i32Stack.push(value.length);
+    }
+    function __bjs_liftArrayGeneric(codec) {
+        const count = i32Stack.pop();
+        if (count === -1) {
+            return taStack.pop();
+        }
+        const result = new Array(count);
+        for (let i = count - 1; i >= 0; i--) {
+            result[i] = codec.lift();
+        }
+        return result;
+    }
+    function __bjs_lowerOptionalGeneric(value, codec) {
+        if (value === null || value === undefined) {
+            i32Stack.push(0);
+        } else {
+            codec.lower(value);
+            i32Stack.push(1);
+        }
+    }
+    function __bjs_liftOptionalGeneric(codec) {
+        if (i32Stack.pop() === 0) {
+            return null;
+        }
+        return codec.lift();
+    }
+    function __bjs_lowerDictGeneric(value, codec) {
+        const keys = Object.keys(value);
+        for (let i = 0; i < keys.length; i++) {
+            __bjs_codecs["String"].lower(keys[i]);
+            codec.lower(value[keys[i]]);
+        }
+        i32Stack.push(keys.length);
+    }
+    function __bjs_liftDictGeneric(codec) {
+        const count = i32Stack.pop();
+        const result = {};
+        for (let i = 0; i < count; i++) {
+            const value = codec.lift();
+            const key = __bjs_codecs["String"].lift();
+            result[key] = value;
+        }
+        return result;
+    }
+
+    let _exports = null;
+    let bjs = null;
+    function __bjs_jsValueLower(value) {
+        let kind;
+        let payload1;
+        let payload2;
+        if (value === null) {
+            kind = 4;
+            payload1 = 0;
+            payload2 = 0;
+        } else {
+            switch (typeof value) {
+                case "boolean":
+                    kind = 0;
+                    payload1 = value ? 1 : 0;
+                    payload2 = 0;
+                    break;
+                case "number":
+                    kind = 2;
+                    payload1 = 0;
+                    payload2 = value;
+                    break;
+                case "string":
+                    kind = 1;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "undefined":
+                    kind = 5;
+                    payload1 = 0;
+                    payload2 = 0;
+                    break;
+                case "object":
+                    kind = 3;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "function":
+                    kind = 3;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "symbol":
+                    kind = 7;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "bigint":
+                    kind = 8;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                default:
+                    throw new TypeError("Unsupported JSValue type");
+            }
+        }
+        return [kind, payload1, payload2];
+    }
+    function __bjs_jsValueLift(kind, payload1, payload2) {
+        let jsValue;
+        switch (kind) {
+            case 0:
+                jsValue = payload1 !== 0;
+                break;
+            case 1:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 2:
+                jsValue = payload2;
+                break;
+            case 3:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 4:
+                jsValue = null;
+                break;
+            case 5:
+                jsValue = undefined;
+                break;
+            case 7:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 8:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            default:
+                throw new TypeError("Unsupported JSValue kind " + kind);
+        }
+        return jsValue;
+    }
+
+    const __bjs_createExportPointHelpers = () => ({
+        lower: (value) => {
+            i32Stack.push((value.x | 0));
+            i32Stack.push((value.y | 0));
+        },
+        lift: () => {
+            const int = i32Stack.pop();
+            const int1 = i32Stack.pop();
+            return { x: int1, y: int };
+        }
+    });
+    const __bjs_createExportNamespace_MetadataHelpers = () => ({
+        lower: (value) => {
+            const bytes = textEncoder.encode(value.label);
+            const id = swift.memory.retain(bytes);
+            i32Stack.push(bytes.length);
+            i32Stack.push(id);
+            i32Stack.push((value.count | 0));
+        },
+        lift: () => {
+            const int = i32Stack.pop();
+            const string = strStack.pop();
+            return { label: string, count: int };
+        }
+    });
+    const __bjs_createGenericPairHelpers = () => ({
+        lower: (value) => {
+        },
+        lift: () => {
+            const instance1 = {  };
+            instance1.first = function(value, typeT) {
+                const tTypeId = __bjs_resolveGenericType(typeT);
+                const codecT = __bjs_codecsById[tTypeId];
+                structHelpers.GenericPair.lower(this);
+                codecT.lower(value);
+                instance.exports.bjs_GenericPair_first(tTypeId);
+                return codecT.lift();
+            }.bind(instance1);
+            instance1.combine = function(a, b, typeT, typet) {
+                const tTypeId = __bjs_resolveGenericType(typeT);
+                const codecT = __bjs_codecsById[tTypeId];
+                const tTypeId1 = __bjs_resolveGenericType(typet);
+                const codect = __bjs_codecsById[tTypeId1];
+                structHelpers.GenericPair.lower(this);
+                codecT.lower(a);
+                codect.lower(b);
+                instance.exports.bjs_GenericPair_combine(tTypeId, tTypeId1);
+                return codecT.lift();
+            }.bind(instance1);
+            instance1.maybe = function(value, typeT) {
+                const tTypeId = __bjs_resolveGenericType(typeT);
+                const codecT = __bjs_codecsById[tTypeId];
+                structHelpers.GenericPair.lower(this);
+                codecT.lower(value);
+                instance.exports.bjs_GenericPair_maybe(tTypeId);
+                return __bjs_liftOptionalGeneric(codecT);
+            }.bind(instance1);
+            instance1.dict = function(value, typeT) {
+                const tTypeId = __bjs_resolveGenericType(typeT);
+                const codecT = __bjs_codecsById[tTypeId];
+                structHelpers.GenericPair.lower(this);
+                codecT.lower(value);
+                instance.exports.bjs_GenericPair_dict(tTypeId);
+                return __bjs_liftDictGeneric(codecT);
+            }.bind(instance1);
+            return instance1;
+        }
+    });
+    const __bjs_createExportTaggedValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case ExportTaggedValues.Tag.Number: {
+                    i32Stack.push((value.value | 0));
+                    return ExportTaggedValues.Tag.Number;
+                }
+                case ExportTaggedValues.Tag.Text: {
+                    const bytes = textEncoder.encode(value.value);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    return ExportTaggedValues.Tag.Text;
+                }
+                default: throw new Error("Unknown ExportTaggedValues tag: " + String(enumTag));
+            }
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case ExportTaggedValues.Tag.Number: {
+                    const int = i32Stack.pop();
+                    return { tag: ExportTaggedValues.Tag.Number, value: int };
+                }
+                case ExportTaggedValues.Tag.Text: {
+                    const string = strStack.pop();
+                    return { tag: ExportTaggedValues.Tag.Text, value: string };
+                }
+                default: throw new Error("Unknown ExportTaggedValues tag returned from Swift: " + String(tag));
+            }
+        }
+    });
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            bjs = {};
+            importObject["bjs"] = bjs;
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                tmpRetString = decodeString(ptr, len);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                return swift.memory.retain(decodeString(ptr, len));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_i32"] = function(v) {
+                i32Stack.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                f32Stack.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                f64Stack.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const value = decodeString(ptr, len);
+                strStack.push(value);
+            }
+            bjs["swift_js_pop_i32"] = function() {
+                return i32Stack.pop();
+            }
+            bjs["swift_js_pop_f32"] = function() {
+                return f32Stack.pop();
+            }
+            bjs["swift_js_pop_f64"] = function() {
+                return f64Stack.pop();
+            }
+            bjs["swift_js_push_pointer"] = function(pointer) {
+                ptrStack.push(pointer);
+            }
+            bjs["swift_js_pop_pointer"] = function() {
+                return ptrStack.pop();
+            }
+            bjs["swift_js_push_i64"] = function(v) {
+                i64Stack.push(v);
+            }
+            bjs["swift_js_pop_i64"] = function() {
+                return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
+            }
+            bjs["swift_js_struct_lower_ExportPoint"] = function(objectId) {
+                structHelpers.ExportPoint.lower(swift.memory.getObject(objectId));
+            }
+            bjs["swift_js_struct_lift_ExportPoint"] = function() {
+                const value = structHelpers.ExportPoint.lift();
+                return swift.memory.retain(value);
+            }
+            bjs["swift_js_struct_lower_ExportNamespace_Metadata"] = function(objectId) {
+                structHelpers.ExportNamespace_Metadata.lower(swift.memory.getObject(objectId));
+            }
+            bjs["swift_js_struct_lift_ExportNamespace_Metadata"] = function() {
+                const value = structHelpers.ExportNamespace_Metadata.lift();
+                return swift.memory.retain(value);
+            }
+            bjs["swift_js_struct_lower_GenericPair"] = function(objectId) {
+                structHelpers.GenericPair.lower(swift.memory.getObject(objectId));
+            }
+            bjs["swift_js_struct_lift_GenericPair"] = function() {
+                const value = structHelpers.GenericPair.lift();
+                return swift.memory.retain(value);
+            }
+            __bjs_codecs = {
+                "Bool": {
+                    lower: (v) => {
+                        i32Stack.push(v ? 1 : 0);
+                    },
+                    lift: () => {
+                        const bool = i32Stack.pop() !== 0;
+                        return bool;
+                    },
+                },
+                "Int": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop();
+                        return int;
+                    },
+                },
+                "Int8": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop();
+                        return int;
+                    },
+                },
+                "UInt8": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop() >>> 0;
+                        return int;
+                    },
+                },
+                "Int16": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop();
+                        return int;
+                    },
+                },
+                "UInt16": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop() >>> 0;
+                        return int;
+                    },
+                },
+                "Int32": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop();
+                        return int;
+                    },
+                },
+                "UInt32": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop() >>> 0;
+                        return int;
+                    },
+                },
+                "UInt": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop() >>> 0;
+                        return int;
+                    },
+                },
+                "Int64": {
+                    lower: (v) => {
+                        i64Stack.push(v);
+                    },
+                    lift: () => {
+                        const int = i64Stack.pop();
+                        return int;
+                    },
+                },
+                "UInt64": {
+                    lower: (v) => {
+                        i64Stack.push(v);
+                    },
+                    lift: () => {
+                        const int = i64Stack.pop();
+                        return int;
+                    },
+                },
+                "Float": {
+                    lower: (v) => {
+                        f32Stack.push(Math.fround(v));
+                    },
+                    lift: () => {
+                        const f32 = f32Stack.pop();
+                        return f32;
+                    },
+                },
+                "Double": {
+                    lower: (v) => {
+                        f64Stack.push(v);
+                    },
+                    lift: () => {
+                        const f64 = f64Stack.pop();
+                        return f64;
+                    },
+                },
+                "String": {
+                    lower: (v) => {
+                        const bytes = textEncoder.encode(v);
+                        const id = swift.memory.retain(bytes);
+                        i32Stack.push(bytes.length);
+                        i32Stack.push(id);
+                    },
+                    lift: () => {
+                        const string = strStack.pop();
+                        return string;
+                    },
+                },
+                "JSValue": {
+                    lower: (v) => {
+                        const [vKind, vPayload1, vPayload2] = __bjs_jsValueLower(v);
+                        i32Stack.push(vKind);
+                        i32Stack.push(vPayload1);
+                        f64Stack.push(vPayload2);
+                    },
+                    lift: () => {
+                        const jsValuePayload2 = f64Stack.pop();
+                        const jsValuePayload1 = i32Stack.pop();
+                        const jsValueKind = i32Stack.pop();
+                        const jsValue = __bjs_jsValueLift(jsValueKind, jsValuePayload1, jsValuePayload2);
+                        return jsValue;
+                    },
+                },
+                "ExportPoint": {
+                    lower: (v) => {
+                        structHelpers.ExportPoint.lower(v);
+                    },
+                    lift: () => {
+                        const struct = structHelpers.ExportPoint.lift();
+                        return struct;
+                    },
+                },
+                "ExportNamespace_Metadata": {
+                    lower: (v) => {
+                        structHelpers.ExportNamespace_Metadata.lower(v);
+                    },
+                    lift: () => {
+                        const struct = structHelpers.ExportNamespace_Metadata.lift();
+                        return struct;
+                    },
+                },
+                "GenericPair": {
+                    lower: (v) => {
+                        structHelpers.GenericPair.lower(v);
+                    },
+                    lift: () => {
+                        const struct = structHelpers.GenericPair.lift();
+                        return struct;
+                    },
+                },
+                "ExportBox": {
+                    lower: (v) => {
+                        ptrStack.push(v.pointer);
+                    },
+                    lift: () => {
+                        const ptr = ptrStack.pop();
+                        const obj = _exports['ExportBox'].__construct(ptr);
+                        return obj;
+                    },
+                },
+                "GenericBox": {
+                    lower: (v) => {
+                        ptrStack.push(v.pointer);
+                    },
+                    lift: () => {
+                        const ptr = ptrStack.pop();
+                        const obj = _exports['GenericBox'].__construct(ptr);
+                        return obj;
+                    },
+                },
+                "ExportNamespace_Level": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const rawValue = i32Stack.pop();
+                        return rawValue;
+                    },
+                },
+                "ExportMode": {
+                    lower: (v) => {
+                        const bytes = textEncoder.encode(v);
+                        const id = swift.memory.retain(bytes);
+                        i32Stack.push(bytes.length);
+                        i32Stack.push(id);
+                    },
+                    lift: () => {
+                        const rawValue = strStack.pop();
+                        return rawValue;
+                    },
+                },
+                "ExportColor": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const caseId = i32Stack.pop();
+                        return caseId;
+                    },
+                },
+                "ExportTagged": {
+                    lower: (v) => {
+                        const caseId = enumHelpers.ExportTagged.lower(v);
+                        i32Stack.push(caseId);
+                    },
+                    lift: () => {
+                        const enumValue = enumHelpers.ExportTagged.lift(i32Stack.pop());
+                        return enumValue;
+                    },
+                },
+                "GenericFactory": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const caseId = i32Stack.pop();
+                        return caseId;
+                    },
+                },
+            };
+            bjs["swift_js_resolve_type_id"] = function(ptr, len) {
+                return __bjs_resolveGenericType(decodeString(ptr, len));
+            }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = decodeString(ptr, len);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            bjs["swift_js_get_optional_int_presence"] = function() {
+                return tmpRetOptionalInt != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_int_value"] = function() {
+                const value = tmpRetOptionalInt;
+                tmpRetOptionalInt = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_string"] = function() {
+                const str = tmpRetString;
+                tmpRetString = undefined;
+                if (str == null) {
+                    return -1;
+                } else {
+                    const bytes = textEncoder.encode(str);
+                    tmpRetBytes = bytes;
+                    return bytes.length;
+                }
+            }
+            bjs["swift_js_get_optional_float_presence"] = function() {
+                return tmpRetOptionalFloat != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_float_value"] = function() {
+                const value = tmpRetOptionalFloat;
+                tmpRetOptionalFloat = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_double_presence"] = function() {
+                return tmpRetOptionalDouble != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_double_value"] = function() {
+                const value = tmpRetOptionalDouble;
+                tmpRetOptionalDouble = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_heap_object_pointer"] = function() {
+                const pointer = tmpRetOptionalHeapObject;
+                tmpRetOptionalHeapObject = undefined;
+                return pointer || 0;
+            }
+            bjs["swift_js_closure_unregister"] = function(funcRef) {}
+            // Wrapper functions for module: TestModule
+            if (!importObject["TestModule"]) {
+                importObject["TestModule"] = {};
+            }
+            importObject["TestModule"]["bjs_ExportBox_wrap"] = function(pointer) {
+                const obj = _exports['ExportBox'].__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+            importObject["TestModule"]["bjs_GenericBox_wrap"] = function(pointer) {
+                const obj = _exports['GenericBox'].__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            decodeString = (ptr, len) => { const bytes = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0); return textDecoder.decode(bytes); }
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            const swiftHeapObjectFinalizationRegistry = (typeof FinalizationRegistry === "undefined") ? { register: () => {}, unregister: () => {} } : new FinalizationRegistry((state) => {
+                if (state.hasReleased) {
+                    return;
+                }
+                state.hasReleased = true;
+                state.identityMap?.delete(state.pointer);
+                state.deinit(state.pointer);
+            });
+
+            /// Represents a Swift heap object like a class instance or an actor instance.
+            class SwiftHeapObject {
+                static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
+                    const makeFresh = (identityMap) => {
+                        const obj = Object.create(prototype);
+                        const state = { pointer, deinit, hasReleased: false, identityMap };
+                        obj.pointer = pointer;
+                        obj.__swiftHeapObjectState = state;
+                        swiftHeapObjectFinalizationRegistry.register(obj, state, state);
+                        if (identityMap) {
+                            identityMap.set(pointer, new WeakRef(obj));
+                        }
+                        return obj;
+                    };
+
+                    if (!identityCache) {
+                        return makeFresh(null);
+                    }
+
+                    const cached = identityCache.get(pointer)?.deref();
+                    if (cached && !cached.__swiftHeapObjectState.hasReleased) {
+                        deinit(pointer);
+                        return cached;
+                    }
+                    if (identityCache.has(pointer)) {
+                        identityCache.delete(pointer);
+                    }
+
+                    return makeFresh(identityCache);
+                }
+
+                release() {
+                    const state = this.__swiftHeapObjectState;
+                    if (state.hasReleased) {
+                        return;
+                    }
+                    state.hasReleased = true;
+                    swiftHeapObjectFinalizationRegistry.unregister(state);
+                    state.identityMap?.delete(state.pointer);
+                    state.deinit(state.pointer);
+                }
+            }
+            class ExportBox extends SwiftHeapObject {
+                static __construct(ptr) {
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_ExportBox_deinit, ExportBox.prototype, null);
+                }
+
+                constructor(value) {
+                    const ret = instance.exports.bjs_ExportBox_init(value);
+                    return ExportBox.__construct(ret);
+                }
+                get() {
+                    const ret = instance.exports.bjs_ExportBox_get(this.pointer);
+                    return ret;
+                }
+                get value() {
+                    const ret = instance.exports.bjs_ExportBox_value_get(this.pointer);
+                    return ret;
+                }
+                set value(value) {
+                    instance.exports.bjs_ExportBox_value_set(this.pointer, value);
+                }
+            }
+            class GenericBox extends SwiftHeapObject {
+                static __construct(ptr) {
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_GenericBox_deinit, GenericBox.prototype, null);
+                }
+
+                constructor() {
+                    const ret = instance.exports.bjs_GenericBox_init();
+                    return GenericBox.__construct(ret);
+                }
+                wrap(value, typeT) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    codecT.lower(value);
+                    instance.exports.bjs_GenericBox_wrap(this.pointer, tTypeId);
+                    return codecT.lift();
+                }
+                combine(a, b, typeT, typet) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const tTypeId1 = __bjs_resolveGenericType(typet);
+                    const codect = __bjs_codecsById[tTypeId1];
+                    codecT.lower(a);
+                    codect.lower(b);
+                    instance.exports.bjs_GenericBox_combine(this.pointer, tTypeId, tTypeId1);
+                    return codecT.lift();
+                }
+                static makeArray(value, typeT) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    codecT.lower(value);
+                    instance.exports.bjs_GenericBox_static_makeArray(tTypeId);
+                    return __bjs_liftArrayGeneric(codecT);
+                }
+            }
+            const ExportPointHelpers = __bjs_createExportPointHelpers();
+            structHelpers.ExportPoint = ExportPointHelpers;
+
+            const ExportNamespace_MetadataHelpers = __bjs_createExportNamespace_MetadataHelpers();
+            structHelpers.ExportNamespace_Metadata = ExportNamespace_MetadataHelpers;
+
+            const GenericPairHelpers = __bjs_createGenericPairHelpers();
+            structHelpers.GenericPair = GenericPairHelpers;
+
+            const ExportTaggedHelpers = __bjs_createExportTaggedValuesHelpers();
+            enumHelpers.ExportTagged = ExportTaggedHelpers;
+
+            const exports = {
+                genericExportIdentity: function bjs_genericExportIdentity(value, typeT) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    codecT.lower(value);
+                    instance.exports.bjs_genericExportIdentity(tTypeId);
+                    return codecT.lift();
+                },
+                genericExportArray: function bjs_genericExportArray(values, typeT) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    __bjs_lowerArrayGeneric(values, codecT);
+                    instance.exports.bjs_genericExportArray(tTypeId);
+                    return __bjs_liftArrayGeneric(codecT);
+                },
+                genericExportOptional: function bjs_genericExportOptional(value, typeT) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    __bjs_lowerOptionalGeneric(value, codecT);
+                    instance.exports.bjs_genericExportOptional(tTypeId);
+                    return __bjs_liftOptionalGeneric(codecT);
+                },
+                genericExportDictionary: function bjs_genericExportDictionary(values, typeT) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    __bjs_lowerDictGeneric(values, codecT);
+                    instance.exports.bjs_genericExportDictionary(tTypeId);
+                    return __bjs_liftDictGeneric(codecT);
+                },
+                genericExportEcho: function bjs_genericExportEcho(value, tag, typeT) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    codecT.lower(value);
+                    instance.exports.bjs_genericExportEcho(tag, tTypeId);
+                    return codecT.lift();
+                },
+                genericExportStructConcreteLeading: function bjs_genericExportStructConcreteLeading(v, p, typeT) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    structHelpers.ExportPoint.lower(p);
+                    codecT.lower(v);
+                    instance.exports.bjs_genericExportStructConcreteLeading(tTypeId);
+                    return codecT.lift();
+                },
+                genericExportStructAndScalar: function bjs_genericExportStructAndScalar(p, tag, v, typeT) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    structHelpers.ExportPoint.lower(p);
+                    codecT.lower(v);
+                    instance.exports.bjs_genericExportStructAndScalar(tag, tTypeId);
+                    return codecT.lift();
+                },
+                genericExportPair: function bjs_genericExportPair(a, b, typeT) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    codecT.lower(a);
+                    codecT.lower(b);
+                    instance.exports.bjs_genericExportPair(tTypeId);
+                    return codecT.lift();
+                },
+                genericExportCombine: function bjs_genericExportCombine(a, b, typeT, typeU) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const uTypeId = __bjs_resolveGenericType(typeU);
+                    const codecU = __bjs_codecsById[uTypeId];
+                    codecT.lower(a);
+                    codecU.lower(b);
+                    instance.exports.bjs_genericExportCombine(tTypeId, uTypeId);
+                    return codecT.lift();
+                },
+                genericExportCombineReturnU: function bjs_genericExportCombineReturnU(a, b, typeT, typeU) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const uTypeId = __bjs_resolveGenericType(typeU);
+                    const codecU = __bjs_codecsById[uTypeId];
+                    codecT.lower(a);
+                    codecU.lower(b);
+                    instance.exports.bjs_genericExportCombineReturnU(tTypeId, uTypeId);
+                    return codecU.lift();
+                },
+                genericExportCaseDistinct: function bjs_genericExportCaseDistinct(a, b, typeT, typet) {
+                    const tTypeId = __bjs_resolveGenericType(typeT);
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const tTypeId1 = __bjs_resolveGenericType(typet);
+                    const codect = __bjs_codecsById[tTypeId1];
+                    codecT.lower(a);
+                    codect.lower(b);
+                    instance.exports.bjs_genericExportCaseDistinct(tTypeId, tTypeId1);
+                    return codecT.lift();
+                },
+                ExportMode: ExportModeValues,
+                ExportColor: ExportColorValues,
+                ExportTagged: ExportTaggedValues,
+                GenericFactory: {
+                    ...GenericFactoryValues,
+                    one: function(value, typeT) {
+                        const tTypeId = __bjs_resolveGenericType(typeT);
+                        const codecT = __bjs_codecsById[tTypeId];
+                        codecT.lower(value);
+                        instance.exports.bjs_GenericFactory_static_one(tTypeId);
+                        return codecT.lift();
+                    }
+                },
+                ExportBox,
+                ExportNamespace: {
+                    Level: LevelValues,
+                },
+                GenericBox,
+                GenericNamespace: {
+                    make: function bjs_GenericNamespace_static_make(value, typeT) {
+                        const tTypeId = __bjs_resolveGenericType(typeT);
+                        const codecT = __bjs_codecsById[tTypeId];
+                        codecT.lower(value);
+                        instance.exports.bjs_GenericNamespace_static_make(tTypeId);
+                        return codecT.lift();
+                    },
+                },
+                GenericPair: {
+                    init: function() {
+                        instance.exports.bjs_GenericPair_init();
+                        const structValue = structHelpers.GenericPair.lift();
+                        return structValue;
+                    },
+                    wrap: function(value, typeT) {
+                        const tTypeId = __bjs_resolveGenericType(typeT);
+                        const codecT = __bjs_codecsById[tTypeId];
+                        codecT.lower(value);
+                        instance.exports.bjs_GenericPair_static_wrap(tTypeId);
+                        return __bjs_liftArrayGeneric(codecT);
+                    },
+                },
+            };
+            _exports = exports;
+            return exports;
+        },
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GenericImports.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GenericImports.d.ts
@@ -1,0 +1,80 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export const GenericColorValues: {
+    readonly Red: 0;
+    readonly Green: 1;
+};
+export type GenericColorTag = typeof GenericColorValues[keyof typeof GenericColorValues];
+
+export const GenericModeValues: {
+    readonly Light: "light";
+    readonly Dark: "dark";
+};
+export type GenericModeTag = typeof GenericModeValues[keyof typeof GenericModeValues];
+
+export const GenericTaggedValues: {
+    readonly Tag: {
+        readonly Number: 0;
+        readonly Text: 1;
+    };
+};
+
+export type GenericTaggedTag =
+  { tag: typeof GenericTaggedValues.Tag.Number; value: number } | { tag: typeof GenericTaggedValues.Tag.Text; value: string }
+
+export interface GenericPoint {
+    x: number;
+    y: number;
+}
+export type GenericColorObject = typeof GenericColorValues;
+
+export type GenericModeObject = typeof GenericModeValues;
+
+export type GenericTaggedObject = typeof GenericTaggedValues;
+
+/// Represents a Swift heap object like a class instance or an actor instance.
+export interface SwiftHeapObject {
+    /// Release the heap object.
+    ///
+    /// Note: Calling this method will release the heap object and it will no longer be accessible.
+    release(): void;
+}
+export interface GenericImportBox extends SwiftHeapObject {
+    get(): number;
+    value: number;
+}
+export interface GenericConsumer {
+    accept<T>(value: T): void;
+    identity<T>(value: T): T;
+}
+export type Exports = {
+    GenericColor: GenericColorObject
+    GenericMode: GenericModeObject
+    GenericTagged: GenericTaggedObject
+    GenericImportBox: {
+        new(value: number): GenericImportBox;
+    },
+}
+export type Imports = {
+    genericRoundTrip<T>(value: T): T;
+    genericParse<T>(json: string): T;
+    importGenericCombine<T, U>(a: T, b: U): U;
+    importGenericCaseDistinct<T, t>(a: T, b: t): T;
+    importGenericArray<T>(values: T[]): T[];
+    importGenericOptional<T>(value: T | null): T | null;
+    importGenericDictionary<T>(values: Record<string, T>): Record<string, T>;
+    GenericConsumer: {
+        box<T>(value: T): T;
+    }
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GenericImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GenericImports.js
@@ -1,0 +1,839 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export const GenericColorValues = {
+    Red: 0,
+    Green: 1,
+};
+
+export const GenericModeValues = {
+    Light: "light",
+    Dark: "dark",
+};
+
+export const GenericTaggedValues = {
+    Tag: {
+        Number: 0,
+        Text: 1,
+    },
+};
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    let decodeString;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let strStack = [];
+    let i32Stack = [];
+    let i64Stack = [];
+    let f32Stack = [];
+    let f64Stack = [];
+    let ptrStack = [];
+    let taStack = [];
+    const enumHelpers = {};
+    const structHelpers = {};
+    let __bjs_codecs;
+    let __bjs_codecsById = [];
+    function __bjs_resolveGenericType(token) {
+        const codec = __bjs_codecs[token];
+        if (!codec) {
+            throw new Error("BridgeJS: no generic codec registered for type '" + token + "'");
+        }
+        let id = __bjs_codecsById.indexOf(codec);
+        if (id === -1) {
+            id = __bjs_codecsById.push(codec) - 1;
+        }
+        return id;
+    }
+    function __bjs_lowerArrayGeneric(value, codec) {
+        for (let i = 0; i < value.length; i++) {
+            codec.lower(value[i]);
+        }
+        i32Stack.push(value.length);
+    }
+    function __bjs_liftArrayGeneric(codec) {
+        const count = i32Stack.pop();
+        if (count === -1) {
+            return taStack.pop();
+        }
+        const result = new Array(count);
+        for (let i = count - 1; i >= 0; i--) {
+            result[i] = codec.lift();
+        }
+        return result;
+    }
+    function __bjs_lowerOptionalGeneric(value, codec) {
+        if (value === null || value === undefined) {
+            i32Stack.push(0);
+        } else {
+            codec.lower(value);
+            i32Stack.push(1);
+        }
+    }
+    function __bjs_liftOptionalGeneric(codec) {
+        if (i32Stack.pop() === 0) {
+            return null;
+        }
+        return codec.lift();
+    }
+    function __bjs_lowerDictGeneric(value, codec) {
+        const keys = Object.keys(value);
+        for (let i = 0; i < keys.length; i++) {
+            __bjs_codecs["String"].lower(keys[i]);
+            codec.lower(value[keys[i]]);
+        }
+        i32Stack.push(keys.length);
+    }
+    function __bjs_liftDictGeneric(codec) {
+        const count = i32Stack.pop();
+        const result = {};
+        for (let i = 0; i < count; i++) {
+            const value = codec.lift();
+            const key = __bjs_codecs["String"].lift();
+            result[key] = value;
+        }
+        return result;
+    }
+
+    let _exports = null;
+    let bjs = null;
+    function __bjs_jsValueLower(value) {
+        let kind;
+        let payload1;
+        let payload2;
+        if (value === null) {
+            kind = 4;
+            payload1 = 0;
+            payload2 = 0;
+        } else {
+            switch (typeof value) {
+                case "boolean":
+                    kind = 0;
+                    payload1 = value ? 1 : 0;
+                    payload2 = 0;
+                    break;
+                case "number":
+                    kind = 2;
+                    payload1 = 0;
+                    payload2 = value;
+                    break;
+                case "string":
+                    kind = 1;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "undefined":
+                    kind = 5;
+                    payload1 = 0;
+                    payload2 = 0;
+                    break;
+                case "object":
+                    kind = 3;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "function":
+                    kind = 3;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "symbol":
+                    kind = 7;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "bigint":
+                    kind = 8;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                default:
+                    throw new TypeError("Unsupported JSValue type");
+            }
+        }
+        return [kind, payload1, payload2];
+    }
+    function __bjs_jsValueLift(kind, payload1, payload2) {
+        let jsValue;
+        switch (kind) {
+            case 0:
+                jsValue = payload1 !== 0;
+                break;
+            case 1:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 2:
+                jsValue = payload2;
+                break;
+            case 3:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 4:
+                jsValue = null;
+                break;
+            case 5:
+                jsValue = undefined;
+                break;
+            case 7:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 8:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            default:
+                throw new TypeError("Unsupported JSValue kind " + kind);
+        }
+        return jsValue;
+    }
+
+    const __bjs_createGenericPointHelpers = () => ({
+        lower: (value) => {
+            i32Stack.push((value.x | 0));
+            i32Stack.push((value.y | 0));
+        },
+        lift: () => {
+            const int = i32Stack.pop();
+            const int1 = i32Stack.pop();
+            return { x: int1, y: int };
+        }
+    });
+    const __bjs_createGenericTaggedValuesHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case GenericTaggedValues.Tag.Number: {
+                    i32Stack.push((value.value | 0));
+                    return GenericTaggedValues.Tag.Number;
+                }
+                case GenericTaggedValues.Tag.Text: {
+                    const bytes = textEncoder.encode(value.value);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    return GenericTaggedValues.Tag.Text;
+                }
+                default: throw new Error("Unknown GenericTaggedValues tag: " + String(enumTag));
+            }
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case GenericTaggedValues.Tag.Number: {
+                    const int = i32Stack.pop();
+                    return { tag: GenericTaggedValues.Tag.Number, value: int };
+                }
+                case GenericTaggedValues.Tag.Text: {
+                    const string = strStack.pop();
+                    return { tag: GenericTaggedValues.Tag.Text, value: string };
+                }
+                default: throw new Error("Unknown GenericTaggedValues tag returned from Swift: " + String(tag));
+            }
+        }
+    });
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            bjs = {};
+            importObject["bjs"] = bjs;
+            const imports = options.getImports(importsContext);
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                tmpRetString = decodeString(ptr, len);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                return swift.memory.retain(decodeString(ptr, len));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_i32"] = function(v) {
+                i32Stack.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                f32Stack.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                f64Stack.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const value = decodeString(ptr, len);
+                strStack.push(value);
+            }
+            bjs["swift_js_pop_i32"] = function() {
+                return i32Stack.pop();
+            }
+            bjs["swift_js_pop_f32"] = function() {
+                return f32Stack.pop();
+            }
+            bjs["swift_js_pop_f64"] = function() {
+                return f64Stack.pop();
+            }
+            bjs["swift_js_push_pointer"] = function(pointer) {
+                ptrStack.push(pointer);
+            }
+            bjs["swift_js_pop_pointer"] = function() {
+                return ptrStack.pop();
+            }
+            bjs["swift_js_push_i64"] = function(v) {
+                i64Stack.push(v);
+            }
+            bjs["swift_js_pop_i64"] = function() {
+                return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
+            }
+            bjs["swift_js_struct_lower_GenericPoint"] = function(objectId) {
+                structHelpers.GenericPoint.lower(swift.memory.getObject(objectId));
+            }
+            bjs["swift_js_struct_lift_GenericPoint"] = function() {
+                const value = structHelpers.GenericPoint.lift();
+                return swift.memory.retain(value);
+            }
+            __bjs_codecs = {
+                "Bool": {
+                    lower: (v) => {
+                        i32Stack.push(v ? 1 : 0);
+                    },
+                    lift: () => {
+                        const bool = i32Stack.pop() !== 0;
+                        return bool;
+                    },
+                },
+                "Int": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop();
+                        return int;
+                    },
+                },
+                "Int8": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop();
+                        return int;
+                    },
+                },
+                "UInt8": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop() >>> 0;
+                        return int;
+                    },
+                },
+                "Int16": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop();
+                        return int;
+                    },
+                },
+                "UInt16": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop() >>> 0;
+                        return int;
+                    },
+                },
+                "Int32": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop();
+                        return int;
+                    },
+                },
+                "UInt32": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop() >>> 0;
+                        return int;
+                    },
+                },
+                "UInt": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const int = i32Stack.pop() >>> 0;
+                        return int;
+                    },
+                },
+                "Int64": {
+                    lower: (v) => {
+                        i64Stack.push(v);
+                    },
+                    lift: () => {
+                        const int = i64Stack.pop();
+                        return int;
+                    },
+                },
+                "UInt64": {
+                    lower: (v) => {
+                        i64Stack.push(v);
+                    },
+                    lift: () => {
+                        const int = i64Stack.pop();
+                        return int;
+                    },
+                },
+                "Float": {
+                    lower: (v) => {
+                        f32Stack.push(Math.fround(v));
+                    },
+                    lift: () => {
+                        const f32 = f32Stack.pop();
+                        return f32;
+                    },
+                },
+                "Double": {
+                    lower: (v) => {
+                        f64Stack.push(v);
+                    },
+                    lift: () => {
+                        const f64 = f64Stack.pop();
+                        return f64;
+                    },
+                },
+                "String": {
+                    lower: (v) => {
+                        const bytes = textEncoder.encode(v);
+                        const id = swift.memory.retain(bytes);
+                        i32Stack.push(bytes.length);
+                        i32Stack.push(id);
+                    },
+                    lift: () => {
+                        const string = strStack.pop();
+                        return string;
+                    },
+                },
+                "JSValue": {
+                    lower: (v) => {
+                        const [vKind, vPayload1, vPayload2] = __bjs_jsValueLower(v);
+                        i32Stack.push(vKind);
+                        i32Stack.push(vPayload1);
+                        f64Stack.push(vPayload2);
+                    },
+                    lift: () => {
+                        const jsValuePayload2 = f64Stack.pop();
+                        const jsValuePayload1 = i32Stack.pop();
+                        const jsValueKind = i32Stack.pop();
+                        const jsValue = __bjs_jsValueLift(jsValueKind, jsValuePayload1, jsValuePayload2);
+                        return jsValue;
+                    },
+                },
+                "GenericPoint": {
+                    lower: (v) => {
+                        structHelpers.GenericPoint.lower(v);
+                    },
+                    lift: () => {
+                        const struct = structHelpers.GenericPoint.lift();
+                        return struct;
+                    },
+                },
+                "GenericImportBox": {
+                    lower: (v) => {
+                        ptrStack.push(v.pointer);
+                    },
+                    lift: () => {
+                        const ptr = ptrStack.pop();
+                        const obj = _exports['GenericImportBox'].__construct(ptr);
+                        return obj;
+                    },
+                },
+                "GenericColor": {
+                    lower: (v) => {
+                        i32Stack.push((v | 0));
+                    },
+                    lift: () => {
+                        const caseId = i32Stack.pop();
+                        return caseId;
+                    },
+                },
+                "GenericMode": {
+                    lower: (v) => {
+                        const bytes = textEncoder.encode(v);
+                        const id = swift.memory.retain(bytes);
+                        i32Stack.push(bytes.length);
+                        i32Stack.push(id);
+                    },
+                    lift: () => {
+                        const rawValue = strStack.pop();
+                        return rawValue;
+                    },
+                },
+                "GenericTagged": {
+                    lower: (v) => {
+                        const caseId = enumHelpers.GenericTagged.lower(v);
+                        i32Stack.push(caseId);
+                    },
+                    lift: () => {
+                        const enumValue = enumHelpers.GenericTagged.lift(i32Stack.pop());
+                        return enumValue;
+                    },
+                },
+            };
+            bjs["swift_js_resolve_type_id"] = function(ptr, len) {
+                return __bjs_resolveGenericType(decodeString(ptr, len));
+            }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = decodeString(ptr, len);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            bjs["swift_js_get_optional_int_presence"] = function() {
+                return tmpRetOptionalInt != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_int_value"] = function() {
+                const value = tmpRetOptionalInt;
+                tmpRetOptionalInt = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_string"] = function() {
+                const str = tmpRetString;
+                tmpRetString = undefined;
+                if (str == null) {
+                    return -1;
+                } else {
+                    const bytes = textEncoder.encode(str);
+                    tmpRetBytes = bytes;
+                    return bytes.length;
+                }
+            }
+            bjs["swift_js_get_optional_float_presence"] = function() {
+                return tmpRetOptionalFloat != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_float_value"] = function() {
+                const value = tmpRetOptionalFloat;
+                tmpRetOptionalFloat = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_double_presence"] = function() {
+                return tmpRetOptionalDouble != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_double_value"] = function() {
+                const value = tmpRetOptionalDouble;
+                tmpRetOptionalDouble = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_heap_object_pointer"] = function() {
+                const pointer = tmpRetOptionalHeapObject;
+                tmpRetOptionalHeapObject = undefined;
+                return pointer || 0;
+            }
+            bjs["swift_js_closure_unregister"] = function(funcRef) {}
+            // Wrapper functions for module: TestModule
+            if (!importObject["TestModule"]) {
+                importObject["TestModule"] = {};
+            }
+            importObject["TestModule"]["bjs_GenericImportBox_wrap"] = function(pointer) {
+                const obj = _exports['GenericImportBox'].__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+            const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
+            TestModule["bjs_genericRoundTrip"] = function bjs_genericRoundTrip(tTypeId) {
+                try {
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const value = codecT.lift();
+                    let ret = imports.genericRoundTrip(value);
+                    codecT.lower(ret);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_genericParse"] = function bjs_genericParse(jsonBytes, jsonCount, tTypeId) {
+                try {
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const string = decodeString(jsonBytes, jsonCount);
+                    let ret = imports.genericParse(string);
+                    codecT.lower(ret);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_importGenericCombine"] = function bjs_importGenericCombine(tTypeId, uTypeId) {
+                try {
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const codecU = __bjs_codecsById[uTypeId];
+                    const a = codecT.lift();
+                    const b = codecU.lift();
+                    let ret = imports.importGenericCombine(a, b);
+                    codecU.lower(ret);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_importGenericCaseDistinct"] = function bjs_importGenericCaseDistinct(tTypeId, tTypeId1) {
+                try {
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const codect = __bjs_codecsById[tTypeId1];
+                    const a = codecT.lift();
+                    const b = codect.lift();
+                    let ret = imports.importGenericCaseDistinct(a, b);
+                    codecT.lower(ret);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_importGenericArray"] = function bjs_importGenericArray(tTypeId) {
+                try {
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const values = __bjs_liftArrayGeneric(codecT);
+                    let ret = imports.importGenericArray(values);
+                    __bjs_lowerArrayGeneric(ret, codecT);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_importGenericOptional"] = function bjs_importGenericOptional(tTypeId) {
+                try {
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const value = __bjs_liftOptionalGeneric(codecT);
+                    let ret = imports.importGenericOptional(value);
+                    __bjs_lowerOptionalGeneric(ret, codecT);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_importGenericDictionary"] = function bjs_importGenericDictionary(tTypeId) {
+                try {
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const values = __bjs_liftDictGeneric(codecT);
+                    let ret = imports.importGenericDictionary(values);
+                    __bjs_lowerDictGeneric(ret, codecT);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_GenericConsumer_box_static"] = function bjs_GenericConsumer_box_static(tTypeId) {
+                try {
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const value = codecT.lift();
+                    let ret = imports.GenericConsumer.box(value);
+                    codecT.lower(ret);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_GenericConsumer_accept"] = function bjs_GenericConsumer_accept(self, tTypeId) {
+                try {
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const value = codecT.lift();
+                    swift.memory.getObject(self).accept(value);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            TestModule["bjs_GenericConsumer_identity"] = function bjs_GenericConsumer_identity(self, tTypeId) {
+                try {
+                    const codecT = __bjs_codecsById[tTypeId];
+                    const value = codecT.lift();
+                    let ret = swift.memory.getObject(self).identity(value);
+                    codecT.lower(ret);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            decodeString = (ptr, len) => { const bytes = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0); return textDecoder.decode(bytes); }
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            const swiftHeapObjectFinalizationRegistry = (typeof FinalizationRegistry === "undefined") ? { register: () => {}, unregister: () => {} } : new FinalizationRegistry((state) => {
+                if (state.hasReleased) {
+                    return;
+                }
+                state.hasReleased = true;
+                state.identityMap?.delete(state.pointer);
+                state.deinit(state.pointer);
+            });
+
+            /// Represents a Swift heap object like a class instance or an actor instance.
+            class SwiftHeapObject {
+                static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
+                    const makeFresh = (identityMap) => {
+                        const obj = Object.create(prototype);
+                        const state = { pointer, deinit, hasReleased: false, identityMap };
+                        obj.pointer = pointer;
+                        obj.__swiftHeapObjectState = state;
+                        swiftHeapObjectFinalizationRegistry.register(obj, state, state);
+                        if (identityMap) {
+                            identityMap.set(pointer, new WeakRef(obj));
+                        }
+                        return obj;
+                    };
+
+                    if (!identityCache) {
+                        return makeFresh(null);
+                    }
+
+                    const cached = identityCache.get(pointer)?.deref();
+                    if (cached && !cached.__swiftHeapObjectState.hasReleased) {
+                        deinit(pointer);
+                        return cached;
+                    }
+                    if (identityCache.has(pointer)) {
+                        identityCache.delete(pointer);
+                    }
+
+                    return makeFresh(identityCache);
+                }
+
+                release() {
+                    const state = this.__swiftHeapObjectState;
+                    if (state.hasReleased) {
+                        return;
+                    }
+                    state.hasReleased = true;
+                    swiftHeapObjectFinalizationRegistry.unregister(state);
+                    state.identityMap?.delete(state.pointer);
+                    state.deinit(state.pointer);
+                }
+            }
+            class GenericImportBox extends SwiftHeapObject {
+                static __construct(ptr) {
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_GenericImportBox_deinit, GenericImportBox.prototype, null);
+                }
+
+                constructor(value) {
+                    const ret = instance.exports.bjs_GenericImportBox_init(value);
+                    return GenericImportBox.__construct(ret);
+                }
+                get() {
+                    const ret = instance.exports.bjs_GenericImportBox_get(this.pointer);
+                    return ret;
+                }
+                get value() {
+                    const ret = instance.exports.bjs_GenericImportBox_value_get(this.pointer);
+                    return ret;
+                }
+                set value(value) {
+                    instance.exports.bjs_GenericImportBox_value_set(this.pointer, value);
+                }
+            }
+            const GenericPointHelpers = __bjs_createGenericPointHelpers();
+            structHelpers.GenericPoint = GenericPointHelpers;
+
+            const GenericTaggedHelpers = __bjs_createGenericTaggedValuesHelpers();
+            enumHelpers.GenericTagged = GenericTaggedHelpers;
+
+            const exports = {
+                GenericColor: GenericColorValues,
+                GenericMode: GenericModeValues,
+                GenericTagged: GenericTaggedValues,
+                GenericImportBox,
+            };
+            _exports = exports;
+            return exports;
+        },
+    }
+}

--- a/Plugins/PackageToJS/Templates/instantiate.js
+++ b/Plugins/PackageToJS/Templates/instantiate.js
@@ -70,6 +70,7 @@ async function createInstantiator(options, swift) {
                 swift_js_closure_unregister: unexpectedBjsCall,
                 swift_js_push_typed_array: unexpectedBjsCall,
                 swift_js_make_promise: unexpectedBjsCall,
+                swift_js_resolve_type_id: unexpectedBjsCall,
             };
         },
         /** @param {WebAssembly.Instance} instance */

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -204,6 +204,26 @@ extension _BridgedSwiftStackType {
     }
 }
 
+public protocol _BridgedSwiftGenericBridgeable: _BridgedSwiftStackType
+where StackLiftResult == Self {
+    @_spi(BridgeJS) static var bridgeJSTypeID: Int32 { get }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_resolve_type_id")
+private func _swift_js_resolve_type_id_extern(_ namePtr: UnsafePointer<UInt8>?, _ length: Int32) -> Int32
+#else
+private func _swift_js_resolve_type_id_extern(_ namePtr: UnsafePointer<UInt8>?, _ length: Int32) -> Int32 {
+    _onlyAvailableOnWasm()
+}
+#endif
+
+@_spi(BridgeJS) @inline(never) public func _swift_js_resolve_type_id(_ name: StaticString) -> Int32 {
+    name.withUTF8Buffer { buffer in
+        _swift_js_resolve_type_id_extern(buffer.baseAddress, Int32(buffer.count))
+    }
+}
+
 /// Types that bridge with the same (isSome, value) ABI as Optional.
 /// Used by JSUndefinedOr so all bridge methods delegate to Optional<Wrapped>.
 public protocol _BridgedAsOptional {
@@ -808,6 +828,49 @@ extension String: _BridgedSwiftStackType {
     }
 }
 
+extension Bool: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Bool")
+}
+extension Int: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Int")
+}
+extension Float: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Float")
+}
+extension Double: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Double")
+}
+extension String: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("String")
+}
+extension UInt: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("UInt")
+}
+extension Int8: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Int8")
+}
+extension UInt8: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("UInt8")
+}
+extension Int16: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Int16")
+}
+extension UInt16: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("UInt16")
+}
+extension Int32: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Int32")
+}
+extension UInt32: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("UInt32")
+}
+extension Int64: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Int64")
+}
+extension UInt64: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("UInt64")
+}
+
 extension JSObject: _BridgedSwiftStackType {
     // JSObject is a non-final class, so we must explicitly specify the associated type
     // rather than relying on the default `Self` (which Swift requires for covariant returns).
@@ -912,6 +975,10 @@ extension JSValue: _BridgedSwiftStackType {
     @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() {
         bridgeJSStackPush()
     }
+}
+
+extension JSValue: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("JSValue")
 }
 
 /// A protocol that Swift heap objects exposed to JavaScript via `@JS class` must conform to.

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -204,7 +204,7 @@ extension _BridgedSwiftStackType {
     }
 }
 
-public protocol _BridgedSwiftGenericBridgeable: _BridgedSwiftStackType
+public protocol BridgedSwiftGenericBridgeable: _BridgedSwiftStackType
 where StackLiftResult == Self {
     @_spi(BridgeJS) static var bridgeJSTypeID: Int32 { get }
 }
@@ -828,46 +828,46 @@ extension String: _BridgedSwiftStackType {
     }
 }
 
-extension Bool: _BridgedSwiftGenericBridgeable {
+extension Bool: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Bool")
 }
-extension Int: _BridgedSwiftGenericBridgeable {
+extension Int: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Int")
 }
-extension Float: _BridgedSwiftGenericBridgeable {
+extension Float: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Float")
 }
-extension Double: _BridgedSwiftGenericBridgeable {
+extension Double: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Double")
 }
-extension String: _BridgedSwiftGenericBridgeable {
+extension String: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("String")
 }
-extension UInt: _BridgedSwiftGenericBridgeable {
+extension UInt: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("UInt")
 }
-extension Int8: _BridgedSwiftGenericBridgeable {
+extension Int8: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Int8")
 }
-extension UInt8: _BridgedSwiftGenericBridgeable {
+extension UInt8: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("UInt8")
 }
-extension Int16: _BridgedSwiftGenericBridgeable {
+extension Int16: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Int16")
 }
-extension UInt16: _BridgedSwiftGenericBridgeable {
+extension UInt16: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("UInt16")
 }
-extension Int32: _BridgedSwiftGenericBridgeable {
+extension Int32: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Int32")
 }
-extension UInt32: _BridgedSwiftGenericBridgeable {
+extension UInt32: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("UInt32")
 }
-extension Int64: _BridgedSwiftGenericBridgeable {
+extension Int64: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Int64")
 }
-extension UInt64: _BridgedSwiftGenericBridgeable {
+extension UInt64: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("UInt64")
 }
 
@@ -977,7 +977,7 @@ extension JSValue: _BridgedSwiftStackType {
     }
 }
 
-extension JSValue: _BridgedSwiftGenericBridgeable {
+extension JSValue: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("JSValue")
 }
 

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/BridgeJS-Internals/Design-Rationale.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/BridgeJS-Internals/Design-Rationale.md
@@ -34,7 +34,7 @@ BridgeJS avoids this by generating **separate** access paths per property or met
 
 ## Generic imports
 
-An imported generic `@JSFunction` (`func parse<T: BridgedSwiftGenericBridgeable>(...)`) lets one piece of glue serve many concrete types. The generic value crosses using the type's own stack ABI, and a runtime type ID (interned once via `swift_js_resolve_type_id`) selects the matching JS codec, so the type-agnostic glue can lower and lift the right representation without a specialized path per call site.
+An imported generic `@JSFunction` (`func parse<T: BridgedSwiftGenericBridgeable>(...)`) lets one piece of glue serve many concrete types. The generic value crosses using the type's own stack ABI, and a runtime type ID (interned once via `swift_js_resolve_type_id`) selects the matching JS codec, so the type-agnostic glue can lower and lift the right representation without a specialized path per call site. Because this path avoids existentials entirely, it also works under Embedded Swift; the Embedded example (`Examples/Embedded`) exercises a generic import, including a `@JS struct` round-trip.
 
 ## Generic exports
 

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/BridgeJS-Internals/Design-Rationale.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/BridgeJS-Internals/Design-Rationale.md
@@ -34,11 +34,11 @@ BridgeJS avoids this by generating **separate** access paths per property or met
 
 ## Generic imports
 
-An imported generic `@JSFunction` (`func parse<T: _BridgedSwiftGenericBridgeable>(...)`) lets one piece of glue serve many concrete types. The generic value crosses using the type's own stack ABI, and a runtime type ID (interned once via `swift_js_resolve_type_id`) selects the matching JS codec, so the type-agnostic glue can lower and lift the right representation without a specialized path per call site.
+An imported generic `@JSFunction` (`func parse<T: BridgedSwiftGenericBridgeable>(...)`) lets one piece of glue serve many concrete types. The generic value crosses using the type's own stack ABI, and a runtime type ID (interned once via `swift_js_resolve_type_id`) selects the matching JS codec, so the type-agnostic glue can lower and lift the right representation without a specialized path per call site.
 
 ## Generic exports
 
-An exported generic `@JS` function reuses the same stack ABI and codec table, with the dispatch reversed. The WebAssembly entry point is a concrete `@_expose` thunk that takes the runtime type ID as a trailing `Int32`. It looks the ID up in a codegen-emitted registry of `_BridgedSwiftGenericBridgeable` types, reifies `T` through an opened existential, and runs an unspecialized helper that pops the argument from the stack, calls your function, and pushes the result. The JavaScript wrapper resolves the `BridgeType<T>` token to the same interned ID and uses the matching codec to lower the argument and lift the return. Because this depends on existential types, generic exports are excluded under Embedded Swift.
+An exported generic `@JS` function reuses the same stack ABI and codec table, with the dispatch reversed. The WebAssembly entry point is a concrete `@_expose` thunk that takes the runtime type ID as a trailing `Int32`. It looks the ID up in a codegen-emitted registry of `BridgedSwiftGenericBridgeable` types, reifies `T` through an opened existential, and runs an unspecialized helper that pops the argument from the stack, calls your function, and pushes the result. The JavaScript wrapper resolves the `BridgeType<T>` token to the same interned ID and uses the matching codec to lower the argument and lift the return. Because this depends on existential types, generic exports are excluded under Embedded Swift.
 
 ## What to read next
 

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/BridgeJS-Internals/Design-Rationale.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/BridgeJS-Internals/Design-Rationale.md
@@ -32,6 +32,14 @@ So even if you cache the property name (e.g. with `CachedJSStrings`), you are st
 
 BridgeJS avoids this by generating **separate** access paths per property or method. Each generated getter/setter or function call has a stable shape at the engine level, so the IC can stay monomorphic or polymorphic and the fast path is used.
 
+## Generic imports
+
+An imported generic `@JSFunction` (`func parse<T: _BridgedSwiftGenericBridgeable>(...)`) lets one piece of glue serve many concrete types. The generic value crosses using the type's own stack ABI, and a runtime type ID (interned once via `swift_js_resolve_type_id`) selects the matching JS codec, so the type-agnostic glue can lower and lift the right representation without a specialized path per call site.
+
+## Generic exports
+
+An exported generic `@JS` function reuses the same stack ABI and codec table, with the dispatch reversed. The WebAssembly entry point is a concrete `@_expose` thunk that takes the runtime type ID as a trailing `Int32`. It looks the ID up in a codegen-emitted registry of `_BridgedSwiftGenericBridgeable` types, reifies `T` through an opened existential, and runs an unspecialized helper that pops the argument from the stack, calls your function, and pushes the result. The JavaScript wrapper resolves the `BridgeType<T>` token to the same interned ID and uses the matching codec to lower the argument and lift the return. Because this depends on existential types, generic exports are excluded under Embedded Swift.
+
 ## What to read next
 
 - ABI and binary interface details will be documented in this section as they stabilize.

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Function.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Function.md
@@ -136,6 +136,97 @@ export type Exports = {
 }
 ```
 
+### Generic functions
+
+A `@JS` function can be generic over a type parameter constrained to `_BridgedSwiftGenericBridgeable`. The concrete type chosen at the call site crosses the bridge:
+
+```swift
+import JavaScriptKit
+
+@JS public func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+    return value
+}
+```
+
+`T` must be a bridgeable type: a supported primitive (`Bool`, any fixed-width integer such as `Int`/`UInt`/`Int8`…`UInt64`, `Float`, `Double`, `String`, or `JSValue`), or a `@JS` struct, `final @JS class`, or `@JS enum`. You do not write any conformance yourself; marking a type `@JS` makes it usable as `T` (see <doc:Supported-Types>).
+
+Because TypeScript erases generics, the JavaScript caller passes a `BridgeType<T>` token as the last argument so the bridge can select the right type at runtime. The tokens come from a generated `BridgeTypes` map exported at the top level of `bridge-js.js`; import it directly rather than reading it from the `exports` object:
+
+```javascript
+import { BridgeTypes } from "./bridge-js.js";
+
+const x = exports.identity(42, BridgeTypes.Int);
+const p = exports.identity({ x: 1, y: 2 }, BridgeTypes.MyPoint);
+```
+
+Concrete parameters keep their positions; the token is always appended last. The non-generic parameters of a generic `@JS` function may be any supported bridged type, including value types such as `@JS` structs, arrays, dictionaries, and associated-value enums alongside the generic parameter. The generated TypeScript declarations look like:
+
+```typescript
+export type BridgeType<T> = string & { readonly __bridgeType?: (value: T) => void };
+export const BridgeTypes: { Bool: BridgeType<boolean>; Int: BridgeType<number>; Float: BridgeType<number>; Double: BridgeType<number>; String: BridgeType<string>; MyPoint: BridgeType<MyPoint>; };
+export type Exports = {
+    identity<T>(value: T, typeT: BridgeType<T>): T;
+}
+```
+
+A single `T` may be used in more than one parameter, and a function may declare multiple distinct generic parameters. Each distinct generic parameter takes its own `BridgeType` token, appended after the regular arguments in declaration order:
+
+```swift
+@JS public func combine<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: U) -> T {
+    a
+}
+```
+
+```typescript
+export type Exports = {
+    combine<T, U>(a: T, b: U, typeT: BridgeType<T>, typeU: BridgeType<U>): T;
+}
+```
+
+The generic parameter may also be wrapped as `[T]`, `T?`, or `[String: T]` in parameters and the result:
+
+```swift
+@JS public func firstOrNil<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) -> T? {
+    values.first
+}
+```
+
+The result must be one of the declared generic parameters (such as `T` or `U`), a supported wrapper of one (`[T]`, `T?`, `[String: T]`), or `Void`. A generic parameter that is never used in any parameter is rejected, and returning a concrete non-`Void` type from a generic `@JS` function is not supported. Generic `@JS` functions must be synchronous (see <doc:Unsupported-Features>).
+
+Generics also work on methods. On a `@JS` class or struct they apply to both instance and static methods. A `@JS enum` (including a namespace-style enum) has no instance methods in BridgeJS, so generics there apply to static methods only. The constraint, the trailing `BridgeType` token, and the generic-or-`Void` return rule all carry over unchanged:
+
+```swift
+import JavaScriptKit
+
+@JS public class Box {
+    @JS public init() {}
+
+    @JS public func wrap<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+        return value
+    }
+}
+```
+
+Call an instance method by passing the `BridgeType` token last, just like a top-level function:
+
+```javascript
+import { BridgeTypes } from "./bridge-js.js";
+
+const box = new exports.Box();
+const wrapped = box.wrap(42, BridgeTypes.Int);
+```
+
+```typescript
+export interface Box extends SwiftHeapObject {
+    wrap<T>(value: T, typeT: BridgeType<T>): T;
+}
+export type Exports = {
+    Box: {
+        new(): Box;
+    }
+}
+```
+
 ## Supported Features
 
 | Swift Feature | Status |
@@ -148,6 +239,6 @@ export type Exports = {
 | Throwing JS exception: `func x() throws(JSException)` | ✅ |
 | Throwing any exception: `func x() throws` | ❌ |
 | Async methods: `func x() async` | ✅ |
-| Generics | ❌ |
+| Generic parameter/result types (constrained to `_BridgedSwiftGenericBridgeable`) | ✅ |
 | Opaque types: `func x() -> some P`, `func y(_: some P)` | ❌ |
 | Default parameter values: `func x(_ foo: String = "")` | ✅ (See <doc:Exporting-Swift-Default-Parameters>) |

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Function.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Function.md
@@ -138,12 +138,12 @@ export type Exports = {
 
 ### Generic functions
 
-A `@JS` function can be generic over a type parameter constrained to `_BridgedSwiftGenericBridgeable`. The concrete type chosen at the call site crosses the bridge:
+A `@JS` function can be generic over a type parameter constrained to `BridgedSwiftGenericBridgeable`. The concrete type chosen at the call site crosses the bridge:
 
 ```swift
 import JavaScriptKit
 
-@JS public func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+@JS public func identity<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T {
     return value
 }
 ```
@@ -172,7 +172,7 @@ export type Exports = {
 A single `T` may be used in more than one parameter, and a function may declare multiple distinct generic parameters. Each distinct generic parameter takes its own `BridgeType` token, appended after the regular arguments in declaration order:
 
 ```swift
-@JS public func combine<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: U) -> T {
+@JS public func combine<T: BridgedSwiftGenericBridgeable, U: BridgedSwiftGenericBridgeable>(_ a: T, _ b: U) -> T {
     a
 }
 ```
@@ -186,7 +186,7 @@ export type Exports = {
 The generic parameter may also be wrapped as `[T]`, `T?`, or `[String: T]` in parameters and the result:
 
 ```swift
-@JS public func firstOrNil<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) -> T? {
+@JS public func firstOrNil<T: BridgedSwiftGenericBridgeable>(_ values: [T]) -> T? {
     values.first
 }
 ```
@@ -201,7 +201,7 @@ import JavaScriptKit
 @JS public class Box {
     @JS public init() {}
 
-    @JS public func wrap<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+    @JS public func wrap<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T {
         return value
     }
 }
@@ -239,6 +239,6 @@ export type Exports = {
 | Throwing JS exception: `func x() throws(JSException)` | ✅ |
 | Throwing any exception: `func x() throws` | ❌ |
 | Async methods: `func x() async` | ✅ |
-| Generic parameter/result types (constrained to `_BridgedSwiftGenericBridgeable`) | ✅ |
+| Generic parameter/result types (constrained to `BridgedSwiftGenericBridgeable`) | ✅ |
 | Opaque types: `func x() -> some P`, `func y(_: some P)` | ❌ |
 | Default parameter values: `func x(_ foo: String = "")` | ✅ (See <doc:Exporting-Swift-Default-Parameters>) |

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Importing-JavaScript/Importing-JS-Function.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Importing-JavaScript/Importing-JS-Function.md
@@ -43,10 +43,10 @@ Bound functions are `throws(JSException)`. Call them with `try` or `try?`; they 
 
 ## Generic functions
 
-A `@JSFunction` can be generic over a type parameter constrained to `_BridgedSwiftGenericBridgeable`. The concrete type chosen at the call site then crosses the bridge:
+A `@JSFunction` can be generic over a type parameter constrained to `BridgedSwiftGenericBridgeable`. The concrete type chosen at the call site then crosses the bridge:
 
 ```swift
-@JSFunction func parse<T: _BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T
+@JSFunction func parse<T: BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T
 
 let user: User = try parse(jsonString)
 ```
@@ -56,19 +56,19 @@ let user: User = try parse(jsonString)
 A generic type parameter may be used in more than one parameter, an imported function may declare more than one distinct generic parameter, and a generic result type may be used on a function that takes no generic parameters (the JavaScript implementation produces the value):
 
 ```swift
-@JSFunction func pickFirst<T: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) throws(JSException) -> T
+@JSFunction func pickFirst<T: BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) throws(JSException) -> T
 
-@JSFunction func makeValue<T: _BridgedSwiftGenericBridgeable>() throws(JSException) -> T
+@JSFunction func makeValue<T: BridgedSwiftGenericBridgeable>() throws(JSException) -> T
 
-@JSFunction func combine<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: U) throws(JSException) -> U
+@JSFunction func combine<T: BridgedSwiftGenericBridgeable, U: BridgedSwiftGenericBridgeable>(_ a: T, _ b: U) throws(JSException) -> U
 ```
 
 The generic parameter may also be wrapped as `[T]`, `T?`, or `[String: T]` in parameters and the result:
 
 ```swift
-@JSFunction func roundTrip<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T]
+@JSFunction func roundTrip<T: BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T]
 
-@JSFunction func lookup<T: _BridgedSwiftGenericBridgeable>(_ values: [String: T]) throws(JSException) -> T?
+@JSFunction func lookup<T: BridgedSwiftGenericBridgeable>(_ values: [String: T]) throws(JSException) -> T?
 ```
 
 ### Generic methods on imported classes
@@ -77,8 +77,8 @@ An imported `@JSClass` type can also have generic methods, both instance and sta
 
 ```swift
 @JSClass struct Store {
-    @JSFunction func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
-    @JSFunction static func box<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+    @JSFunction func identity<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+    @JSFunction static func box<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
 }
 ```
 
@@ -88,5 +88,5 @@ An imported `@JSClass` type can also have generic methods, both instance and sta
 |:--|:--|
 | Primitive parameter/result types (e.g. `Double`, `Bool`) | ✅ |
 | `String` parameter/result type | ✅ |
-| Generic parameter/result types (constrained to `_BridgedSwiftGenericBridgeable`) | ✅ |
+| Generic parameter/result types (constrained to `BridgedSwiftGenericBridgeable`) | ✅ |
 | Async function | ❌ |

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Importing-JavaScript/Importing-JS-Function.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Importing-JavaScript/Importing-JS-Function.md
@@ -41,11 +41,52 @@ If you used `from: .global`, do not pass the function in `getImports()`; the run
 
 Bound functions are `throws(JSException)`. Call them with `try` or `try?`; they throw when the JavaScript implementation throws.
 
+## Generic functions
+
+A `@JSFunction` can be generic over a type parameter constrained to `_BridgedSwiftGenericBridgeable`. The concrete type chosen at the call site then crosses the bridge:
+
+```swift
+@JSFunction func parse<T: _BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T
+
+let user: User = try parse(jsonString)
+```
+
+`T` must be a bridgeable type: a supported primitive (`Bool`, any fixed-width integer such as `Int`/`UInt`/`Int8`…`UInt64`, `Float`, `Double`, `String`, or `JSValue`), or a `@JS` struct, `final @JS class`, or `@JS enum`. You do not write any conformance yourself; marking a type `@JS` makes it usable as `T` (see <doc:Supported-Types>). Generics are not supported for `async` functions or `where` clauses (see <doc:Unsupported-Features>).
+
+A generic type parameter may be used in more than one parameter, an imported function may declare more than one distinct generic parameter, and a generic result type may be used on a function that takes no generic parameters (the JavaScript implementation produces the value):
+
+```swift
+@JSFunction func pickFirst<T: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) throws(JSException) -> T
+
+@JSFunction func makeValue<T: _BridgedSwiftGenericBridgeable>() throws(JSException) -> T
+
+@JSFunction func combine<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: U) throws(JSException) -> U
+```
+
+The generic parameter may also be wrapped as `[T]`, `T?`, or `[String: T]` in parameters and the result:
+
+```swift
+@JSFunction func roundTrip<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T]
+
+@JSFunction func lookup<T: _BridgedSwiftGenericBridgeable>(_ values: [String: T]) throws(JSException) -> T?
+```
+
+### Generic methods on imported classes
+
+An imported `@JSClass` type can also have generic methods, both instance and static. The same constraint applies. The Swift to JavaScript bridge resolves the concrete type through an internal type id, and the JavaScript implementation is called with only the method's declared arguments:
+
+```swift
+@JSClass struct Store {
+    @JSFunction func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+    @JSFunction static func box<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+}
+```
+
 ## Supported features
 
 | Feature | Status |
 |:--|:--|
 | Primitive parameter/result types (e.g. `Double`, `Bool`) | ✅ |
 | `String` parameter/result type | ✅ |
+| Generic parameter/result types (constrained to `_BridgedSwiftGenericBridgeable`) | ✅ |
 | Async function | ❌ |
-| Generics | ❌ |

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Supported-Types.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Supported-Types.md
@@ -33,7 +33,7 @@ See <doc:Exporting-Swift-Array> for usage details.
 
 ## Generic type parameters
 
-A generic type parameter constrained to `_BridgedSwiftGenericBridgeable` is supported as a parameter or result type in both directions: an imported `@JSFunction` (see <doc:Importing-JS-Function>) and an exported `@JS` function (see <doc:Exporting-Swift-Function>). The types that satisfy that constraint are:
+A generic type parameter constrained to `BridgedSwiftGenericBridgeable` is supported as a parameter or result type in both directions: an imported `@JSFunction` (see <doc:Importing-JS-Function>) and an exported `@JS` function (see <doc:Exporting-Swift-Function>). The types that satisfy that constraint are:
 
 - `Bool`, `Float`, `Double`, `String`, and `JSValue`
 - every fixed-width integer: `Int`, `UInt`, `Int8`/`Int16`/`Int32`/`Int64`, and `UInt8`/`UInt16`/`UInt32`/`UInt64`

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Supported-Types.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Supported-Types.md
@@ -31,6 +31,18 @@ When using `JSTypedArray<T>` (or convenience typealiases) in `@JS` signatures, t
 
 See <doc:Exporting-Swift-Array> for usage details.
 
+## Generic type parameters
+
+A generic type parameter constrained to `_BridgedSwiftGenericBridgeable` is supported as a parameter or result type in both directions: an imported `@JSFunction` (see <doc:Importing-JS-Function>) and an exported `@JS` function (see <doc:Exporting-Swift-Function>). The types that satisfy that constraint are:
+
+- `Bool`, `Float`, `Double`, `String`, and `JSValue`
+- every fixed-width integer: `Int`, `UInt`, `Int8`/`Int16`/`Int32`/`Int64`, and `UInt8`/`UInt16`/`UInt32`/`UInt64`
+- any `@JS` struct, `final @JS class`, or `@JS enum` (case, raw-value, or associated-value) defined in the same module as the generic function
+
+You do not write the conformance by hand: marking a type `@JS` (or using a built-in primitive) is what makes it usable as the generic argument.
+
+The generic parameter may be used bare (`T`) or wrapped in `[T]`, `T?`, or `[String: T]`. Other or nested wrappings (for example `[T?]`, `[[T]]`, or `[Int: T]`) are not supported. `JSObject` cannot be used as the generic argument; use `JSValue` instead.
+
 ## See Also
 
 - <doc:Generating-from-TypeScript>

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Unsupported-Features.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Unsupported-Features.md
@@ -49,4 +49,4 @@ The generic parameter may be used bare (`T`) or wrapped in `[T]`, `T?`, or `[Str
 
 The generic argument must be a primitive or a type defined in the same module as the generic function. Using a `@JS` type from another module as the generic argument is not supported yet: at an imported `@JSFunction` call site this surfaces as a Swift conformance error, and an exported `@JS` function traps at runtime when passed such a type's token.
 
-Exported generic functions additionally require runtime existential support, so they are not available under Embedded Swift. Imported generics remain available there.
+Exported generic functions additionally require runtime existential support, so they are not available under Embedded Swift. Imported generics remain available there and are exercised by the Embedded example (`Examples/Embedded`).

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Unsupported-Features.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Unsupported-Features.md
@@ -37,7 +37,7 @@ Types defined in a separate Swift package cannot yet be referenced from `@JS` de
 
 ## Generics
 
-Generic functions are supported in both directions, through a type parameter constrained to `_BridgedSwiftGenericBridgeable`: an imported `@JSFunction` (see <doc:Importing-JS-Function>) and an exported `@JS` function (see <doc:Exporting-Swift-Function>). Generics also work on methods of an exported `@JS` class or struct (both instance and static), on static methods of an exported `@JS` enum or namespace enum, and on imported `@JSClass` methods. A function may declare one or more distinct generic parameters, such as `combine<T, U>(_ a: T, _ b: U) -> T`. The following forms are not supported and produce build-time diagnostics:
+Generic functions are supported in both directions, through a type parameter constrained to `BridgedSwiftGenericBridgeable`: an imported `@JSFunction` (see <doc:Importing-JS-Function>) and an exported `@JS` function (see <doc:Exporting-Swift-Function>). Generics also work on methods of an exported `@JS` class or struct (both instance and static), on static methods of an exported `@JS` enum or namespace enum, and on imported `@JSClass` methods. A function may declare one or more distinct generic parameters, such as `combine<T, U>(_ a: T, _ b: U) -> T`. The following forms are not supported and produce build-time diagnostics:
 
 - `async` generic functions.
 - `where` clauses on a generic declaration.

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Unsupported-Features.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Unsupported-Features.md
@@ -34,3 +34,19 @@ While using `@JS` types from another Swift module is supported, it is not possib
 ### Exporting Swift: types from another Swift package
 
 Types defined in a separate Swift package cannot yet be referenced from `@JS` declarations in your package.
+
+## Generics
+
+Generic functions are supported in both directions, through a type parameter constrained to `_BridgedSwiftGenericBridgeable`: an imported `@JSFunction` (see <doc:Importing-JS-Function>) and an exported `@JS` function (see <doc:Exporting-Swift-Function>). Generics also work on methods of an exported `@JS` class or struct (both instance and static), on static methods of an exported `@JS` enum or namespace enum, and on imported `@JSClass` methods. A function may declare one or more distinct generic parameters, such as `combine<T, U>(_ a: T, _ b: U) -> T`. The following forms are not supported and produce build-time diagnostics:
+
+- `async` generic functions.
+- `where` clauses on a generic declaration.
+- An exported `@JS` generic function that is `throws`. (Imported `@JSFunction` generics may still use `throws(JSException)`.)
+- A declared generic parameter on an exported `@JS` function that is not used in any parameter. A return-only generic (such as `make<T>() -> T`) is supported for imported `@JSFunction`s, where the JavaScript implementation produces the value.
+- An exported generic function that returns a concrete, non-`Void` type. The result of an exported generic function must be one of the declared generic parameters (optionally wrapped in `[T]`, `T?`, or `[String: T]`) or `Void`.
+
+The generic parameter may be used bare (`T`) or wrapped in `[T]`, `T?`, or `[String: T]`. Nested or other wrappings, such as `[T?]`, `[[T]]`, `T??`, or `[Int: T]`, are not supported and produce build-time diagnostics. `JSObject` cannot be used as the generic argument (it is a non-final class); use `JSValue` instead.
+
+The generic argument must be a primitive or a type defined in the same module as the generic function. Using a `@JS` type from another module as the generic argument is not supported yet: at an imported `@JSFunction` call site this surfaces as a Swift conformance error, and an exported `@JS` function traps at runtime when passed such a type's token.
+
+Exported generic functions additionally require runtime existential support, so they are not available under Embedded Swift. Imported generics remain available there.

--- a/Tests/BridgeJSRuntimeTests/ExportGenericAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportGenericAPIs.swift
@@ -21,19 +21,19 @@ import JavaScriptKit
     }
 }
 
-@JS public func exportGenericIdentity<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+@JS public func exportGenericIdentity<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T {
     value
 }
 
-@JS public func exportGenericEcho<T: _BridgedSwiftGenericBridgeable>(_ value: T, tag: Int) -> T {
+@JS public func exportGenericEcho<T: BridgedSwiftGenericBridgeable>(_ value: T, tag: Int) -> T {
     value
 }
 
-@JS public func exportGenericPickFirst<T: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) -> T {
+@JS public func exportGenericPickFirst<T: BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) -> T {
     a
 }
 
-@JS public func exportGenericPickSecond<T: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) -> T {
+@JS public func exportGenericPickSecond<T: BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) -> T {
     b
 }
 
@@ -53,22 +53,22 @@ import JavaScriptKit
     return -1
 }
 
-@JS public func exportGenericArrayIdentity<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) -> [T] {
+@JS public func exportGenericArrayIdentity<T: BridgedSwiftGenericBridgeable>(_ values: [T]) -> [T] {
     values
 }
 
-@JS public func exportGenericOptionalIdentity<T: _BridgedSwiftGenericBridgeable>(_ value: T?) -> T? {
+@JS public func exportGenericOptionalIdentity<T: BridgedSwiftGenericBridgeable>(_ value: T?) -> T? {
     value
 }
 
-@JS public func exportGenericDictIdentity<T: _BridgedSwiftGenericBridgeable>(_ values: [String: T]) -> [String: T] {
+@JS public func exportGenericDictIdentity<T: BridgedSwiftGenericBridgeable>(_ values: [String: T]) -> [String: T] {
     values
 }
 
 nonisolated(unsafe) var _lastWrappedPoint = ExportGenericPoint(x: 0, y: 0)
 nonisolated(unsafe) var _lastTag = 0
 
-@JS public func exportGenericWrapPointAndTag<T: _BridgedSwiftGenericBridgeable>(
+@JS public func exportGenericWrapPointAndTag<T: BridgedSwiftGenericBridgeable>(
     _ p: ExportGenericPoint,
     tag: Int,
     _ value: T
@@ -80,71 +80,71 @@ nonisolated(unsafe) var _lastTag = 0
 
 @JS
 public func exportGenericCombineFirst<
-    T: _BridgedSwiftGenericBridgeable,
-    U: _BridgedSwiftGenericBridgeable
+    T: BridgedSwiftGenericBridgeable,
+    U: BridgedSwiftGenericBridgeable
 >(_ a: T, _ b: U) -> T {
     a
 }
 
 @JS
 public func exportGenericCombineSecond<
-    T: _BridgedSwiftGenericBridgeable,
-    U: _BridgedSwiftGenericBridgeable
+    T: BridgedSwiftGenericBridgeable,
+    U: BridgedSwiftGenericBridgeable
 >(_ a: T, _ b: U) -> U {
     b
 }
 
 @JS
 public func exportGenericCombineTripleLast<
-    T: _BridgedSwiftGenericBridgeable,
-    U: _BridgedSwiftGenericBridgeable,
-    V: _BridgedSwiftGenericBridgeable
+    T: BridgedSwiftGenericBridgeable,
+    U: BridgedSwiftGenericBridgeable,
+    V: BridgedSwiftGenericBridgeable
 >(_ a: T, _ b: U, _ c: V) -> V {
     c
 }
 
 @JS public final class ExportGenericMethodBox {
     @JS public init() {}
-    @JS public func echo<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+    @JS public func echo<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T {
         value
     }
     @JS
     public func combine<
-        T: _BridgedSwiftGenericBridgeable,
-        U: _BridgedSwiftGenericBridgeable
+        T: BridgedSwiftGenericBridgeable,
+        U: BridgedSwiftGenericBridgeable
     >(_ a: T, _ b: U) -> U {
         b
     }
-    @JS public static func wrapArray<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> [T] {
+    @JS public static func wrapArray<T: BridgedSwiftGenericBridgeable>(_ value: T) -> [T] {
         [value]
     }
 }
 
 @JS public struct ExportGenericMethodPair {
     @JS public init() {}
-    @JS public func first<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+    @JS public func first<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T {
         value
     }
-    @JS public func maybe<T: _BridgedSwiftGenericBridgeable>(_ value: T, present: Bool) -> T? {
+    @JS public func maybe<T: BridgedSwiftGenericBridgeable>(_ value: T, present: Bool) -> T? {
         present ? value : nil
     }
-    @JS public func dict<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> [String: T] {
+    @JS public func dict<T: BridgedSwiftGenericBridgeable>(_ value: T) -> [String: T] {
         ["value": value]
     }
-    @JS public static func wrap<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> [T] {
+    @JS public static func wrap<T: BridgedSwiftGenericBridgeable>(_ value: T) -> [T] {
         [value]
     }
 }
 
 @JS public enum ExportGenericMethodFactory {
     case primary
-    @JS public static func one<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+    @JS public static func one<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T {
         value
     }
 }
 
 @JS public enum ExportGenericMethodNamespace {
-    @JS public static func make<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+    @JS public static func make<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T {
         value
     }
 }

--- a/Tests/BridgeJSRuntimeTests/ExportGenericAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportGenericAPIs.swift
@@ -1,4 +1,4 @@
-import XCTest
+import Testing
 import JavaScriptKit
 
 @JS public struct ExportGenericPoint {
@@ -157,8 +157,8 @@ public func exportGenericCombineTripleLast<
 @_extern(c)
 func runExportGenericTests() -> Void
 
-final class ExportGenericAPITests: XCTestCase {
-    func testExportGenerics() throws {
+@Suite struct ExportGenericAPITests {
+    @Test func exportGenerics() {
         runExportGenericTests()
     }
 }

--- a/Tests/BridgeJSRuntimeTests/ExportGenericAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/ExportGenericAPIs.swift
@@ -1,0 +1,164 @@
+import XCTest
+import JavaScriptKit
+
+@JS public struct ExportGenericPoint {
+    public var x: Int
+    public var y: Int
+
+    @JS public init(x: Int, y: Int) {
+        self.x = x
+        self.y = y
+    }
+}
+
+@JS public final class ExportGenericBox {
+    @JS public var value: Int
+    @JS public init(value: Int) {
+        self.value = value
+    }
+    @JS public func get() -> Int {
+        value
+    }
+}
+
+@JS public func exportGenericIdentity<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+    value
+}
+
+@JS public func exportGenericEcho<T: _BridgedSwiftGenericBridgeable>(_ value: T, tag: Int) -> T {
+    value
+}
+
+@JS public func exportGenericPickFirst<T: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) -> T {
+    a
+}
+
+@JS public func exportGenericPickSecond<T: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) -> T {
+    b
+}
+
+@JS public enum ExportGenericOutcome {
+    case ok(value: Int)
+    case fail(reason: String)
+}
+
+@JS public func makeExportGenericOutcome(_ value: Int) -> ExportGenericOutcome {
+    .ok(value: value)
+}
+
+@JS public func exportGenericOutcomeValue(_ outcome: ExportGenericOutcome) -> Int {
+    if case .ok(let value) = outcome {
+        return value
+    }
+    return -1
+}
+
+@JS public func exportGenericArrayIdentity<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) -> [T] {
+    values
+}
+
+@JS public func exportGenericOptionalIdentity<T: _BridgedSwiftGenericBridgeable>(_ value: T?) -> T? {
+    value
+}
+
+@JS public func exportGenericDictIdentity<T: _BridgedSwiftGenericBridgeable>(_ values: [String: T]) -> [String: T] {
+    values
+}
+
+nonisolated(unsafe) var _lastWrappedPoint = ExportGenericPoint(x: 0, y: 0)
+nonisolated(unsafe) var _lastTag = 0
+
+@JS public func exportGenericWrapPointAndTag<T: _BridgedSwiftGenericBridgeable>(
+    _ p: ExportGenericPoint,
+    tag: Int,
+    _ value: T
+) -> T {
+    _lastWrappedPoint = p
+    _lastTag = tag
+    return value
+}
+
+@JS
+public func exportGenericCombineFirst<
+    T: _BridgedSwiftGenericBridgeable,
+    U: _BridgedSwiftGenericBridgeable
+>(_ a: T, _ b: U) -> T {
+    a
+}
+
+@JS
+public func exportGenericCombineSecond<
+    T: _BridgedSwiftGenericBridgeable,
+    U: _BridgedSwiftGenericBridgeable
+>(_ a: T, _ b: U) -> U {
+    b
+}
+
+@JS
+public func exportGenericCombineTripleLast<
+    T: _BridgedSwiftGenericBridgeable,
+    U: _BridgedSwiftGenericBridgeable,
+    V: _BridgedSwiftGenericBridgeable
+>(_ a: T, _ b: U, _ c: V) -> V {
+    c
+}
+
+@JS public final class ExportGenericMethodBox {
+    @JS public init() {}
+    @JS public func echo<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+        value
+    }
+    @JS
+    public func combine<
+        T: _BridgedSwiftGenericBridgeable,
+        U: _BridgedSwiftGenericBridgeable
+    >(_ a: T, _ b: U) -> U {
+        b
+    }
+    @JS public static func wrapArray<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> [T] {
+        [value]
+    }
+}
+
+@JS public struct ExportGenericMethodPair {
+    @JS public init() {}
+    @JS public func first<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+        value
+    }
+    @JS public func maybe<T: _BridgedSwiftGenericBridgeable>(_ value: T, present: Bool) -> T? {
+        present ? value : nil
+    }
+    @JS public func dict<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> [String: T] {
+        ["value": value]
+    }
+    @JS public static func wrap<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> [T] {
+        [value]
+    }
+}
+
+@JS public enum ExportGenericMethodFactory {
+    case primary
+    @JS public static func one<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+        value
+    }
+}
+
+@JS public enum ExportGenericMethodNamespace {
+    @JS public static func make<T: _BridgedSwiftGenericBridgeable>(_ value: T) -> T {
+        value
+    }
+}
+
+@JS public func lastWrappedPointX() -> Int { _lastWrappedPoint.x }
+@JS public func lastWrappedPointY() -> Int { _lastWrappedPoint.y }
+@JS public func lastTag() -> Int { _lastTag }
+
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "runExportGenericTests")
+@_extern(c)
+func runExportGenericTests() -> Void
+
+final class ExportGenericAPITests: XCTestCase {
+    func testExportGenerics() throws {
+        runExportGenericTests()
+    }
+}

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -4196,6 +4196,10 @@ extension Severity: _BridgedSwiftCaseEnum {
     }
 }
 
+extension Severity: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Severity")
+}
+
 extension Shape: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Shape {
         switch caseId {
@@ -4219,6 +4223,10 @@ extension Shape: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
+extension Shape: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Shape")
+}
+
 extension InnerTag: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> InnerTag {
         switch caseId {
@@ -4240,6 +4248,10 @@ extension InnerTag: _BridgedSwiftAssociatedValueEnum {
             return Int32(1)
         }
     }
+}
+
+extension InnerTag: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("InnerTag")
 }
 
 @_expose(wasm, "bjs_ArraySupportExports_static_roundTripIntArray")
@@ -4754,6 +4766,10 @@ extension AsyncImportedPayloadResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
+extension AsyncImportedPayloadResult: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("AsyncImportedPayloadResult")
+}
+
 @_expose(wasm, "bjs_DefaultArgumentExports_static_testStringDefault")
 @_cdecl("bjs_DefaultArgumentExports_static_testStringDefault")
 public func _bjs_DefaultArgumentExports_static_testStringDefault(_ messageBytes: Int32, _ messageLength: Int32) -> Void {
@@ -4962,6 +4978,10 @@ extension Direction: _BridgedSwiftCaseEnum {
     }
 }
 
+extension Direction: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Direction")
+}
+
 extension Status: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
@@ -5001,22 +5021,50 @@ extension Status: _BridgedSwiftCaseEnum {
     }
 }
 
+extension Status: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Status")
+}
+
 extension Theme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+}
+
+extension Theme: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Theme")
 }
 
 extension HttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
+extension HttpStatus: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("HttpStatus")
+}
+
 extension FileSize: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+}
+
+extension FileSize: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("FileSize")
 }
 
 extension SessionId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
+extension SessionId: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("SessionId")
+}
+
 extension Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
+extension Precision: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Precision")
+}
+
 extension Ratio: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+}
+
+extension Ratio: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Ratio")
 }
 
 extension TSDirection: _BridgedSwiftCaseEnum {
@@ -5062,7 +5110,15 @@ extension TSDirection: _BridgedSwiftCaseEnum {
     }
 }
 
+extension TSDirection: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("TSDirection")
+}
+
 extension TSTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+}
+
+extension TSTheme: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("TSTheme")
 }
 
 extension AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
@@ -5091,6 +5147,10 @@ extension AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
             return Int32(2)
         }
     }
+}
+
+extension AsyncPayloadResult: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("AsyncPayloadResult")
 }
 
 @_expose(wasm, "bjs_Utils_StringUtils_static_uppercase")
@@ -5158,10 +5218,22 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
     }
 }
 
+extension Networking.API.Method: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Networking_API_Method")
+}
+
 extension Configuration.LogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
+extension Configuration.LogLevel: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Configuration_LogLevel")
+}
+
 extension Configuration.Port: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+}
+
+extension Configuration.Port: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Configuration_Port")
 }
 
 extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
@@ -5197,6 +5269,10 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
             return 1
         }
     }
+}
+
+extension Internal.SupportedMethod: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Networking_APIV2_Internal_SupportedMethod")
 }
 
 extension APIResult: _BridgedSwiftAssociatedValueEnum {
@@ -5240,6 +5316,10 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
             return Int32(5)
         }
     }
+}
+
+extension APIResult: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("APIResult")
 }
 
 extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
@@ -5305,6 +5385,10 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
+extension ComplexResult: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ComplexResult")
+}
+
 extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Utilities.Result {
         switch caseId {
@@ -5337,6 +5421,10 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
+extension Utilities.Result: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Utilities_Result")
+}
+
 extension API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> API.NetworkingResult {
         switch caseId {
@@ -5360,6 +5448,10 @@ extension API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
             return Int32(1)
         }
     }
+}
+
+extension API.NetworkingResult: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("API_NetworkingResult")
 }
 
 extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
@@ -5410,6 +5502,10 @@ extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
+extension AllTypesResult: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("AllTypesResult")
+}
+
 extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TypedPayloadResult {
         switch caseId {
@@ -5448,6 +5544,10 @@ extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
+extension TypedPayloadResult: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("TypedPayloadResult")
+}
+
 extension StaticCalculator: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
@@ -5481,6 +5581,10 @@ extension StaticCalculator: _BridgedSwiftCaseEnum {
             return 1
         }
     }
+}
+
+extension StaticCalculator: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("StaticCalculator")
 }
 
 @_expose(wasm, "bjs_StaticCalculator_static_roundtrip")
@@ -5582,6 +5686,10 @@ extension StaticPropertyEnum: _BridgedSwiftCaseEnum {
             return 1
         }
     }
+}
+
+extension StaticPropertyEnum: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("StaticPropertyEnum")
 }
 
 @_expose(wasm, "bjs_StaticPropertyEnum_static_enumProperty_get")
@@ -5800,6 +5908,125 @@ public func _bjs_NestedStructGroupB_static_roundtripMetadata() -> Void {
 extension NestedTypeHost.Variant: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
+extension NestedTypeHost.Variant: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("NestedTypeHost_Variant")
+}
+
+extension ExportGenericOutcome: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> ExportGenericOutcome {
+        switch caseId {
+        case 0:
+            return .ok(value: Int.bridgeJSStackPop())
+        case 1:
+            return .fail(reason: String.bridgeJSStackPop())
+        default:
+            fatalError("Unknown ExportGenericOutcome case ID: \(caseId)")
+        }
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
+        switch self {
+        case .ok(let value):
+            value.bridgeJSStackPush()
+            return Int32(0)
+        case .fail(let reason):
+            reason.bridgeJSStackPush()
+            return Int32(1)
+        }
+    }
+}
+
+extension ExportGenericOutcome: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportGenericOutcome")
+}
+
+extension ExportGenericMethodFactory: _BridgedSwiftCaseEnum {
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
+        return bridgeJSRawValue
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> ExportGenericMethodFactory {
+        return bridgeJSLiftParameter(value)
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> ExportGenericMethodFactory {
+        return ExportGenericMethodFactory(bridgeJSRawValue: value)!
+    }
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
+        return bridgeJSLowerParameter()
+    }
+
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
+        switch bridgeJSRawValue {
+        case 0:
+            self = .primary
+        default:
+            return nil
+        }
+    }
+
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
+        switch self {
+        case .primary:
+            return 0
+        }
+    }
+}
+
+extension ExportGenericMethodFactory: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportGenericMethodFactory")
+}
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_ExportGenericMethodFactory_static_one")
+@_cdecl("bjs_ExportGenericMethodFactory_static_one")
+public func _bjs_ExportGenericMethodFactory_static_one(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_ExportGenericMethodFactory_static_one")
+@_cdecl("bjs_ExportGenericMethodFactory_static_one")
+public func _bjs_ExportGenericMethodFactory_static_one(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_ExportGenericMethodFactory_static_one_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_ExportGenericMethodFactory_static_one_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let ret = ExportGenericMethodFactory.one(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_ExportGenericMethodNamespace_static_make")
+@_cdecl("bjs_ExportGenericMethodNamespace_static_make")
+public func _bjs_ExportGenericMethodNamespace_static_make(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_ExportGenericMethodNamespace_static_make")
+@_cdecl("bjs_ExportGenericMethodNamespace_static_make")
+public func _bjs_ExportGenericMethodNamespace_static_make(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_ExportGenericMethodNamespace_static_make_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_ExportGenericMethodNamespace_static_make_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let ret = ExportGenericMethodNamespace.make(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
 extension LightColor: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
@@ -5839,6 +6066,10 @@ extension LightColor: _BridgedSwiftCaseEnum {
     }
 }
 
+extension LightColor: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("LightColor")
+}
+
 extension ImportedPayloadSignal: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> ImportedPayloadSignal {
         switch caseId {
@@ -5865,6 +6096,95 @@ extension ImportedPayloadSignal: _BridgedSwiftAssociatedValueEnum {
             return Int32(2)
         }
     }
+}
+
+extension ImportedPayloadSignal: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ImportedPayloadSignal")
+}
+
+extension GenericRTColor: _BridgedSwiftCaseEnum {
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
+        return bridgeJSRawValue
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> GenericRTColor {
+        return bridgeJSLiftParameter(value)
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> GenericRTColor {
+        return GenericRTColor(bridgeJSRawValue: value)!
+    }
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
+        return bridgeJSLowerParameter()
+    }
+
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
+        switch bridgeJSRawValue {
+        case 0:
+            self = .red
+        case 1:
+            self = .green
+        case 2:
+            self = .blue
+        default:
+            return nil
+        }
+    }
+
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
+        switch self {
+        case .red:
+            return 0
+        case .green:
+            return 1
+        case .blue:
+            return 2
+        }
+    }
+}
+
+extension GenericRTColor: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericRTColor")
+}
+
+extension GenericRTMode: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+}
+
+extension GenericRTMode: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericRTMode")
+}
+
+extension GenericRTLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+}
+
+extension GenericRTLevel: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericRTLevel")
+}
+
+extension GenericRTOutcome: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> GenericRTOutcome {
+        switch caseId {
+        case 0:
+            return .ok(code: Int.bridgeJSStackPop())
+        case 1:
+            return .fail(message: String.bridgeJSStackPop())
+        default:
+            fatalError("Unknown GenericRTOutcome case ID: \(caseId)")
+        }
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPushPayload() -> Int32 {
+        switch self {
+        case .ok(let code):
+            code.bridgeJSStackPush()
+            return Int32(0)
+        case .fail(let message):
+            message.bridgeJSStackPush()
+            return Int32(1)
+        }
+    }
+}
+
+extension GenericRTOutcome: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericRTOutcome")
 }
 
 @_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripInt")
@@ -6389,6 +6709,10 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
+extension OptionalAllTypesResult: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("OptionalAllTypesResult")
+}
+
 extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIOptionalResult {
         switch caseId {
@@ -6419,6 +6743,10 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
             return Int32(2)
         }
     }
+}
+
+extension APIOptionalResult: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("APIOptionalResult")
 }
 
 extension JSCoordinate: _BridgedSwiftStruct {
@@ -6467,6 +6795,10 @@ fileprivate func _bjs_struct_lift_JSCoordinate_extern() -> Int32 {
 #endif
 @inline(never) fileprivate func _bjs_struct_lift_JSCoordinate() -> Int32 {
     return _bjs_struct_lift_JSCoordinate_extern()
+}
+
+extension JSCoordinate: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("JSCoordinate")
 }
 
 @_expose(wasm, "bjs_JSCoordinate_init")
@@ -6528,6 +6860,10 @@ fileprivate func _bjs_struct_lift_NestedStructGroupA_Metadata_extern() -> Int32 
     return _bjs_struct_lift_NestedStructGroupA_Metadata_extern()
 }
 
+extension NestedStructGroupA.Metadata: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("NestedStructGroupA_Metadata")
+}
+
 extension NestedStructGroupB.Metadata: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> NestedStructGroupB.Metadata {
         let value = Double.bridgeJSStackPop()
@@ -6576,6 +6912,10 @@ fileprivate func _bjs_struct_lift_NestedStructGroupB_Metadata_extern() -> Int32 
     return _bjs_struct_lift_NestedStructGroupB_Metadata_extern()
 }
 
+extension NestedStructGroupB.Metadata: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("NestedStructGroupB_Metadata")
+}
+
 extension NestedTypeHost.Label: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> NestedTypeHost.Label {
         let text = String.bridgeJSStackPop()
@@ -6622,6 +6962,10 @@ fileprivate func _bjs_struct_lift_NestedTypeHost_Label_extern() -> Int32 {
     return _bjs_struct_lift_NestedTypeHost_Label_extern()
 }
 
+extension NestedTypeHost.Label: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("NestedTypeHost_Label")
+}
+
 @_expose(wasm, "bjs_NestedTypeHost_Label_init")
 @_cdecl("bjs_NestedTypeHost_Label_init")
 public func _bjs_NestedTypeHost_Label_init(_ textBytes: Int32, _ textLength: Int32) -> Void {
@@ -6653,6 +6997,340 @@ public func _bjs_NestedTypeHost_Label_static_untitled() -> Void {
     #else
     fatalError("Only available on WebAssembly")
     #endif
+}
+
+extension ExportGenericPoint: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ExportGenericPoint {
+        let y = Int.bridgeJSStackPop()
+        let x = Int.bridgeJSStackPop()
+        return ExportGenericPoint(x: x, y: y)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
+    }
+
+    public init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_ExportGenericPoint(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    public func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ExportGenericPoint()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ExportGenericPoint")
+fileprivate func _bjs_struct_lower_ExportGenericPoint_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_ExportGenericPoint_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_ExportGenericPoint(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_ExportGenericPoint_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ExportGenericPoint")
+fileprivate func _bjs_struct_lift_ExportGenericPoint_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_ExportGenericPoint_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_ExportGenericPoint() -> Int32 {
+    return _bjs_struct_lift_ExportGenericPoint_extern()
+}
+
+extension ExportGenericPoint: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportGenericPoint")
+}
+
+@_expose(wasm, "bjs_ExportGenericPoint_init")
+@_cdecl("bjs_ExportGenericPoint_init")
+public func _bjs_ExportGenericPoint_init(_ x: Int32, _ y: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = ExportGenericPoint(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension ExportGenericMethodPair: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ExportGenericMethodPair {
+        return ExportGenericMethodPair()
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+    }
+
+    public init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_ExportGenericMethodPair(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    public func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ExportGenericMethodPair()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ExportGenericMethodPair")
+fileprivate func _bjs_struct_lower_ExportGenericMethodPair_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_ExportGenericMethodPair_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_ExportGenericMethodPair(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_ExportGenericMethodPair_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ExportGenericMethodPair")
+fileprivate func _bjs_struct_lift_ExportGenericMethodPair_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_ExportGenericMethodPair_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_ExportGenericMethodPair() -> Int32 {
+    return _bjs_struct_lift_ExportGenericMethodPair_extern()
+}
+
+extension ExportGenericMethodPair: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportGenericMethodPair")
+}
+
+@_expose(wasm, "bjs_ExportGenericMethodPair_init")
+@_cdecl("bjs_ExportGenericMethodPair_init")
+public func _bjs_ExportGenericMethodPair_init() -> Void {
+    #if arch(wasm32)
+    let ret = ExportGenericMethodPair()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_ExportGenericMethodPair_first")
+@_cdecl("bjs_ExportGenericMethodPair_first")
+public func _bjs_ExportGenericMethodPair_first(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_ExportGenericMethodPair_first")
+@_cdecl("bjs_ExportGenericMethodPair_first")
+public func _bjs_ExportGenericMethodPair_first(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_ExportGenericMethodPair_first_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_ExportGenericMethodPair_first_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let _tmp__self = ExportGenericMethodPair.bridgeJSLiftParameter()
+    let ret = _tmp__self.first(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_ExportGenericMethodPair_maybe")
+@_cdecl("bjs_ExportGenericMethodPair_maybe")
+public func _bjs_ExportGenericMethodPair_maybe(_ present: Int32, _ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_ExportGenericMethodPair_maybe")
+@_cdecl("bjs_ExportGenericMethodPair_maybe")
+public func _bjs_ExportGenericMethodPair_maybe(_ present: Int32, _ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_ExportGenericMethodPair_maybe_open1(_generic0Type, present)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_ExportGenericMethodPair_maybe_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ present: Int32) {
+    let value = T.bridgeJSStackPop()
+    let _tmp__self = ExportGenericMethodPair.bridgeJSLiftParameter()
+    let _val_present = Bool.bridgeJSLiftParameter(present)
+    let ret = _tmp__self.maybe(value, present: _val_present)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_ExportGenericMethodPair_dict")
+@_cdecl("bjs_ExportGenericMethodPair_dict")
+public func _bjs_ExportGenericMethodPair_dict(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_ExportGenericMethodPair_dict")
+@_cdecl("bjs_ExportGenericMethodPair_dict")
+public func _bjs_ExportGenericMethodPair_dict(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_ExportGenericMethodPair_dict_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_ExportGenericMethodPair_dict_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let _tmp__self = ExportGenericMethodPair.bridgeJSLiftParameter()
+    let ret = _tmp__self.dict(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_ExportGenericMethodPair_static_wrap")
+@_cdecl("bjs_ExportGenericMethodPair_static_wrap")
+public func _bjs_ExportGenericMethodPair_static_wrap(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_ExportGenericMethodPair_static_wrap")
+@_cdecl("bjs_ExportGenericMethodPair_static_wrap")
+public func _bjs_ExportGenericMethodPair_static_wrap(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_ExportGenericMethodPair_static_wrap_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_ExportGenericMethodPair_static_wrap_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let ret = ExportGenericMethodPair.wrap(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+extension GenericRTPoint: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> GenericRTPoint {
+        let y = Int.bridgeJSStackPop()
+        let x = Int.bridgeJSStackPop()
+        return GenericRTPoint(x: x, y: y)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.x.bridgeJSStackPush()
+        self.y.bridgeJSStackPush()
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_GenericRTPoint(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_GenericRTPoint()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_GenericRTPoint")
+fileprivate func _bjs_struct_lower_GenericRTPoint_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_GenericRTPoint_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_GenericRTPoint(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_GenericRTPoint_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_GenericRTPoint")
+fileprivate func _bjs_struct_lift_GenericRTPoint_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_GenericRTPoint_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_GenericRTPoint() -> Int32 {
+    return _bjs_struct_lift_GenericRTPoint_extern()
+}
+
+extension GenericRTPoint: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericRTPoint")
+}
+
+extension GenericRTNamespace.Metadata: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> GenericRTNamespace.Metadata {
+        let count = Int.bridgeJSStackPop()
+        let label = String.bridgeJSStackPop()
+        return GenericRTNamespace.Metadata(label: label, count: count)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.label.bridgeJSStackPush()
+        self.count.bridgeJSStackPush()
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_GenericRTNamespace_Metadata(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_GenericRTNamespace_Metadata()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_GenericRTNamespace_Metadata")
+fileprivate func _bjs_struct_lower_GenericRTNamespace_Metadata_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_GenericRTNamespace_Metadata_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_GenericRTNamespace_Metadata(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_GenericRTNamespace_Metadata_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_GenericRTNamespace_Metadata")
+fileprivate func _bjs_struct_lift_GenericRTNamespace_Metadata_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_GenericRTNamespace_Metadata_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_GenericRTNamespace_Metadata() -> Int32 {
+    return _bjs_struct_lift_GenericRTNamespace_Metadata_extern()
+}
+
+extension GenericRTNamespace.Metadata: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericRTNamespace_Metadata")
 }
 
 extension Point: _BridgedSwiftStruct {
@@ -6701,6 +7379,10 @@ fileprivate func _bjs_struct_lift_Point_extern() -> Int32 {
 #endif
 @inline(never) fileprivate func _bjs_struct_lift_Point() -> Int32 {
     return _bjs_struct_lift_Point_extern()
+}
+
+extension Point: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Point")
 }
 
 extension PointerFields: _BridgedSwiftStruct {
@@ -6755,6 +7437,10 @@ fileprivate func _bjs_struct_lift_PointerFields_extern() -> Int32 {
 #endif
 @inline(never) fileprivate func _bjs_struct_lift_PointerFields() -> Int32 {
     return _bjs_struct_lift_PointerFields_extern()
+}
+
+extension PointerFields: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("PointerFields")
 }
 
 @_expose(wasm, "bjs_PointerFields_init")
@@ -6820,6 +7506,10 @@ fileprivate func _bjs_struct_lift_DataPoint_extern() -> Int32 {
 #endif
 @inline(never) fileprivate func _bjs_struct_lift_DataPoint() -> Int32 {
     return _bjs_struct_lift_DataPoint_extern()
+}
+
+extension DataPoint: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("DataPoint")
 }
 
 @_expose(wasm, "bjs_DataPoint_init")
@@ -6903,6 +7593,10 @@ fileprivate func _bjs_struct_lift_PublicPoint_extern() -> Int32 {
     return _bjs_struct_lift_PublicPoint_extern()
 }
 
+extension PublicPoint: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("PublicPoint")
+}
+
 @_expose(wasm, "bjs_PublicPoint_init")
 @_cdecl("bjs_PublicPoint_init")
 public func _bjs_PublicPoint_init(_ x: Int32, _ y: Int32) -> Void {
@@ -6964,6 +7658,10 @@ fileprivate func _bjs_struct_lift_Address_extern() -> Int32 {
     return _bjs_struct_lift_Address_extern()
 }
 
+extension Address: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Address")
+}
+
 extension Contact: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Contact {
         let secondaryAddress = Optional<Address>.bridgeJSStackPop()
@@ -7018,6 +7716,10 @@ fileprivate func _bjs_struct_lift_Contact_extern() -> Int32 {
     return _bjs_struct_lift_Contact_extern()
 }
 
+extension Contact: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Contact")
+}
+
 extension Config: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Config {
         let status = Status.bridgeJSStackPop()
@@ -7070,6 +7772,10 @@ fileprivate func _bjs_struct_lift_Config_extern() -> Int32 {
     return _bjs_struct_lift_Config_extern()
 }
 
+extension Config: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Config")
+}
+
 extension SessionData: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> SessionData {
         let owner = Optional<Greeter>.bridgeJSStackPop()
@@ -7116,6 +7822,10 @@ fileprivate func _bjs_struct_lift_SessionData_extern() -> Int32 {
 #endif
 @inline(never) fileprivate func _bjs_struct_lift_SessionData() -> Int32 {
     return _bjs_struct_lift_SessionData_extern()
+}
+
+extension SessionData: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("SessionData")
 }
 
 extension ValidationReport: _BridgedSwiftStruct {
@@ -7168,6 +7878,10 @@ fileprivate func _bjs_struct_lift_ValidationReport_extern() -> Int32 {
 #endif
 @inline(never) fileprivate func _bjs_struct_lift_ValidationReport() -> Int32 {
     return _bjs_struct_lift_ValidationReport_extern()
+}
+
+extension ValidationReport: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ValidationReport")
 }
 
 extension AdvancedConfig: _BridgedSwiftStruct {
@@ -7234,6 +7948,10 @@ fileprivate func _bjs_struct_lift_AdvancedConfig_extern() -> Int32 {
     return _bjs_struct_lift_AdvancedConfig_extern()
 }
 
+extension AdvancedConfig: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("AdvancedConfig")
+}
+
 extension MeasurementConfig: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> MeasurementConfig {
         let optionalRatio = Optional<Ratio>.bridgeJSStackPop()
@@ -7286,6 +8004,10 @@ fileprivate func _bjs_struct_lift_MeasurementConfig_extern() -> Int32 {
     return _bjs_struct_lift_MeasurementConfig_extern()
 }
 
+extension MeasurementConfig: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("MeasurementConfig")
+}
+
 extension MathOperations: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> MathOperations {
         let baseValue = Double.bridgeJSStackPop()
@@ -7330,6 +8052,10 @@ fileprivate func _bjs_struct_lift_MathOperations_extern() -> Int32 {
 #endif
 @inline(never) fileprivate func _bjs_struct_lift_MathOperations() -> Int32 {
     return _bjs_struct_lift_MathOperations_extern()
+}
+
+extension MathOperations: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("MathOperations")
 }
 
 @_expose(wasm, "bjs_MathOperations_init")
@@ -7424,6 +8150,10 @@ fileprivate func _bjs_struct_lift_CopyableCart_extern() -> Int32 {
     return _bjs_struct_lift_CopyableCart_extern()
 }
 
+extension CopyableCart: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("CopyableCart")
+}
+
 @_expose(wasm, "bjs_CopyableCart_static_fromJSObject")
 @_cdecl("bjs_CopyableCart_static_fromJSObject")
 public func _bjs_CopyableCart_static_fromJSObject(_ object: Int32) -> Void {
@@ -7483,6 +8213,10 @@ fileprivate func _bjs_struct_lift_CopyableCartItem_extern() -> Int32 {
     return _bjs_struct_lift_CopyableCartItem_extern()
 }
 
+extension CopyableCartItem: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("CopyableCartItem")
+}
+
 extension CopyableNestedCart: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> CopyableNestedCart {
         let shippingAddress = Optional<Address>.bridgeJSStackPop()
@@ -7531,6 +8265,10 @@ fileprivate func _bjs_struct_lift_CopyableNestedCart_extern() -> Int32 {
 #endif
 @inline(never) fileprivate func _bjs_struct_lift_CopyableNestedCart() -> Int32 {
     return _bjs_struct_lift_CopyableNestedCart_extern()
+}
+
+extension CopyableNestedCart: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("CopyableNestedCart")
 }
 
 @_expose(wasm, "bjs_CopyableNestedCart_static_fromJSObject")
@@ -7590,6 +8328,10 @@ fileprivate func _bjs_struct_lift_ConfigStruct_extern() -> Int32 {
 #endif
 @inline(never) fileprivate func _bjs_struct_lift_ConfigStruct() -> Int32 {
     return _bjs_struct_lift_ConfigStruct_extern()
+}
+
+extension ConfigStruct: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ConfigStruct")
 }
 
 @_expose(wasm, "bjs_ConfigStruct_static_defaultConfig_get")
@@ -7704,6 +8446,10 @@ fileprivate func _bjs_struct_lift_Vector2D_extern() -> Int32 {
     return _bjs_struct_lift_Vector2D_extern()
 }
 
+extension Vector2D: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Vector2D")
+}
+
 @_expose(wasm, "bjs_Vector2D_init")
 @_cdecl("bjs_Vector2D_init")
 public func _bjs_Vector2D_init(_ dx: Float64, _ dy: Float64) -> Void {
@@ -7785,6 +8531,10 @@ fileprivate func _bjs_struct_lift_JSObjectContainer_extern() -> Int32 {
     return _bjs_struct_lift_JSObjectContainer_extern()
 }
 
+extension JSObjectContainer: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("JSObjectContainer")
+}
+
 extension FooContainer: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> FooContainer {
         let optionalFoo = Optional<JSObject>.bridgeJSStackPop().map { Foo(unsafelyWrapping: $0) }
@@ -7833,6 +8583,10 @@ fileprivate func _bjs_struct_lift_FooContainer_extern() -> Int32 {
     return _bjs_struct_lift_FooContainer_extern()
 }
 
+extension FooContainer: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("FooContainer")
+}
+
 extension ArrayMembers: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ArrayMembers {
         let optStrings = Optional<[String]>.bridgeJSStackPop()
@@ -7879,6 +8633,10 @@ fileprivate func _bjs_struct_lift_ArrayMembers_extern() -> Int32 {
 #endif
 @inline(never) fileprivate func _bjs_struct_lift_ArrayMembers() -> Int32 {
     return _bjs_struct_lift_ArrayMembers_extern()
+}
+
+extension ArrayMembers: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ArrayMembers")
 }
 
 @_expose(wasm, "bjs_ArrayMembers_sumValues")
@@ -9690,6 +10448,380 @@ public func _bjs_makeAdder(_ base: Int32) -> Int32 {
     #endif
 }
 
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_exportGenericIdentity")
+@_cdecl("bjs_exportGenericIdentity")
+public func _bjs_exportGenericIdentity(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_exportGenericIdentity")
+@_cdecl("bjs_exportGenericIdentity")
+public func _bjs_exportGenericIdentity(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_exportGenericIdentity_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_exportGenericIdentity_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let ret = exportGenericIdentity(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_exportGenericEcho")
+@_cdecl("bjs_exportGenericEcho")
+public func _bjs_exportGenericEcho(_ tag: Int32, _ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_exportGenericEcho")
+@_cdecl("bjs_exportGenericEcho")
+public func _bjs_exportGenericEcho(_ tag: Int32, _ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_exportGenericEcho_open1(_generic0Type, tag)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_exportGenericEcho_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ tag: Int32) {
+    let value = T.bridgeJSStackPop()
+    let _val_tag = Int.bridgeJSLiftParameter(tag)
+    let ret = exportGenericEcho(value, tag: _val_tag)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_exportGenericPickFirst")
+@_cdecl("bjs_exportGenericPickFirst")
+public func _bjs_exportGenericPickFirst(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_exportGenericPickFirst")
+@_cdecl("bjs_exportGenericPickFirst")
+public func _bjs_exportGenericPickFirst(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_exportGenericPickFirst_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_exportGenericPickFirst_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let b = T.bridgeJSStackPop()
+    let a = T.bridgeJSStackPop()
+    let ret = exportGenericPickFirst(a, b)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_exportGenericPickSecond")
+@_cdecl("bjs_exportGenericPickSecond")
+public func _bjs_exportGenericPickSecond(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_exportGenericPickSecond")
+@_cdecl("bjs_exportGenericPickSecond")
+public func _bjs_exportGenericPickSecond(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_exportGenericPickSecond_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_exportGenericPickSecond_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let b = T.bridgeJSStackPop()
+    let a = T.bridgeJSStackPop()
+    let ret = exportGenericPickSecond(a, b)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+@_expose(wasm, "bjs_makeExportGenericOutcome")
+@_cdecl("bjs_makeExportGenericOutcome")
+public func _bjs_makeExportGenericOutcome(_ value: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = makeExportGenericOutcome(_: Int.bridgeJSLiftParameter(value))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_exportGenericOutcomeValue")
+@_cdecl("bjs_exportGenericOutcomeValue")
+public func _bjs_exportGenericOutcomeValue(_ outcome: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = exportGenericOutcomeValue(_: ExportGenericOutcome.bridgeJSLiftParameter(outcome))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_exportGenericArrayIdentity")
+@_cdecl("bjs_exportGenericArrayIdentity")
+public func _bjs_exportGenericArrayIdentity(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_exportGenericArrayIdentity")
+@_cdecl("bjs_exportGenericArrayIdentity")
+public func _bjs_exportGenericArrayIdentity(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_exportGenericArrayIdentity_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_exportGenericArrayIdentity_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let values = Array<T>.bridgeJSStackPop()
+    let ret = exportGenericArrayIdentity(values)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_exportGenericOptionalIdentity")
+@_cdecl("bjs_exportGenericOptionalIdentity")
+public func _bjs_exportGenericOptionalIdentity(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_exportGenericOptionalIdentity")
+@_cdecl("bjs_exportGenericOptionalIdentity")
+public func _bjs_exportGenericOptionalIdentity(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_exportGenericOptionalIdentity_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_exportGenericOptionalIdentity_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = Optional<T>.bridgeJSStackPop()
+    let ret = exportGenericOptionalIdentity(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_exportGenericDictIdentity")
+@_cdecl("bjs_exportGenericDictIdentity")
+public func _bjs_exportGenericDictIdentity(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_exportGenericDictIdentity")
+@_cdecl("bjs_exportGenericDictIdentity")
+public func _bjs_exportGenericDictIdentity(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_exportGenericDictIdentity_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_exportGenericDictIdentity_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let values = Dictionary<String, T>.bridgeJSStackPop()
+    let ret = exportGenericDictIdentity(values)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_exportGenericWrapPointAndTag")
+@_cdecl("bjs_exportGenericWrapPointAndTag")
+public func _bjs_exportGenericWrapPointAndTag(_ tag: Int32, _ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_exportGenericWrapPointAndTag")
+@_cdecl("bjs_exportGenericWrapPointAndTag")
+public func _bjs_exportGenericWrapPointAndTag(_ tag: Int32, _ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_exportGenericWrapPointAndTag_open1(_generic0Type, tag)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_exportGenericWrapPointAndTag_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ tag: Int32) {
+    let value = T.bridgeJSStackPop()
+    let _tmp_p = ExportGenericPoint.bridgeJSLiftParameter()
+    let _val_tag = Int.bridgeJSLiftParameter(tag)
+    let ret = exportGenericWrapPointAndTag(_tmp_p, tag: _val_tag, value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_exportGenericCombineFirst")
+@_cdecl("bjs_exportGenericCombineFirst")
+public func _bjs_exportGenericCombineFirst(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_exportGenericCombineFirst")
+@_cdecl("bjs_exportGenericCombineFirst")
+public func _bjs_exportGenericCombineFirst(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    guard let _generic1Type = _bridgeJSExportTypeRegistry[_generic1TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic1TypeId)")
+    }
+    _bjs_exportGenericCombineFirst_open1(_generic0Type, _generic1Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_exportGenericCombineFirst_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type) {
+    _bjs_exportGenericCombineFirst_open2(_generic1Type, asT: T.self)
+}
+private func _bjs_exportGenericCombineFirst_open2<U: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type) {
+    let b = U.bridgeJSStackPop()
+    let a = T.bridgeJSStackPop()
+    let ret = exportGenericCombineFirst(a, b)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_exportGenericCombineSecond")
+@_cdecl("bjs_exportGenericCombineSecond")
+public func _bjs_exportGenericCombineSecond(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_exportGenericCombineSecond")
+@_cdecl("bjs_exportGenericCombineSecond")
+public func _bjs_exportGenericCombineSecond(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    guard let _generic1Type = _bridgeJSExportTypeRegistry[_generic1TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic1TypeId)")
+    }
+    _bjs_exportGenericCombineSecond_open1(_generic0Type, _generic1Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_exportGenericCombineSecond_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type) {
+    _bjs_exportGenericCombineSecond_open2(_generic1Type, asT: T.self)
+}
+private func _bjs_exportGenericCombineSecond_open2<U: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type) {
+    let b = U.bridgeJSStackPop()
+    let a = T.bridgeJSStackPop()
+    let ret = exportGenericCombineSecond(a, b)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_exportGenericCombineTripleLast")
+@_cdecl("bjs_exportGenericCombineTripleLast")
+public func _bjs_exportGenericCombineTripleLast(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32, _ _generic2TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_exportGenericCombineTripleLast")
+@_cdecl("bjs_exportGenericCombineTripleLast")
+public func _bjs_exportGenericCombineTripleLast(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32, _ _generic2TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    guard let _generic1Type = _bridgeJSExportTypeRegistry[_generic1TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic1TypeId)")
+    }
+    guard let _generic2Type = _bridgeJSExportTypeRegistry[_generic2TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic2TypeId)")
+    }
+    _bjs_exportGenericCombineTripleLast_open1(_generic0Type, _generic1Type, _generic2Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_exportGenericCombineTripleLast_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type, _ _generic2Type: any _BridgedSwiftGenericBridgeable.Type) {
+    _bjs_exportGenericCombineTripleLast_open2(_generic1Type, asT: T.self, _generic2Type)
+}
+private func _bjs_exportGenericCombineTripleLast_open2<U: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type, _ _generic2Type: any _BridgedSwiftGenericBridgeable.Type) {
+    _bjs_exportGenericCombineTripleLast_open3(_generic2Type, asT: T.self, asU: U.self)
+}
+private func _bjs_exportGenericCombineTripleLast_open3<V: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(_ _generic2Type: V.Type, asT _generic0Type: T.Type, asU _generic1Type: U.Type) {
+    let c = V.bridgeJSStackPop()
+    let b = U.bridgeJSStackPop()
+    let a = T.bridgeJSStackPop()
+    let ret = exportGenericCombineTripleLast(a, b, c)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+@_expose(wasm, "bjs_lastWrappedPointX")
+@_cdecl("bjs_lastWrappedPointX")
+public func _bjs_lastWrappedPointX() -> Int32 {
+    #if arch(wasm32)
+    let ret = lastWrappedPointX()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_lastWrappedPointY")
+@_cdecl("bjs_lastWrappedPointY")
+public func _bjs_lastWrappedPointY() -> Int32 {
+    #if arch(wasm32)
+    let ret = lastWrappedPointY()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_lastTag")
+@_cdecl("bjs_lastTag")
+public func _bjs_lastTag() -> Int32 {
+    #if arch(wasm32)
+    let ret = lastTag()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_roundTripPointerFields")
 @_cdecl("bjs_roundTripPointerFields")
 public func _bjs_roundTripPointerFields() -> Void {
@@ -10009,6 +11141,104 @@ public func _bjs_arrayMembersFirst() -> Void {
     #endif
 }
 
+#if !hasFeature(Embedded)
+private let _bridgeJSExportTypeRegistry: [Int32: any _BridgedSwiftGenericBridgeable.Type] = {
+    var registry: [Int32: any _BridgedSwiftGenericBridgeable.Type] = [:]
+    func register<T: _BridgedSwiftGenericBridgeable>(_ type: T.Type) {
+        registry[T.bridgeJSTypeID] = type
+    }
+    register(Bool.self)
+    register(Int.self)
+    register(Int8.self)
+    register(UInt8.self)
+    register(Int16.self)
+    register(UInt16.self)
+    register(Int32.self)
+    register(UInt32.self)
+    register(UInt.self)
+    register(Int64.self)
+    register(UInt64.self)
+    register(Float.self)
+    register(Double.self)
+    register(String.self)
+    register(JSValue.self)
+    register(JSCoordinate.self)
+    register(NestedStructGroupA.Metadata.self)
+    register(NestedStructGroupB.Metadata.self)
+    register(NestedTypeHost.Label.self)
+    register(ExportGenericPoint.self)
+    register(ExportGenericMethodPair.self)
+    register(GenericRTPoint.self)
+    register(GenericRTNamespace.Metadata.self)
+    register(Point.self)
+    register(PointerFields.self)
+    register(DataPoint.self)
+    register(PublicPoint.self)
+    register(Address.self)
+    register(Contact.self)
+    register(Config.self)
+    register(SessionData.self)
+    register(ValidationReport.self)
+    register(AdvancedConfig.self)
+    register(MeasurementConfig.self)
+    register(MathOperations.self)
+    register(CopyableCart.self)
+    register(CopyableCartItem.self)
+    register(CopyableNestedCart.self)
+    register(ConfigStruct.self)
+    register(Vector2D.self)
+    register(JSObjectContainer.self)
+    register(FooContainer.self)
+    register(ArrayMembers.self)
+    register(PolygonReference.self)
+    register(TagReference.self)
+    register(TagHolderReference.self)
+    register(PriorityReference.self)
+    register(ExportGenericBox.self)
+    register(ExportGenericMethodBox.self)
+    register(ImportGenericBox.self)
+    register(Severity.self)
+    register(Shape.self)
+    register(InnerTag.self)
+    register(AsyncImportedPayloadResult.self)
+    register(Direction.self)
+    register(Status.self)
+    register(Theme.self)
+    register(HttpStatus.self)
+    register(FileSize.self)
+    register(SessionId.self)
+    register(Precision.self)
+    register(Ratio.self)
+    register(TSDirection.self)
+    register(TSTheme.self)
+    register(AsyncPayloadResult.self)
+    register(Networking.API.Method.self)
+    register(Configuration.LogLevel.self)
+    register(Configuration.Port.self)
+    register(Internal.SupportedMethod.self)
+    register(APIResult.self)
+    register(ComplexResult.self)
+    register(Utilities.Result.self)
+    register(API.NetworkingResult.self)
+    register(AllTypesResult.self)
+    register(TypedPayloadResult.self)
+    register(StaticCalculator.self)
+    register(StaticPropertyEnum.self)
+    register(NestedTypeHost.Variant.self)
+    register(ExportGenericOutcome.self)
+    register(ExportGenericMethodFactory.self)
+    register(LightColor.self)
+    register(ImportedPayloadSignal.self)
+    register(GenericRTColor.self)
+    register(GenericRTMode.self)
+    register(GenericRTLevel.self)
+    register(GenericRTOutcome.self)
+    register(OptionalAllTypesResult.self)
+    register(APIOptionalResult.self)
+    return registry
+}()
+#endif
+
 @_expose(wasm, "bjs_PolygonReference_init")
 @_cdecl("bjs_PolygonReference_init")
 public func _bjs_PolygonReference_init(_ labelBytes: Int32, _ labelLength: Int32) -> UnsafeMutableRawPointer {
@@ -10106,6 +11336,10 @@ fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPo
     return _bjs_PolygonReference_wrap_extern(pointer)
 }
 
+extension PolygonReference: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("PolygonReference")
+}
+
 @_expose(wasm, "bjs_TagReference_describe")
 @_cdecl("bjs_TagReference_describe")
 public func _bjs_TagReference_describe(_ _self: UnsafeMutableRawPointer) -> Void {
@@ -10146,6 +11380,10 @@ fileprivate func _bjs_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointe
 #endif
 @inline(never) fileprivate func _bjs_TagReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     return _bjs_TagReference_wrap_extern(pointer)
+}
+
+extension TagReference: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("TagReference")
 }
 
 @_expose(wasm, "bjs_TagHolderReference_init")
@@ -10243,6 +11481,10 @@ fileprivate func _bjs_TagHolderReference_wrap_extern(_ pointer: UnsafeMutableRaw
     return _bjs_TagHolderReference_wrap_extern(pointer)
 }
 
+extension TagHolderReference: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("TagHolderReference")
+}
+
 @_expose(wasm, "bjs_PriorityReference_describe")
 @_cdecl("bjs_PriorityReference_describe")
 public func _bjs_PriorityReference_describe(_ _self: UnsafeMutableRawPointer) -> Void {
@@ -10327,6 +11569,10 @@ fileprivate func _bjs_PriorityReference_wrap_extern(_ pointer: UnsafeMutableRawP
 #endif
 @inline(never) fileprivate func _bjs_PriorityReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     return _bjs_PriorityReference_wrap_extern(pointer)
+}
+
+extension PriorityReference: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("PriorityReference")
 }
 
 @_expose(wasm, "bjs_ClosureSupportExports_static_makeIntToInt")
@@ -13015,6 +14261,295 @@ fileprivate func _bjs_NestedTypeHost_wrap_extern(_ pointer: UnsafeMutableRawPoin
 #endif
 @inline(never) fileprivate func _bjs_NestedTypeHost_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     return _bjs_NestedTypeHost_wrap_extern(pointer)
+}
+
+@_expose(wasm, "bjs_ExportGenericBox_init")
+@_cdecl("bjs_ExportGenericBox_init")
+public func _bjs_ExportGenericBox_init(_ value: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = ExportGenericBox(value: Int.bridgeJSLiftParameter(value))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ExportGenericBox_get")
+@_cdecl("bjs_ExportGenericBox_get")
+public func _bjs_ExportGenericBox_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = ExportGenericBox.bridgeJSLiftParameter(_self).get()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ExportGenericBox_value_get")
+@_cdecl("bjs_ExportGenericBox_value_get")
+public func _bjs_ExportGenericBox_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = ExportGenericBox.bridgeJSLiftParameter(_self).value
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ExportGenericBox_value_set")
+@_cdecl("bjs_ExportGenericBox_value_set")
+public func _bjs_ExportGenericBox_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+    #if arch(wasm32)
+    ExportGenericBox.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ExportGenericBox_deinit")
+@_cdecl("bjs_ExportGenericBox_deinit")
+public func _bjs_ExportGenericBox_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<ExportGenericBox>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension ExportGenericBox: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    public var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_ExportGenericBox_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    public consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_ExportGenericBox_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ExportGenericBox_wrap")
+fileprivate func _bjs_ExportGenericBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_ExportGenericBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_ExportGenericBox_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_ExportGenericBox_wrap_extern(pointer)
+}
+
+extension ExportGenericBox: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportGenericBox")
+}
+
+@_expose(wasm, "bjs_ExportGenericMethodBox_init")
+@_cdecl("bjs_ExportGenericMethodBox_init")
+public func _bjs_ExportGenericMethodBox_init() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = ExportGenericMethodBox()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_ExportGenericMethodBox_echo")
+@_cdecl("bjs_ExportGenericMethodBox_echo")
+public func _bjs_ExportGenericMethodBox_echo(_ _self: UnsafeMutableRawPointer, _ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_ExportGenericMethodBox_echo")
+@_cdecl("bjs_ExportGenericMethodBox_echo")
+public func _bjs_ExportGenericMethodBox_echo(_ _self: UnsafeMutableRawPointer, _ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_ExportGenericMethodBox_echo_open1(_generic0Type, _self)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_ExportGenericMethodBox_echo_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _self: UnsafeMutableRawPointer) {
+    let value = T.bridgeJSStackPop()
+    let _val__self = ExportGenericMethodBox.bridgeJSLiftParameter(_self)
+    let ret = _val__self.echo(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_ExportGenericMethodBox_combine")
+@_cdecl("bjs_ExportGenericMethodBox_combine")
+public func _bjs_ExportGenericMethodBox_combine(_ _self: UnsafeMutableRawPointer, _ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_ExportGenericMethodBox_combine")
+@_cdecl("bjs_ExportGenericMethodBox_combine")
+public func _bjs_ExportGenericMethodBox_combine(_ _self: UnsafeMutableRawPointer, _ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    guard let _generic1Type = _bridgeJSExportTypeRegistry[_generic1TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic1TypeId)")
+    }
+    _bjs_ExportGenericMethodBox_combine_open1(_generic0Type, _generic1Type, _self)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_ExportGenericMethodBox_combine_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type, _ _self: UnsafeMutableRawPointer) {
+    _bjs_ExportGenericMethodBox_combine_open2(_generic1Type, asT: T.self, _self)
+}
+private func _bjs_ExportGenericMethodBox_combine_open2<U: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type, _ _self: UnsafeMutableRawPointer) {
+    let b = U.bridgeJSStackPop()
+    let a = T.bridgeJSStackPop()
+    let _val__self = ExportGenericMethodBox.bridgeJSLiftParameter(_self)
+    let ret = _val__self.combine(a, b)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+#if hasFeature(Embedded)
+@_expose(wasm, "bjs_ExportGenericMethodBox_static_wrapArray")
+@_cdecl("bjs_ExportGenericMethodBox_static_wrapArray")
+public func _bjs_ExportGenericMethodBox_static_wrapArray(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Generic @JS exported functions are not supported in Embedded Swift")
+}
+#else
+@_expose(wasm, "bjs_ExportGenericMethodBox_static_wrapArray")
+@_cdecl("bjs_ExportGenericMethodBox_static_wrapArray")
+public func _bjs_ExportGenericMethodBox_static_wrapArray(_ _generic0TypeId: Int32) -> Void {
+    #if arch(wasm32)
+    guard let _generic0Type = _bridgeJSExportTypeRegistry[_generic0TypeId] else {
+        fatalError("BridgeJS: unknown generic type id \(_generic0TypeId)")
+    }
+    _bjs_ExportGenericMethodBox_static_wrapArray_open1(_generic0Type)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+private func _bjs_ExportGenericMethodBox_static_wrapArray_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+    let value = T.bridgeJSStackPop()
+    let ret = ExportGenericMethodBox.wrapArray(value)
+    ret.bridgeJSStackPush()
+}
+#endif
+
+@_expose(wasm, "bjs_ExportGenericMethodBox_deinit")
+@_cdecl("bjs_ExportGenericMethodBox_deinit")
+public func _bjs_ExportGenericMethodBox_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<ExportGenericMethodBox>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension ExportGenericMethodBox: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    public var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_ExportGenericMethodBox_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    public consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_ExportGenericMethodBox_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ExportGenericMethodBox_wrap")
+fileprivate func _bjs_ExportGenericMethodBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_ExportGenericMethodBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_ExportGenericMethodBox_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_ExportGenericMethodBox_wrap_extern(pointer)
+}
+
+extension ExportGenericMethodBox: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportGenericMethodBox")
+}
+
+@_expose(wasm, "bjs_ImportGenericBox_init")
+@_cdecl("bjs_ImportGenericBox_init")
+public func _bjs_ImportGenericBox_init(_ value: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = ImportGenericBox(value: Int.bridgeJSLiftParameter(value))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ImportGenericBox_get")
+@_cdecl("bjs_ImportGenericBox_get")
+public func _bjs_ImportGenericBox_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = ImportGenericBox.bridgeJSLiftParameter(_self).get()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ImportGenericBox_value_get")
+@_cdecl("bjs_ImportGenericBox_value_get")
+public func _bjs_ImportGenericBox_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = ImportGenericBox.bridgeJSLiftParameter(_self).value
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ImportGenericBox_value_set")
+@_cdecl("bjs_ImportGenericBox_value_set")
+public func _bjs_ImportGenericBox_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+    #if arch(wasm32)
+    ImportGenericBox.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_ImportGenericBox_deinit")
+@_cdecl("bjs_ImportGenericBox_deinit")
+public func _bjs_ImportGenericBox_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<ImportGenericBox>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension ImportGenericBox: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_ImportGenericBox_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_ImportGenericBox_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ImportGenericBox_wrap")
+fileprivate func _bjs_ImportGenericBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_ImportGenericBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_ImportGenericBox_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_ImportGenericBox_wrap_extern(pointer)
+}
+
+extension ImportGenericBox: _BridgedSwiftGenericBridgeable {
+    @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ImportGenericBox")
 }
 
 @_expose(wasm, "bjs_OptionalHolder_init")
@@ -16449,6 +17984,260 @@ func _$jsRoundTripOptionalImportedPayloadSignal(_ value: Optional<ImportedPayloa
         throw error
     }
     return Optional<ImportedPayloadSignal>.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsGenericRoundTrip")
+fileprivate func bjs_jsGenericRoundTrip_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_jsGenericRoundTrip_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsGenericRoundTrip(_ _generic0TypeId: Int32) -> Void {
+    return bjs_jsGenericRoundTrip_extern(_generic0TypeId)
+}
+
+func _$jsGenericRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
+    value.bridgeJSStackPush()
+    bjs_jsGenericRoundTrip(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return T.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsGenericRoundTripClass")
+fileprivate func bjs_jsGenericRoundTripClass_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_jsGenericRoundTripClass_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsGenericRoundTripClass(_ _generic0TypeId: Int32) -> Void {
+    return bjs_jsGenericRoundTripClass_extern(_generic0TypeId)
+}
+
+func _$jsGenericRoundTripClass<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
+    value.bridgeJSStackPush()
+    bjs_jsGenericRoundTripClass(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return T.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsGenericParsePoint")
+fileprivate func bjs_jsGenericParsePoint_extern(_ jsonBytes: Int32, _ jsonLength: Int32, _ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_jsGenericParsePoint_extern(_ jsonBytes: Int32, _ jsonLength: Int32, _ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsGenericParsePoint(_ jsonBytes: Int32, _ jsonLength: Int32, _ _generic0TypeId: Int32) -> Void {
+    return bjs_jsGenericParsePoint_extern(jsonBytes, jsonLength, _generic0TypeId)
+}
+
+func _$jsGenericParsePoint<T: _BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T {
+    json.bridgeJSWithLoweredParameter { (jsonBytes, jsonLength) in
+        bjs_jsGenericParsePoint(jsonBytes, jsonLength, T.bridgeJSTypeID)
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return T.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsImportPickFirst")
+fileprivate func bjs_jsImportPickFirst_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_jsImportPickFirst_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsImportPickFirst(_ _generic0TypeId: Int32) -> Void {
+    return bjs_jsImportPickFirst_extern(_generic0TypeId)
+}
+
+func _$jsImportPickFirst<T: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) throws(JSException) -> T {
+    b.bridgeJSStackPush()
+    a.bridgeJSStackPush()
+    bjs_jsImportPickFirst(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return T.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsImportMakeInt")
+fileprivate func bjs_jsImportMakeInt_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_jsImportMakeInt_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsImportMakeInt(_ _generic0TypeId: Int32) -> Void {
+    return bjs_jsImportMakeInt_extern(_generic0TypeId)
+}
+
+func _$jsImportMakeInt<T: _BridgedSwiftGenericBridgeable>() throws(JSException) -> T {
+    bjs_jsImportMakeInt(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return T.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsImportCombineSecond")
+fileprivate func bjs_jsImportCombineSecond_extern(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void
+#else
+fileprivate func bjs_jsImportCombineSecond_extern(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsImportCombineSecond(_ _generic0TypeId: Int32, _ _generic1TypeId: Int32) -> Void {
+    return bjs_jsImportCombineSecond_extern(_generic0TypeId, _generic1TypeId)
+}
+
+func _$jsImportCombineSecond<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: U) throws(JSException) -> U {
+    b.bridgeJSStackPush()
+    a.bridgeJSStackPush()
+    bjs_jsImportCombineSecond(T.bridgeJSTypeID, U.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return U.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsGenericArrayRoundTrip")
+fileprivate func bjs_jsGenericArrayRoundTrip_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_jsGenericArrayRoundTrip_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsGenericArrayRoundTrip(_ _generic0TypeId: Int32) -> Void {
+    return bjs_jsGenericArrayRoundTrip_extern(_generic0TypeId)
+}
+
+func _$jsGenericArrayRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T] {
+    values.bridgeJSStackPush()
+    bjs_jsGenericArrayRoundTrip(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Array<T>.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsGenericOptionalRoundTrip")
+fileprivate func bjs_jsGenericOptionalRoundTrip_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_jsGenericOptionalRoundTrip_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsGenericOptionalRoundTrip(_ _generic0TypeId: Int32) -> Void {
+    return bjs_jsGenericOptionalRoundTrip_extern(_generic0TypeId)
+}
+
+func _$jsGenericOptionalRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ value: Optional<T>) throws(JSException) -> Optional<T> {
+    value.bridgeJSStackPush()
+    bjs_jsGenericOptionalRoundTrip(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<T>.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsGenericDictRoundTrip")
+fileprivate func bjs_jsGenericDictRoundTrip_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_jsGenericDictRoundTrip_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsGenericDictRoundTrip(_ _generic0TypeId: Int32) -> Void {
+    return bjs_jsGenericDictRoundTrip_extern(_generic0TypeId)
+}
+
+func _$jsGenericDictRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ values: [String: T]) throws(JSException) -> [String: T] {
+    values.bridgeJSStackPush()
+    bjs_jsGenericDictRoundTrip(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Dictionary<String, T>.bridgeJSStackPop()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ImportGenericConsumer_init")
+fileprivate func bjs_ImportGenericConsumer_init_extern() -> Int32
+#else
+fileprivate func bjs_ImportGenericConsumer_init_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_ImportGenericConsumer_init() -> Int32 {
+    return bjs_ImportGenericConsumer_init_extern()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ImportGenericConsumer_box_static")
+fileprivate func bjs_ImportGenericConsumer_box_static_extern(_ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_ImportGenericConsumer_box_static_extern(_ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_ImportGenericConsumer_box_static(_ _generic0TypeId: Int32) -> Void {
+    return bjs_ImportGenericConsumer_box_static_extern(_generic0TypeId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ImportGenericConsumer_identity")
+fileprivate func bjs_ImportGenericConsumer_identity_extern(_ self: Int32, _ _generic0TypeId: Int32) -> Void
+#else
+fileprivate func bjs_ImportGenericConsumer_identity_extern(_ self: Int32, _ _generic0TypeId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_ImportGenericConsumer_identity(_ self: Int32, _ _generic0TypeId: Int32) -> Void {
+    return bjs_ImportGenericConsumer_identity_extern(self, _generic0TypeId)
+}
+
+func _$ImportGenericConsumer_init() throws(JSException) -> JSObject {
+    let ret = bjs_ImportGenericConsumer_init()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSObject.bridgeJSLiftReturn(ret)
+}
+
+func _$ImportGenericConsumer_box<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
+    value.bridgeJSStackPush()
+    bjs_ImportGenericConsumer_box_static(T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return T.bridgeJSStackPop()
+}
+
+func _$ImportGenericConsumer_identity<T: _BridgedSwiftGenericBridgeable>(_ self: JSObject, _ value: T) throws(JSException) -> T {
+    let selfValue = self.bridgeJSLowerParameter()
+    value.bridgeJSStackPush()
+    bjs_ImportGenericConsumer_identity(selfValue, T.bridgeJSTypeID)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return T.bridgeJSStackPop()
 }
 
 #if arch(wasm32)

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -4196,7 +4196,7 @@ extension Severity: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Severity: _BridgedSwiftGenericBridgeable {
+extension Severity: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Severity")
 }
 
@@ -4223,7 +4223,7 @@ extension Shape: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension Shape: _BridgedSwiftGenericBridgeable {
+extension Shape: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Shape")
 }
 
@@ -4250,7 +4250,7 @@ extension InnerTag: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension InnerTag: _BridgedSwiftGenericBridgeable {
+extension InnerTag: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("InnerTag")
 }
 
@@ -4766,7 +4766,7 @@ extension AsyncImportedPayloadResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension AsyncImportedPayloadResult: _BridgedSwiftGenericBridgeable {
+extension AsyncImportedPayloadResult: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("AsyncImportedPayloadResult")
 }
 
@@ -4978,7 +4978,7 @@ extension Direction: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Direction: _BridgedSwiftGenericBridgeable {
+extension Direction: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Direction")
 }
 
@@ -5021,49 +5021,49 @@ extension Status: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Status: _BridgedSwiftGenericBridgeable {
+extension Status: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Status")
 }
 
 extension Theme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Theme: _BridgedSwiftGenericBridgeable {
+extension Theme: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Theme")
 }
 
 extension HttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension HttpStatus: _BridgedSwiftGenericBridgeable {
+extension HttpStatus: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("HttpStatus")
 }
 
 extension FileSize: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension FileSize: _BridgedSwiftGenericBridgeable {
+extension FileSize: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("FileSize")
 }
 
 extension SessionId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension SessionId: _BridgedSwiftGenericBridgeable {
+extension SessionId: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("SessionId")
 }
 
 extension Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Precision: _BridgedSwiftGenericBridgeable {
+extension Precision: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Precision")
 }
 
 extension Ratio: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Ratio: _BridgedSwiftGenericBridgeable {
+extension Ratio: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Ratio")
 }
 
@@ -5110,14 +5110,14 @@ extension TSDirection: _BridgedSwiftCaseEnum {
     }
 }
 
-extension TSDirection: _BridgedSwiftGenericBridgeable {
+extension TSDirection: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("TSDirection")
 }
 
 extension TSTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension TSTheme: _BridgedSwiftGenericBridgeable {
+extension TSTheme: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("TSTheme")
 }
 
@@ -5149,7 +5149,7 @@ extension AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension AsyncPayloadResult: _BridgedSwiftGenericBridgeable {
+extension AsyncPayloadResult: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("AsyncPayloadResult")
 }
 
@@ -5218,21 +5218,21 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Networking.API.Method: _BridgedSwiftGenericBridgeable {
+extension Networking.API.Method: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Networking_API_Method")
 }
 
 extension Configuration.LogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Configuration.LogLevel: _BridgedSwiftGenericBridgeable {
+extension Configuration.LogLevel: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Configuration_LogLevel")
 }
 
 extension Configuration.Port: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Configuration.Port: _BridgedSwiftGenericBridgeable {
+extension Configuration.Port: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Configuration_Port")
 }
 
@@ -5271,7 +5271,7 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Internal.SupportedMethod: _BridgedSwiftGenericBridgeable {
+extension Internal.SupportedMethod: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Networking_APIV2_Internal_SupportedMethod")
 }
 
@@ -5318,7 +5318,7 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension APIResult: _BridgedSwiftGenericBridgeable {
+extension APIResult: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("APIResult")
 }
 
@@ -5385,7 +5385,7 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension ComplexResult: _BridgedSwiftGenericBridgeable {
+extension ComplexResult: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ComplexResult")
 }
 
@@ -5421,7 +5421,7 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension Utilities.Result: _BridgedSwiftGenericBridgeable {
+extension Utilities.Result: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Utilities_Result")
 }
 
@@ -5450,7 +5450,7 @@ extension API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension API.NetworkingResult: _BridgedSwiftGenericBridgeable {
+extension API.NetworkingResult: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("API_NetworkingResult")
 }
 
@@ -5502,7 +5502,7 @@ extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension AllTypesResult: _BridgedSwiftGenericBridgeable {
+extension AllTypesResult: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("AllTypesResult")
 }
 
@@ -5544,7 +5544,7 @@ extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension TypedPayloadResult: _BridgedSwiftGenericBridgeable {
+extension TypedPayloadResult: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("TypedPayloadResult")
 }
 
@@ -5583,7 +5583,7 @@ extension StaticCalculator: _BridgedSwiftCaseEnum {
     }
 }
 
-extension StaticCalculator: _BridgedSwiftGenericBridgeable {
+extension StaticCalculator: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("StaticCalculator")
 }
 
@@ -5688,7 +5688,7 @@ extension StaticPropertyEnum: _BridgedSwiftCaseEnum {
     }
 }
 
-extension StaticPropertyEnum: _BridgedSwiftGenericBridgeable {
+extension StaticPropertyEnum: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("StaticPropertyEnum")
 }
 
@@ -5908,7 +5908,7 @@ public func _bjs_NestedStructGroupB_static_roundtripMetadata() -> Void {
 extension NestedTypeHost.Variant: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension NestedTypeHost.Variant: _BridgedSwiftGenericBridgeable {
+extension NestedTypeHost.Variant: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("NestedTypeHost_Variant")
 }
 
@@ -5936,7 +5936,7 @@ extension ExportGenericOutcome: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension ExportGenericOutcome: _BridgedSwiftGenericBridgeable {
+extension ExportGenericOutcome: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportGenericOutcome")
 }
 
@@ -5971,7 +5971,7 @@ extension ExportGenericMethodFactory: _BridgedSwiftCaseEnum {
     }
 }
 
-extension ExportGenericMethodFactory: _BridgedSwiftGenericBridgeable {
+extension ExportGenericMethodFactory: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportGenericMethodFactory")
 }
 
@@ -5994,7 +5994,7 @@ public func _bjs_ExportGenericMethodFactory_static_one(_ _generic0TypeId: Int32)
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_ExportGenericMethodFactory_static_one_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_ExportGenericMethodFactory_static_one_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let ret = ExportGenericMethodFactory.one(value)
     ret.bridgeJSStackPush()
@@ -6020,7 +6020,7 @@ public func _bjs_ExportGenericMethodNamespace_static_make(_ _generic0TypeId: Int
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_ExportGenericMethodNamespace_static_make_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_ExportGenericMethodNamespace_static_make_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let ret = ExportGenericMethodNamespace.make(value)
     ret.bridgeJSStackPush()
@@ -6066,7 +6066,7 @@ extension LightColor: _BridgedSwiftCaseEnum {
     }
 }
 
-extension LightColor: _BridgedSwiftGenericBridgeable {
+extension LightColor: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("LightColor")
 }
 
@@ -6098,7 +6098,7 @@ extension ImportedPayloadSignal: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension ImportedPayloadSignal: _BridgedSwiftGenericBridgeable {
+extension ImportedPayloadSignal: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ImportedPayloadSignal")
 }
 
@@ -6141,21 +6141,21 @@ extension GenericRTColor: _BridgedSwiftCaseEnum {
     }
 }
 
-extension GenericRTColor: _BridgedSwiftGenericBridgeable {
+extension GenericRTColor: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericRTColor")
 }
 
 extension GenericRTMode: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension GenericRTMode: _BridgedSwiftGenericBridgeable {
+extension GenericRTMode: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericRTMode")
 }
 
 extension GenericRTLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension GenericRTLevel: _BridgedSwiftGenericBridgeable {
+extension GenericRTLevel: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericRTLevel")
 }
 
@@ -6183,7 +6183,7 @@ extension GenericRTOutcome: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension GenericRTOutcome: _BridgedSwiftGenericBridgeable {
+extension GenericRTOutcome: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericRTOutcome")
 }
 
@@ -6709,7 +6709,7 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension OptionalAllTypesResult: _BridgedSwiftGenericBridgeable {
+extension OptionalAllTypesResult: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("OptionalAllTypesResult")
 }
 
@@ -6745,7 +6745,7 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension APIOptionalResult: _BridgedSwiftGenericBridgeable {
+extension APIOptionalResult: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("APIOptionalResult")
 }
 
@@ -6797,7 +6797,7 @@ fileprivate func _bjs_struct_lift_JSCoordinate_extern() -> Int32 {
     return _bjs_struct_lift_JSCoordinate_extern()
 }
 
-extension JSCoordinate: _BridgedSwiftGenericBridgeable {
+extension JSCoordinate: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("JSCoordinate")
 }
 
@@ -6860,7 +6860,7 @@ fileprivate func _bjs_struct_lift_NestedStructGroupA_Metadata_extern() -> Int32 
     return _bjs_struct_lift_NestedStructGroupA_Metadata_extern()
 }
 
-extension NestedStructGroupA.Metadata: _BridgedSwiftGenericBridgeable {
+extension NestedStructGroupA.Metadata: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("NestedStructGroupA_Metadata")
 }
 
@@ -6912,7 +6912,7 @@ fileprivate func _bjs_struct_lift_NestedStructGroupB_Metadata_extern() -> Int32 
     return _bjs_struct_lift_NestedStructGroupB_Metadata_extern()
 }
 
-extension NestedStructGroupB.Metadata: _BridgedSwiftGenericBridgeable {
+extension NestedStructGroupB.Metadata: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("NestedStructGroupB_Metadata")
 }
 
@@ -6962,7 +6962,7 @@ fileprivate func _bjs_struct_lift_NestedTypeHost_Label_extern() -> Int32 {
     return _bjs_struct_lift_NestedTypeHost_Label_extern()
 }
 
-extension NestedTypeHost.Label: _BridgedSwiftGenericBridgeable {
+extension NestedTypeHost.Label: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("NestedTypeHost_Label")
 }
 
@@ -7047,7 +7047,7 @@ fileprivate func _bjs_struct_lift_ExportGenericPoint_extern() -> Int32 {
     return _bjs_struct_lift_ExportGenericPoint_extern()
 }
 
-extension ExportGenericPoint: _BridgedSwiftGenericBridgeable {
+extension ExportGenericPoint: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportGenericPoint")
 }
 
@@ -7106,7 +7106,7 @@ fileprivate func _bjs_struct_lift_ExportGenericMethodPair_extern() -> Int32 {
     return _bjs_struct_lift_ExportGenericMethodPair_extern()
 }
 
-extension ExportGenericMethodPair: _BridgedSwiftGenericBridgeable {
+extension ExportGenericMethodPair: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportGenericMethodPair")
 }
 
@@ -7140,7 +7140,7 @@ public func _bjs_ExportGenericMethodPair_first(_ _generic0TypeId: Int32) -> Void
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_ExportGenericMethodPair_first_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_ExportGenericMethodPair_first_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let _tmp__self = ExportGenericMethodPair.bridgeJSLiftParameter()
     let ret = _tmp__self.first(value)
@@ -7167,7 +7167,7 @@ public func _bjs_ExportGenericMethodPair_maybe(_ present: Int32, _ _generic0Type
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_ExportGenericMethodPair_maybe_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ present: Int32) {
+private func _bjs_ExportGenericMethodPair_maybe_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ present: Int32) {
     let value = T.bridgeJSStackPop()
     let _tmp__self = ExportGenericMethodPair.bridgeJSLiftParameter()
     let _val_present = Bool.bridgeJSLiftParameter(present)
@@ -7195,7 +7195,7 @@ public func _bjs_ExportGenericMethodPair_dict(_ _generic0TypeId: Int32) -> Void 
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_ExportGenericMethodPair_dict_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_ExportGenericMethodPair_dict_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let _tmp__self = ExportGenericMethodPair.bridgeJSLiftParameter()
     let ret = _tmp__self.dict(value)
@@ -7222,7 +7222,7 @@ public func _bjs_ExportGenericMethodPair_static_wrap(_ _generic0TypeId: Int32) -
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_ExportGenericMethodPair_static_wrap_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_ExportGenericMethodPair_static_wrap_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let ret = ExportGenericMethodPair.wrap(value)
     ret.bridgeJSStackPush()
@@ -7277,7 +7277,7 @@ fileprivate func _bjs_struct_lift_GenericRTPoint_extern() -> Int32 {
     return _bjs_struct_lift_GenericRTPoint_extern()
 }
 
-extension GenericRTPoint: _BridgedSwiftGenericBridgeable {
+extension GenericRTPoint: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericRTPoint")
 }
 
@@ -7329,7 +7329,7 @@ fileprivate func _bjs_struct_lift_GenericRTNamespace_Metadata_extern() -> Int32 
     return _bjs_struct_lift_GenericRTNamespace_Metadata_extern()
 }
 
-extension GenericRTNamespace.Metadata: _BridgedSwiftGenericBridgeable {
+extension GenericRTNamespace.Metadata: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("GenericRTNamespace_Metadata")
 }
 
@@ -7381,7 +7381,7 @@ fileprivate func _bjs_struct_lift_Point_extern() -> Int32 {
     return _bjs_struct_lift_Point_extern()
 }
 
-extension Point: _BridgedSwiftGenericBridgeable {
+extension Point: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Point")
 }
 
@@ -7439,7 +7439,7 @@ fileprivate func _bjs_struct_lift_PointerFields_extern() -> Int32 {
     return _bjs_struct_lift_PointerFields_extern()
 }
 
-extension PointerFields: _BridgedSwiftGenericBridgeable {
+extension PointerFields: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("PointerFields")
 }
 
@@ -7508,7 +7508,7 @@ fileprivate func _bjs_struct_lift_DataPoint_extern() -> Int32 {
     return _bjs_struct_lift_DataPoint_extern()
 }
 
-extension DataPoint: _BridgedSwiftGenericBridgeable {
+extension DataPoint: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("DataPoint")
 }
 
@@ -7593,7 +7593,7 @@ fileprivate func _bjs_struct_lift_PublicPoint_extern() -> Int32 {
     return _bjs_struct_lift_PublicPoint_extern()
 }
 
-extension PublicPoint: _BridgedSwiftGenericBridgeable {
+extension PublicPoint: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("PublicPoint")
 }
 
@@ -7658,7 +7658,7 @@ fileprivate func _bjs_struct_lift_Address_extern() -> Int32 {
     return _bjs_struct_lift_Address_extern()
 }
 
-extension Address: _BridgedSwiftGenericBridgeable {
+extension Address: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Address")
 }
 
@@ -7716,7 +7716,7 @@ fileprivate func _bjs_struct_lift_Contact_extern() -> Int32 {
     return _bjs_struct_lift_Contact_extern()
 }
 
-extension Contact: _BridgedSwiftGenericBridgeable {
+extension Contact: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Contact")
 }
 
@@ -7772,7 +7772,7 @@ fileprivate func _bjs_struct_lift_Config_extern() -> Int32 {
     return _bjs_struct_lift_Config_extern()
 }
 
-extension Config: _BridgedSwiftGenericBridgeable {
+extension Config: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Config")
 }
 
@@ -7824,7 +7824,7 @@ fileprivate func _bjs_struct_lift_SessionData_extern() -> Int32 {
     return _bjs_struct_lift_SessionData_extern()
 }
 
-extension SessionData: _BridgedSwiftGenericBridgeable {
+extension SessionData: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("SessionData")
 }
 
@@ -7880,7 +7880,7 @@ fileprivate func _bjs_struct_lift_ValidationReport_extern() -> Int32 {
     return _bjs_struct_lift_ValidationReport_extern()
 }
 
-extension ValidationReport: _BridgedSwiftGenericBridgeable {
+extension ValidationReport: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ValidationReport")
 }
 
@@ -7948,7 +7948,7 @@ fileprivate func _bjs_struct_lift_AdvancedConfig_extern() -> Int32 {
     return _bjs_struct_lift_AdvancedConfig_extern()
 }
 
-extension AdvancedConfig: _BridgedSwiftGenericBridgeable {
+extension AdvancedConfig: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("AdvancedConfig")
 }
 
@@ -8004,7 +8004,7 @@ fileprivate func _bjs_struct_lift_MeasurementConfig_extern() -> Int32 {
     return _bjs_struct_lift_MeasurementConfig_extern()
 }
 
-extension MeasurementConfig: _BridgedSwiftGenericBridgeable {
+extension MeasurementConfig: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("MeasurementConfig")
 }
 
@@ -8054,7 +8054,7 @@ fileprivate func _bjs_struct_lift_MathOperations_extern() -> Int32 {
     return _bjs_struct_lift_MathOperations_extern()
 }
 
-extension MathOperations: _BridgedSwiftGenericBridgeable {
+extension MathOperations: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("MathOperations")
 }
 
@@ -8150,7 +8150,7 @@ fileprivate func _bjs_struct_lift_CopyableCart_extern() -> Int32 {
     return _bjs_struct_lift_CopyableCart_extern()
 }
 
-extension CopyableCart: _BridgedSwiftGenericBridgeable {
+extension CopyableCart: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("CopyableCart")
 }
 
@@ -8213,7 +8213,7 @@ fileprivate func _bjs_struct_lift_CopyableCartItem_extern() -> Int32 {
     return _bjs_struct_lift_CopyableCartItem_extern()
 }
 
-extension CopyableCartItem: _BridgedSwiftGenericBridgeable {
+extension CopyableCartItem: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("CopyableCartItem")
 }
 
@@ -8267,7 +8267,7 @@ fileprivate func _bjs_struct_lift_CopyableNestedCart_extern() -> Int32 {
     return _bjs_struct_lift_CopyableNestedCart_extern()
 }
 
-extension CopyableNestedCart: _BridgedSwiftGenericBridgeable {
+extension CopyableNestedCart: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("CopyableNestedCart")
 }
 
@@ -8330,7 +8330,7 @@ fileprivate func _bjs_struct_lift_ConfigStruct_extern() -> Int32 {
     return _bjs_struct_lift_ConfigStruct_extern()
 }
 
-extension ConfigStruct: _BridgedSwiftGenericBridgeable {
+extension ConfigStruct: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ConfigStruct")
 }
 
@@ -8446,7 +8446,7 @@ fileprivate func _bjs_struct_lift_Vector2D_extern() -> Int32 {
     return _bjs_struct_lift_Vector2D_extern()
 }
 
-extension Vector2D: _BridgedSwiftGenericBridgeable {
+extension Vector2D: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("Vector2D")
 }
 
@@ -8531,7 +8531,7 @@ fileprivate func _bjs_struct_lift_JSObjectContainer_extern() -> Int32 {
     return _bjs_struct_lift_JSObjectContainer_extern()
 }
 
-extension JSObjectContainer: _BridgedSwiftGenericBridgeable {
+extension JSObjectContainer: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("JSObjectContainer")
 }
 
@@ -8583,7 +8583,7 @@ fileprivate func _bjs_struct_lift_FooContainer_extern() -> Int32 {
     return _bjs_struct_lift_FooContainer_extern()
 }
 
-extension FooContainer: _BridgedSwiftGenericBridgeable {
+extension FooContainer: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("FooContainer")
 }
 
@@ -8635,7 +8635,7 @@ fileprivate func _bjs_struct_lift_ArrayMembers_extern() -> Int32 {
     return _bjs_struct_lift_ArrayMembers_extern()
 }
 
-extension ArrayMembers: _BridgedSwiftGenericBridgeable {
+extension ArrayMembers: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ArrayMembers")
 }
 
@@ -10467,7 +10467,7 @@ public func _bjs_exportGenericIdentity(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_exportGenericIdentity_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_exportGenericIdentity_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let ret = exportGenericIdentity(value)
     ret.bridgeJSStackPush()
@@ -10493,7 +10493,7 @@ public func _bjs_exportGenericEcho(_ tag: Int32, _ _generic0TypeId: Int32) -> Vo
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_exportGenericEcho_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ tag: Int32) {
+private func _bjs_exportGenericEcho_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ tag: Int32) {
     let value = T.bridgeJSStackPop()
     let _val_tag = Int.bridgeJSLiftParameter(tag)
     let ret = exportGenericEcho(value, tag: _val_tag)
@@ -10520,7 +10520,7 @@ public func _bjs_exportGenericPickFirst(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_exportGenericPickFirst_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_exportGenericPickFirst_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let b = T.bridgeJSStackPop()
     let a = T.bridgeJSStackPop()
     let ret = exportGenericPickFirst(a, b)
@@ -10547,7 +10547,7 @@ public func _bjs_exportGenericPickSecond(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_exportGenericPickSecond_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_exportGenericPickSecond_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let b = T.bridgeJSStackPop()
     let a = T.bridgeJSStackPop()
     let ret = exportGenericPickSecond(a, b)
@@ -10596,7 +10596,7 @@ public func _bjs_exportGenericArrayIdentity(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_exportGenericArrayIdentity_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_exportGenericArrayIdentity_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let values = Array<T>.bridgeJSStackPop()
     let ret = exportGenericArrayIdentity(values)
     ret.bridgeJSStackPush()
@@ -10622,7 +10622,7 @@ public func _bjs_exportGenericOptionalIdentity(_ _generic0TypeId: Int32) -> Void
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_exportGenericOptionalIdentity_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_exportGenericOptionalIdentity_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = Optional<T>.bridgeJSStackPop()
     let ret = exportGenericOptionalIdentity(value)
     ret.bridgeJSStackPush()
@@ -10648,7 +10648,7 @@ public func _bjs_exportGenericDictIdentity(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_exportGenericDictIdentity_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_exportGenericDictIdentity_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let values = Dictionary<String, T>.bridgeJSStackPop()
     let ret = exportGenericDictIdentity(values)
     ret.bridgeJSStackPush()
@@ -10674,7 +10674,7 @@ public func _bjs_exportGenericWrapPointAndTag(_ tag: Int32, _ _generic0TypeId: I
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_exportGenericWrapPointAndTag_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ tag: Int32) {
+private func _bjs_exportGenericWrapPointAndTag_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ tag: Int32) {
     let value = T.bridgeJSStackPop()
     let _tmp_p = ExportGenericPoint.bridgeJSLiftParameter()
     let _val_tag = Int.bridgeJSLiftParameter(tag)
@@ -10705,10 +10705,10 @@ public func _bjs_exportGenericCombineFirst(_ _generic0TypeId: Int32, _ _generic1
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_exportGenericCombineFirst_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type) {
+private func _bjs_exportGenericCombineFirst_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any BridgedSwiftGenericBridgeable.Type) {
     _bjs_exportGenericCombineFirst_open2(_generic1Type, asT: T.self)
 }
-private func _bjs_exportGenericCombineFirst_open2<U: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type) {
+private func _bjs_exportGenericCombineFirst_open2<U: BridgedSwiftGenericBridgeable, T: BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type) {
     let b = U.bridgeJSStackPop()
     let a = T.bridgeJSStackPop()
     let ret = exportGenericCombineFirst(a, b)
@@ -10738,10 +10738,10 @@ public func _bjs_exportGenericCombineSecond(_ _generic0TypeId: Int32, _ _generic
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_exportGenericCombineSecond_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type) {
+private func _bjs_exportGenericCombineSecond_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any BridgedSwiftGenericBridgeable.Type) {
     _bjs_exportGenericCombineSecond_open2(_generic1Type, asT: T.self)
 }
-private func _bjs_exportGenericCombineSecond_open2<U: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type) {
+private func _bjs_exportGenericCombineSecond_open2<U: BridgedSwiftGenericBridgeable, T: BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type) {
     let b = U.bridgeJSStackPop()
     let a = T.bridgeJSStackPop()
     let ret = exportGenericCombineSecond(a, b)
@@ -10774,13 +10774,13 @@ public func _bjs_exportGenericCombineTripleLast(_ _generic0TypeId: Int32, _ _gen
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_exportGenericCombineTripleLast_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type, _ _generic2Type: any _BridgedSwiftGenericBridgeable.Type) {
+private func _bjs_exportGenericCombineTripleLast_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any BridgedSwiftGenericBridgeable.Type, _ _generic2Type: any BridgedSwiftGenericBridgeable.Type) {
     _bjs_exportGenericCombineTripleLast_open2(_generic1Type, asT: T.self, _generic2Type)
 }
-private func _bjs_exportGenericCombineTripleLast_open2<U: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type, _ _generic2Type: any _BridgedSwiftGenericBridgeable.Type) {
+private func _bjs_exportGenericCombineTripleLast_open2<U: BridgedSwiftGenericBridgeable, T: BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type, _ _generic2Type: any BridgedSwiftGenericBridgeable.Type) {
     _bjs_exportGenericCombineTripleLast_open3(_generic2Type, asT: T.self, asU: U.self)
 }
-private func _bjs_exportGenericCombineTripleLast_open3<V: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(_ _generic2Type: V.Type, asT _generic0Type: T.Type, asU _generic1Type: U.Type) {
+private func _bjs_exportGenericCombineTripleLast_open3<V: BridgedSwiftGenericBridgeable, T: BridgedSwiftGenericBridgeable, U: BridgedSwiftGenericBridgeable>(_ _generic2Type: V.Type, asT _generic0Type: T.Type, asU _generic1Type: U.Type) {
     let c = V.bridgeJSStackPop()
     let b = U.bridgeJSStackPop()
     let a = T.bridgeJSStackPop()
@@ -11142,9 +11142,9 @@ public func _bjs_arrayMembersFirst() -> Void {
 }
 
 #if !hasFeature(Embedded)
-private let _bridgeJSExportTypeRegistry: [Int32: any _BridgedSwiftGenericBridgeable.Type] = {
-    var registry: [Int32: any _BridgedSwiftGenericBridgeable.Type] = [:]
-    func register<T: _BridgedSwiftGenericBridgeable>(_ type: T.Type) {
+private let _bridgeJSExportTypeRegistry: [Int32: any BridgedSwiftGenericBridgeable.Type] = {
+    var registry: [Int32: any BridgedSwiftGenericBridgeable.Type] = [:]
+    func register<T: BridgedSwiftGenericBridgeable>(_ type: T.Type) {
         registry[T.bridgeJSTypeID] = type
     }
     register(Bool.self)
@@ -11336,7 +11336,7 @@ fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPo
     return _bjs_PolygonReference_wrap_extern(pointer)
 }
 
-extension PolygonReference: _BridgedSwiftGenericBridgeable {
+extension PolygonReference: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("PolygonReference")
 }
 
@@ -11382,7 +11382,7 @@ fileprivate func _bjs_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointe
     return _bjs_TagReference_wrap_extern(pointer)
 }
 
-extension TagReference: _BridgedSwiftGenericBridgeable {
+extension TagReference: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("TagReference")
 }
 
@@ -11481,7 +11481,7 @@ fileprivate func _bjs_TagHolderReference_wrap_extern(_ pointer: UnsafeMutableRaw
     return _bjs_TagHolderReference_wrap_extern(pointer)
 }
 
-extension TagHolderReference: _BridgedSwiftGenericBridgeable {
+extension TagHolderReference: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("TagHolderReference")
 }
 
@@ -11571,7 +11571,7 @@ fileprivate func _bjs_PriorityReference_wrap_extern(_ pointer: UnsafeMutableRawP
     return _bjs_PriorityReference_wrap_extern(pointer)
 }
 
-extension PriorityReference: _BridgedSwiftGenericBridgeable {
+extension PriorityReference: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("PriorityReference")
 }
 
@@ -14337,7 +14337,7 @@ fileprivate func _bjs_ExportGenericBox_wrap_extern(_ pointer: UnsafeMutableRawPo
     return _bjs_ExportGenericBox_wrap_extern(pointer)
 }
 
-extension ExportGenericBox: _BridgedSwiftGenericBridgeable {
+extension ExportGenericBox: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportGenericBox")
 }
 
@@ -14371,7 +14371,7 @@ public func _bjs_ExportGenericMethodBox_echo(_ _self: UnsafeMutableRawPointer, _
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_ExportGenericMethodBox_echo_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _self: UnsafeMutableRawPointer) {
+private func _bjs_ExportGenericMethodBox_echo_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _self: UnsafeMutableRawPointer) {
     let value = T.bridgeJSStackPop()
     let _val__self = ExportGenericMethodBox.bridgeJSLiftParameter(_self)
     let ret = _val__self.echo(value)
@@ -14401,10 +14401,10 @@ public func _bjs_ExportGenericMethodBox_combine(_ _self: UnsafeMutableRawPointer
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_ExportGenericMethodBox_combine_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any _BridgedSwiftGenericBridgeable.Type, _ _self: UnsafeMutableRawPointer) {
+private func _bjs_ExportGenericMethodBox_combine_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type, _ _generic1Type: any BridgedSwiftGenericBridgeable.Type, _ _self: UnsafeMutableRawPointer) {
     _bjs_ExportGenericMethodBox_combine_open2(_generic1Type, asT: T.self, _self)
 }
-private func _bjs_ExportGenericMethodBox_combine_open2<U: _BridgedSwiftGenericBridgeable, T: _BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type, _ _self: UnsafeMutableRawPointer) {
+private func _bjs_ExportGenericMethodBox_combine_open2<U: BridgedSwiftGenericBridgeable, T: BridgedSwiftGenericBridgeable>(_ _generic1Type: U.Type, asT _generic0Type: T.Type, _ _self: UnsafeMutableRawPointer) {
     let b = U.bridgeJSStackPop()
     let a = T.bridgeJSStackPop()
     let _val__self = ExportGenericMethodBox.bridgeJSLiftParameter(_self)
@@ -14432,7 +14432,7 @@ public func _bjs_ExportGenericMethodBox_static_wrapArray(_ _generic0TypeId: Int3
     fatalError("Only available on WebAssembly")
     #endif
 }
-private func _bjs_ExportGenericMethodBox_static_wrapArray_open1<T: _BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
+private func _bjs_ExportGenericMethodBox_static_wrapArray_open1<T: BridgedSwiftGenericBridgeable>(_ _generic0Type: T.Type) {
     let value = T.bridgeJSStackPop()
     let ret = ExportGenericMethodBox.wrapArray(value)
     ret.bridgeJSStackPush()
@@ -14470,7 +14470,7 @@ fileprivate func _bjs_ExportGenericMethodBox_wrap_extern(_ pointer: UnsafeMutabl
     return _bjs_ExportGenericMethodBox_wrap_extern(pointer)
 }
 
-extension ExportGenericMethodBox: _BridgedSwiftGenericBridgeable {
+extension ExportGenericMethodBox: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ExportGenericMethodBox")
 }
 
@@ -14548,7 +14548,7 @@ fileprivate func _bjs_ImportGenericBox_wrap_extern(_ pointer: UnsafeMutableRawPo
     return _bjs_ImportGenericBox_wrap_extern(pointer)
 }
 
-extension ImportGenericBox: _BridgedSwiftGenericBridgeable {
+extension ImportGenericBox: BridgedSwiftGenericBridgeable {
     @_spi(BridgeJS) public static let bridgeJSTypeID: Int32 = _swift_js_resolve_type_id("ImportGenericBox")
 }
 
@@ -17998,7 +17998,7 @@ fileprivate func bjs_jsGenericRoundTrip_extern(_ _generic0TypeId: Int32) -> Void
     return bjs_jsGenericRoundTrip_extern(_generic0TypeId)
 }
 
-func _$jsGenericRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
+func _$jsGenericRoundTrip<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
     value.bridgeJSStackPush()
     bjs_jsGenericRoundTrip(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
@@ -18019,7 +18019,7 @@ fileprivate func bjs_jsGenericRoundTripClass_extern(_ _generic0TypeId: Int32) ->
     return bjs_jsGenericRoundTripClass_extern(_generic0TypeId)
 }
 
-func _$jsGenericRoundTripClass<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
+func _$jsGenericRoundTripClass<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
     value.bridgeJSStackPush()
     bjs_jsGenericRoundTripClass(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
@@ -18040,7 +18040,7 @@ fileprivate func bjs_jsGenericParsePoint_extern(_ jsonBytes: Int32, _ jsonLength
     return bjs_jsGenericParsePoint_extern(jsonBytes, jsonLength, _generic0TypeId)
 }
 
-func _$jsGenericParsePoint<T: _BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T {
+func _$jsGenericParsePoint<T: BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T {
     json.bridgeJSWithLoweredParameter { (jsonBytes, jsonLength) in
         bjs_jsGenericParsePoint(jsonBytes, jsonLength, T.bridgeJSTypeID)
     }
@@ -18062,7 +18062,7 @@ fileprivate func bjs_jsImportPickFirst_extern(_ _generic0TypeId: Int32) -> Void 
     return bjs_jsImportPickFirst_extern(_generic0TypeId)
 }
 
-func _$jsImportPickFirst<T: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) throws(JSException) -> T {
+func _$jsImportPickFirst<T: BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) throws(JSException) -> T {
     b.bridgeJSStackPush()
     a.bridgeJSStackPush()
     bjs_jsImportPickFirst(T.bridgeJSTypeID)
@@ -18084,7 +18084,7 @@ fileprivate func bjs_jsImportMakeInt_extern(_ _generic0TypeId: Int32) -> Void {
     return bjs_jsImportMakeInt_extern(_generic0TypeId)
 }
 
-func _$jsImportMakeInt<T: _BridgedSwiftGenericBridgeable>() throws(JSException) -> T {
+func _$jsImportMakeInt<T: BridgedSwiftGenericBridgeable>() throws(JSException) -> T {
     bjs_jsImportMakeInt(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
         throw error
@@ -18104,7 +18104,7 @@ fileprivate func bjs_jsImportCombineSecond_extern(_ _generic0TypeId: Int32, _ _g
     return bjs_jsImportCombineSecond_extern(_generic0TypeId, _generic1TypeId)
 }
 
-func _$jsImportCombineSecond<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: U) throws(JSException) -> U {
+func _$jsImportCombineSecond<T: BridgedSwiftGenericBridgeable, U: BridgedSwiftGenericBridgeable>(_ a: T, _ b: U) throws(JSException) -> U {
     b.bridgeJSStackPush()
     a.bridgeJSStackPush()
     bjs_jsImportCombineSecond(T.bridgeJSTypeID, U.bridgeJSTypeID)
@@ -18126,7 +18126,7 @@ fileprivate func bjs_jsGenericArrayRoundTrip_extern(_ _generic0TypeId: Int32) ->
     return bjs_jsGenericArrayRoundTrip_extern(_generic0TypeId)
 }
 
-func _$jsGenericArrayRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T] {
+func _$jsGenericArrayRoundTrip<T: BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T] {
     values.bridgeJSStackPush()
     bjs_jsGenericArrayRoundTrip(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
@@ -18147,7 +18147,7 @@ fileprivate func bjs_jsGenericOptionalRoundTrip_extern(_ _generic0TypeId: Int32)
     return bjs_jsGenericOptionalRoundTrip_extern(_generic0TypeId)
 }
 
-func _$jsGenericOptionalRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ value: Optional<T>) throws(JSException) -> Optional<T> {
+func _$jsGenericOptionalRoundTrip<T: BridgedSwiftGenericBridgeable>(_ value: Optional<T>) throws(JSException) -> Optional<T> {
     value.bridgeJSStackPush()
     bjs_jsGenericOptionalRoundTrip(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
@@ -18168,7 +18168,7 @@ fileprivate func bjs_jsGenericDictRoundTrip_extern(_ _generic0TypeId: Int32) -> 
     return bjs_jsGenericDictRoundTrip_extern(_generic0TypeId)
 }
 
-func _$jsGenericDictRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ values: [String: T]) throws(JSException) -> [String: T] {
+func _$jsGenericDictRoundTrip<T: BridgedSwiftGenericBridgeable>(_ values: [String: T]) throws(JSException) -> [String: T] {
     values.bridgeJSStackPush()
     bjs_jsGenericDictRoundTrip(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
@@ -18221,7 +18221,7 @@ func _$ImportGenericConsumer_init() throws(JSException) -> JSObject {
     return JSObject.bridgeJSLiftReturn(ret)
 }
 
-func _$ImportGenericConsumer_box<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
+func _$ImportGenericConsumer_box<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T {
     value.bridgeJSStackPush()
     bjs_ImportGenericConsumer_box_static(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
@@ -18230,7 +18230,7 @@ func _$ImportGenericConsumer_box<T: _BridgedSwiftGenericBridgeable>(_ value: T) 
     return T.bridgeJSStackPop()
 }
 
-func _$ImportGenericConsumer_identity<T: _BridgedSwiftGenericBridgeable>(_ self: JSObject, _ value: T) throws(JSException) -> T {
+func _$ImportGenericConsumer_identity<T: BridgedSwiftGenericBridgeable>(_ self: JSObject, _ value: T) throws(JSException) -> T {
     let selfValue = self.bridgeJSLowerParameter()
     value.bridgeJSStackPush()
     bjs_ImportGenericConsumer_identity(selfValue, T.bridgeJSTypeID)

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -127,6 +127,7 @@
             }
           ]
         },
+        "isFinal" : true,
         "methods" : [
           {
             "abiName" : "bjs_PolygonReference_vertexCount",
@@ -265,6 +266,7 @@
         "swiftCallName" : "PolygonReference"
       },
       {
+        "isFinal" : true,
         "methods" : [
           {
             "abiName" : "bjs_TagReference_describe",
@@ -327,6 +329,7 @@
             }
           ]
         },
+        "isFinal" : true,
         "methods" : [
           {
             "abiName" : "bjs_TagHolderReference_describe",
@@ -380,6 +383,7 @@
         "swiftCallName" : "TagHolderReference"
       },
       {
+        "isFinal" : true,
         "methods" : [
           {
             "abiName" : "bjs_PriorityReference_describe",
@@ -4741,6 +4745,260 @@
 
         ],
         "swiftCallName" : "NestedTypeHost"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_ExportGenericBox_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "value",
+              "name" : "value",
+              "type" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "explicitAccessControl" : "public",
+        "isFinal" : true,
+        "methods" : [
+          {
+            "abiName" : "bjs_ExportGenericBox_get",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "get",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "name" : "ExportGenericBox",
+        "properties" : [
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "name" : "value",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "ExportGenericBox"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_ExportGenericMethodBox_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+
+          ]
+        },
+        "explicitAccessControl" : "public",
+        "isFinal" : true,
+        "methods" : [
+          {
+            "abiName" : "bjs_ExportGenericMethodBox_echo",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "echo",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ExportGenericMethodBox_combine",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T",
+              "U"
+            ],
+            "name" : "combine",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "a",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              },
+              {
+                "label" : "_",
+                "name" : "b",
+                "type" : {
+                  "generic" : {
+                    "_0" : "U"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "U"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ExportGenericMethodBox_static_wrapArray",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "wrapArray",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            },
+            "staticContext" : {
+              "className" : {
+                "_0" : "ExportGenericMethodBox"
+              }
+            }
+          }
+        ],
+        "name" : "ExportGenericMethodBox",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "ExportGenericMethodBox"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_ImportGenericBox_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "value",
+              "name" : "value",
+              "type" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "isFinal" : true,
+        "methods" : [
+          {
+            "abiName" : "bjs_ImportGenericBox_get",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "get",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "name" : "ImportGenericBox",
+        "properties" : [
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "name" : "value",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "ImportGenericBox"
       },
       {
         "constructor" : {
@@ -10068,6 +10326,154 @@
         "cases" : [
           {
             "associatedValues" : [
+              {
+                "label" : "value",
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "name" : "ok"
+          },
+          {
+            "associatedValues" : [
+              {
+                "label" : "reason",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "name" : "fail"
+          }
+        ],
+        "emitStyle" : "const",
+        "explicitAccessControl" : "public",
+        "name" : "ExportGenericOutcome",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "ExportGenericOutcome",
+        "tsFullPath" : "ExportGenericOutcome"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "primary"
+          }
+        ],
+        "emitStyle" : "const",
+        "explicitAccessControl" : "public",
+        "name" : "ExportGenericMethodFactory",
+        "staticMethods" : [
+          {
+            "abiName" : "bjs_ExportGenericMethodFactory_static_one",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "one",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            },
+            "staticContext" : {
+              "enumName" : {
+                "_0" : "ExportGenericMethodFactory"
+              }
+            }
+          }
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "ExportGenericMethodFactory",
+        "tsFullPath" : "ExportGenericMethodFactory"
+      },
+      {
+        "cases" : [
+
+        ],
+        "emitStyle" : "const",
+        "explicitAccessControl" : "public",
+        "name" : "ExportGenericMethodNamespace",
+        "staticMethods" : [
+          {
+            "abiName" : "bjs_ExportGenericMethodNamespace_static_make",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "make",
+            "namespace" : [
+              "ExportGenericMethodNamespace"
+            ],
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            },
+            "staticContext" : {
+              "namespaceEnum" : {
+                "_0" : "ExportGenericMethodNamespace"
+              }
+            }
+          }
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "ExportGenericMethodNamespace",
+        "tsFullPath" : "ExportGenericMethodNamespace"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
 
             ],
             "name" : "red"
@@ -10142,6 +10548,152 @@
         ],
         "swiftCallName" : "ImportedPayloadSignal",
         "tsFullPath" : "ImportedPayloadSignal"
+      },
+      {
+        "cases" : [
+
+        ],
+        "emitStyle" : "const",
+        "name" : "GenericRTNamespace",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "GenericRTNamespace",
+        "tsFullPath" : "GenericRTNamespace"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "red"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "green"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "blue"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "GenericRTColor",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "GenericRTColor",
+        "tsFullPath" : "GenericRTColor"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "light"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "dark"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "GenericRTMode",
+        "rawType" : "String",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "GenericRTMode",
+        "tsFullPath" : "GenericRTMode"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "low",
+            "rawValue" : "1"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "high",
+            "rawValue" : "9"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "GenericRTLevel",
+        "rawType" : "Int",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "GenericRTLevel",
+        "tsFullPath" : "GenericRTLevel"
+      },
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+              {
+                "label" : "code",
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "name" : "ok"
+          },
+          {
+            "associatedValues" : [
+              {
+                "label" : "message",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "name" : "fail"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "GenericRTOutcome",
+        "staticMethods" : [
+
+        ],
+        "staticProperties" : [
+
+        ],
+        "swiftCallName" : "GenericRTOutcome",
+        "tsFullPath" : "GenericRTOutcome"
       },
       {
         "cases" : [
@@ -16735,6 +17287,547 @@
         }
       },
       {
+        "abiName" : "bjs_exportGenericIdentity",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "exportGenericIdentity",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_exportGenericEcho",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "exportGenericEcho",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "label" : "tag",
+            "name" : "tag",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_exportGenericPickFirst",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "exportGenericPickFirst",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "a",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "b",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_exportGenericPickSecond",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "exportGenericPickSecond",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "a",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "b",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeExportGenericOutcome",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeExportGenericOutcome",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "associatedValueEnum" : {
+            "_0" : "ExportGenericOutcome"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_exportGenericOutcomeValue",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "exportGenericOutcomeValue",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "outcome",
+            "type" : {
+              "associatedValueEnum" : {
+                "_0" : "ExportGenericOutcome"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "integer" : {
+            "_0" : {
+              "isSigned" : true,
+              "width" : "word"
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_exportGenericArrayIdentity",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "exportGenericArrayIdentity",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "array" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "array" : {
+            "_0" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_exportGenericOptionalIdentity",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "exportGenericOptionalIdentity",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "nullable" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "nullable" : {
+            "_0" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            },
+            "_1" : "null"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_exportGenericDictIdentity",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "exportGenericDictIdentity",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "values",
+            "type" : {
+              "dictionary" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "dictionary" : {
+            "_0" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_exportGenericWrapPointAndTag",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T"
+        ],
+        "name" : "exportGenericWrapPointAndTag",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "p",
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "ExportGenericPoint"
+              }
+            }
+          },
+          {
+            "label" : "tag",
+            "name" : "tag",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_exportGenericCombineFirst",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T",
+          "U"
+        ],
+        "name" : "exportGenericCombineFirst",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "a",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "b",
+            "type" : {
+              "generic" : {
+                "_0" : "U"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "T"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_exportGenericCombineSecond",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T",
+          "U"
+        ],
+        "name" : "exportGenericCombineSecond",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "a",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "b",
+            "type" : {
+              "generic" : {
+                "_0" : "U"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "U"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_exportGenericCombineTripleLast",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "genericParameters" : [
+          "T",
+          "U",
+          "V"
+        ],
+        "name" : "exportGenericCombineTripleLast",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "a",
+            "type" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "b",
+            "type" : {
+              "generic" : {
+                "_0" : "U"
+              }
+            }
+          },
+          {
+            "label" : "_",
+            "name" : "c",
+            "type" : {
+              "generic" : {
+                "_0" : "V"
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "generic" : {
+            "_0" : "V"
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_lastWrappedPointX",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "lastWrappedPointX",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "integer" : {
+            "_0" : {
+              "isSigned" : true,
+              "width" : "word"
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_lastWrappedPointY",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "lastWrappedPointY",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "integer" : {
+            "_0" : {
+              "isSigned" : true,
+              "width" : "word"
+            }
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_lastTag",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "lastTag",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "integer" : {
+            "_0" : {
+              "isSigned" : true,
+              "width" : "word"
+            }
+          }
+        }
+      },
+      {
         "abiName" : "bjs_roundTripPointerFields",
         "effects" : {
           "isAsync" : false,
@@ -18186,6 +19279,312 @@
           }
         ],
         "swiftCallName" : "NestedTypeHost.Label"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_ExportGenericPoint_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "x",
+              "name" : "x",
+              "type" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              }
+            },
+            {
+              "label" : "y",
+              "name" : "y",
+              "type" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "explicitAccessControl" : "public",
+        "methods" : [
+
+        ],
+        "name" : "ExportGenericPoint",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "x",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "y",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "ExportGenericPoint"
+      },
+      {
+        "constructor" : {
+          "abiName" : "bjs_ExportGenericMethodPair_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+
+          ]
+        },
+        "explicitAccessControl" : "public",
+        "methods" : [
+          {
+            "abiName" : "bjs_ExportGenericMethodPair_first",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "first",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ExportGenericMethodPair_maybe",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "maybe",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              },
+              {
+                "label" : "present",
+                "name" : "present",
+                "type" : {
+                  "bool" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ExportGenericMethodPair_dict",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "dict",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "dictionary" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_ExportGenericMethodPair_static_wrap",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "wrap",
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            },
+            "staticContext" : {
+              "structName" : {
+                "_0" : "ExportGenericMethodPair"
+              }
+            }
+          }
+        ],
+        "name" : "ExportGenericMethodPair",
+        "properties" : [
+
+        ],
+        "swiftCallName" : "ExportGenericMethodPair"
+      },
+      {
+        "methods" : [
+
+        ],
+        "name" : "GenericRTPoint",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "x",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "y",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "GenericRTPoint"
+      },
+      {
+        "methods" : [
+
+        ],
+        "name" : "Metadata",
+        "namespace" : [
+          "GenericRTNamespace"
+        ],
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "label",
+            "namespace" : [
+              "GenericRTNamespace"
+            ],
+            "type" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "count",
+            "namespace" : [
+              "GenericRTNamespace"
+            ],
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "GenericRTNamespace.Metadata"
       },
       {
         "methods" : [
@@ -23285,6 +24684,365 @@
         ],
         "types" : [
 
+        ]
+      },
+      {
+        "functions" : [
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "jsGenericRoundTrip",
+            "parameters" : [
+              {
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "jsGenericRoundTripClass",
+            "parameters" : [
+              {
+                "name" : "value",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "jsGenericParsePoint",
+            "parameters" : [
+              {
+                "name" : "json",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "jsImportPickFirst",
+            "parameters" : [
+              {
+                "name" : "a",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              },
+              {
+                "name" : "b",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "jsImportMakeInt",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "T"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T",
+              "U"
+            ],
+            "name" : "jsImportCombineSecond",
+            "parameters" : [
+              {
+                "name" : "a",
+                "type" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              },
+              {
+                "name" : "b",
+                "type" : {
+                  "generic" : {
+                    "_0" : "U"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "generic" : {
+                "_0" : "U"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "jsGenericArrayRoundTrip",
+            "parameters" : [
+              {
+                "name" : "values",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "generic" : {
+                        "_0" : "T"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "array" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "jsGenericOptionalRoundTrip",
+            "parameters" : [
+              {
+                "name" : "value",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "generic" : {
+                        "_0" : "T"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "nullable" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                },
+                "_1" : "null"
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "genericParameters" : [
+              "T"
+            ],
+            "name" : "jsGenericDictRoundTrip",
+            "parameters" : [
+              {
+                "name" : "values",
+                "type" : {
+                  "dictionary" : {
+                    "_0" : {
+                      "generic" : {
+                        "_0" : "T"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "dictionary" : {
+                "_0" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "types" : [
+          {
+            "accessLevel" : "internal",
+            "constructor" : {
+              "accessLevel" : "internal",
+              "parameters" : [
+
+              ]
+            },
+            "getters" : [
+
+            ],
+            "methods" : [
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "genericParameters" : [
+                  "T"
+                ],
+                "name" : "identity",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "generic" : {
+                        "_0" : "T"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ],
+            "name" : "ImportGenericConsumer",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "genericParameters" : [
+                  "T"
+                ],
+                "name" : "box",
+                "parameters" : [
+                  {
+                    "name" : "value",
+                    "type" : {
+                      "generic" : {
+                        "_0" : "T"
+                      }
+                    }
+                  }
+                ],
+                "returnType" : {
+                  "generic" : {
+                    "_0" : "T"
+                  }
+                }
+              }
+            ]
+          }
         ]
       },
       {

--- a/Tests/BridgeJSRuntimeTests/ImportGenericAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/ImportGenericAPIs.swift
@@ -1,4 +1,4 @@
-import XCTest
+import Testing
 import JavaScriptKit
 
 @JS struct GenericRTPoint {
@@ -65,166 +65,169 @@ import JavaScriptKit
     @JSFunction static func box<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
 }
 
-class ImportGenericAPITests: XCTestCase {
-    func testGenericRoundTripScalars() throws {
-        XCTAssertEqual(try jsGenericRoundTrip(42), 42)
-        XCTAssertEqual(try jsGenericRoundTrip(-7), -7)
-        XCTAssertEqual(try jsGenericRoundTrip(3.5), 3.5)
-        XCTAssertEqual(try jsGenericRoundTrip(Float(1.25)), Float(1.25))
-        XCTAssertEqual(try jsGenericRoundTrip(true), true)
-        XCTAssertEqual(try jsGenericRoundTrip(false), false)
-        XCTAssertEqual(try jsGenericRoundTrip("hello"), "hello")
-        XCTAssertEqual(try jsGenericRoundTrip(""), "")
+@Suite struct ImportGenericAPITests {
+    @Test func genericRoundTripScalars() throws {
+        #expect(try jsGenericRoundTrip(42) == 42)
+        #expect(try jsGenericRoundTrip(-7) == -7)
+        #expect(try jsGenericRoundTrip(3.5) == 3.5)
+        #expect(try jsGenericRoundTrip(Float(1.25)) == Float(1.25))
+        #expect(try jsGenericRoundTrip(true) == true)
+        #expect(try jsGenericRoundTrip(false) == false)
+        #expect(try jsGenericRoundTrip("hello") == "hello")
+        #expect(try jsGenericRoundTrip("") == "")
     }
 
-    func testGenericRoundTripNumerics() throws {
-        XCTAssertEqual(try jsGenericRoundTrip(Int8(-5)), Int8(-5))
-        XCTAssertEqual(try jsGenericRoundTrip(Int8.min), Int8.min)
-        XCTAssertEqual(try jsGenericRoundTrip(Int8.max), Int8.max)
-        XCTAssertEqual(try jsGenericRoundTrip(UInt8(200)), UInt8(200))
-        XCTAssertEqual(try jsGenericRoundTrip(UInt8.max), UInt8.max)
-        XCTAssertEqual(try jsGenericRoundTrip(Int16(-1000)), Int16(-1000))
-        XCTAssertEqual(try jsGenericRoundTrip(UInt16(60000)), UInt16(60000))
-        XCTAssertEqual(try jsGenericRoundTrip(Int32(-123456)), Int32(-123456))
-        XCTAssertEqual(try jsGenericRoundTrip(UInt32(3_000_000_000)), UInt32(3_000_000_000))
-        XCTAssertEqual(try jsGenericRoundTrip(UInt32.max), UInt32.max)
-        XCTAssertEqual(try jsGenericRoundTrip(UInt(42)), UInt(42))
-        XCTAssertEqual(try jsGenericRoundTrip(UInt(4_000_000_000)), UInt(4_000_000_000))
-        XCTAssertEqual(try jsGenericRoundTrip(Int64(-9_000_000_000)), Int64(-9_000_000_000))
-        XCTAssertEqual(try jsGenericRoundTrip(Int64.min), Int64.min)
-        XCTAssertEqual(try jsGenericRoundTrip(Int64.max), Int64.max)
-        XCTAssertEqual(try jsGenericRoundTrip(UInt64(18_000_000_000_000_000_000)), UInt64(18_000_000_000_000_000_000))
-        XCTAssertEqual(try jsGenericRoundTrip(UInt64.max), UInt64.max)
+    @Test func genericRoundTripNumerics() throws {
+        #expect(try jsGenericRoundTrip(Int8(-5)) == Int8(-5))
+        #expect(try jsGenericRoundTrip(Int8.min) == Int8.min)
+        #expect(try jsGenericRoundTrip(Int8.max) == Int8.max)
+        #expect(try jsGenericRoundTrip(UInt8(200)) == UInt8(200))
+        #expect(try jsGenericRoundTrip(UInt8.max) == UInt8.max)
+        #expect(try jsGenericRoundTrip(Int16(-1000)) == Int16(-1000))
+        #expect(try jsGenericRoundTrip(UInt16(60000)) == UInt16(60000))
+        #expect(try jsGenericRoundTrip(Int32(-123456)) == Int32(-123456))
+        #expect(try jsGenericRoundTrip(UInt32(3_000_000_000)) == UInt32(3_000_000_000))
+        #expect(try jsGenericRoundTrip(UInt32.max) == UInt32.max)
+        #expect(try jsGenericRoundTrip(UInt(42)) == UInt(42))
+        #expect(try jsGenericRoundTrip(UInt(4_000_000_000)) == UInt(4_000_000_000))
+        #expect(try jsGenericRoundTrip(Int64(-9_000_000_000)) == Int64(-9_000_000_000))
+        #expect(try jsGenericRoundTrip(Int64.min) == Int64.min)
+        #expect(try jsGenericRoundTrip(Int64.max) == Int64.max)
+        #expect(try jsGenericRoundTrip(UInt64(18_000_000_000_000_000_000)) == UInt64(18_000_000_000_000_000_000))
+        #expect(try jsGenericRoundTrip(UInt64.max) == UInt64.max)
     }
 
-    func testGenericRoundTripJSValue() throws {
+    @Test func genericRoundTripJSValue() throws {
         let number = try jsGenericRoundTrip(JSValue.number(3.5))
-        XCTAssertEqual(number.number, 3.5)
+        #expect(number.number == 3.5)
         let string = try jsGenericRoundTrip(JSValue.string("hi"))
-        XCTAssertEqual(string.string, "hi")
+        #expect(string.string == "hi")
         let boolean = try jsGenericRoundTrip(JSValue.boolean(true))
-        XCTAssertEqual(boolean.boolean, true)
-        XCTAssertTrue(try jsGenericRoundTrip(JSValue.null).isNull)
-        XCTAssertTrue(try jsGenericRoundTrip(JSValue.undefined).isUndefined)
+        #expect(boolean.boolean == true)
+        #expect(try jsGenericRoundTrip(JSValue.null).isNull)
+        #expect(try jsGenericRoundTrip(JSValue.undefined).isUndefined)
         let object = JSObject.global.Object.function!.new()
         object.tag = 7
         let roundTripped = try jsGenericRoundTrip(JSValue.object(object))
-        XCTAssertEqual(roundTripped.object?.tag.number, 7)
+        #expect(roundTripped.object?.tag.number == 7)
     }
 
-    func testGenericWrappedRoundTrip() throws {
-        XCTAssertEqual(try jsGenericArrayRoundTrip([1, 2, 3]), [1, 2, 3])
-        XCTAssertEqual(try jsGenericArrayRoundTrip(["a", "b"]), ["a", "b"])
-        XCTAssertEqual(try jsGenericArrayRoundTrip([Int]()), [])
-        XCTAssertEqual(try jsGenericOptionalRoundTrip(Optional<Int>.some(7)), 7)
-        XCTAssertEqual(try jsGenericOptionalRoundTrip(Optional<Int>.none), nil)
-        XCTAssertEqual(try jsGenericOptionalRoundTrip(Optional<String>.some("hi")), "hi")
+    @Test func genericWrappedRoundTrip() throws {
+        #expect(try jsGenericArrayRoundTrip([1, 2, 3]) == [1, 2, 3])
+        #expect(try jsGenericArrayRoundTrip(["a", "b"]) == ["a", "b"])
+        #expect(try jsGenericArrayRoundTrip([Int]()) == [])
+        #expect(try jsGenericOptionalRoundTrip(Optional<Int>.some(7)) == 7)
+        #expect(try jsGenericOptionalRoundTrip(Optional<Int>.none) == nil)
+        #expect(try jsGenericOptionalRoundTrip(Optional<String>.some("hi")) == "hi")
         let outcome = try jsGenericOptionalRoundTrip(Optional<GenericRTOutcome>.some(.ok(code: 5)))
         guard case .some(.ok(let code)) = outcome else {
-            return XCTFail("expected .ok")
+            Issue.record("expected .ok")
+            return
         }
-        XCTAssertEqual(code, 5)
-        XCTAssertNil(try jsGenericOptionalRoundTrip(Optional<GenericRTOutcome>.none))
-        XCTAssertEqual(try jsGenericDictRoundTrip(["x": 1, "y": 2]), ["x": 1, "y": 2])
-        XCTAssertEqual(try jsGenericDictRoundTrip([String: String]()), [:])
+        #expect(code == 5)
+        #expect(try jsGenericOptionalRoundTrip(Optional<GenericRTOutcome>.none) == nil)
+        #expect(try jsGenericDictRoundTrip(["x": 1, "y": 2]) == ["x": 1, "y": 2])
+        #expect(try jsGenericDictRoundTrip([String: String]()) == [:])
     }
 
-    func testGenericRoundTripEnums() throws {
-        XCTAssertEqual(try jsGenericRoundTrip(GenericRTColor.red), .red)
-        XCTAssertEqual(try jsGenericRoundTrip(GenericRTColor.blue), .blue)
-        XCTAssertEqual(try jsGenericRoundTrip(GenericRTMode.dark), .dark)
-        XCTAssertEqual(try jsGenericRoundTrip(GenericRTMode.light).rawValue, "light")
-        XCTAssertEqual(try jsGenericRoundTrip(GenericRTLevel.high), .high)
+    @Test func genericRoundTripEnums() throws {
+        #expect(try jsGenericRoundTrip(GenericRTColor.red) == .red)
+        #expect(try jsGenericRoundTrip(GenericRTColor.blue) == .blue)
+        #expect(try jsGenericRoundTrip(GenericRTMode.dark) == .dark)
+        #expect(try jsGenericRoundTrip(GenericRTMode.light).rawValue == "light")
+        #expect(try jsGenericRoundTrip(GenericRTLevel.high) == .high)
         let outcome = try jsGenericRoundTrip(GenericRTOutcome.ok(code: 42))
         guard case .ok(let code) = outcome else {
-            return XCTFail("expected .ok")
+            Issue.record("expected .ok")
+            return
         }
-        XCTAssertEqual(code, 42)
+        #expect(code == 42)
         let failure = try jsGenericRoundTrip(GenericRTOutcome.fail(message: "boom"))
         guard case .fail(let message) = failure else {
-            return XCTFail("expected .fail")
+            Issue.record("expected .fail")
+            return
         }
-        XCTAssertEqual(message, "boom")
+        #expect(message == "boom")
     }
 
-    func testGenericRoundTripStruct() throws {
+    @Test func genericRoundTripStruct() throws {
         let point = try jsGenericRoundTrip(GenericRTPoint(x: 1, y: 2))
-        XCTAssertEqual(point.x, 1)
-        XCTAssertEqual(point.y, 2)
+        #expect(point.x == 1)
+        #expect(point.y == 2)
     }
 
-    func testGenericRoundTripNestedStruct() throws {
+    @Test func genericRoundTripNestedStruct() throws {
         let metadata = try jsGenericRoundTrip(GenericRTNamespace.Metadata(label: "alpha", count: 7))
-        XCTAssertEqual(metadata.label, "alpha")
-        XCTAssertEqual(metadata.count, 7)
+        #expect(metadata.label == "alpha")
+        #expect(metadata.count == 7)
     }
 
-    func testGenericParse() throws {
+    @Test func genericParse() throws {
         let point: GenericRTPoint = try jsGenericParsePoint("{\"x\": 10, \"y\": 20}")
-        XCTAssertEqual(point.x, 10)
-        XCTAssertEqual(point.y, 20)
+        #expect(point.x == 10)
+        #expect(point.y == 20)
         let n: Int = try jsGenericParsePoint("42")
-        XCTAssertEqual(n, 42)
+        #expect(n == 42)
         let string: String = try jsGenericParsePoint("\"hi\"")
-        XCTAssertEqual(string, "hi")
+        #expect(string == "hi")
     }
 
-    func testGenericPickFirstMultiUse() throws {
-        XCTAssertEqual(try jsImportPickFirst(10, 20) as Int, 10)
-        XCTAssertEqual(try jsImportPickFirst("a", "b") as String, "a")
+    @Test func genericPickFirstMultiUse() throws {
+        #expect(try jsImportPickFirst(10, 20) as Int == 10)
+        #expect(try jsImportPickFirst("a", "b") as String == "a")
         let firstPoint = try jsImportPickFirst(GenericRTPoint(x: 1, y: 2), GenericRTPoint(x: 3, y: 4))
-        XCTAssertEqual(firstPoint.x, 1)
-        XCTAssertEqual(firstPoint.y, 2)
+        #expect(firstPoint.x == 1)
+        #expect(firstPoint.y == 2)
     }
 
-    func testGenericMakeReturnOnly() throws {
+    @Test func genericMakeReturnOnly() throws {
         let made: Int = try jsImportMakeInt()
-        XCTAssertEqual(made, 123)
+        #expect(made == 123)
     }
 
-    func testGenericCombineSecondMultiParameter() throws {
-        XCTAssertEqual(try jsImportCombineSecond(7, "hello") as String, "hello")
-        XCTAssertEqual(try jsImportCombineSecond("x", 9) as Int, 9)
+    @Test func genericCombineSecondMultiParameter() throws {
+        #expect(try jsImportCombineSecond(7, "hello") as String == "hello")
+        #expect(try jsImportCombineSecond("x", 9) as Int == 9)
         let point = try jsImportCombineSecond(42, GenericRTPoint(x: 5, y: 6))
-        XCTAssertEqual(point.x, 5)
-        XCTAssertEqual(point.y, 6)
+        #expect(point.x == 5)
+        #expect(point.y == 6)
     }
 
-    func testGenericRoundTripHeapObjectClass() throws {
+    @Test func genericRoundTripHeapObjectClass() throws {
         let box = ImportGenericBox(value: 314)
-        XCTAssertEqual(box.get(), 314)
+        #expect(box.get() == 314)
         let sameBox = try jsGenericRoundTripClass(box)
-        XCTAssertEqual(sameBox.get(), 314)
+        #expect(sameBox.get() == 314)
         sameBox.value = 271
-        XCTAssertEqual(box.get(), 271)
+        #expect(box.get() == 271)
     }
 
-    func testGenericMixedConsecutiveCalls() throws {
-        XCTAssertEqual(try jsGenericRoundTrip(1), 1)
-        XCTAssertEqual(try jsGenericRoundTrip("two"), "two")
-        XCTAssertEqual(try jsGenericRoundTrip(3.0), 3.0)
+    @Test func genericMixedConsecutiveCalls() throws {
+        #expect(try jsGenericRoundTrip(1) == 1)
+        #expect(try jsGenericRoundTrip("two") == "two")
+        #expect(try jsGenericRoundTrip(3.0) == 3.0)
         let p = try jsGenericRoundTrip(GenericRTPoint(x: 4, y: 5))
-        XCTAssertEqual(p.x, 4)
-        XCTAssertEqual(p.y, 5)
+        #expect(p.x == 4)
+        #expect(p.y == 5)
     }
 
-    func testImportGenericInstanceMethod() throws {
+    @Test func importGenericInstanceMethod() throws {
         let consumer = try ImportGenericConsumer()
-        XCTAssertEqual(try consumer.identity(42), 42)
-        XCTAssertEqual(try consumer.identity(-7), -7)
-        XCTAssertEqual(try consumer.identity("hi"), "hi")
-        XCTAssertEqual(try consumer.identity(true), true)
-        XCTAssertEqual(try consumer.identity(false), false)
+        #expect(try consumer.identity(42) == 42)
+        #expect(try consumer.identity(-7) == -7)
+        #expect(try consumer.identity("hi") == "hi")
+        #expect(try consumer.identity(true) == true)
+        #expect(try consumer.identity(false) == false)
         let point = try consumer.identity(GenericRTPoint(x: 3, y: 4))
-        XCTAssertEqual(point.x, 3)
-        XCTAssertEqual(point.y, 4)
+        #expect(point.x == 3)
+        #expect(point.y == 4)
     }
 
-    func testImportGenericStaticMethod() throws {
-        XCTAssertEqual(try ImportGenericConsumer.box(7), 7)
-        XCTAssertEqual(try ImportGenericConsumer.box("s"), "s")
-        XCTAssertEqual(try ImportGenericConsumer.box(true), true)
+    @Test func importGenericStaticMethod() throws {
+        #expect(try ImportGenericConsumer.box(7) == 7)
+        #expect(try ImportGenericConsumer.box("s") == "s")
+        #expect(try ImportGenericConsumer.box(true) == true)
         let color = try ImportGenericConsumer.box(GenericRTColor.green)
-        XCTAssertEqual(color, .green)
+        #expect(color == .green)
     }
 }

--- a/Tests/BridgeJSRuntimeTests/ImportGenericAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/ImportGenericAPIs.swift
@@ -1,0 +1,230 @@
+import XCTest
+import JavaScriptKit
+
+@JS struct GenericRTPoint {
+    var x: Int
+    var y: Int
+}
+
+@JS enum GenericRTNamespace {
+    @JS struct Metadata {
+        var label: String
+        var count: Int
+    }
+}
+
+@JS enum GenericRTColor {
+    case red
+    case green
+    case blue
+}
+
+@JS enum GenericRTMode: String {
+    case light
+    case dark
+}
+
+@JS enum GenericRTLevel: Int {
+    case low = 1
+    case high = 9
+}
+
+@JS enum GenericRTOutcome {
+    case ok(code: Int)
+    case fail(message: String)
+}
+
+@JS final class ImportGenericBox {
+    @JS var value: Int
+    @JS init(value: Int) {
+        self.value = value
+    }
+    @JS func get() -> Int {
+        value
+    }
+}
+
+@JSFunction func jsGenericRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+@JSFunction func jsGenericRoundTripClass<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+@JSFunction func jsGenericParsePoint<T: _BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T
+@JSFunction func jsImportPickFirst<T: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) throws(JSException) -> T
+@JSFunction func jsImportMakeInt<T: _BridgedSwiftGenericBridgeable>() throws(JSException) -> T
+@JSFunction func jsImportCombineSecond<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(
+    _ a: T,
+    _ b: U
+) throws(JSException) -> U
+@JSFunction func jsGenericArrayRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T]
+@JSFunction func jsGenericOptionalRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ value: T?) throws(JSException) -> T?
+@JSFunction func jsGenericDictRoundTrip<T: _BridgedSwiftGenericBridgeable>(
+    _ values: [String: T]
+) throws(JSException) -> [String: T]
+
+@JSClass struct ImportGenericConsumer {
+    @JSFunction init() throws(JSException)
+    @JSFunction func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+    @JSFunction static func box<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+}
+
+class ImportGenericAPITests: XCTestCase {
+    func testGenericRoundTripScalars() throws {
+        XCTAssertEqual(try jsGenericRoundTrip(42), 42)
+        XCTAssertEqual(try jsGenericRoundTrip(-7), -7)
+        XCTAssertEqual(try jsGenericRoundTrip(3.5), 3.5)
+        XCTAssertEqual(try jsGenericRoundTrip(Float(1.25)), Float(1.25))
+        XCTAssertEqual(try jsGenericRoundTrip(true), true)
+        XCTAssertEqual(try jsGenericRoundTrip(false), false)
+        XCTAssertEqual(try jsGenericRoundTrip("hello"), "hello")
+        XCTAssertEqual(try jsGenericRoundTrip(""), "")
+    }
+
+    func testGenericRoundTripNumerics() throws {
+        XCTAssertEqual(try jsGenericRoundTrip(Int8(-5)), Int8(-5))
+        XCTAssertEqual(try jsGenericRoundTrip(Int8.min), Int8.min)
+        XCTAssertEqual(try jsGenericRoundTrip(Int8.max), Int8.max)
+        XCTAssertEqual(try jsGenericRoundTrip(UInt8(200)), UInt8(200))
+        XCTAssertEqual(try jsGenericRoundTrip(UInt8.max), UInt8.max)
+        XCTAssertEqual(try jsGenericRoundTrip(Int16(-1000)), Int16(-1000))
+        XCTAssertEqual(try jsGenericRoundTrip(UInt16(60000)), UInt16(60000))
+        XCTAssertEqual(try jsGenericRoundTrip(Int32(-123456)), Int32(-123456))
+        XCTAssertEqual(try jsGenericRoundTrip(UInt32(3_000_000_000)), UInt32(3_000_000_000))
+        XCTAssertEqual(try jsGenericRoundTrip(UInt32.max), UInt32.max)
+        XCTAssertEqual(try jsGenericRoundTrip(UInt(42)), UInt(42))
+        XCTAssertEqual(try jsGenericRoundTrip(UInt(4_000_000_000)), UInt(4_000_000_000))
+        XCTAssertEqual(try jsGenericRoundTrip(Int64(-9_000_000_000)), Int64(-9_000_000_000))
+        XCTAssertEqual(try jsGenericRoundTrip(Int64.min), Int64.min)
+        XCTAssertEqual(try jsGenericRoundTrip(Int64.max), Int64.max)
+        XCTAssertEqual(try jsGenericRoundTrip(UInt64(18_000_000_000_000_000_000)), UInt64(18_000_000_000_000_000_000))
+        XCTAssertEqual(try jsGenericRoundTrip(UInt64.max), UInt64.max)
+    }
+
+    func testGenericRoundTripJSValue() throws {
+        let number = try jsGenericRoundTrip(JSValue.number(3.5))
+        XCTAssertEqual(number.number, 3.5)
+        let string = try jsGenericRoundTrip(JSValue.string("hi"))
+        XCTAssertEqual(string.string, "hi")
+        let boolean = try jsGenericRoundTrip(JSValue.boolean(true))
+        XCTAssertEqual(boolean.boolean, true)
+        XCTAssertTrue(try jsGenericRoundTrip(JSValue.null).isNull)
+        XCTAssertTrue(try jsGenericRoundTrip(JSValue.undefined).isUndefined)
+        let object = JSObject.global.Object.function!.new()
+        object.tag = 7
+        let roundTripped = try jsGenericRoundTrip(JSValue.object(object))
+        XCTAssertEqual(roundTripped.object?.tag.number, 7)
+    }
+
+    func testGenericWrappedRoundTrip() throws {
+        XCTAssertEqual(try jsGenericArrayRoundTrip([1, 2, 3]), [1, 2, 3])
+        XCTAssertEqual(try jsGenericArrayRoundTrip(["a", "b"]), ["a", "b"])
+        XCTAssertEqual(try jsGenericArrayRoundTrip([Int]()), [])
+        XCTAssertEqual(try jsGenericOptionalRoundTrip(Optional<Int>.some(7)), 7)
+        XCTAssertEqual(try jsGenericOptionalRoundTrip(Optional<Int>.none), nil)
+        XCTAssertEqual(try jsGenericOptionalRoundTrip(Optional<String>.some("hi")), "hi")
+        let outcome = try jsGenericOptionalRoundTrip(Optional<GenericRTOutcome>.some(.ok(code: 5)))
+        guard case .some(.ok(let code)) = outcome else {
+            return XCTFail("expected .ok")
+        }
+        XCTAssertEqual(code, 5)
+        XCTAssertNil(try jsGenericOptionalRoundTrip(Optional<GenericRTOutcome>.none))
+        XCTAssertEqual(try jsGenericDictRoundTrip(["x": 1, "y": 2]), ["x": 1, "y": 2])
+        XCTAssertEqual(try jsGenericDictRoundTrip([String: String]()), [:])
+    }
+
+    func testGenericRoundTripEnums() throws {
+        XCTAssertEqual(try jsGenericRoundTrip(GenericRTColor.red), .red)
+        XCTAssertEqual(try jsGenericRoundTrip(GenericRTColor.blue), .blue)
+        XCTAssertEqual(try jsGenericRoundTrip(GenericRTMode.dark), .dark)
+        XCTAssertEqual(try jsGenericRoundTrip(GenericRTMode.light).rawValue, "light")
+        XCTAssertEqual(try jsGenericRoundTrip(GenericRTLevel.high), .high)
+        let outcome = try jsGenericRoundTrip(GenericRTOutcome.ok(code: 42))
+        guard case .ok(let code) = outcome else {
+            return XCTFail("expected .ok")
+        }
+        XCTAssertEqual(code, 42)
+        let failure = try jsGenericRoundTrip(GenericRTOutcome.fail(message: "boom"))
+        guard case .fail(let message) = failure else {
+            return XCTFail("expected .fail")
+        }
+        XCTAssertEqual(message, "boom")
+    }
+
+    func testGenericRoundTripStruct() throws {
+        let point = try jsGenericRoundTrip(GenericRTPoint(x: 1, y: 2))
+        XCTAssertEqual(point.x, 1)
+        XCTAssertEqual(point.y, 2)
+    }
+
+    func testGenericRoundTripNestedStruct() throws {
+        let metadata = try jsGenericRoundTrip(GenericRTNamespace.Metadata(label: "alpha", count: 7))
+        XCTAssertEqual(metadata.label, "alpha")
+        XCTAssertEqual(metadata.count, 7)
+    }
+
+    func testGenericParse() throws {
+        let point: GenericRTPoint = try jsGenericParsePoint("{\"x\": 10, \"y\": 20}")
+        XCTAssertEqual(point.x, 10)
+        XCTAssertEqual(point.y, 20)
+        let n: Int = try jsGenericParsePoint("42")
+        XCTAssertEqual(n, 42)
+        let string: String = try jsGenericParsePoint("\"hi\"")
+        XCTAssertEqual(string, "hi")
+    }
+
+    func testGenericPickFirstMultiUse() throws {
+        XCTAssertEqual(try jsImportPickFirst(10, 20) as Int, 10)
+        XCTAssertEqual(try jsImportPickFirst("a", "b") as String, "a")
+        let firstPoint = try jsImportPickFirst(GenericRTPoint(x: 1, y: 2), GenericRTPoint(x: 3, y: 4))
+        XCTAssertEqual(firstPoint.x, 1)
+        XCTAssertEqual(firstPoint.y, 2)
+    }
+
+    func testGenericMakeReturnOnly() throws {
+        let made: Int = try jsImportMakeInt()
+        XCTAssertEqual(made, 123)
+    }
+
+    func testGenericCombineSecondMultiParameter() throws {
+        XCTAssertEqual(try jsImportCombineSecond(7, "hello") as String, "hello")
+        XCTAssertEqual(try jsImportCombineSecond("x", 9) as Int, 9)
+        let point = try jsImportCombineSecond(42, GenericRTPoint(x: 5, y: 6))
+        XCTAssertEqual(point.x, 5)
+        XCTAssertEqual(point.y, 6)
+    }
+
+    func testGenericRoundTripHeapObjectClass() throws {
+        let box = ImportGenericBox(value: 314)
+        XCTAssertEqual(box.get(), 314)
+        let sameBox = try jsGenericRoundTripClass(box)
+        XCTAssertEqual(sameBox.get(), 314)
+        sameBox.value = 271
+        XCTAssertEqual(box.get(), 271)
+    }
+
+    func testGenericMixedConsecutiveCalls() throws {
+        XCTAssertEqual(try jsGenericRoundTrip(1), 1)
+        XCTAssertEqual(try jsGenericRoundTrip("two"), "two")
+        XCTAssertEqual(try jsGenericRoundTrip(3.0), 3.0)
+        let p = try jsGenericRoundTrip(GenericRTPoint(x: 4, y: 5))
+        XCTAssertEqual(p.x, 4)
+        XCTAssertEqual(p.y, 5)
+    }
+
+    func testImportGenericInstanceMethod() throws {
+        let consumer = try ImportGenericConsumer()
+        XCTAssertEqual(try consumer.identity(42), 42)
+        XCTAssertEqual(try consumer.identity(-7), -7)
+        XCTAssertEqual(try consumer.identity("hi"), "hi")
+        XCTAssertEqual(try consumer.identity(true), true)
+        XCTAssertEqual(try consumer.identity(false), false)
+        let point = try consumer.identity(GenericRTPoint(x: 3, y: 4))
+        XCTAssertEqual(point.x, 3)
+        XCTAssertEqual(point.y, 4)
+    }
+
+    func testImportGenericStaticMethod() throws {
+        XCTAssertEqual(try ImportGenericConsumer.box(7), 7)
+        XCTAssertEqual(try ImportGenericConsumer.box("s"), "s")
+        XCTAssertEqual(try ImportGenericConsumer.box(true), true)
+        let color = try ImportGenericConsumer.box(GenericRTColor.green)
+        XCTAssertEqual(color, .green)
+    }
+}

--- a/Tests/BridgeJSRuntimeTests/ImportGenericAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/ImportGenericAPIs.swift
@@ -44,25 +44,25 @@ import JavaScriptKit
     }
 }
 
-@JSFunction func jsGenericRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
-@JSFunction func jsGenericRoundTripClass<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
-@JSFunction func jsGenericParsePoint<T: _BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T
-@JSFunction func jsImportPickFirst<T: _BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) throws(JSException) -> T
-@JSFunction func jsImportMakeInt<T: _BridgedSwiftGenericBridgeable>() throws(JSException) -> T
-@JSFunction func jsImportCombineSecond<T: _BridgedSwiftGenericBridgeable, U: _BridgedSwiftGenericBridgeable>(
+@JSFunction func jsGenericRoundTrip<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+@JSFunction func jsGenericRoundTripClass<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+@JSFunction func jsGenericParsePoint<T: BridgedSwiftGenericBridgeable>(_ json: String) throws(JSException) -> T
+@JSFunction func jsImportPickFirst<T: BridgedSwiftGenericBridgeable>(_ a: T, _ b: T) throws(JSException) -> T
+@JSFunction func jsImportMakeInt<T: BridgedSwiftGenericBridgeable>() throws(JSException) -> T
+@JSFunction func jsImportCombineSecond<T: BridgedSwiftGenericBridgeable, U: BridgedSwiftGenericBridgeable>(
     _ a: T,
     _ b: U
 ) throws(JSException) -> U
-@JSFunction func jsGenericArrayRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T]
-@JSFunction func jsGenericOptionalRoundTrip<T: _BridgedSwiftGenericBridgeable>(_ value: T?) throws(JSException) -> T?
-@JSFunction func jsGenericDictRoundTrip<T: _BridgedSwiftGenericBridgeable>(
+@JSFunction func jsGenericArrayRoundTrip<T: BridgedSwiftGenericBridgeable>(_ values: [T]) throws(JSException) -> [T]
+@JSFunction func jsGenericOptionalRoundTrip<T: BridgedSwiftGenericBridgeable>(_ value: T?) throws(JSException) -> T?
+@JSFunction func jsGenericDictRoundTrip<T: BridgedSwiftGenericBridgeable>(
     _ values: [String: T]
 ) throws(JSException) -> [String: T]
 
 @JSClass struct ImportGenericConsumer {
     @JSFunction init() throws(JSException)
-    @JSFunction func identity<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
-    @JSFunction static func box<T: _BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+    @JSFunction func identity<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
+    @JSFunction static func box<T: BridgedSwiftGenericBridgeable>(_ value: T) throws(JSException) -> T
 }
 
 class ImportGenericAPITests: XCTestCase {

--- a/Tests/BridgeJSRuntimeTests/JavaScript/ExportGenericTests.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/ExportGenericTests.mjs
@@ -1,0 +1,162 @@
+// @ts-check
+
+import assert from 'node:assert';
+import { BridgeTypes } from '../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.js';
+
+/** @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports */
+export function runExportGenericTests(exports) {
+    // The import-direction tests sweep every supported T through the same codecs;
+    // the export direction checks representatives of each codec family.
+    assert.equal(exports.exportGenericIdentity(42, BridgeTypes.Int), 42);
+    assert.equal(exports.exportGenericIdentity(-7, BridgeTypes.Int), -7);
+    assert.equal(exports.exportGenericIdentity(true, BridgeTypes.Bool), true);
+    assert.equal(exports.exportGenericIdentity(3000000000, BridgeTypes.UInt32), 3000000000);
+    assert.equal(exports.exportGenericIdentity(-9000000000n, BridgeTypes.Int64), -9000000000n);
+    assert.equal(exports.exportGenericIdentity(Math.fround(1.25), BridgeTypes.Float), Math.fround(1.25));
+    assert.equal(exports.exportGenericIdentity(3.5, BridgeTypes.Double), 3.5);
+    assert.equal(exports.exportGenericIdentity("hi", BridgeTypes.String), "hi");
+    assert.equal(exports.exportGenericIdentity("", BridgeTypes.String), "");
+
+    assert.equal(exports.exportGenericIdentity(3.5, BridgeTypes.JSValue), 3.5);
+    assert.equal(exports.exportGenericIdentity("hey", BridgeTypes.JSValue), "hey");
+    assert.equal(exports.exportGenericIdentity(true, BridgeTypes.JSValue), true);
+    assert.equal(exports.exportGenericIdentity(null, BridgeTypes.JSValue), null);
+    assert.equal(exports.exportGenericIdentity(undefined, BridgeTypes.JSValue), undefined);
+    const jsValueObject = exports.exportGenericIdentity({ tag: 5 }, BridgeTypes.JSValue);
+    assert.equal(jsValueObject.tag, 5);
+
+    assert.equal(exports.exportGenericIdentity(0, BridgeTypes.GenericRTColor), 0);
+    assert.equal(exports.exportGenericIdentity(2, BridgeTypes.GenericRTColor), 2);
+    assert.equal(exports.exportGenericIdentity("dark", BridgeTypes.GenericRTMode), "dark");
+    assert.equal(exports.exportGenericIdentity(9, BridgeTypes.GenericRTLevel), 9);
+
+    const outcome = exports.makeExportGenericOutcome(42);
+    const sameOutcome = exports.exportGenericIdentity(outcome, BridgeTypes.ExportGenericOutcome);
+    assert.equal(exports.exportGenericOutcomeValue(sameOutcome), 42);
+
+    const point = exports.exportGenericIdentity({ x: 1, y: 2 }, BridgeTypes.ExportGenericPoint);
+    assert.equal(point.x, 1);
+    assert.equal(point.y, 2);
+
+    assert.equal(exports.exportGenericEcho(9, 0, BridgeTypes.Int), 9);
+    assert.equal(exports.exportGenericEcho(-3, 1, BridgeTypes.Int), -3);
+    assert.equal(exports.exportGenericEcho("tagged", 5, BridgeTypes.String), "tagged");
+
+    const echoedPoint = exports.exportGenericEcho({ x: 4, y: 5 }, 7, BridgeTypes.ExportGenericPoint);
+    assert.equal(echoedPoint.x, 4);
+    assert.equal(echoedPoint.y, 5);
+
+    assert.equal(exports.exportGenericPickFirst(1, 2, BridgeTypes.Int), 1);
+    assert.equal(exports.exportGenericPickSecond(1, 2, BridgeTypes.Int), 2);
+
+    assert.deepEqual(exports.exportGenericArrayIdentity([1, 2, 3], BridgeTypes.Int), [1, 2, 3]);
+    assert.deepEqual(exports.exportGenericArrayIdentity(["a", "b"], BridgeTypes.String), ["a", "b"]);
+    assert.deepEqual(exports.exportGenericArrayIdentity([], BridgeTypes.Int), []);
+    assert.equal(exports.exportGenericOptionalIdentity(7, BridgeTypes.Int), 7);
+    assert.equal(exports.exportGenericOptionalIdentity(null, BridgeTypes.Int), null);
+    assert.equal(exports.exportGenericOptionalIdentity("hi", BridgeTypes.String), "hi");
+    assert.deepEqual(exports.exportGenericDictIdentity({ x: 1, y: 2 }, BridgeTypes.Int), { x: 1, y: 2 });
+
+    // Stack ordering with side effects: struct + scalar + generic, across a scalar and a struct value.
+    assert.equal(exports.exportGenericWrapPointAndTag({ x: 1, y: 1 }, 7, "z", BridgeTypes.String), "z");
+    assert.equal(exports.lastTag(), 7);
+    assert.equal(exports.lastWrappedPointX(), 1);
+    assert.equal(exports.lastWrappedPointY(), 1);
+
+    const wrappedStruct = exports.exportGenericWrapPointAndTag({ x: 5, y: 6 }, 8, { x: 7, y: 8 }, BridgeTypes.ExportGenericPoint);
+    assert.equal(wrappedStruct.x, 7);
+    assert.equal(wrappedStruct.y, 8);
+    assert.equal(exports.lastWrappedPointX(), 5);
+    assert.equal(exports.lastWrappedPointY(), 6);
+    assert.equal(exports.lastTag(), 8);
+
+    // Multiple distinct generic parameters: T and U cross independently via their own codecs.
+    assert.equal(exports.exportGenericCombineFirst(7, "hello", BridgeTypes.Int, BridgeTypes.String), 7);
+    assert.equal(exports.exportGenericCombineSecond(7, "hello", BridgeTypes.Int, BridgeTypes.String), "hello");
+
+    // Swapped concrete types prove the type ids and codecs are not mixed up.
+    assert.equal(exports.exportGenericCombineFirst("hello", 7, BridgeTypes.String, BridgeTypes.Int), "hello");
+    assert.equal(exports.exportGenericCombineSecond("hello", 7, BridgeTypes.String, BridgeTypes.Int), 7);
+
+    // Struct as one of the generics mixed with a scalar.
+    const combinedStructFirst = exports.exportGenericCombineFirst(
+        { x: 1, y: 2 },
+        9,
+        BridgeTypes.ExportGenericPoint,
+        BridgeTypes.Int
+    );
+    assert.equal(combinedStructFirst.x, 1);
+    assert.equal(combinedStructFirst.y, 2);
+    assert.equal(exports.exportGenericCombineSecond({ x: 1, y: 2 }, 9, BridgeTypes.ExportGenericPoint, BridgeTypes.Int), 9);
+
+    // T and U are the SAME concrete type but distinct values: ensure no swap.
+    assert.equal(exports.exportGenericCombineFirst(1, 2, BridgeTypes.Int, BridgeTypes.Int), 1);
+    assert.equal(exports.exportGenericCombineSecond(1, 2, BridgeTypes.Int, BridgeTypes.Int), 2);
+
+    // Three distinct generic parameters prove the nested-open chain.
+    assert.equal(
+        exports.exportGenericCombineTripleLast(11, "two", true, BridgeTypes.Int, BridgeTypes.String, BridgeTypes.Bool),
+        true
+    );
+
+    const box = new exports.ExportGenericBox(123);
+    assert.equal(box.get(), 123);
+    const sameBox = exports.exportGenericIdentity(box, BridgeTypes.ExportGenericBox);
+    assert.equal(sameBox.get(), 123);
+    sameBox.release();
+
+    const firstBox = new exports.ExportGenericBox(7);
+    const secondBox = new exports.ExportGenericBox(9);
+    const pickedFirstBox = exports.exportGenericPickFirst(firstBox, secondBox, BridgeTypes.ExportGenericBox);
+    assert.equal(pickedFirstBox.get(), 7);
+    const pickedSecondBox = exports.exportGenericPickSecond(firstBox, secondBox, BridgeTypes.ExportGenericBox);
+    assert.equal(pickedSecondBox.get(), 9);
+    pickedFirstBox.release();
+    pickedSecondBox.release();
+    firstBox.release();
+    secondBox.release();
+    box.release();
+
+    const methodBox = new exports.ExportGenericMethodBox();
+    assert.equal(methodBox.echo(42, BridgeTypes.Int), 42);
+    assert.equal(methodBox.echo(-7, BridgeTypes.Int), -7);
+    assert.equal(methodBox.echo("hi", BridgeTypes.String), "hi");
+    assert.equal(methodBox.echo(true, BridgeTypes.Bool), true);
+    assert.equal(methodBox.echo(false, BridgeTypes.Bool), false);
+
+    const methodOutcome = exports.makeExportGenericOutcome(77);
+    const echoedOutcome = methodBox.echo(methodOutcome, BridgeTypes.ExportGenericOutcome);
+    assert.equal(exports.exportGenericOutcomeValue(echoedOutcome), 77);
+
+    assert.equal(methodBox.combine(7, "hello", BridgeTypes.Int, BridgeTypes.String), "hello");
+    assert.equal(methodBox.combine("hello", 7, BridgeTypes.String, BridgeTypes.Int), 7);
+    methodBox.release();
+
+    assert.deepEqual(exports.ExportGenericMethodBox.wrapArray(5, BridgeTypes.Int), [5]);
+    assert.deepEqual(exports.ExportGenericMethodBox.wrapArray("x", BridgeTypes.String), ["x"]);
+    assert.deepEqual(exports.ExportGenericMethodBox.wrapArray(true, BridgeTypes.Bool), [true]);
+
+    const methodPair = exports.ExportGenericMethodPair.init();
+    assert.equal(methodPair.first(9, BridgeTypes.Int), 9);
+    assert.equal(methodPair.first("p", BridgeTypes.String), "p");
+    assert.equal(methodPair.first(true, BridgeTypes.Bool), true);
+
+    assert.equal(methodPair.maybe(42, true, BridgeTypes.Int), 42);
+    assert.equal(methodPair.maybe(42, false, BridgeTypes.Int), null);
+    assert.equal(methodPair.maybe("present", true, BridgeTypes.String), "present");
+    assert.equal(methodPair.maybe("present", false, BridgeTypes.String), null);
+
+    assert.deepEqual(methodPair.dict(7, BridgeTypes.Int), { value: 7 });
+    assert.deepEqual(methodPair.dict("d", BridgeTypes.String), { value: "d" });
+
+    assert.deepEqual(exports.ExportGenericMethodPair.wrap(3, BridgeTypes.Int), [3]);
+    assert.deepEqual(exports.ExportGenericMethodPair.wrap("q", BridgeTypes.String), ["q"]);
+
+    assert.equal(exports.ExportGenericMethodFactory.one(11, BridgeTypes.Int), 11);
+    assert.equal(exports.ExportGenericMethodFactory.one("e", BridgeTypes.String), "e");
+    assert.equal(exports.ExportGenericMethodFactory.one(false, BridgeTypes.Bool), false);
+
+    assert.equal(exports.ExportGenericMethodNamespace.make(13, BridgeTypes.Int), 13);
+    assert.equal(exports.ExportGenericMethodNamespace.make("n", BridgeTypes.String), "n");
+    assert.equal(exports.ExportGenericMethodNamespace.make(true, BridgeTypes.Bool), true);
+}

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -6,6 +6,7 @@ import {
 import { ImportedFoo } from './BridgeJSRuntimeTests/JavaScript/Types.mjs';
 import { runJsOptionalSupportTests } from './BridgeJSRuntimeTests/JavaScript/OptionalSupportTests.mjs';
 import { runAliasWorks, getImports as getAliasImports, Surface } from './BridgeJSRuntimeTests/JavaScript/AliasTests.mjs';
+import { runExportGenericTests } from './BridgeJSRuntimeTests/JavaScript/ExportGenericTests.mjs';
 import { getImports as getClosureSupportImports } from './BridgeJSRuntimeTests/JavaScript/ClosureSupportTests.mjs';
 import { getImports as getClosureThrowsImports } from './BridgeJSRuntimeTests/JavaScript/ClosureThrowsTests.mjs';
 import { getImports as getClosureAsyncImports } from './BridgeJSRuntimeTests/JavaScript/ClosureAsyncTests.mjs';
@@ -155,6 +156,23 @@ export async function setupOptions(options, context) {
                     return { x: (point.x | 0) + (dx | 0), y: (point.y | 0) + (dy | 0) };
                 },
                 jsRoundTripOptionalPoint: (point) => point,
+                jsGenericRoundTrip: (v) => v,
+                jsGenericRoundTripClass: (v) => v,
+                jsGenericParsePoint: (json) => JSON.parse(json),
+                jsImportPickFirst: (a, b) => a,
+                jsImportMakeInt: () => 123,
+                jsImportCombineSecond: (a, b) => b,
+                jsGenericArrayRoundTrip: (v) => v,
+                jsGenericOptionalRoundTrip: (v) => v,
+                jsGenericDictRoundTrip: (v) => v,
+                ImportGenericConsumer: class {
+                    identity(value) {
+                        return value;
+                    }
+                    static box(value) {
+                        return value;
+                    }
+                },
                 roundTripArrayMembers: (value) => {
                     return value;
                 },
@@ -205,6 +223,13 @@ export async function setupOptions(options, context) {
                     throw new Error("No exports!?");
                 }
                 runAliasWorks(exports);
+            }
+            bridgeJSRuntimeTests["runExportGenericTests"] = () => {
+                const exports = getExports();
+                if (!exports) {
+                    throw new Error("No exports!?");
+                }
+                return runExportGenericTests(exports);
             }
             const bridgeJSGlobalTests = importObject["BridgeJSGlobalTests"] || {};
             bridgeJSGlobalTests["runJsWorksGlobal"] = () => {


### PR DESCRIPTION
## Overview

Adds support for generic functions and methods to BridgeJS in both directions, constrained to a new bridgeable bound `BridgedSwiftGenericBridgeable`. Values cross the boundary using each type's existing stack ABI, and a runtime type-ID registry selects the correct per-type codec, so the per-function glue stays type-agnostic. The `@JS` / `@JSFunction` macros are unchanged.

The bound is `_BridgedSwiftStackType` refined with `StackLiftResult == Self` (so a generic thunk can pop a `T`, which also structurally excludes `JSObject`) plus a single `bridgeJSTypeID: Int32` requirement. That ID is the runtime identity handshake: each type's token string is interned through one wasm import exactly once (a lazy `static let`), after which both sides exchange plain `i32`s; name-based interning is what keeps IDs consistent across independently compiled modules.

```swift
// Import: call a generic JS function from Swift
@JSFunction func parse<T: BridgedSwiftGenericBridgeable>(_ json: String) -> T
let user: User = try parse(jsonString)

// Export: call a generic Swift function from JavaScript
@JS public func identity<T: BridgedSwiftGenericBridgeable>(_ value: T) -> T { value }
```
```ts
import { BridgeTypes } from "./bridge-js.js";
const n = exports.identity(42, BridgeTypes.Int);       // token recovers T, since TS erases generics
const p = exports.identity({ x: 1, y: 2 }, BridgeTypes.Point);
```

`T` may be a supported primitive (`Bool`, any fixed-width integer, `Float`, `Double`, `String`, or `JSValue`), or any `@JS` struct, `final @JS class`, or `@JS enum` defined in the same module. It may be used bare (`T`) or wrapped as `[T]`, `T?`, or `[String: T]`. `JSObject` cannot be used as `T`; use `JSValue` instead.

## What's included

**1. Import direction.** Generic `@JSFunction` thunks (top-level or `@JSClass` members) are generic and monomorphized by the Swift compiler at the call site. One type-agnostic wasm import carries a trailing type-ID per generic parameter, and JS dispatches through a shared codec table. Supports a generic used in one or many parameters, multiple distinct generic parameters, and return-only generics (`make<T>() -> T`).

**2. Export direction.** Generics work on top-level functions, instance and static methods of `@JS` classes and structs, and static methods of `@JS` enums. The wasm entry point is a concrete `@_expose`/`@_cdecl` thunk taking a trailing type-ID per generic parameter; the generic value crosses on the stack, and `self` is threaded through the existential open-chain for instance methods. The thunk looks the type-ID up in a codegen-emitted registry and reifies `T` through an opened existential (nested opening chain for multiple parameters). Concrete parameters of any supported bridged type may be mixed in with correct stack ordering. JavaScript callers pass a generated `BridgeType<T>` token, exported as a `BridgeTypes` map. Because this relies on opened existentials, the exported thunk is emitted as a `fatalError` stub under `#if hasFeature(Embedded)`; the import side stays Embedded-compatible and is now exercised end-to-end by `Examples/Embedded` (generic `@JSFunction` round-tripping scalars, `String`, and a `@JS` struct).

**3. Codecs and wrapped generics.** Each codec (`{ lower, lift }`) is generated from the canonical per-type stack fragments (`stackLowerFragment` / `stackLiftFragment`), the same path the non-generic glue uses, so there is no duplicated lowering to drift. `[T]`, `T?`, and `[String: T]` bridge through the existing `Array`/`Optional`/`Dictionary` conditional conformances on the Swift side, exactly like concrete types; in particular, numeric arrays keep the bulk typed-array fast path (the JS composition helper honors the existing `-1` bulk discriminator). This builds on the optional stack encoding unification (previous PR in this series), which made the optional stack form uniform across all types.

**4. Diagnostics.** Build-time, source-located diagnostics for unsupported forms: missing or incorrect constraint, `where` clauses, `async` or `throws` generics, generics in `@JSClass` or static members, unsupported wrappings (`[[T]]`, `[T?]`, `[Int: T]`), and an export return type that is neither a declared generic (optionally wrapped) nor `Void`. The linker also fails the build when two linked modules define same-named `@JS` types while generics are in use, since generic tokens are unqualified type names.

**5. Documentation.** DocC articles (exporting/importing functions, supported types, unsupported features, internals rationale) and the BridgeJS README bridged-type table.

## Testing

- Codegen snapshot fixtures for both directions pin every distinct thunk shape: bare and wrapped generics, return-only generics, a generic used in multiple parameters, multiple distinct generic parameters, concrete parameters mixed with the generic, case-colliding names (`T` vs `t`), and generic methods on each owning construct (class, struct, enum, namespace enum, `@JSClass`).
- Diagnostics tests pin each build-time rejection listed above.
- WebAssembly runtime tests round-trip every supported `T` in both directions, including the `[T]`/`T?`/`[String: T]` wrappers with empty collections and `nil`, bulk numeric arrays, heap-object reference semantics, consecutive calls with different types, and generic instance/static methods on classes, structs, and enums.
- Linker tests verify that modules without generics produce unchanged output and that duplicate type tokens across linked modules fail the build.

## Open questions

- The generic infrastructure (conformances, codec table, `BridgeTypes`, resolver, type registry) is only emitted for modules that actually declare generics. I considered dropping the gating to streamline the codegen, but the gates themselves are a handful of trivial conditionals, while removing them would regenerate every snapshot fixture and grow the generated output of every module that never uses generics. If you would rather have unconditional emission for simplicity, I am happy to remove the gating.

Addresses https://github.com/swiftwasm/JavaScriptKit/issues/398

