### PR TITLE
BridgeJS: Fix syntax error in generated JS

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -2381,14 +2381,10 @@ struct IntrinsicJSFragment: Sendable {
                     if method.returnType == .void {
                         printer.write("\(callExpr);")
                     } else {
-                        printer.write("const ret = \(callExpr);")
-                    }
-
-                    // Lift return value if needed
-                    if method.returnType != .void {
                         let liftFragment = try IntrinsicJSFragment.liftReturn(type: method.returnType)
-                        let liftArgs = liftFragment.parameters.isEmpty ? [] : ["ret"]
-                        let lifted = try liftFragment.printCode(liftArgs, context)
+                        let returnVariable = context.scope.variable("ret")
+                        printer.write("const \(returnVariable) = \(callExpr);")
+                        let lifted = try liftFragment.printCode([returnVariable], context)
                         if let liftedValue = lifted.first {
                             printer.write("return \(liftedValue);")
                         }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/SwiftStruct.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/SwiftStruct.swift
@@ -74,6 +74,10 @@ extension Vector2D {
     @JS func scaled(by factor: Double) -> Vector2D {
         return Vector2D(dx: dx * factor, dy: dy * factor)
     }
+
+    @JS func describe() -> String {
+        return "Vector2D(\(dx), \(dy))"
+    }
 }
 
 extension DataPoint {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.json
@@ -686,6 +686,23 @@
                 "_0" : "Vector2D"
               }
             }
+          },
+          {
+            "abiName" : "bjs_Vector2D_describe",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "describe",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
           }
         ],
         "name" : "Vector2D",

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.swift
@@ -525,6 +525,17 @@ public func _bjs_Vector2D_scaled(_ factor: Float64) -> Void {
     #endif
 }
 
+@_expose(wasm, "bjs_Vector2D_describe")
+@_cdecl("bjs_Vector2D_describe")
+public func _bjs_Vector2D_describe() -> Void {
+    #if arch(wasm32)
+    let ret = Vector2D.bridgeJSLiftParameter().describe()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_roundtrip")
 @_cdecl("bjs_roundtrip")
 public func _bjs_roundtrip() -> Void {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
@@ -67,8 +67,8 @@ export async function createInstantiator(options, swift) {
             }.bind(instance1);
             instance1.multiply = function(a, b) {
                 structHelpers.MathOperations.lower(this);
-                const ret = instance.exports.bjs_MathOperations_multiply(a, b);
-                return ret;
+                const ret1 = instance.exports.bjs_MathOperations_multiply(a, b);
+                return ret1;
             }.bind(instance1);
             return instance1;
         }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.d.ts
@@ -48,6 +48,7 @@ export interface Vector2D {
     dy: number;
     magnitude(): number;
     scaled(factor: number): Vector2D;
+    describe(): string;
 }
 export type PrecisionObject = typeof PrecisionValues;
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
@@ -237,9 +237,16 @@ export async function createInstantiator(options, swift) {
             }.bind(instance1);
             instance1.scaled = function(factor) {
                 structHelpers.Vector2D.lower(this);
-                const ret = instance.exports.bjs_Vector2D_scaled(factor);
+                const ret1 = instance.exports.bjs_Vector2D_scaled(factor);
                 const structValue = structHelpers.Vector2D.lift();
                 return structValue;
+            }.bind(instance1);
+            instance1.describe = function() {
+                structHelpers.Vector2D.lower(this);
+                const ret2 = instance.exports.bjs_Vector2D_describe();
+                const ret3 = tmpRetString;
+                tmpRetString = undefined;
+                return ret3;
             }.bind(instance1);
             return instance1;
         }


### PR DESCRIPTION
When lifting a string return from an instance method on a struct, the following invalid JavaScript could be generated:
```js
const ret = instance.exports.bjs_Vector2D_describe();
const ret = tmpRetString;
```

This PR addresses this using the existing scoped variable identifier disambiguator.