### PR TITLE
BridgeJS: Fix argument order for stack-lowered imported parameters

### DIFF
--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.swift
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.swift
@@ -264,8 +264,8 @@ fileprivate func bjs_TS2Swift_convert_extern(_ self: Int32, _ tsBytes: Int32, _ 
 }
 
 func _$TS2Swift_convert(_ self: JSObject, _ ts: String) throws(JSException) -> String {
-    let selfValue = self.bridgeJSLowerParameter()
     let ret0 = ts.bridgeJSWithLoweredParameter { (tsBytes, tsLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         let ret = bjs_TS2Swift_convert(selfValue, tsBytes, tsLength)
         return ret
     }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -107,7 +107,7 @@ public struct ImportTS {
         let abiReturnType: WasmCoreType?
         // Track destructured variable names for multiple lowered parameters
         var destructuredVarNames: [String] = []
-        // Stack-lowered parameters should be evaluated in reverse order to match LIFO stacks
+        // Parameters are lowered in reverse order to match the LIFO stacks they push onto
         var stackLoweringStmts: [String] = []
         // Values to extend lifetime during call
         var valuesToExtendLifetimeDuringCall: [String] = []
@@ -206,12 +206,8 @@ public struct ImportTS {
                     initializerExpr = ExprSyntax("\(raw: param.name).bridgeJSLowerParameter()")
                 }
 
-                if loweringInfo.loweredParameters.isEmpty {
-                    stackLoweringStmts.insert("let _ = \(initializerExpr)", at: 0)
-                    return
-                }
-
-                body.write("let \(pattern) = \(initializerExpr)")
+                let binding = loweringInfo.loweredParameters.isEmpty ? "_" : pattern
+                stackLoweringStmts.insert("let \(binding) = \(initializerExpr)", at: 0)
             }
             destructuredVarNames.append(contentsOf: destructuredNames)
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/ImportArray.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/ImportArray.swift
@@ -1,2 +1,11 @@
 @JSFunction func roundtrip(_ items: [Int]) throws(JSException) -> [Int]
 @JSFunction func logStrings(_ items: [String]) throws(JSException)
+
+// An optional container lowers to an `isSome` parameter *and* a stack payload,
+// so it has to be ordered with the other stack-lowered parameters.
+@JSFunction func optionalArrayThenArray(_ a: [Int]?, _ b: [Int]) throws(JSException) -> Int
+@JSFunction func borrowedStringAroundStackParams(
+    _ s: String,
+    _ a: [Int]?,
+    _ b: [Int]
+) throws(JSException) -> Int

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.swift
@@ -27,8 +27,8 @@ private enum _BJS_Closure_10TestModuleAl7Polygon_Si {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Pointer = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si(callbackValue, param0Pointer)
             return Int.bridgeJSLiftReturn(ret)
             #else

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
@@ -534,8 +534,8 @@ fileprivate func bjs_checkArrayWithLength_extern(_ a: Int32, _ b: Float64) -> Vo
 }
 
 func _$checkArrayWithLength(_ a: JSObject, _ b: Double) throws(JSException) -> Void {
-    let aValue = a.bridgeJSLowerParameter()
     let bValue = b.bridgeJSLowerParameter()
+    let aValue = a.bridgeJSLowerParameter()
     bjs_checkArrayWithLength(aValue, bValue)
     if let error = _swift_js_take_exception() {
         throw error

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.swift
@@ -350,8 +350,8 @@ fileprivate func promise_reject_TestModule_extern(_ promise: Int32, _ valueKind:
 }
 
 func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let (valueKind, valuePayload1, valuePayload2) = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_reject_TestModule(promiseValue, valueKind, valuePayload1, valuePayload2)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -391,8 +391,8 @@ fileprivate func promise_resolve_TestModule_Si_extern(_ promise: Int32, _ value:
 }
 
 func _$Promise_resolve_Si(_ promise: JSObject, _ value: Int) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_Si(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -412,8 +412,8 @@ fileprivate func promise_resolve_TestModule_SS_extern(_ promise: Int32, _ valueB
 }
 
 func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        let promiseValue = promise.bridgeJSLowerParameter()
         promise_resolve_TestModule_SS(promiseValue, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() { throw error }
@@ -434,8 +434,8 @@ fileprivate func promise_resolve_TestModule_Sb_extern(_ promise: Int32, _ value:
 }
 
 func _$Promise_resolve_Sb(_ promise: JSObject, _ value: Bool) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_Sb(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -455,8 +455,8 @@ fileprivate func promise_resolve_TestModule_Sf_extern(_ promise: Int32, _ value:
 }
 
 func _$Promise_resolve_Sf(_ promise: JSObject, _ value: Float) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_Sf(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -476,8 +476,8 @@ fileprivate func promise_resolve_TestModule_Sd_extern(_ promise: Int32, _ value:
 }
 
 func _$Promise_resolve_Sd(_ promise: JSObject, _ value: Double) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_Sd(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -497,8 +497,8 @@ fileprivate func promise_resolve_TestModule_8JSObjectC_extern(_ promise: Int32, 
 }
 
 func _$Promise_resolve_8JSObjectC(_ promise: JSObject, _ value: JSObject) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_8JSObjectC(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -518,8 +518,8 @@ fileprivate func promise_resolve_TestModule_10AsyncPointV_extern(_ promise: Int3
 }
 
 func _$Promise_resolve_10AsyncPointV(_ promise: JSObject, _ value: AsyncPoint) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueObjectId = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_10AsyncPointV(promiseValue, valueObjectId)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -539,8 +539,8 @@ fileprivate func promise_resolve_TestModule_14AsyncDirectionO_extern(_ promise: 
 }
 
 func _$Promise_resolve_14AsyncDirectionO(_ promise: JSObject, _ value: AsyncDirection) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_14AsyncDirectionO(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -560,8 +560,8 @@ fileprivate func promise_resolve_TestModule_10AsyncThemeO_extern(_ promise: Int3
 }
 
 func _$Promise_resolve_10AsyncThemeO(_ promise: JSObject, _ value: AsyncTheme) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        let promiseValue = promise.bridgeJSLowerParameter()
         promise_resolve_TestModule_10AsyncThemeO(promiseValue, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() { throw error }
@@ -582,8 +582,8 @@ fileprivate func promise_resolve_TestModule_Sq14AsyncDirectionO_extern(_ promise
 }
 
 func _$Promise_resolve_Sq14AsyncDirectionO(_ promise: JSObject, _ value: Optional<AsyncDirection>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_Sq14AsyncDirectionO(promiseValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -603,8 +603,8 @@ fileprivate func promise_resolve_TestModule_Sq10AsyncThemeO_extern(_ promise: In
 }
 
 func _$Promise_resolve_Sq10AsyncThemeO(_ promise: JSObject, _ value: Optional<AsyncTheme>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
+        let promiseValue = promise.bridgeJSLowerParameter()
         promise_resolve_TestModule_Sq10AsyncThemeO(promiseValue, valueIsSome, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() { throw error }
@@ -625,8 +625,8 @@ fileprivate func promise_resolve_TestModule_Sq10AsyncPointV_extern(_ promise: In
 }
 
 func _$Promise_resolve_Sq10AsyncPointV(_ promise: JSObject, _ value: Optional<AsyncPoint>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueIsSome = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_Sq10AsyncPointV(promiseValue, valueIsSome)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -646,8 +646,8 @@ fileprivate func promise_resolve_TestModule_Sa10AsyncPointV_extern(_ promise: In
 }
 
 func _$Promise_resolve_Sa10AsyncPointV(_ promise: JSObject, _ value: [AsyncPoint]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_Sa10AsyncPointV(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -667,8 +667,8 @@ fileprivate func promise_resolve_TestModule_Sa14AsyncDirectionO_extern(_ promise
 }
 
 func _$Promise_resolve_Sa14AsyncDirectionO(_ promise: JSObject, _ value: [AsyncDirection]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_Sa14AsyncDirectionO(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -688,8 +688,8 @@ fileprivate func promise_resolve_TestModule_SD10AsyncPointV_extern(_ promise: In
 }
 
 func _$Promise_resolve_SD10AsyncPointV(_ promise: JSObject, _ value: [String: AsyncPoint]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_SD10AsyncPointV(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -709,8 +709,8 @@ fileprivate func promise_resolve_TestModule_SD14AsyncDirectionO_extern(_ promise
 }
 
 func _$Promise_resolve_SD14AsyncDirectionO(_ promise: JSObject, _ value: [String: AsyncDirection]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_SD14AsyncDirectionO(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AsyncAssociatedValueEnum.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AsyncAssociatedValueEnum.swift
@@ -67,8 +67,8 @@ fileprivate func promise_reject_TestModule_extern(_ promise: Int32, _ valueKind:
 }
 
 func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let (valueKind, valuePayload1, valuePayload2) = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_reject_TestModule(promiseValue, valueKind, valuePayload1, valuePayload2)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -88,8 +88,8 @@ fileprivate func promise_resolve_TestModule_18AsyncPayloadResultO_extern(_ promi
 }
 
 func _$Promise_resolve_18AsyncPayloadResultO(_ promise: JSObject, _ value: AsyncPayloadResult) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueCaseId = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_18AsyncPayloadResultO(promiseValue, valueCaseId)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -109,8 +109,8 @@ fileprivate func promise_resolve_TestModule_Sq18AsyncPayloadResultO_extern(_ pro
 }
 
 func _$Promise_resolve_Sq18AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<AsyncPayloadResult>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let (valueIsSome, valueCaseId) = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_Sq18AsyncPayloadResultO(promiseValue, valueIsSome, valueCaseId)
     if let error = _swift_js_take_exception() { throw error }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AsyncImport.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AsyncImport.swift
@@ -27,8 +27,8 @@ private enum _BJS_Closure_10TestModules7JSValueV_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0Kind, param0Payload1, param0Payload2) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModules7JSValueV_y(callbackValue, param0Kind, param0Payload1, param0Payload2)
             #else
             fatalError("Only available on WebAssembly")
@@ -88,8 +88,8 @@ private enum _BJS_Closure_10TestModules8JSObjectC_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModules8JSObjectC_y(callbackValue, param0Value)
             #else
             fatalError("Only available on WebAssembly")
@@ -149,8 +149,8 @@ private enum _BJS_Closure_10TestModulesSS_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 invoke_js_callback_TestModule_10TestModulesSS_y(callbackValue, param0Bytes, param0Length)
             }
             #else
@@ -211,8 +211,8 @@ private enum _BJS_Closure_10TestModulesSb_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModulesSb_y(callbackValue, param0Value)
             #else
             fatalError("Only available on WebAssembly")
@@ -272,8 +272,8 @@ private enum _BJS_Closure_10TestModulesSd_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModulesSd_y(callbackValue, param0Value)
             #else
             fatalError("Only available on WebAssembly")
@@ -333,8 +333,8 @@ private enum _BJS_Closure_10TestModulesSi_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModulesSi_y(callbackValue, param0Value)
             #else
             fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AsyncStaticImport.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AsyncStaticImport.swift
@@ -27,8 +27,8 @@ private enum _BJS_Closure_10TestModules7JSValueV_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0Kind, param0Payload1, param0Payload2) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModules7JSValueV_y(callbackValue, param0Kind, param0Payload1, param0Payload2)
             #else
             fatalError("Only available on WebAssembly")
@@ -88,8 +88,8 @@ private enum _BJS_Closure_10TestModulesSd_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModulesSd_y(callbackValue, param0Value)
             #else
             fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DocComments.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DocComments.swift
@@ -2,8 +2,8 @@ struct AnyListener: Listener, _BridgedSwiftProtocolWrapper {
     let jsObject: JSObject
 
     func onEvent(id: Int) -> Void {
-        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let idValue = id.bridgeJSLowerParameter()
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         _extern_onEvent(jsObjectValue, idValue)
     }
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValueImport.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValueImport.swift
@@ -84,8 +84,8 @@ func _$PayloadSignalControls_roundTrip(_ signal: PayloadSignal) throws(JSExcepti
 }
 
 func _$PayloadSignalControls_send(_ self: JSObject, _ signal: PayloadSignal) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let signalCaseId = signal.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_PayloadSignalControls_send(selfValue, signalCaseId)
     if let error = _swift_js_take_exception() {
         throw error
@@ -102,8 +102,8 @@ func _$PayloadSignalControls_current(_ self: JSObject) throws(JSException) -> Pa
 }
 
 func _$PayloadSignalControls_roundTripOptional(_ self: JSObject, _ signal: Optional<PayloadSignal>) throws(JSException) -> Optional<PayloadSignal> {
-    let selfValue = self.bridgeJSLowerParameter()
     let (signalIsSome, signalCaseId) = signal.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     let ret = bjs_PayloadSignalControls_roundTripOptional(selfValue, signalIsSome, signalCaseId)
     if let error = _swift_js_take_exception() {
         throw error

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCaseImport.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCaseImport.swift
@@ -79,8 +79,8 @@ func _$SignalControls_roundTrip(_ signal: Signal) throws(JSException) -> Signal 
 }
 
 func _$SignalControls_send(_ self: JSObject, _ signal: Signal) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let signalValue = signal.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_SignalControls_send(selfValue, signalValue)
     if let error = _swift_js_take_exception() {
         throw error

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GlobalGetter.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GlobalGetter.swift
@@ -31,8 +31,8 @@ fileprivate func bjs_JSConsole_log_extern(_ self: Int32, _ messageBytes: Int32, 
 }
 
 func _$JSConsole_log(_ self: JSObject, _ message: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     message.bridgeJSWithLoweredParameter { (messageBytes, messageLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_JSConsole_log(selfValue, messageBytes, messageLength)
     }
     if let error = _swift_js_take_exception() {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GlobalThisImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GlobalThisImports.swift
@@ -55,8 +55,8 @@ fileprivate func bjs_JSConsole_log_extern(_ self: Int32, _ messageBytes: Int32, 
 }
 
 func _$JSConsole_log(_ self: JSObject, _ message: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     message.bridgeJSWithLoweredParameter { (messageBytes, messageLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_JSConsole_log(selfValue, messageBytes, messageLength)
     }
     if let error = _swift_js_take_exception() {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.json
@@ -68,6 +68,122 @@
 
               }
             }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "optionalArrayThenArray",
+            "parameters" : [
+              {
+                "name" : "a",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "array" : {
+                        "_0" : {
+                          "integer" : {
+                            "_0" : {
+                              "isSigned" : true,
+                              "width" : "word"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              },
+              {
+                "name" : "b",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "integer" : {
+                        "_0" : {
+                          "isSigned" : true,
+                          "width" : "word"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "borrowedStringAroundStackParams",
+            "parameters" : [
+              {
+                "name" : "s",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              },
+              {
+                "name" : "a",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "array" : {
+                        "_0" : {
+                          "integer" : {
+                            "_0" : {
+                              "isSigned" : true,
+                              "width" : "word"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              },
+              {
+                "name" : "b",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "integer" : {
+                        "_0" : {
+                          "isSigned" : true,
+                          "width" : "word"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
           }
         ],
         "types" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.swift
@@ -38,3 +38,51 @@ func _$logStrings(_ items: [String]) throws(JSException) -> Void {
         throw error
     }
 }
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_optionalArrayThenArray")
+fileprivate func bjs_optionalArrayThenArray_extern(_ a: Int32) -> Int32
+#else
+fileprivate func bjs_optionalArrayThenArray_extern(_ a: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_optionalArrayThenArray(_ a: Int32) -> Int32 {
+    return bjs_optionalArrayThenArray_extern(a)
+}
+
+func _$optionalArrayThenArray(_ a: Optional<[Int]>, _ b: [Int]) throws(JSException) -> Int {
+    let _ = b.bridgeJSLowerParameter()
+    let aIsSome = a.bridgeJSLowerParameter()
+    let ret = bjs_optionalArrayThenArray(aIsSome)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Int.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_borrowedStringAroundStackParams")
+fileprivate func bjs_borrowedStringAroundStackParams_extern(_ sBytes: Int32, _ sLength: Int32, _ a: Int32) -> Int32
+#else
+fileprivate func bjs_borrowedStringAroundStackParams_extern(_ sBytes: Int32, _ sLength: Int32, _ a: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_borrowedStringAroundStackParams(_ sBytes: Int32, _ sLength: Int32, _ a: Int32) -> Int32 {
+    return bjs_borrowedStringAroundStackParams_extern(sBytes, sLength, a)
+}
+
+func _$borrowedStringAroundStackParams(_ s: String, _ a: Optional<[Int]>, _ b: [Int]) throws(JSException) -> Int {
+    let ret0 = s.bridgeJSWithLoweredParameter { (sBytes, sLength) in
+        let _ = b.bridgeJSLowerParameter()
+        let aIsSome = a.bridgeJSLowerParameter()
+        let ret = bjs_borrowedStringAroundStackParams(sBytes, sLength, aIsSome)
+        return ret
+    }
+    let ret = ret0
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Int.bridgeJSLiftReturn(ret)
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/InvalidPropertyNames.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/InvalidPropertyNames.swift
@@ -327,8 +327,8 @@ func _$WeirdNaming_Any_get(_ self: JSObject) throws(JSException) -> String {
 }
 
 func _$WeirdNaming_normalProperty_set(_ self: JSObject, _ newValue: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     newValue.bridgeJSWithLoweredParameter { (newValueBytes, newValueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_WeirdNaming_normalProperty_set(selfValue, newValueBytes, newValueLength)
     }
     if let error = _swift_js_take_exception() {
@@ -337,8 +337,8 @@ func _$WeirdNaming_normalProperty_set(_ self: JSObject, _ newValue: String) thro
 }
 
 func _$WeirdNaming_property_with_dashes_set(_ self: JSObject, _ newValue: Double) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let newValueValue = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WeirdNaming_property_with_dashes_set(selfValue, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -346,8 +346,8 @@ func _$WeirdNaming_property_with_dashes_set(_ self: JSObject, _ newValue: Double
 }
 
 func _$WeirdNaming__123invalidStart_set(_ self: JSObject, _ newValue: Bool) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let newValueValue = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WeirdNaming__123invalidStart_set(selfValue, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -355,8 +355,8 @@ func _$WeirdNaming__123invalidStart_set(_ self: JSObject, _ newValue: Bool) thro
 }
 
 func _$WeirdNaming_property_with_spaces_set(_ self: JSObject, _ newValue: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     newValue.bridgeJSWithLoweredParameter { (newValueBytes, newValueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_WeirdNaming_property_with_spaces_set(selfValue, newValueBytes, newValueLength)
     }
     if let error = _swift_js_take_exception() {
@@ -365,8 +365,8 @@ func _$WeirdNaming_property_with_spaces_set(_ self: JSObject, _ newValue: String
 }
 
 func _$WeirdNaming__specialChar_set(_ self: JSObject, _ newValue: Double) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let newValueValue = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WeirdNaming__specialChar_set(selfValue, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -374,8 +374,8 @@ func _$WeirdNaming__specialChar_set(_ self: JSObject, _ newValue: Double) throws
 }
 
 func _$WeirdNaming_constructor_set(_ self: JSObject, _ newValue: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     newValue.bridgeJSWithLoweredParameter { (newValueBytes, newValueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_WeirdNaming_constructor_set(selfValue, newValueBytes, newValueLength)
     }
     if let error = _swift_js_take_exception() {
@@ -384,8 +384,8 @@ func _$WeirdNaming_constructor_set(_ self: JSObject, _ newValue: String) throws(
 }
 
 func _$WeirdNaming_for_set(_ self: JSObject, _ newValue: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     newValue.bridgeJSWithLoweredParameter { (newValueBytes, newValueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_WeirdNaming_for_set(selfValue, newValueBytes, newValueLength)
     }
     if let error = _swift_js_take_exception() {
@@ -394,8 +394,8 @@ func _$WeirdNaming_for_set(_ self: JSObject, _ newValue: String) throws(JSExcept
 }
 
 func _$WeirdNaming_any_set(_ self: JSObject, _ newValue: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     newValue.bridgeJSWithLoweredParameter { (newValueBytes, newValueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_WeirdNaming_any_set(selfValue, newValueBytes, newValueLength)
     }
     if let error = _swift_js_take_exception() {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSClass.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSClass.swift
@@ -121,8 +121,8 @@ func _$Greeter_age_get(_ self: JSObject) throws(JSException) -> Double {
 }
 
 func _$Greeter_name_set(_ self: JSObject, _ newValue: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     newValue.bridgeJSWithLoweredParameter { (newValueBytes, newValueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_Greeter_name_set(selfValue, newValueBytes, newValueLength)
     }
     if let error = _swift_js_take_exception() {
@@ -140,8 +140,8 @@ func _$Greeter_greet(_ self: JSObject) throws(JSException) -> String {
 }
 
 func _$Greeter_changeName(_ self: JSObject, _ name: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     name.bridgeJSWithLoweredParameter { (nameBytes, nameLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_Greeter_changeName(selfValue, nameBytes, nameLength)
     }
     if let error = _swift_js_take_exception() {
@@ -174,9 +174,9 @@ fileprivate func bjs_Animatable_getAnimations_extern(_ self: Int32, _ options: I
 }
 
 func _$Animatable_animate(_ self: JSObject, _ keyframes: JSObject, _ options: JSObject) throws(JSException) -> JSObject {
-    let selfValue = self.bridgeJSLowerParameter()
-    let keyframesValue = keyframes.bridgeJSLowerParameter()
     let optionsValue = options.bridgeJSLowerParameter()
+    let keyframesValue = keyframes.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     let ret = bjs_Animatable_animate(selfValue, keyframesValue, optionsValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -185,8 +185,8 @@ func _$Animatable_animate(_ self: JSObject, _ keyframes: JSObject, _ options: JS
 }
 
 func _$Animatable_getAnimations(_ self: JSObject, _ options: JSObject) throws(JSException) -> JSObject {
-    let selfValue = self.bridgeJSLowerParameter()
     let optionsValue = options.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     let ret = bjs_Animatable_getAnimations(selfValue, optionsValue)
     if let error = _swift_js_take_exception() {
         throw error

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.swift
@@ -873,8 +873,8 @@ func _$WithOptionalJSClass_childOrNull_get(_ self: JSObject) throws(JSException)
 }
 
 func _$WithOptionalJSClass_stringOrNull_set(_ self: JSObject, _ newValue: Optional<String>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     newValue.bridgeJSWithLoweredParameter { (newValueIsSome, newValueBytes, newValueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_WithOptionalJSClass_stringOrNull_set(selfValue, newValueIsSome, newValueBytes, newValueLength)
     }
     if let error = _swift_js_take_exception() {
@@ -883,8 +883,8 @@ func _$WithOptionalJSClass_stringOrNull_set(_ self: JSObject, _ newValue: Option
 }
 
 func _$WithOptionalJSClass_stringOrUndefined_set(_ self: JSObject, _ newValue: JSUndefinedOr<String>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     newValue.bridgeJSWithLoweredParameter { (newValueIsSome, newValueBytes, newValueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_WithOptionalJSClass_stringOrUndefined_set(selfValue, newValueIsSome, newValueBytes, newValueLength)
     }
     if let error = _swift_js_take_exception() {
@@ -893,8 +893,8 @@ func _$WithOptionalJSClass_stringOrUndefined_set(_ self: JSObject, _ newValue: J
 }
 
 func _$WithOptionalJSClass_doubleOrNull_set(_ self: JSObject, _ newValue: Optional<Double>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_doubleOrNull_set(selfValue, newValueIsSome, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -902,8 +902,8 @@ func _$WithOptionalJSClass_doubleOrNull_set(_ self: JSObject, _ newValue: Option
 }
 
 func _$WithOptionalJSClass_doubleOrUndefined_set(_ self: JSObject, _ newValue: JSUndefinedOr<Double>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_doubleOrUndefined_set(selfValue, newValueIsSome, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -911,8 +911,8 @@ func _$WithOptionalJSClass_doubleOrUndefined_set(_ self: JSObject, _ newValue: J
 }
 
 func _$WithOptionalJSClass_boolOrNull_set(_ self: JSObject, _ newValue: Optional<Bool>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_boolOrNull_set(selfValue, newValueIsSome, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -920,8 +920,8 @@ func _$WithOptionalJSClass_boolOrNull_set(_ self: JSObject, _ newValue: Optional
 }
 
 func _$WithOptionalJSClass_boolOrUndefined_set(_ self: JSObject, _ newValue: JSUndefinedOr<Bool>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_boolOrUndefined_set(selfValue, newValueIsSome, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -929,8 +929,8 @@ func _$WithOptionalJSClass_boolOrUndefined_set(_ self: JSObject, _ newValue: JSU
 }
 
 func _$WithOptionalJSClass_intOrNull_set(_ self: JSObject, _ newValue: Optional<Int>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_intOrNull_set(selfValue, newValueIsSome, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -938,8 +938,8 @@ func _$WithOptionalJSClass_intOrNull_set(_ self: JSObject, _ newValue: Optional<
 }
 
 func _$WithOptionalJSClass_intOrUndefined_set(_ self: JSObject, _ newValue: JSUndefinedOr<Int>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_intOrUndefined_set(selfValue, newValueIsSome, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -947,8 +947,8 @@ func _$WithOptionalJSClass_intOrUndefined_set(_ self: JSObject, _ newValue: JSUn
 }
 
 func _$WithOptionalJSClass_childOrNull_set(_ self: JSObject, _ newValue: Optional<WithOptionalJSClass>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_childOrNull_set(selfValue, newValueIsSome, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -956,8 +956,8 @@ func _$WithOptionalJSClass_childOrNull_set(_ self: JSObject, _ newValue: Optiona
 }
 
 func _$WithOptionalJSClass_roundTripStringOrNull(_ self: JSObject, _ value: Optional<String>) throws(JSException) -> Optional<String> {
-    let selfValue = self.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_WithOptionalJSClass_roundTripStringOrNull(selfValue, valueIsSome, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() {
@@ -967,8 +967,8 @@ func _$WithOptionalJSClass_roundTripStringOrNull(_ self: JSObject, _ value: Opti
 }
 
 func _$WithOptionalJSClass_roundTripStringOrUndefined(_ self: JSObject, _ value: JSUndefinedOr<String>) throws(JSException) -> JSUndefinedOr<String> {
-    let selfValue = self.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_WithOptionalJSClass_roundTripStringOrUndefined(selfValue, valueIsSome, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() {
@@ -978,8 +978,8 @@ func _$WithOptionalJSClass_roundTripStringOrUndefined(_ self: JSObject, _ value:
 }
 
 func _$WithOptionalJSClass_roundTripDoubleOrNull(_ self: JSObject, _ value: Optional<Double>) throws(JSException) -> Optional<Double> {
-    let selfValue = self.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_roundTripDoubleOrNull(selfValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -988,8 +988,8 @@ func _$WithOptionalJSClass_roundTripDoubleOrNull(_ self: JSObject, _ value: Opti
 }
 
 func _$WithOptionalJSClass_roundTripDoubleOrUndefined(_ self: JSObject, _ value: JSUndefinedOr<Double>) throws(JSException) -> JSUndefinedOr<Double> {
-    let selfValue = self.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_roundTripDoubleOrUndefined(selfValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -998,8 +998,8 @@ func _$WithOptionalJSClass_roundTripDoubleOrUndefined(_ self: JSObject, _ value:
 }
 
 func _$WithOptionalJSClass_roundTripBoolOrNull(_ self: JSObject, _ value: Optional<Bool>) throws(JSException) -> Optional<Bool> {
-    let selfValue = self.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     let ret = bjs_WithOptionalJSClass_roundTripBoolOrNull(selfValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -1008,8 +1008,8 @@ func _$WithOptionalJSClass_roundTripBoolOrNull(_ self: JSObject, _ value: Option
 }
 
 func _$WithOptionalJSClass_roundTripBoolOrUndefined(_ self: JSObject, _ value: JSUndefinedOr<Bool>) throws(JSException) -> JSUndefinedOr<Bool> {
-    let selfValue = self.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     let ret = bjs_WithOptionalJSClass_roundTripBoolOrUndefined(selfValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -1018,8 +1018,8 @@ func _$WithOptionalJSClass_roundTripBoolOrUndefined(_ self: JSObject, _ value: J
 }
 
 func _$WithOptionalJSClass_roundTripIntOrNull(_ self: JSObject, _ value: Optional<Int>) throws(JSException) -> Optional<Int> {
-    let selfValue = self.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_roundTripIntOrNull(selfValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -1028,8 +1028,8 @@ func _$WithOptionalJSClass_roundTripIntOrNull(_ self: JSObject, _ value: Optiona
 }
 
 func _$WithOptionalJSClass_roundTripIntOrUndefined(_ self: JSObject, _ value: JSUndefinedOr<Int>) throws(JSException) -> JSUndefinedOr<Int> {
-    let selfValue = self.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_roundTripIntOrUndefined(selfValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -1038,8 +1038,8 @@ func _$WithOptionalJSClass_roundTripIntOrUndefined(_ self: JSObject, _ value: JS
 }
 
 func _$WithOptionalJSClass_roundTripChildOrNull(_ self: JSObject, _ value: Optional<WithOptionalJSClass>) throws(JSException) -> Optional<WithOptionalJSClass> {
-    let selfValue = self.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WithOptionalJSClass_roundTripChildOrNull(selfValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() {
         throw error

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveParameters.swift
@@ -21,8 +21,8 @@ fileprivate func bjs_check_extern(_ a: Float64, _ b: Int32) -> Void {
 }
 
 func _$check(_ a: Double, _ b: Bool) throws(JSException) -> Void {
-    let aValue = a.bridgeJSLowerParameter()
     let bValue = b.bridgeJSLowerParameter()
+    let aValue = a.bridgeJSLowerParameter()
     bjs_check(aValue, bValue)
     if let error = _swift_js_take_exception() {
         throw error

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
@@ -7,23 +7,23 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
     }
 
     func onValueChanged(_ value: String) -> Void {
-        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             _extern_onValueChanged(jsObjectValue, valueBytes, valueLength)
         }
     }
 
     func onCountUpdated(count: Int) -> Bool {
-        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let countValue = count.bridgeJSLowerParameter()
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_onCountUpdated(jsObjectValue, countValue)
         return Bool.bridgeJSLiftReturn(ret)
     }
 
     func onLabelUpdated(_ prefix: String, _ suffix: String) -> Void {
-        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         prefix.bridgeJSWithLoweredParameter { (prefixBytes, prefixLength) in
             suffix.bridgeJSWithLoweredParameter { (suffixBytes, suffixLength) in
+                let jsObjectValue = jsObject.bridgeJSLowerParameter()
                 _extern_onLabelUpdated(jsObjectValue, prefixBytes, prefixLength, suffixBytes, suffixLength)
             }
         }
@@ -36,8 +36,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
     }
 
     func onHelperUpdated(_ helper: Helper) -> Void {
-        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let helperPointer = helper.bridgeJSLowerParameter()
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         _extern_onHelperUpdated(jsObjectValue, helperPointer)
     }
 
@@ -48,8 +48,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
     }
 
     func onOptionalHelperUpdated(_ helper: Optional<Helper>) -> Void {
-        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let (helperIsSome, helperPointer) = helper.bridgeJSLowerParameter()
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         _extern_onOptionalHelperUpdated(jsObjectValue, helperIsSome, helperPointer)
     }
 
@@ -66,8 +66,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
     }
 
     func handleResult(_ result: Result) -> Void {
-        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let resultCaseId = result.bridgeJSLowerParameter()
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         _extern_handleResult(jsObjectValue, resultCaseId)
     }
 
@@ -84,8 +84,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
             return Int.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let newValueValue = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_MyViewControllerDelegate_eventCount_set(jsObjectValue, newValueValue)
         }
     }
@@ -105,8 +105,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
             return Optional<String>.bridgeJSLiftReturnFromSideChannel()
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             newValue.bridgeJSWithLoweredParameter { (newValueIsSome, newValueBytes, newValueLength) in
+                let jsObjectValue = jsObject.bridgeJSLowerParameter()
                 bjs_MyViewControllerDelegate_optionalName_set(jsObjectValue, newValueIsSome, newValueBytes, newValueLength)
             }
         }
@@ -119,8 +119,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
             return Optional<ExampleEnum>.bridgeJSLiftReturnFromSideChannel()
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             newValue.bridgeJSWithLoweredParameter { (newValueIsSome, newValueBytes, newValueLength) in
+                let jsObjectValue = jsObject.bridgeJSLowerParameter()
                 bjs_MyViewControllerDelegate_optionalRawEnum_set(jsObjectValue, newValueIsSome, newValueBytes, newValueLength)
             }
         }
@@ -133,8 +133,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
             return ExampleEnum.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             newValue.bridgeJSWithLoweredParameter { (newValueBytes, newValueLength) in
+                let jsObjectValue = jsObject.bridgeJSLowerParameter()
                 bjs_MyViewControllerDelegate_rawStringEnum_set(jsObjectValue, newValueBytes, newValueLength)
             }
         }
@@ -147,8 +147,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
             return Result.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let newValueCaseId = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_MyViewControllerDelegate_result_set(jsObjectValue, newValueCaseId)
         }
     }
@@ -160,8 +160,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
             return Optional<Result>.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let (newValueIsSome, newValueCaseId) = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_MyViewControllerDelegate_optionalResult_set(jsObjectValue, newValueIsSome, newValueCaseId)
         }
     }
@@ -173,8 +173,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
             return Direction.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let newValueValue = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_MyViewControllerDelegate_direction_set(jsObjectValue, newValueValue)
         }
     }
@@ -186,8 +186,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
             return Optional<Direction>.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_MyViewControllerDelegate_directionOptional_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
@@ -199,8 +199,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
             return Priority.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let newValueValue = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_MyViewControllerDelegate_priority_set(jsObjectValue, newValueValue)
         }
     }
@@ -212,8 +212,8 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
             return Optional<Priority>.bridgeJSLiftReturnFromSideChannel()
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_MyViewControllerDelegate_priorityOptional_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ProtocolInClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ProtocolInClosure.swift
@@ -27,8 +27,8 @@ private enum _BJS_Closure_10TestModule10RenderableP_10RenderableP {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0ObjectId = (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModule10RenderableP_10RenderableP(callbackValue, param0ObjectId)
             return AnyRenderable.bridgeJSLiftReturn(ret)
             #else
@@ -90,8 +90,8 @@ private enum _BJS_Closure_10TestModule10RenderableP_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0ObjectId = (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModule10RenderableP_SS(callbackValue, param0ObjectId)
             return String.bridgeJSLiftReturn(ret)
             #else
@@ -153,13 +153,13 @@ private enum _BJS_Closure_10TestModuleSq10RenderableP_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0ObjectId): (Int32, Int32)
             if let param0 {
                 (param0IsSome, param0ObjectId) = (1, (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
             } else {
                 (param0IsSome, param0ObjectId) = (0, 0)
             }
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuleSq10RenderableP_SS(callbackValue, param0IsSome, param0ObjectId)
             return String.bridgeJSLiftReturn(ret)
             #else

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
@@ -27,8 +27,8 @@ private enum _BJS_Closure_10TestModule10HttpStatusO_10HttpStatusO {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModule10HttpStatusO_10HttpStatusO(callbackValue, param0Value)
             return HttpStatus.bridgeJSLiftReturn(ret)
             #else
@@ -90,8 +90,8 @@ private enum _BJS_Closure_10TestModule5ThemeO_5ThemeO {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_TestModule_10TestModule5ThemeO_5ThemeO(callbackValue, param0Bytes, param0Length)
                 return ret
             }
@@ -156,8 +156,8 @@ private enum _BJS_Closure_10TestModule6AnimalV_6AnimalV {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let _ = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV(callbackValue)
             return Animal.bridgeJSLiftReturn()
             #else
@@ -219,8 +219,8 @@ private enum _BJS_Closure_10TestModule6PersonC_6PersonC {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Pointer = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModule6PersonC_6PersonC(callbackValue, param0Pointer)
             return Person.bridgeJSLiftReturn(ret)
             #else
@@ -282,8 +282,8 @@ private enum _BJS_Closure_10TestModule9APIResultO_9APIResultO {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0CaseId = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModule9APIResultO_9APIResultO(callbackValue, param0CaseId)
             return APIResult.bridgeJSLiftReturn(ret)
             #else
@@ -345,8 +345,8 @@ private enum _BJS_Closure_10TestModule9DirectionO_9DirectionO {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModule9DirectionO_9DirectionO(callbackValue, param0Value)
             return Direction.bridgeJSLiftReturn(ret)
             #else
@@ -408,8 +408,8 @@ private enum _BJS_Closure_10TestModuleKSS_Sb {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] (param0: String) throws(JSException) -> Bool in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_TestModule_10TestModuleKSS_Sb(callbackValue, param0Bytes, param0Length)
                 return ret
             }
@@ -491,8 +491,8 @@ private enum _BJS_Closure_10TestModuleKSS_Si {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] (param0: String) throws(JSException) -> Int in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_TestModule_10TestModuleKSS_Si(callbackValue, param0Bytes, param0Length)
                 return ret
             }
@@ -574,8 +574,8 @@ private enum _BJS_Closure_10TestModuleSS_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_TestModule_10TestModuleSS_SS(callbackValue, param0Bytes, param0Length)
                 return ret
             }
@@ -640,8 +640,8 @@ private enum _BJS_Closure_10TestModuleSb_Sb {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuleSb_Sb(callbackValue, param0Value)
             return Bool.bridgeJSLiftReturn(ret)
             #else
@@ -703,8 +703,8 @@ private enum _BJS_Closure_10TestModuleSd_Sd {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuleSd_Sd(callbackValue, param0Value)
             return Double.bridgeJSLiftReturn(ret)
             #else
@@ -766,8 +766,8 @@ private enum _BJS_Closure_10TestModuleSf_Sf {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuleSf_Sf(callbackValue, param0Value)
             return Float.bridgeJSLiftReturn(ret)
             #else
@@ -829,8 +829,8 @@ private enum _BJS_Closure_10TestModuleSi_Si {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuleSi_Si(callbackValue, param0Value)
             return Int.bridgeJSLiftReturn(ret)
             #else
@@ -892,8 +892,8 @@ private enum _BJS_Closure_10TestModuleSq10HttpStatusO_Sq10HttpStatusO {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO(callbackValue, param0IsSome, param0Value)
             return Optional<HttpStatus>.bridgeJSLiftReturnFromSideChannel()
             #else
@@ -955,8 +955,8 @@ private enum _BJS_Closure_10TestModuleSq5ThemeO_Sq5ThemeO {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             param0.bridgeJSWithLoweredParameter { (param0IsSome, param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 invoke_js_callback_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO(callbackValue, param0IsSome, param0Bytes, param0Length)
             }
             return Optional<Theme>.bridgeJSLiftReturnFromSideChannel()
@@ -1019,8 +1019,8 @@ private enum _BJS_Closure_10TestModuleSq6AnimalV_Sq6AnimalV {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0IsSome = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(callbackValue, param0IsSome)
             return Optional<Animal>.bridgeJSLiftReturn()
             #else
@@ -1082,8 +1082,8 @@ private enum _BJS_Closure_10TestModuleSq6PersonC_Sq6PersonC {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Pointer) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC(callbackValue, param0IsSome, param0Pointer)
             return Optional<Person>.bridgeJSLiftReturn(ret)
             #else
@@ -1145,8 +1145,8 @@ private enum _BJS_Closure_10TestModuleSq9APIResultO_Sq9APIResultO {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0CaseId) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO(callbackValue, param0IsSome, param0CaseId)
             return Optional<APIResult>.bridgeJSLiftReturn(ret)
             #else
@@ -1208,8 +1208,8 @@ private enum _BJS_Closure_10TestModuleSq9DirectionO_Sq9DirectionO {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO(callbackValue, param0IsSome, param0Value)
             return Optional<Direction>.bridgeJSLiftReturn(ret)
             #else
@@ -1271,8 +1271,8 @@ private enum _BJS_Closure_10TestModuleSqSS_SqSS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             param0.bridgeJSWithLoweredParameter { (param0IsSome, param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 invoke_js_callback_TestModule_10TestModuleSqSS_SqSS(callbackValue, param0IsSome, param0Bytes, param0Length)
             }
             return Optional<String>.bridgeJSLiftReturnFromSideChannel()
@@ -1335,8 +1335,8 @@ private enum _BJS_Closure_10TestModuleSqSb_SqSb {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuleSqSb_SqSb(callbackValue, param0IsSome, param0Value)
             return Optional<Bool>.bridgeJSLiftReturn(ret)
             #else
@@ -1398,8 +1398,8 @@ private enum _BJS_Closure_10TestModuleSqSd_SqSd {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModuleSqSd_SqSd(callbackValue, param0IsSome, param0Value)
             return Optional<Double>.bridgeJSLiftReturnFromSideChannel()
             #else
@@ -1461,8 +1461,8 @@ private enum _BJS_Closure_10TestModuleSqSf_SqSf {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModuleSqSf_SqSf(callbackValue, param0IsSome, param0Value)
             return Optional<Float>.bridgeJSLiftReturnFromSideChannel()
             #else
@@ -1524,8 +1524,8 @@ private enum _BJS_Closure_10TestModuleSqSi_SqSi {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModuleSqSi_SqSi(callbackValue, param0IsSome, param0Value)
             return Optional<Int>.bridgeJSLiftReturnFromSideChannel()
             #else
@@ -1592,8 +1592,8 @@ private enum _BJS_Closure_10TestModuleYaKSS_SS {
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
                 param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    let callbackValue = callback.bridgeJSLowerParameter()
                     invoke_js_callback_TestModule_10TestModuleYaKSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
                 }
             }
@@ -1663,8 +1663,8 @@ private enum _BJS_Closure_10TestModuleYaKSb_9APIResultO {
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
                 let param0Value = param0.bridgeJSLowerParameter()
+                let callbackValue = callback.bridgeJSLowerParameter()
                 invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO(resolveRef, rejectRef, callbackValue, param0Value)
             }
             return resolved
@@ -1733,8 +1733,8 @@ private enum _BJS_Closure_10TestModuleYaSS_6AnimalV {
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
                 param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    let callbackValue = callback.bridgeJSLowerParameter()
                     invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
                 }
             }
@@ -1804,8 +1804,8 @@ private enum _BJS_Closure_10TestModuleYaSS_SS {
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
                 param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    let callbackValue = callback.bridgeJSLowerParameter()
                     invoke_js_callback_TestModule_10TestModuleYaSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
                 }
             }
@@ -1870,8 +1870,8 @@ private enum _BJS_Closure_10TestModules6AnimalV_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let _ = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModules6AnimalV_y(callbackValue)
             #else
             fatalError("Only available on WebAssembly")
@@ -1931,8 +1931,8 @@ private enum _BJS_Closure_10TestModules7JSValueV_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0Kind, param0Payload1, param0Payload2) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModules7JSValueV_y(callbackValue, param0Kind, param0Payload1, param0Payload2)
             #else
             fatalError("Only available on WebAssembly")
@@ -1992,8 +1992,8 @@ private enum _BJS_Closure_10TestModules9APIResultO_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0CaseId = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModules9APIResultO_y(callbackValue, param0CaseId)
             #else
             fatalError("Only available on WebAssembly")
@@ -2053,8 +2053,8 @@ private enum _BJS_Closure_10TestModulesSS_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 invoke_js_callback_TestModule_10TestModulesSS_y(callbackValue, param0Bytes, param0Length)
             }
             #else
@@ -2652,8 +2652,8 @@ fileprivate func promise_reject_TestModule_extern(_ promise: Int32, _ valueKind:
 }
 
 func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let (valueKind, valuePayload1, valuePayload2) = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_reject_TestModule(promiseValue, valueKind, valuePayload1, valuePayload2)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -2673,8 +2673,8 @@ fileprivate func promise_resolve_TestModule_SS_extern(_ promise: Int32, _ valueB
 }
 
 func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        let promiseValue = promise.bridgeJSLowerParameter()
         promise_resolve_TestModule_SS(promiseValue, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() { throw error }
@@ -2695,8 +2695,8 @@ fileprivate func promise_resolve_TestModule_6AnimalV_extern(_ promise: Int32, _ 
 }
 
 func _$Promise_resolve_6AnimalV(_ promise: JSObject, _ value: Animal) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueObjectId = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_6AnimalV(promiseValue, valueObjectId)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -2716,8 +2716,8 @@ fileprivate func promise_resolve_TestModule_9APIResultO_extern(_ promise: Int32,
 }
 
 func _$Promise_resolve_9APIResultO(_ promise: JSObject, _ value: APIResult) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueCaseId = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_TestModule_9APIResultO(promiseValue, valueCaseId)
     if let error = _swift_js_take_exception() { throw error }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosureImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosureImports.swift
@@ -27,8 +27,8 @@ private enum _BJS_Closure_10TestModuleKSS_Sb {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] (param0: String) throws(JSException) -> Bool in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_TestModule_10TestModuleKSS_Sb(callbackValue, param0Bytes, param0Length)
                 return ret
             }
@@ -110,8 +110,8 @@ private enum _BJS_Closure_10TestModuleSi_Si {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_TestModule_10TestModuleSi_Si(callbackValue, param0Value)
             return Int.bridgeJSLiftReturn(ret)
             #else
@@ -178,8 +178,8 @@ private enum _BJS_Closure_10TestModuleYaKSS_SS {
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
                 param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    let callbackValue = callback.bridgeJSLowerParameter()
                     invoke_js_callback_TestModule_10TestModuleYaKSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
                 }
             }
@@ -244,8 +244,8 @@ private enum _BJS_Closure_10TestModules7JSValueV_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0Kind, param0Payload1, param0Payload2) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModules7JSValueV_y(callbackValue, param0Kind, param0Payload1, param0Payload2)
             #else
             fatalError("Only available on WebAssembly")
@@ -305,8 +305,8 @@ private enum _BJS_Closure_10TestModulesSS_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 invoke_js_callback_TestModule_10TestModulesSS_y(callbackValue, param0Bytes, param0Length)
             }
             #else
@@ -373,8 +373,8 @@ fileprivate func promise_reject_TestModule_extern(_ promise: Int32, _ valueKind:
 }
 
 func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let (valueKind, valuePayload1, valuePayload2) = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_reject_TestModule(promiseValue, valueKind, valuePayload1, valuePayload2)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -394,8 +394,8 @@ fileprivate func promise_resolve_TestModule_SS_extern(_ promise: Int32, _ valueB
 }
 
 func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        let promiseValue = promise.bridgeJSLowerParameter()
         promise_resolve_TestModule_SS(promiseValue, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() { throw error }
@@ -414,9 +414,9 @@ fileprivate func bjs_applyInt_extern(_ value: Int32, _ transform: Int32) -> Int3
 }
 
 func _$applyInt(_ value: Int, _ transform: @escaping (Int) -> Int) throws(JSException) -> Int {
-    let valueValue = value.bridgeJSLowerParameter()
     let transform = JSTypedClosure<(Int) -> Int>(transform)
     let transformFuncRef = transform.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
     let ret = withExtendedLifetime((transform)) {
         bjs_applyInt(valueValue, transformFuncRef)
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
@@ -59,9 +59,9 @@ fileprivate func bjs_translate_extern(_ point: Int32, _ dx: Int32, _ dy: Int32) 
 }
 
 func _$translate(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException) -> Point {
-    let pointObjectId = point.bridgeJSLowerParameter()
-    let dxValue = dx.bridgeJSLowerParameter()
     let dyValue = dy.bridgeJSLowerParameter()
+    let dxValue = dx.bridgeJSLowerParameter()
+    let pointObjectId = point.bridgeJSLowerParameter()
     let ret = bjs_translate(pointObjectId, dxValue, dyValue)
     if let error = _swift_js_take_exception() {
         throw error

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftTypedClosureAccess.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftTypedClosureAccess.swift
@@ -27,8 +27,8 @@ private enum _BJS_Closure_10TestModule13JSPublicEventC_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModule13JSPublicEventC_y(callbackValue, param0Value)
             #else
             fatalError("Only available on WebAssembly")
@@ -88,8 +88,8 @@ private enum _BJS_Closure_10TestModule14JSPackageEventC_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModule14JSPackageEventC_y(callbackValue, param0Value)
             #else
             fatalError("Only available on WebAssembly")
@@ -149,8 +149,8 @@ private enum _BJS_Closure_10TestModule15JSInternalEventC_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_TestModule_10TestModule15JSInternalEventC_y(callbackValue, param0Value)
             #else
             fatalError("Only available on WebAssembly")
@@ -206,8 +206,8 @@ fileprivate func bjs_JSPublicTarget_addInternalListener_extern(_ self: Int32, _ 
 }
 
 func _$JSPublicTarget_addPublicListener(_ self: JSObject, _ handler: JSTypedClosure<(JSPublicEvent) -> Void>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let handlerFuncRef = handler.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_JSPublicTarget_addPublicListener(selfValue, handlerFuncRef)
     if let error = _swift_js_take_exception() {
         throw error
@@ -215,8 +215,8 @@ func _$JSPublicTarget_addPublicListener(_ self: JSObject, _ handler: JSTypedClos
 }
 
 func _$JSPublicTarget_addInternalListener(_ self: JSObject, _ handler: JSTypedClosure<(JSPublicEvent) -> Void>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let handlerFuncRef = handler.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_JSPublicTarget_addInternalListener(selfValue, handlerFuncRef)
     if let error = _swift_js_take_exception() {
         throw error
@@ -236,8 +236,8 @@ fileprivate func bjs_JSPackageTarget_addPackageListener_extern(_ self: Int32, _ 
 }
 
 func _$JSPackageTarget_addPackageListener(_ self: JSObject, _ handler: JSTypedClosure<(JSPackageEvent) -> Void>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let handlerFuncRef = handler.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_JSPackageTarget_addPackageListener(selfValue, handlerFuncRef)
     if let error = _swift_js_take_exception() {
         throw error
@@ -257,8 +257,8 @@ fileprivate func bjs_JSInternalTarget_addInternalListener_extern(_ self: Int32, 
 }
 
 func _$JSInternalTarget_addInternalListener(_ self: JSObject, _ handler: JSTypedClosure<(JSInternalEvent) -> Void>) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let handlerFuncRef = handler.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_JSInternalTarget_addInternalListener(selfValue, handlerFuncRef)
     if let error = _swift_js_take_exception() {
         throw error

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.d.ts
@@ -9,6 +9,8 @@ export type Exports = {
 export type Imports = {
     roundtrip(items: number[]): number[];
     logStrings(items: string[]): void;
+    optionalArrayThenArray(a: number[] | null, b: number[]): number;
+    borrowedStringAroundStackParams(s: string, a: number[] | null, b: number[]): number;
 }
 export function createInstantiator(options: {
     imports: Imports;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
@@ -247,6 +247,85 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
+            TestModule["bjs_optionalArrayThenArray"] = function bjs_optionalArrayThenArray(a) {
+                try {
+                    let optResult;
+                    if (a) {
+                        const arrayLen = i32Stack.pop();
+                        let arrayResult;
+                        if (arrayLen === -1) {
+                            arrayResult = taStack.pop();
+                        } else {
+                            arrayResult = [];
+                            for (let i = 0; i < arrayLen; i++) {
+                                const int = i32Stack.pop();
+                                arrayResult.push(int);
+                            }
+                            arrayResult.reverse();
+                        }
+                        optResult = arrayResult;
+                    } else {
+                        optResult = null;
+                    }
+                    const arrayLen1 = i32Stack.pop();
+                    let arrayResult1;
+                    if (arrayLen1 === -1) {
+                        arrayResult1 = taStack.pop();
+                    } else {
+                        arrayResult1 = [];
+                        for (let i1 = 0; i1 < arrayLen1; i1++) {
+                            const int1 = i32Stack.pop();
+                            arrayResult1.push(int1);
+                        }
+                        arrayResult1.reverse();
+                    }
+                    let ret = imports.optionalArrayThenArray(optResult, arrayResult1);
+                    return ret;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            TestModule["bjs_borrowedStringAroundStackParams"] = function bjs_borrowedStringAroundStackParams(sBytes, sCount, a) {
+                try {
+                    const string = decodeString(sBytes, sCount);
+                    let optResult;
+                    if (a) {
+                        const arrayLen = i32Stack.pop();
+                        let arrayResult;
+                        if (arrayLen === -1) {
+                            arrayResult = taStack.pop();
+                        } else {
+                            arrayResult = [];
+                            for (let i = 0; i < arrayLen; i++) {
+                                const int = i32Stack.pop();
+                                arrayResult.push(int);
+                            }
+                            arrayResult.reverse();
+                        }
+                        optResult = arrayResult;
+                    } else {
+                        optResult = null;
+                    }
+                    const arrayLen1 = i32Stack.pop();
+                    let arrayResult1;
+                    if (arrayLen1 === -1) {
+                        arrayResult1 = taStack.pop();
+                    } else {
+                        arrayResult1 = [];
+                        for (let i1 = 0; i1 < arrayLen1; i1++) {
+                            const int1 = i32Stack.pop();
+                            arrayResult1.push(int1);
+                        }
+                        arrayResult1.reverse();
+                    }
+                    let ret = imports.borrowedStringAroundStackParams(string, optResult, arrayResult1);
+                    return ret;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
         },
         setInstance: (i) => {
             instance = i;

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -37,8 +37,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests10HttpStatusO_Si {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si(callbackValue, param0Value)
             return Int.bridgeJSLiftReturn(ret)
             #else
@@ -100,8 +100,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessor
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0ObjectId = (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP(callbackValue, param0ObjectId)
             return AnyDataProcessor.bridgeJSLiftReturn(ret)
             #else
@@ -163,8 +163,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests13DataProcessorP_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0ObjectId = (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS(callbackValue, param0ObjectId)
             return String.bridgeJSLiftReturn(ret)
             #else
@@ -226,8 +226,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests5ThemeO_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS(callbackValue, param0Bytes, param0Length)
                 return ret
             }
@@ -292,8 +292,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests5ThemeO_Sb {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb(callbackValue, param0Bytes, param0Length)
                 return ret
             }
@@ -358,8 +358,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests7GreeterC_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Pointer = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS(callbackValue, param0Pointer)
             return String.bridgeJSLiftReturn(ret)
             #else
@@ -421,8 +421,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests8JSObjectC_8JSObjectC {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests8JSObjectC_8JSObjectC(callbackValue, param0Value)
             return JSObject.bridgeJSLiftReturn(ret)
             #else
@@ -484,8 +484,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests9APIResultO_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0CaseId = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS(callbackValue, param0CaseId)
             return String.bridgeJSLiftReturn(ret)
             #else
@@ -547,8 +547,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests9DirectionO_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS(callbackValue, param0Value)
             return String.bridgeJSLiftReturn(ret)
             #else
@@ -610,8 +610,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests9DirectionO_Sb {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb(callbackValue, param0Value)
             return Bool.bridgeJSLiftReturn(ret)
             #else
@@ -673,8 +673,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsAl7Polygon_Si {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Pointer = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si(callbackValue, param0Pointer)
             return Int.bridgeJSLiftReturn(ret)
             #else
@@ -736,8 +736,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsKSS_Sb {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] (param0: String) throws(JSException) -> Bool in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(callbackValue, param0Bytes, param0Length)
                 return ret
             }
@@ -819,8 +819,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsKSS_Si {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] (param0: String) throws(JSException) -> Int in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(callbackValue, param0Bytes, param0Length)
                 return ret
             }
@@ -902,8 +902,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSS_7GreeterC {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC(callbackValue, param0Bytes, param0Length)
                 return ret
             }
@@ -968,8 +968,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSS_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_SS(callbackValue, param0Bytes, param0Length)
                 return ret
             }
@@ -1034,8 +1034,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSd_8Vector2DV {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV(callbackValue, param0Value)
             return Vector2D.bridgeJSLiftReturn()
             #else
@@ -1097,8 +1097,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSd_Sd {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sd(callbackValue, param0Value)
             return Double.bridgeJSLiftReturn(ret)
             #else
@@ -1160,8 +1160,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSd_Sq8Vector2DV {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV(callbackValue, param0Value)
             return Optional<Vector2D>.bridgeJSLiftReturn()
             #else
@@ -1223,10 +1223,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSiSSSd_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] (param0, param1, param2) in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0Value = param0.bridgeJSLowerParameter()
             let ret0 = param1.bridgeJSWithLoweredParameter { (param1Bytes, param1Length) in
                 let param2Value = param2.bridgeJSLowerParameter()
+                let param0Value = param0.bridgeJSLowerParameter()
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSiSSSd_SS(callbackValue, param0Value, param1Bytes, param1Length, param2Value)
                 return ret
             }
@@ -1291,10 +1291,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSiSiSi_Si {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] (param0, param1, param2) in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0Value = param0.bridgeJSLowerParameter()
-            let param1Value = param1.bridgeJSLowerParameter()
             let param2Value = param2.bridgeJSLowerParameter()
+            let param1Value = param1.bridgeJSLowerParameter()
+            let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSiSiSi_Si(callbackValue, param0Value, param1Value, param2Value)
             return Int.bridgeJSLiftReturn(ret)
             #else
@@ -1356,9 +1356,9 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSiSi_Si {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] (param0, param1) in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0Value = param0.bridgeJSLowerParameter()
             let param1Value = param1.bridgeJSLowerParameter()
+            let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSiSi_Si(callbackValue, param0Value, param1Value)
             return Int.bridgeJSLiftReturn(ret)
             #else
@@ -1420,8 +1420,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSi_Si {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSi_Si(callbackValue, param0Value)
             return Int.bridgeJSLiftReturn(ret)
             #else
@@ -1483,8 +1483,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSi_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSi_y(callbackValue, param0Value)
             #else
             fatalError("Only available on WebAssembly")
@@ -1544,13 +1544,13 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSq13DataProcessorP_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0ObjectId): (Int32, Int32)
             if let param0 {
                 (param0IsSome, param0ObjectId) = (1, (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
             } else {
                 (param0IsSome, param0ObjectId) = (0, 0)
             }
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS(callbackValue, param0IsSome, param0ObjectId)
             return String.bridgeJSLiftReturn(ret)
             #else
@@ -1612,8 +1612,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSq5ThemeO_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0IsSome, param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS(callbackValue, param0IsSome, param0Bytes, param0Length)
                 return ret
             }
@@ -1678,8 +1678,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSq7GreeterC_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Pointer) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS(callbackValue, param0IsSome, param0Pointer)
             return String.bridgeJSLiftReturn(ret)
             #else
@@ -1741,8 +1741,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Pointer) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC(callbackValue, param0IsSome, param0Pointer)
             return Optional<Greeter>.bridgeJSLiftReturn(ret)
             #else
@@ -1804,8 +1804,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSq9APIResultO_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0CaseId) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS(callbackValue, param0IsSome, param0CaseId)
             return String.bridgeJSLiftReturn(ret)
             #else
@@ -1867,8 +1867,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSq9DirectionO_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS(callbackValue, param0IsSome, param0Value)
             return String.bridgeJSLiftReturn(ret)
             #else
@@ -1930,8 +1930,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSqSS_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0IsSome, param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSqSS_SS(callbackValue, param0IsSome, param0Bytes, param0Length)
                 return ret
             }
@@ -1996,8 +1996,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSqSi_SS {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSqSi_SS(callbackValue, param0IsSome, param0Value)
             return String.bridgeJSLiftReturn(ret)
             #else
@@ -2064,8 +2064,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSS_SS {
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
                 param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    let callbackValue = callback.bridgeJSLowerParameter()
                     invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
                 }
             }
@@ -2135,8 +2135,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSS_y {
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
                 param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    let callbackValue = callback.bridgeJSLowerParameter()
                     invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
                 }
             }
@@ -2205,8 +2205,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO {
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
                 let param0Value = param0.bridgeJSLowerParameter()
+                let callbackValue = callback.bridgeJSLowerParameter()
                 invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(resolveRef, rejectRef, callbackValue, param0Value)
             }
             return resolved
@@ -2275,8 +2275,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsYaSS_SS {
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
                 param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    let callbackValue = callback.bridgeJSLowerParameter()
                     invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
                 }
             }
@@ -2346,8 +2346,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsYaSd_9DataPointV {
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
-                let callbackValue = callback.bridgeJSLowerParameter()
                 let param0Value = param0.bridgeJSLowerParameter()
+                let callbackValue = callback.bridgeJSLowerParameter()
                 invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(resolveRef, rejectRef, callbackValue, param0Value)
             }
             return resolved
@@ -2411,8 +2411,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestss11FeatureFlagO_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y(callbackValue, param0Bytes, param0Length)
             }
             #else
@@ -2473,8 +2473,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestss11WeatherDataC_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11WeatherDataC_y(callbackValue, param0Value)
             #else
             fatalError("Only available on WebAssembly")
@@ -2534,8 +2534,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0CaseId = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(callbackValue, param0CaseId)
             #else
             fatalError("Only available on WebAssembly")
@@ -2595,8 +2595,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0CaseId = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(callbackValue, param0CaseId)
             #else
             fatalError("Only available on WebAssembly")
@@ -2656,8 +2656,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestss7JSValueV_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0Kind, param0Payload1, param0Payload2) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss7JSValueV_y(callbackValue, param0Kind, param0Payload1, param0Payload2)
             #else
             fatalError("Only available on WebAssembly")
@@ -2717,8 +2717,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestss9DataPointV_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let _ = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(callbackValue)
             #else
             fatalError("Only available on WebAssembly")
@@ -2778,8 +2778,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestssSS_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSS_y(callbackValue, param0Bytes, param0Length)
             }
             #else
@@ -2840,8 +2840,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestssSaSS_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let _ = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSaSS_y(callbackValue)
             #else
             fatalError("Only available on WebAssembly")
@@ -2901,8 +2901,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestssSaSb_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let _ = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSaSb_y(callbackValue)
             #else
             fatalError("Only available on WebAssembly")
@@ -2962,8 +2962,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestssSaSd_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let _ = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSaSd_y(callbackValue)
             #else
             fatalError("Only available on WebAssembly")
@@ -3023,8 +3023,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestssSb_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSb_y(callbackValue, param0Value)
             #else
             fatalError("Only available on WebAssembly")
@@ -3084,8 +3084,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestssSd_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSd_y(callbackValue, param0Value)
             #else
             fatalError("Only available on WebAssembly")
@@ -3145,8 +3145,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0CaseId) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(callbackValue, param0IsSome, param0CaseId)
             #else
             fatalError("Only available on WebAssembly")
@@ -3206,8 +3206,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestssSqSS_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             param0.bridgeJSWithLoweredParameter { (param0IsSome, param0Bytes, param0Length) in
+                let callbackValue = callback.bridgeJSLowerParameter()
                 invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSqSS_y(callbackValue, param0IsSome, param0Bytes, param0Length)
             }
             #else
@@ -3268,8 +3268,8 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestssSqSd_y {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
+            let callbackValue = callback.bridgeJSLowerParameter()
             invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSqSd_y(callbackValue, param0IsSome, param0Value)
             #else
             fatalError("Only available on WebAssembly")
@@ -3556,8 +3556,8 @@ struct AnyArrayElementProtocol: ArrayElementProtocol, _BridgedSwiftProtocolWrapp
             return Int.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let newValueValue = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_ArrayElementProtocol_value_set(jsObjectValue, newValueValue)
         }
     }
@@ -3595,8 +3595,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
     let jsObject: JSObject
 
     func increment(by amount: Int) -> Void {
-        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let amountValue = amount.bridgeJSLowerParameter()
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         _extern_increment(jsObjectValue, amountValue)
     }
 
@@ -3607,9 +3607,9 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
     }
 
     func setLabelElements(_ labelPrefix: String, _ labelSuffix: String) -> Void {
-        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         labelPrefix.bridgeJSWithLoweredParameter { (labelPrefixBytes, labelPrefixLength) in
             labelSuffix.bridgeJSWithLoweredParameter { (labelSuffixBytes, labelSuffixLength) in
+                let jsObjectValue = jsObject.bridgeJSLowerParameter()
                 _extern_setLabelElements(jsObjectValue, labelPrefixBytes, labelPrefixLength, labelSuffixBytes, labelSuffixLength)
             }
         }
@@ -3628,8 +3628,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
     }
 
     func processGreeter(_ greeter: Greeter) -> String {
-        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let greeterPointer = greeter.bridgeJSLowerParameter()
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_processGreeter(jsObjectValue, greeterPointer)
         return String.bridgeJSLiftReturn(ret)
     }
@@ -3641,8 +3641,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
     }
 
     func processOptionalGreeter(_ greeter: Optional<Greeter>) -> String {
-        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let (greeterIsSome, greeterPointer) = greeter.bridgeJSLowerParameter()
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_processOptionalGreeter(jsObjectValue, greeterIsSome, greeterPointer)
         return String.bridgeJSLiftReturn(ret)
     }
@@ -3654,8 +3654,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
     }
 
     func handleAPIResult(_ result: Optional<APIResult>) -> Void {
-        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let (resultIsSome, resultCaseId) = result.bridgeJSLowerParameter()
+        let jsObjectValue = jsObject.bridgeJSLowerParameter()
         _extern_handleAPIResult(jsObjectValue, resultIsSome, resultCaseId)
     }
 
@@ -3672,8 +3672,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
             return Int.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let newValueValue = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_count_set(jsObjectValue, newValueValue)
         }
     }
@@ -3693,8 +3693,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
             return Optional<String>.bridgeJSLiftReturnFromSideChannel()
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             newValue.bridgeJSWithLoweredParameter { (newValueIsSome, newValueBytes, newValueLength) in
+                let jsObjectValue = jsObject.bridgeJSLowerParameter()
                 bjs_DataProcessor_optionalTag_set(jsObjectValue, newValueIsSome, newValueBytes, newValueLength)
             }
         }
@@ -3707,8 +3707,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
             return Optional<Int>.bridgeJSLiftReturnFromSideChannel()
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_optionalCount_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
@@ -3720,8 +3720,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
             return Optional<Direction>.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_direction_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
@@ -3733,8 +3733,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
             return Optional<Theme>.bridgeJSLiftReturnFromSideChannel()
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             newValue.bridgeJSWithLoweredParameter { (newValueIsSome, newValueBytes, newValueLength) in
+                let jsObjectValue = jsObject.bridgeJSLowerParameter()
                 bjs_DataProcessor_optionalTheme_set(jsObjectValue, newValueIsSome, newValueBytes, newValueLength)
             }
         }
@@ -3747,8 +3747,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
             return Optional<HttpStatus>.bridgeJSLiftReturnFromSideChannel()
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let (newValueIsSome, newValueValue) = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_httpStatus_set(jsObjectValue, newValueIsSome, newValueValue)
         }
     }
@@ -3760,8 +3760,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
             return Optional<APIResult>.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let (newValueIsSome, newValueCaseId) = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_apiResult_set(jsObjectValue, newValueIsSome, newValueCaseId)
         }
     }
@@ -3773,8 +3773,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
             return Greeter.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let newValuePointer = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_helper_set(jsObjectValue, newValuePointer)
         }
     }
@@ -3786,8 +3786,8 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
             return Optional<Greeter>.bridgeJSLiftReturn(ret)
         }
         set {
-            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let (newValueIsSome, newValuePointer) = newValue.bridgeJSLowerParameter()
+            let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_optionalHelper_set(jsObjectValue, newValueIsSome, newValuePointer)
         }
     }
@@ -13349,8 +13349,8 @@ fileprivate func promise_reject_BridgeJSRuntimeTests_extern(_ promise: Int32, _ 
 }
 
 func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let (valueKind, valuePayload1, valuePayload2) = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_reject_BridgeJSRuntimeTests(promiseValue, valueKind, valuePayload1, valuePayload2)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13370,8 +13370,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_SS_extern(_ promise: Int32
 }
 
 func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        let promiseValue = promise.bridgeJSLowerParameter()
         promise_resolve_BridgeJSRuntimeTests_SS(promiseValue, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() { throw error }
@@ -13412,8 +13412,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_Si_extern(_ promise: Int32
 }
 
 func _$Promise_resolve_Si(_ promise: JSObject, _ value: Int) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_Si(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13433,8 +13433,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_Sf_extern(_ promise: Int32
 }
 
 func _$Promise_resolve_Sf(_ promise: JSObject, _ value: Float) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_Sf(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13454,8 +13454,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_Sd_extern(_ promise: Int32
 }
 
 func _$Promise_resolve_Sd(_ promise: JSObject, _ value: Double) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_Sd(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13475,8 +13475,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_Sb_extern(_ promise: Int32
 }
 
 func _$Promise_resolve_Sb(_ promise: JSObject, _ value: Bool) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_Sb(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13496,8 +13496,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(_ promise
 }
 
 func _$Promise_resolve_7GreeterC(_ promise: JSObject, _ value: Greeter) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valuePointer = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_7GreeterC(promiseValue, valuePointer)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13517,8 +13517,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_8JSObjectC_extern(_ promis
 }
 
 func _$Promise_resolve_8JSObjectC(_ promise: JSObject, _ value: JSObject) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_8JSObjectC(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13538,8 +13538,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(_ promise: 
 }
 
 func _$Promise_resolve_5ThemeO(_ promise: JSObject, _ value: Theme) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        let promiseValue = promise.bridgeJSLowerParameter()
         promise_resolve_BridgeJSRuntimeTests_5ThemeO(promiseValue, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() { throw error }
@@ -13560,8 +13560,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(_ promi
 }
 
 func _$Promise_resolve_9DirectionO(_ promise: JSObject, _ value: Direction) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_9DirectionO(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13581,8 +13581,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(_ promise
 }
 
 func _$Promise_resolve_Sq5ThemeO(_ promise: JSObject, _ value: Optional<Theme>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
+        let promiseValue = promise.bridgeJSLowerParameter()
         promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO(promiseValue, valueIsSome, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() { throw error }
@@ -13603,8 +13603,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(_ pro
 }
 
 func _$Promise_resolve_Sq9DirectionO(_ promise: JSObject, _ value: Optional<Direction>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO(promiseValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13624,8 +13624,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(_ pro
 }
 
 func _$Promise_resolve_Sa9DirectionO(_ promise: JSObject, _ value: [Direction]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13645,8 +13645,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(_ pro
 }
 
 func _$Promise_resolve_SD9DirectionO(_ promise: JSObject, _ value: [String: Direction]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_SD9DirectionO(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13666,8 +13666,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(_ promise
 }
 
 func _$Promise_resolve_Sa5ThemeO(_ promise: JSObject, _ value: [Theme]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13687,8 +13687,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(_ promise
 }
 
 func _$Promise_resolve_SD5ThemeO(_ promise: JSObject, _ value: [String: Theme]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_SD5ThemeO(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13708,8 +13708,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(_ promis
 }
 
 func _$Promise_resolve_8FileSizeO(_ promise: JSObject, _ value: FileSize) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_8FileSizeO(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13729,8 +13729,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(_ prom
 }
 
 func _$Promise_resolve_Sq8FileSizeO(_ promise: JSObject, _ value: Optional<FileSize>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO(promiseValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13750,8 +13750,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO_exte
 }
 
 func _$Promise_resolve_18AsyncPayloadResultO(_ promise: JSObject, _ value: AsyncPayloadResult) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueCaseId = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO(promiseValue, valueCaseId)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13771,8 +13771,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO_ex
 }
 
 func _$Promise_resolve_Sq18AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<AsyncPayloadResult>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let (valueIsSome, valueCaseId) = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO(promiseValue, valueIsSome, valueCaseId)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13792,8 +13792,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(_ pr
 }
 
 func _$Promise_resolve_11PublicPointV(_ promise: JSObject, _ value: PublicPoint) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueObjectId = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_11PublicPointV(promiseValue, valueObjectId)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13813,8 +13813,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(_ promise
 }
 
 func _$Promise_resolve_7ContactV(_ promise: JSObject, _ value: Contact) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueObjectId = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_7ContactV(promiseValue, valueObjectId)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13834,8 +13834,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(_ 
 }
 
 func _$Promise_resolve_Sa11PublicPointV(_ promise: JSObject, _ value: [PublicPoint]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13855,8 +13855,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ 
 }
 
 func _$Promise_resolve_Sq11PublicPointV(_ promise: JSObject, _ value: Optional<PublicPoint>) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueIsSome = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(promiseValue, valueIsSome)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13876,8 +13876,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(_ 
 }
 
 func _$Promise_resolve_SD11PublicPointV(_ promise: JSObject, _ value: [String: PublicPoint]) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -13897,8 +13897,8 @@ fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(_ promi
 }
 
 func _$Promise_resolve_9DataPointV(_ promise: JSObject, _ value: DataPoint) throws(JSException) -> Void {
-    let promiseValue = promise.bridgeJSLowerParameter()
     let valueObjectId = value.bridgeJSLowerParameter()
+    let promiseValue = promise.bridgeJSLowerParameter()
     promise_resolve_BridgeJSRuntimeTests_9DataPointV(promiseValue, valueObjectId)
     if let error = _swift_js_take_exception() { throw error }
 }
@@ -15087,8 +15087,8 @@ func _$ClosureSupportImports_jsApplyBool(_ callback: JSTypedClosure<() -> Bool>)
 }
 
 func _$ClosureSupportImports_jsApplyInt(_ value: Int, _ transform: JSTypedClosure<(Int) -> Int>) throws(JSException) -> Int {
-    let valueValue = value.bridgeJSLowerParameter()
     let transformFuncRef = transform.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
     let ret = bjs_ClosureSupportImports_jsApplyInt_static(valueValue, transformFuncRef)
     if let error = _swift_js_take_exception() {
         throw error
@@ -15097,8 +15097,8 @@ func _$ClosureSupportImports_jsApplyInt(_ value: Int, _ transform: JSTypedClosur
 }
 
 func _$ClosureSupportImports_jsApplyDouble(_ value: Double, _ transform: JSTypedClosure<(Double) -> Double>) throws(JSException) -> Double {
-    let valueValue = value.bridgeJSLowerParameter()
     let transformFuncRef = transform.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
     let ret = bjs_ClosureSupportImports_jsApplyDouble_static(valueValue, transformFuncRef)
     if let error = _swift_js_take_exception() {
         throw error
@@ -15120,8 +15120,8 @@ func _$ClosureSupportImports_jsApplyString(_ value: String, _ transform: JSTyped
 }
 
 func _$ClosureSupportImports_jsApplyJSObject(_ value: JSObject, _ transform: JSTypedClosure<(JSObject) -> JSObject>) throws(JSException) -> JSObject {
-    let valueValue = value.bridgeJSLowerParameter()
     let transformFuncRef = transform.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
     let ret = bjs_ClosureSupportImports_jsApplyJSObject_static(valueValue, transformFuncRef)
     if let error = _swift_js_take_exception() {
         throw error
@@ -15160,8 +15160,8 @@ func _$ClosureSupportImports_jsMakeStringToString(_ prefix: String) throws(JSExc
 }
 
 func _$ClosureSupportImports_jsCallTwice(_ value: Int, _ callback: JSTypedClosure<(Int) -> Void>) throws(JSException) -> Int {
-    let valueValue = value.bridgeJSLowerParameter()
     let callbackFuncRef = callback.bridgeJSLowerParameter()
+    let valueValue = value.bridgeJSLowerParameter()
     let ret = bjs_ClosureSupportImports_jsCallTwice_static(valueValue, callbackFuncRef)
     if let error = _swift_js_take_exception() {
         throw error
@@ -15874,8 +15874,8 @@ func _$JsGreeter_prefix_get(_ self: JSObject) throws(JSException) -> String {
 }
 
 func _$JsGreeter_name_set(_ self: JSObject, _ newValue: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     newValue.bridgeJSWithLoweredParameter { (newValueBytes, newValueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_JsGreeter_name_set(selfValue, newValueBytes, newValueLength)
     }
     if let error = _swift_js_take_exception() {
@@ -15893,8 +15893,8 @@ func _$JsGreeter_greet(_ self: JSObject) throws(JSException) -> String {
 }
 
 func _$JsGreeter_changeName(_ self: JSObject, _ name: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     name.bridgeJSWithLoweredParameter { (nameBytes, nameLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_JsGreeter_changeName(selfValue, nameBytes, nameLength)
     }
     if let error = _swift_js_take_exception() {
@@ -16002,8 +16002,8 @@ func _$WeatherData_humidity_get(_ self: JSObject) throws(JSException) -> Double 
 }
 
 func _$WeatherData_temperature_set(_ self: JSObject, _ newValue: Double) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let newValueValue = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WeatherData_temperature_set(selfValue, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -16011,8 +16011,8 @@ func _$WeatherData_temperature_set(_ self: JSObject, _ newValue: Double) throws(
 }
 
 func _$WeatherData_description_set(_ self: JSObject, _ newValue: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     newValue.bridgeJSWithLoweredParameter { (newValueBytes, newValueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_WeatherData_description_set(selfValue, newValueBytes, newValueLength)
     }
     if let error = _swift_js_take_exception() {
@@ -16021,8 +16021,8 @@ func _$WeatherData_description_set(_ self: JSObject, _ newValue: String) throws(
 }
 
 func _$WeatherData_humidity_set(_ self: JSObject, _ newValue: Double) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let newValueValue = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_WeatherData_humidity_set(selfValue, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -16303,8 +16303,8 @@ fileprivate func bjs_Animal_getIsCat_extern(_ self: Int32) -> Int32 {
 
 func _$Animal_init(_ name: String, _ age: Double, _ isCat: Bool) throws(JSException) -> JSObject {
     let ret0 = name.bridgeJSWithLoweredParameter { (nameBytes, nameLength) in
-        let ageValue = age.bridgeJSLowerParameter()
         let isCatValue = isCat.bridgeJSLowerParameter()
+        let ageValue = age.bridgeJSLowerParameter()
         let ret = bjs_Animal_init(nameBytes, nameLength, ageValue, isCatValue)
         return ret
     }
@@ -16343,8 +16343,8 @@ func _$Animal_isCat_get(_ self: JSObject) throws(JSException) -> Bool {
 }
 
 func _$Animal_name_set(_ self: JSObject, _ newValue: String) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     newValue.bridgeJSWithLoweredParameter { (newValueBytes, newValueLength) in
+        let selfValue = self.bridgeJSLowerParameter()
         bjs_Animal_name_set(selfValue, newValueBytes, newValueLength)
     }
     if let error = _swift_js_take_exception() {
@@ -16353,8 +16353,8 @@ func _$Animal_name_set(_ self: JSObject, _ newValue: String) throws(JSException)
 }
 
 func _$Animal_age_set(_ self: JSObject, _ newValue: Double) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let newValueValue = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_Animal_age_set(selfValue, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -16362,8 +16362,8 @@ func _$Animal_age_set(_ self: JSObject, _ newValue: Double) throws(JSException) 
 }
 
 func _$Animal_isCat_set(_ self: JSObject, _ newValue: Bool) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let newValueValue = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_Animal_isCat_set(selfValue, newValueValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -16452,6 +16452,98 @@ func _$jsRoundTripOptionalImportedPayloadSignal(_ value: Optional<ImportedPayloa
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsJoinOptionalArrayThenArray")
+fileprivate func bjs_jsJoinOptionalArrayThenArray_extern(_ a: Int32) -> Int32
+#else
+fileprivate func bjs_jsJoinOptionalArrayThenArray_extern(_ a: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsJoinOptionalArrayThenArray(_ a: Int32) -> Int32 {
+    return bjs_jsJoinOptionalArrayThenArray_extern(a)
+}
+
+func _$jsJoinOptionalArrayThenArray(_ a: Optional<[Int]>, _ b: [Int]) throws(JSException) -> String {
+    let _ = b.bridgeJSLowerParameter()
+    let aIsSome = a.bridgeJSLowerParameter()
+    let ret = bjs_jsJoinOptionalArrayThenArray(aIsSome)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return String.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsJoinOptionalStructThenArray")
+fileprivate func bjs_jsJoinOptionalStructThenArray_extern(_ a: Int32) -> Int32
+#else
+fileprivate func bjs_jsJoinOptionalStructThenArray_extern(_ a: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsJoinOptionalStructThenArray(_ a: Int32) -> Int32 {
+    return bjs_jsJoinOptionalStructThenArray_extern(a)
+}
+
+func _$jsJoinOptionalStructThenArray(_ a: Optional<Point>, _ b: [Int]) throws(JSException) -> String {
+    let _ = b.bridgeJSLowerParameter()
+    let aIsSome = a.bridgeJSLowerParameter()
+    let ret = bjs_jsJoinOptionalStructThenArray(aIsSome)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return String.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsJoinEnumThenArray")
+fileprivate func bjs_jsJoinEnumThenArray_extern(_ a: Int32) -> Int32
+#else
+fileprivate func bjs_jsJoinEnumThenArray_extern(_ a: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsJoinEnumThenArray(_ a: Int32) -> Int32 {
+    return bjs_jsJoinEnumThenArray_extern(a)
+}
+
+func _$jsJoinEnumThenArray(_ a: ImportedPayloadSignal, _ b: [Int]) throws(JSException) -> String {
+    let _ = b.bridgeJSLowerParameter()
+    let aCaseId = a.bridgeJSLowerParameter()
+    let ret = bjs_jsJoinEnumThenArray(aCaseId)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return String.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsJoinStringThenStackParams")
+fileprivate func bjs_jsJoinStringThenStackParams_extern(_ sBytes: Int32, _ sLength: Int32, _ a: Int32) -> Int32
+#else
+fileprivate func bjs_jsJoinStringThenStackParams_extern(_ sBytes: Int32, _ sLength: Int32, _ a: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_jsJoinStringThenStackParams(_ sBytes: Int32, _ sLength: Int32, _ a: Int32) -> Int32 {
+    return bjs_jsJoinStringThenStackParams_extern(sBytes, sLength, a)
+}
+
+func _$jsJoinStringThenStackParams(_ s: String, _ a: Optional<[Int]>, _ b: [Int]) throws(JSException) -> String {
+    let ret0 = s.bridgeJSWithLoweredParameter { (sBytes, sLength) in
+        let _ = b.bridgeJSLowerParameter()
+        let aIsSome = a.bridgeJSLowerParameter()
+        let ret = bjs_jsJoinStringThenStackParams(sBytes, sLength, aIsSome)
+        return ret
+    }
+    let ret = ret0
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return String.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsTranslatePoint")
 fileprivate func bjs_jsTranslatePoint_extern(_ point: Int32, _ dx: Int32, _ dy: Int32) -> Int32
 #else
@@ -16464,9 +16556,9 @@ fileprivate func bjs_jsTranslatePoint_extern(_ point: Int32, _ dx: Int32, _ dy: 
 }
 
 func _$jsTranslatePoint(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException) -> Point {
-    let pointObjectId = point.bridgeJSLowerParameter()
-    let dxValue = dx.bridgeJSLowerParameter()
     let dyValue = dy.bridgeJSLowerParameter()
+    let dxValue = dx.bridgeJSLowerParameter()
+    let pointObjectId = point.bridgeJSLowerParameter()
     let ret = bjs_jsTranslatePoint(pointObjectId, dxValue, dyValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -16849,8 +16941,8 @@ func _$JSClassWithArrayMembers_labels_get(_ self: JSObject) throws(JSException) 
 }
 
 func _$JSClassWithArrayMembers_numbers_set(_ self: JSObject, _ newValue: [Int]) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let _ = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_JSClassWithArrayMembers_numbers_set(selfValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -16858,8 +16950,8 @@ func _$JSClassWithArrayMembers_numbers_set(_ self: JSObject, _ newValue: [Int]) 
 }
 
 func _$JSClassWithArrayMembers_labels_set(_ self: JSObject, _ newValue: [String]) throws(JSException) -> Void {
-    let selfValue = self.bridgeJSLowerParameter()
     let _ = newValue.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_JSClassWithArrayMembers_labels_set(selfValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -16867,8 +16959,8 @@ func _$JSClassWithArrayMembers_labels_set(_ self: JSObject, _ newValue: [String]
 }
 
 func _$JSClassWithArrayMembers_concatNumbers(_ self: JSObject, _ values: [Int]) throws(JSException) -> [Int] {
-    let selfValue = self.bridgeJSLowerParameter()
     let _ = values.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_JSClassWithArrayMembers_concatNumbers(selfValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -16877,8 +16969,8 @@ func _$JSClassWithArrayMembers_concatNumbers(_ self: JSObject, _ values: [Int]) 
 }
 
 func _$JSClassWithArrayMembers_concatLabels(_ self: JSObject, _ values: [String]) throws(JSException) -> [String] {
-    let selfValue = self.bridgeJSLowerParameter()
     let _ = values.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     bjs_JSClassWithArrayMembers_concatLabels(selfValue)
     if let error = _swift_js_take_exception() {
         throw error
@@ -16887,8 +16979,8 @@ func _$JSClassWithArrayMembers_concatLabels(_ self: JSObject, _ values: [String]
 }
 
 func _$JSClassWithArrayMembers_firstLabel(_ self: JSObject, _ values: [String]) throws(JSException) -> String {
-    let selfValue = self.bridgeJSLowerParameter()
     let _ = values.bridgeJSLowerParameter()
+    let selfValue = self.bridgeJSLowerParameter()
     let ret = bjs_JSClassWithArrayMembers_firstLabel(selfValue)
     if let error = _swift_js_take_exception() {
         throw error

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -23281,6 +23281,199 @@
                 "_1" : "null"
               }
             }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "jsJoinOptionalArrayThenArray",
+            "parameters" : [
+              {
+                "name" : "a",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "array" : {
+                        "_0" : {
+                          "integer" : {
+                            "_0" : {
+                              "isSigned" : true,
+                              "width" : "word"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              },
+              {
+                "name" : "b",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "integer" : {
+                        "_0" : {
+                          "isSigned" : true,
+                          "width" : "word"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "jsJoinOptionalStructThenArray",
+            "parameters" : [
+              {
+                "name" : "a",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "swiftStruct" : {
+                        "_0" : "Point"
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              },
+              {
+                "name" : "b",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "integer" : {
+                        "_0" : {
+                          "isSigned" : true,
+                          "width" : "word"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "jsJoinEnumThenArray",
+            "parameters" : [
+              {
+                "name" : "a",
+                "type" : {
+                  "associatedValueEnum" : {
+                    "_0" : "ImportedPayloadSignal"
+                  }
+                }
+              },
+              {
+                "name" : "b",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "integer" : {
+                        "_0" : {
+                          "isSigned" : true,
+                          "width" : "word"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "accessLevel" : "internal",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : true
+            },
+            "name" : "jsJoinStringThenStackParams",
+            "parameters" : [
+              {
+                "name" : "s",
+                "type" : {
+                  "string" : {
+
+                  }
+                }
+              },
+              {
+                "name" : "a",
+                "type" : {
+                  "nullable" : {
+                    "_0" : {
+                      "array" : {
+                        "_0" : {
+                          "integer" : {
+                            "_0" : {
+                              "isSigned" : true,
+                              "width" : "word"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "_1" : "null"
+                  }
+                }
+              },
+              {
+                "name" : "b",
+                "type" : {
+                  "array" : {
+                    "_0" : {
+                      "integer" : {
+                        "_0" : {
+                          "isSigned" : true,
+                          "width" : "word"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
           }
         ],
         "types" : [

--- a/Tests/BridgeJSRuntimeTests/ImportAPITests.swift
+++ b/Tests/BridgeJSRuntimeTests/ImportAPITests.swift
@@ -21,6 +21,16 @@ import JavaScriptKit
     _ value: ImportedPayloadSignal?
 ) throws(JSException) -> ImportedPayloadSignal?
 
+// Parameters that push onto the shared stacks must arrive in declaration order.
+@JSFunction func jsJoinOptionalArrayThenArray(_ a: [Int]?, _ b: [Int]) throws(JSException) -> String
+@JSFunction func jsJoinOptionalStructThenArray(_ a: Point?, _ b: [Int]) throws(JSException) -> String
+@JSFunction func jsJoinEnumThenArray(_ a: ImportedPayloadSignal, _ b: [Int]) throws(JSException) -> String
+@JSFunction func jsJoinStringThenStackParams(
+    _ s: String,
+    _ a: [Int]?,
+    _ b: [Int]
+) throws(JSException) -> String
+
 class ImportAPITests: XCTestCase {
     func testRoundTripVoid() throws {
         try jsRoundTripVoid()
@@ -183,5 +193,22 @@ class ImportAPITests: XCTestCase {
 
         let dashed = try StaticBox.with_dashes()
         XCTAssertEqual(try dashed.value(), 7)
+    }
+
+    func testStackLoweredParameterOrder() throws {
+        XCTAssertEqual(try jsJoinOptionalArrayThenArray([1, 2], [7, 8, 9]), "[1,2]|[7,8,9]")
+        XCTAssertEqual(try jsJoinOptionalArrayThenArray(nil, [7, 8, 9]), "null|[7,8,9]")
+        XCTAssertEqual(
+            try jsJoinOptionalStructThenArray(Point(x: 1, y: 2), [7, 8, 9]),
+            #"{"x":1,"y":2}|[7,8,9]"#
+        )
+        XCTAssertEqual(
+            try jsJoinEnumThenArray(.stop(5), [7, 8, 9]),
+            #"{"tag":1,"param0":5}|[7,8,9]"#
+        )
+        XCTAssertEqual(
+            try jsJoinStringThenStackParams("s", [1, 2], [7, 8, 9]),
+            #""s"|[1,2]|[7,8,9]"#
+        )
     }
 }

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -46,6 +46,8 @@ export async function setupOptions(options, context) {
         }
     }
 
+    const joinStackParams = (...args) => args.map((v) => JSON.stringify(v)).join("|");
+
     return {
         ...options,
         getImports: (importsContext) => {
@@ -155,6 +157,10 @@ export async function setupOptions(options, context) {
                     return { x: (point.x | 0) + (dx | 0), y: (point.y | 0) + (dy | 0) };
                 },
                 jsRoundTripOptionalPoint: (point) => point,
+                jsJoinOptionalArrayThenArray: joinStackParams,
+                jsJoinOptionalStructThenArray: joinStackParams,
+                jsJoinEnumThenArray: joinStackParams,
+                jsJoinStringThenStackParams: joinStackParams,
                 roundTripArrayMembers: (value) => {
                     return value;
                 },


### PR DESCRIPTION
## Overview

Imported parameters that push onto the shared value stacks are lowered in reverse declaration order, because the JavaScript side pops them in declaration order and the stacks are LIFO. `CallJSEmission` selected that bucket with `loweredParameters.isEmpty`, which is wrong for a parameter that does both: an optional container passes an `isSome` discriminator as a wasm parameter *and* its payload on the stack, so it was emitted in forward order ahead of everything in the reversed bucket.

Combining one with any other stack-lowered parameter therefore transposed the arguments. With `[String: V]?`, a `@JS struct?`, or a `@JS` enum with associated values it is worse than a transposition: the array codec reads the other parameter's scalar as an element count and builds a garbage-length array.

Every parameter is now lowered into `stackLoweringStmts` in reverse declaration order, so there is one order rather than two and no per-type judgement to keep in sync. The JavaScript side is unchanged, and the 21 changed snapshots are a pure reordering of independent scalar lowerings.

### Before / after

```swift
@JSFunction func f(_ a: [Int]?, _ b: [Int]) throws(JSException) -> Int

f([1, 2], [7, 8, 9])   // before: JavaScript received f([7, 8, 9], [1, 2])
```

```swift
// before — a's payload is pushed first, so JS pops it as b
let aIsSome = a.bridgeJSLowerParameter()
let _ = b.bridgeJSLowerParameter()

// after
let _ = b.bridgeJSLowerParameter()
let aIsSome = a.bridgeJSLowerParameter()
```
