### PR TITLE
BridgeJS: Add runtime test for instance method String returns on a struct

### DIFF
--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -7861,6 +7861,17 @@ public func _bjs_Vector2D_scaled(_ factor: Float64) -> Void {
     #endif
 }
 
+@_expose(wasm, "bjs_Vector2D_describe")
+@_cdecl("bjs_Vector2D_describe")
+public func _bjs_Vector2D_describe() -> Void {
+    #if arch(wasm32)
+    let ret = Vector2D.bridgeJSLiftParameter().describe()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 extension JSObjectContainer: _BridgedSwiftStruct {
     @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> JSObjectContainer {
         let optionalObject = Optional<JSObject>.bridgeJSStackPop()

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -19680,6 +19680,23 @@
                 "_0" : "Vector2D"
               }
             }
+          },
+          {
+            "abiName" : "bjs_Vector2D_describe",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "name" : "describe",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
           }
         ],
         "name" : "Vector2D",

--- a/Tests/BridgeJSRuntimeTests/StructAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/StructAPIs.swift
@@ -200,6 +200,10 @@ extension Vector2D {
     @JS func scaled(by factor: Double) -> Vector2D {
         return Vector2D(dx: dx * factor, dy: dy * factor)
     }
+
+    @JS func describe() -> String {
+        return "Vector2D(\(dx), \(dy))"
+    }
 }
 
 @JS func roundTripDataPoint(_ data: DataPoint) -> DataPoint {

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -871,6 +871,7 @@ function testStructSupport(exports) {
     const scaled = vec.scaled(2.0);
     assert.equal(scaled.dx, 6.0);
     assert.equal(scaled.dy, 8.0);
+    assert.equal(vec.describe(), "Vector2D(3.0, 4.0)");
 
     const publicPoint = { x: 9, y: -3 };
     assert.deepEqual(exports.roundTripPublicPoint(publicPoint), publicPoint);


### PR DESCRIPTION
Follow up to https://github.com/swiftwasm/JavaScriptKit/pull/789 to address @kateinoigakukun’s comment