### PR TITLE
BridgeJS: Export with a different JS name

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -731,6 +731,23 @@ public final class SwiftToSkeleton {
         return String(name.dropFirst().dropLast())
     }
 
+    fileprivate static func isValidJSIdentifier(_ name: String) -> Bool {
+        func isIdentifierPart(_ scalar: Unicode.Scalar, isStart: Bool) -> Bool {
+            switch scalar {
+            case "a"..."z", "A"..."Z", "_", "$":
+                return true
+            case "0"..."9":
+                return !isStart
+            default:
+                return false
+            }
+        }
+        guard let first = name.unicodeScalars.first, isIdentifierPart(first, isStart: true) else {
+            return false
+        }
+        return name.unicodeScalars.dropFirst().allSatisfy { isIdentifierPart($0, isStart: false) }
+    }
+
 }
 
 private enum ExportSwiftConstants {
@@ -1291,6 +1308,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         }
 
         let name = node.name.text
+        let jsName = extractValidatedJSName(from: jsAttribute)
 
         let attributeNamespace = extractNamespace(from: jsAttribute)
         let computedNamespace = computeNamespace(for: node)
@@ -1378,7 +1396,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             classNameForABI = nil
         }
         abiName = ABINameGenerator.generateABIName(
-            baseName: name,
+            baseName: jsName ?? name,
             namespace: finalNamespace,
             staticContext: isStatic ? staticContext : nil,
             className: classNameForABI
@@ -1390,6 +1408,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
 
         return ExportedFunction(
             name: name,
+            jsName: jsName,
             abiName: abiName,
             parameters: parameters,
             returnType: returnType,
@@ -1469,6 +1488,45 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         return Effects(isAsync: isAsync, isThrows: isThrows, isStatic: isStatic)
     }
 
+    private func extractJSName(
+        from jsAttribute: AttributeSyntax
+    ) -> String? {
+        guard let arguments = jsAttribute.arguments?.as(LabeledExprListSyntax.self),
+            let nameArg = arguments.first,
+            nameArg.label == nil,
+            let stringLiteral = nameArg.expression.as(StringLiteralExprSyntax.self),
+            stringLiteral.segments.count == 1,
+            let name = stringLiteral.segments.first?.as(StringSegmentSyntax.self)?.content.text
+        else {
+            return nil
+        }
+        return name
+    }
+
+    private func extractValidatedJSName(
+        from jsAttribute: AttributeSyntax
+    ) -> String? {
+        guard let jsName = extractJSName(from: jsAttribute) else { return nil }
+        guard SwiftToSkeleton.isValidJSIdentifier(jsName) else {
+            diagnose(
+                node: jsAttribute,
+                message: "`\(jsName)` is not a valid JavaScript identifier"
+            )
+            return nil
+        }
+        return jsName
+    }
+
+    private func diagnoseUnsupportedJSName(
+        from jsAttribute: AttributeSyntax
+    ) {
+        guard extractJSName(from: jsAttribute) != nil else { return }
+        diagnose(
+            node: jsAttribute,
+            message: "A separate name for JavaScript is not supported here"
+        )
+    }
+
     private func extractNamespace(
         from jsAttribute: AttributeSyntax
     ) -> [String]? {
@@ -1514,6 +1572,8 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
 
     override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
         guard let jsAttribute = node.attributes.firstJSAttribute else { return .skipChildren }
+
+        diagnoseUnsupportedJSName(from: jsAttribute)
 
         switch state {
         case .classBody(_, let classKey):
@@ -1636,6 +1696,15 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             }
         }
 
+        let jsName = extractValidatedJSName(from: jsAttribute)
+        if jsName != nil, node.bindings.count > 1 {
+            diagnose(
+                node: jsAttribute,
+                message: "Name targets declaration with multiple bindings",
+                hint: "Declare each property with a different JS name separately"
+            )
+        }
+
         // Process each binding (variable declaration)
         for binding in node.bindings {
             guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self) else {
@@ -1663,6 +1732,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
 
             let exportedProperty = ExportedProperty(
                 name: propertyName,
+                jsName: jsName,
                 type: propertyType,
                 isReadonly: isReadonly,
                 isStatic: isStatic,
@@ -1692,6 +1762,8 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         guard let jsAttribute = node.attributes.firstJSAttribute else {
             return .skipChildren
         }
+
+        diagnoseUnsupportedJSName(from: jsAttribute)
 
         if let aliasTarget = parent.extractAliasTarget(from: jsAttribute) {
             recordAlias(node: node, jsAttribute: jsAttribute, aliasTarget: aliasTarget)
@@ -1843,6 +1915,8 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             return .skipChildren
         }
 
+        diagnoseUnsupportedJSName(from: jsAttribute)
+
         if let aliasTarget = parent.extractAliasTarget(from: jsAttribute) {
             recordAlias(node: node, jsAttribute: jsAttribute, aliasTarget: aliasTarget)
             return .skipChildren
@@ -1968,6 +2042,8 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             return .skipChildren
         }
 
+        diagnoseUnsupportedJSName(from: jsAttribute)
+
         let name = node.name.text
 
         let namespaceResult = resolveNamespace(from: jsAttribute, for: node, declarationType: "protocol")
@@ -2030,6 +2106,8 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         guard let jsAttribute = node.attributes.firstJSAttribute else {
             return .skipChildren
         }
+
+        diagnoseUnsupportedJSName(from: jsAttribute)
 
         if let aliasTarget = parent.extractAliasTarget(from: jsAttribute) {
             recordAlias(node: node, jsAttribute: jsAttribute, aliasTarget: aliasTarget)
@@ -2169,6 +2247,10 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         protocolName: String,
         namespace: [String]?
     ) -> ExportedFunction? {
+        if let jsAttribute = node.attributes.firstJSAttribute {
+            diagnoseUnsupportedJSName(from: jsAttribute)
+        }
+
         let name = node.name.text
 
         let parameters = parseParameters(from: node.signature.parameterClause, allowDefaults: false)
@@ -2215,6 +2297,10 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         protocolName: String,
         protocolKey: String
     ) -> SyntaxVisitorContinueKind {
+        if let jsAttribute = node.attributes.firstJSAttribute {
+            diagnoseUnsupportedJSName(from: jsAttribute)
+        }
+
         for binding in node.bindings {
             guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self) else {
                 diagnose(node: binding.pattern, message: "Complex patterns not supported for protocol properties")

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -235,7 +235,7 @@ public struct BridgeJSLink {
             for function in skeleton.functions {
                 if function.namespace == nil {
                     var (js, dts) = try renderExportedFunction(function: function)
-                    js[0] = "\(function.name): " + js[0]
+                    js[0] = "\(function.resolvedJSName): " + js[0]
                     js[js.count - 1] += ","
                     data.exportsLines.append(contentsOf: js)
                     data.dtsExportLines.append(contentsOf: dts)
@@ -973,13 +973,15 @@ public struct BridgeJSLink {
                                 )
                             )
                             printer.write(
-                                "\(function.name)\(renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
+                                "\(function.resolvedJSName)\(renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
                             )
                         }
                         for property in enumDefinition.staticProperties {
                             let readonly = property.isReadonly ? "readonly " : ""
                             printer.write(lines: renderJSDoc(documentation: property.documentation, parameters: []))
-                            printer.write("\(readonly)\(property.name): \(resolveTypeScriptType(property.type));")
+                            printer.write(
+                                "\(readonly)\(property.resolvedJSName): \(resolveTypeScriptType(property.type));"
+                            )
                         }
                     }
                     printer.write("};")
@@ -1025,13 +1027,13 @@ public struct BridgeJSLink {
             renderFunctionEntry: { function in
                 self.renderJSDoc(documentation: function.documentation, parameters: function.parameters)
                     + [
-                        "\(function.name)\(self.renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
+                        "\(function.resolvedJSName)\(self.renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
                     ]
             },
             renderPropertyEntry: { property in
                 let readonly = property.isReadonly ? "readonly " : ""
                 return self.renderJSDoc(documentation: property.documentation, parameters: [])
-                    + ["\(readonly)\(property.name): \(property.type.tsType);"]
+                    + ["\(readonly)\(property.resolvedJSName): \(property.type.tsType);"]
             }
         )
         printer.write("export type Exports = {")
@@ -1370,7 +1372,7 @@ public struct BridgeJSLink {
 
                     // Add methods
                     for method in type.methods {
-                        let methodName = method.jsName ?? method.name
+                        let methodName = method.resolvedJSName
                         let methodSignature =
                             "\(renderTSPropertyName(methodName))\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
                         printer.write(methodSignature)
@@ -1379,9 +1381,9 @@ public struct BridgeJSLink {
                     // Add properties from getters
                     var propertyNames = Set<String>()
                     for getter in type.getters {
-                        let propertyName = getter.jsName ?? getter.name
+                        let propertyName = getter.resolvedJSName
                         propertyNames.insert(propertyName)
-                        let hasSetter = type.setters.contains { ($0.jsName ?? $0.name) == propertyName }
+                        let hasSetter = type.setters.contains { $0.resolvedJSName == propertyName }
                         let propertySignature =
                             hasSetter
                             ? "\(renderTSPropertyName(propertyName)): \(resolveTypeScriptType(getter.type));"
@@ -1390,7 +1392,7 @@ public struct BridgeJSLink {
                     }
                     // Add setters that don't have corresponding getters
                     for setter in type.setters {
-                        let propertyName = setter.jsName ?? setter.name
+                        let propertyName = setter.resolvedJSName
                         guard !propertyNames.contains(propertyName) else { continue }
                         printer.write("\(renderTSPropertyName(propertyName)): \(resolveTypeScriptType(setter.type));")
                     }
@@ -1628,7 +1630,7 @@ public struct BridgeJSLink {
                     returnType: method.returnType,
                     effects: method.effects
                 )
-                dtsTypePrinter.write("\(method.name)\(signature);")
+                dtsTypePrinter.write("\(method.resolvedJSName)\(signature);")
             }
         }
         dtsTypePrinter.write("}")
@@ -1649,13 +1651,15 @@ public struct BridgeJSLink {
         for property in structDefinition.properties where property.isStatic {
             let readonly = property.isReadonly ? "readonly " : ""
             dtsExportEntryPrinter.write(lines: renderJSDoc(documentation: property.documentation, parameters: []))
-            dtsExportEntryPrinter.write("\(readonly)\(property.name): \(resolveTypeScriptType(property.type));")
+            dtsExportEntryPrinter.write(
+                "\(readonly)\(property.resolvedJSName): \(resolveTypeScriptType(property.type));"
+            )
         }
         for method in structDefinition.methods where method.effects.isStatic {
             let jsDocLines = renderJSDoc(documentation: method.documentation, parameters: method.parameters)
             dtsExportEntryPrinter.write(lines: jsDocLines)
             dtsExportEntryPrinter.write(
-                "\(method.name)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
+                "\(method.resolvedJSName)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
             )
         }
 
@@ -1914,7 +1918,7 @@ extension BridgeJSLink {
         dtsLines.append(contentsOf: renderJSDoc(documentation: function.documentation, parameters: function.parameters))
 
         dtsLines.append(
-            "\(function.name)\(renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
+            "\(function.resolvedJSName)\(renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
         )
 
         return (funcLines, dtsLines)
@@ -1955,7 +1959,7 @@ extension BridgeJSLink {
         let returnExpr = try thunkBuilder.call(abiName: function.abiName, returnType: function.returnType)
 
         let funcLines = thunkBuilder.renderFunction(
-            name: function.name,
+            name: function.resolvedJSName,
             parameters: function.parameters,
             returnExpr: returnExpr,
             declarationPrefixKeyword: "static"
@@ -1966,7 +1970,7 @@ extension BridgeJSLink {
         dtsLines.append(contentsOf: renderJSDoc(documentation: function.documentation, parameters: function.parameters))
 
         dtsLines.append(
-            "static \(function.name)\(renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
+            "static \(function.resolvedJSName)\(renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
         )
 
         return (funcLines, dtsLines)
@@ -1986,7 +1990,7 @@ extension BridgeJSLink {
         let returnExpr = try thunkBuilder.call(abiName: function.abiName, returnType: function.returnType)
 
         let printer = CodeFragmentPrinter()
-        printer.write("\(function.name)(\(DefaultValueUtils.formatParameterList(function.parameters))) {")
+        printer.write("\(function.resolvedJSName)(\(DefaultValueUtils.formatParameterList(function.parameters))) {")
         printer.indent {
             thunkBuilder.renderFunctionBody(into: printer, returnExpr: returnExpr)
         }
@@ -1997,7 +2001,7 @@ extension BridgeJSLink {
         dtsLines.append(contentsOf: renderJSDoc(documentation: function.documentation, parameters: function.parameters))
 
         dtsLines.append(
-            "\(function.name)\(renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
+            "\(function.resolvedJSName)\(renderTSSignature(parameters: function.parameters, returnType: function.returnType, effects: function.effects));"
         )
 
         return (printer.lines, dtsLines)
@@ -2043,7 +2047,7 @@ extension BridgeJSLink {
 
         let methodPrinter = CodeFragmentPrinter()
         methodPrinter.write(
-            "\(method.name): function(\(DefaultValueUtils.formatParameterList(method.parameters))) {"
+            "\(method.resolvedJSName): function(\(DefaultValueUtils.formatParameterList(method.parameters))) {"
         )
         methodPrinter.indent {
             thunkBuilder.renderFunctionBody(into: methodPrinter, returnExpr: returnExpr)
@@ -2071,7 +2075,7 @@ extension BridgeJSLink {
             returnType: property.type
         )
 
-        propertyPrinter.write("get \(property.name)() {")
+        propertyPrinter.write("get \(property.resolvedJSName)() {")
         propertyPrinter.indent {
             getterThunkBuilder.renderFunctionBody(into: propertyPrinter, returnExpr: getterReturnExpr)
         }
@@ -2093,7 +2097,7 @@ extension BridgeJSLink {
                 returnType: .void
             )
 
-            propertyPrinter.write("set \(property.name)(value) {")
+            propertyPrinter.write("set \(property.resolvedJSName)(value) {")
             propertyPrinter.indent {
                 setterThunkBuilder.renderFunctionBody(into: propertyPrinter, returnExpr: nil)
             }
@@ -2177,7 +2181,7 @@ extension BridgeJSLink {
                 jsPrinter.indent {
                     jsPrinter.write(
                         lines: thunkBuilder.renderFunction(
-                            name: method.name,
+                            name: method.resolvedJSName,
                             parameters: method.parameters,
                             returnExpr: returnExpr,
                             declarationPrefixKeyword: "static"
@@ -2198,7 +2202,7 @@ extension BridgeJSLink {
                 jsPrinter.indent {
                     jsPrinter.write(
                         lines: thunkBuilder.renderFunction(
-                            name: method.name,
+                            name: method.resolvedJSName,
                             parameters: method.parameters,
                             returnExpr: returnExpr,
                             declarationPrefixKeyword: nil
@@ -2214,7 +2218,7 @@ extension BridgeJSLink {
                         dtsTypePrinter.write(line)
                     }
                     dtsTypePrinter.write(
-                        "\(method.name)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
+                        "\(method.resolvedJSName)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
                     )
                 }
             }
@@ -2252,13 +2256,13 @@ extension BridgeJSLink {
         for method in klass.methods where method.effects.isStatic {
             printer.write(lines: renderJSDoc(documentation: method.documentation, parameters: method.parameters))
             printer.write(
-                "\(method.name)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
+                "\(method.resolvedJSName)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
             )
         }
         for property in klass.properties where property.isStatic {
             let readonly = property.isReadonly ? "readonly " : ""
             printer.write(lines: renderJSDoc(documentation: property.documentation, parameters: []))
-            printer.write("\(readonly)\(property.name): \(resolveTypeScriptType(property.type));")
+            printer.write("\(readonly)\(property.resolvedJSName): \(resolveTypeScriptType(property.type));")
         }
         return printer.lines
     }
@@ -2280,18 +2284,20 @@ extension BridgeJSLink {
                 )
                 printer.write("constructor(\(paramSignatures.joined(separator: ", ")));")
             }
-            for method in klass.methods.sorted(by: { $0.name < $1.name }) {
+            for method in klass.methods.sorted(by: { $0.resolvedJSName < $1.resolvedJSName }) {
                 let staticKeyword = method.effects.isStatic ? "static " : ""
                 printer.write(lines: renderJSDoc(documentation: method.documentation, parameters: method.parameters))
                 printer.write(
-                    "\(staticKeyword)\(method.name)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
+                    "\(staticKeyword)\(method.resolvedJSName)\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
                 )
             }
-            for property in klass.properties.sorted(by: { $0.name < $1.name }) {
+            for property in klass.properties.sorted(by: { $0.resolvedJSName < $1.resolvedJSName }) {
                 let staticKeyword = property.isStatic ? "static " : ""
                 let readonly = property.isReadonly ? "readonly " : ""
                 printer.write(lines: renderJSDoc(documentation: property.documentation, parameters: []))
-                printer.write("\(staticKeyword)\(readonly)\(property.name): \(resolveTypeScriptType(property.type));")
+                printer.write(
+                    "\(staticKeyword)\(readonly)\(property.resolvedJSName): \(resolveTypeScriptType(property.type));"
+                )
             }
             printer.write("release(): void;")
         }
@@ -2321,7 +2327,7 @@ extension BridgeJSLink {
         jsPrinter.indent {
             jsPrinter.write(
                 lines: getterThunkBuilder.renderFunction(
-                    name: property.name,
+                    name: property.resolvedJSName,
                     parameters: [],
                     returnExpr: getterReturnExpr,
                     declarationPrefixKeyword: getterKeyword
@@ -2349,7 +2355,7 @@ extension BridgeJSLink {
             jsPrinter.indent {
                 jsPrinter.write(
                     lines: setterThunkBuilder.renderFunction(
-                        name: property.name,
+                        name: property.resolvedJSName,
                         parameters: [.init(label: nil, name: "value", type: property.type)],
                         returnExpr: nil,
                         declarationPrefixKeyword: setterKeyword
@@ -2365,7 +2371,7 @@ extension BridgeJSLink {
                 for line in renderJSDoc(documentation: property.documentation, parameters: []) {
                     dtsPrinter.write(line)
                 }
-                dtsPrinter.write("\(readonly)\(property.name): \(resolveTypeScriptType(property.type));")
+                dtsPrinter.write("\(readonly)\(property.resolvedJSName): \(resolveTypeScriptType(property.type));")
             }
         }
     }
@@ -2738,7 +2744,7 @@ extension BridgeJSLink {
                 for function in skeleton.functions where function.namespace != nil {
                     let namespacePath = function.namespace!.joined(separator: ".")
                     printer.write(
-                        "globalThis.\(namespacePath).\(function.name) = exports.\(namespacePath).\(function.name);"
+                        "globalThis.\(namespacePath).\(function.resolvedJSName) = exports.\(namespacePath).\(function.resolvedJSName);"
                     )
                 }
                 for enumDef in skeleton.enums where enumDef.enumType == .namespace {
@@ -2746,7 +2752,7 @@ extension BridgeJSLink {
                         let fullNamespace = (enumDef.namespace ?? []) + [enumDef.name]
                         let namespacePath = fullNamespace.joined(separator: ".")
                         printer.write(
-                            "globalThis.\(namespacePath).\(function.name) = exports.\(namespacePath).\(function.name);"
+                            "globalThis.\(namespacePath).\(function.resolvedJSName) = exports.\(namespacePath).\(function.resolvedJSName);"
                         )
                     }
                     for property in enumDef.staticProperties {
@@ -2754,11 +2760,13 @@ extension BridgeJSLink {
                         let namespacePath = fullNamespace.joined(separator: ".")
                         let exportsPath = "exports.\(namespacePath)"
 
-                        printer.write("Object.defineProperty(globalThis.\(namespacePath), '\(property.name)', {")
+                        printer.write(
+                            "Object.defineProperty(globalThis.\(namespacePath), '\(property.resolvedJSName)', {"
+                        )
                         printer.indent {
-                            printer.write("get: () => \(exportsPath).\(property.name),")
+                            printer.write("get: () => \(exportsPath).\(property.resolvedJSName),")
                             if !property.isReadonly {
-                                printer.write("set: (value) => { \(exportsPath).\(property.name) = value; }")
+                                printer.write("set: (value) => { \(exportsPath).\(property.resolvedJSName) = value; }")
                             }
                         }
                         printer.write("});")
@@ -2940,7 +2948,7 @@ extension BridgeJSLink {
             renderPropertyEntry: (ExportedProperty) -> [String]
         ) {
             for function in node.content.functions {
-                node.content.functionDtsLines.append((function.name, renderFunctionEntry(function)))
+                node.content.functionDtsLines.append((function.resolvedJSName, renderFunctionEntry(function)))
             }
 
             switch node.content.declaration {
@@ -2953,7 +2961,7 @@ extension BridgeJSLink {
             }
 
             for property in node.content.staticProperties {
-                node.content.staticPropertyDtsLines.append((property.name, renderPropertyEntry(property)))
+                node.content.staticPropertyDtsLines.append((property.resolvedJSName, renderPropertyEntry(property)))
             }
 
             for enumDef in node.content.enums {
@@ -3005,7 +3013,7 @@ extension BridgeJSLink {
         ) throws {
             for function in node.content.functions {
                 let impl = try renderFunctionImpl(function)
-                node.content.functionJsLines.append((function.name, impl))
+                node.content.functionJsLines.append((function.resolvedJSName, impl))
             }
 
             switch node.content.declaration {
@@ -3039,7 +3047,7 @@ extension BridgeJSLink {
                 )
 
                 let getterPrinter = CodeFragmentPrinter()
-                getterPrinter.write("get \(property.name)() {")
+                getterPrinter.write("get \(property.resolvedJSName)() {")
                 getterPrinter.indent {
                     getterPrinter.write(contentsOf: getterThunkBuilder.body)
                     getterPrinter.write(lines: getterThunkBuilder.checkExceptionLines())
@@ -3066,7 +3074,7 @@ extension BridgeJSLink {
                     )
 
                     let setterPrinter = CodeFragmentPrinter()
-                    setterPrinter.write("set \(property.name)(value) {")
+                    setterPrinter.write("set \(property.resolvedJSName)(value) {")
                     setterPrinter.indent {
                         setterPrinter.write(contentsOf: setterThunkBuilder.body)
                         setterPrinter.write(lines: setterThunkBuilder.checkExceptionLines())
@@ -3431,18 +3439,22 @@ extension BridgeJSLink {
 
                     // Only include functions and properties when exposeToGlobal is true
                     if exposeToGlobal {
-                        let sortedFunctions = childNode.content.functions.sorted { $0.name < $1.name }
+                        let sortedFunctions = childNode.content.functions.sorted {
+                            $0.resolvedJSName < $1.resolvedJSName
+                        }
                         for function in sortedFunctions {
                             let signature =
-                                "function \(function.name)\(renderTSSignatureCallback(function.parameters, function.returnType, function.effects));"
+                                "function \(function.resolvedJSName)\(renderTSSignatureCallback(function.parameters, function.returnType, function.effects));"
                             printer.write(lines: renderDocCallback(function.documentation, function.parameters))
                             printer.write(signature)
                         }
-                        let sortedProperties = childNode.content.staticProperties.sorted { $0.name < $1.name }
+                        let sortedProperties = childNode.content.staticProperties.sorted {
+                            $0.resolvedJSName < $1.resolvedJSName
+                        }
                         for property in sortedProperties {
                             let readonly = property.isReadonly ? "var " : "let "
                             printer.write(lines: renderDocCallback(property.documentation, []))
-                            printer.write("\(readonly)\(property.name): \(property.type.tsType);")
+                            printer.write("\(readonly)\(property.resolvedJSName): \(property.type.tsType);")
                         }
                     }
 
@@ -3479,7 +3491,7 @@ extension BridgeJSLink {
         for param in function.parameters {
             try thunkBuilder.liftParameter(param: param)
         }
-        let jsName = function.jsName ?? function.name
+        let jsName = function.resolvedJSName
         let calleeExpr = try importedModuleRegistry.memberExpression(
             swiftModuleName: importObjectBuilder.moduleName,
             from: function.from,
@@ -3507,7 +3519,7 @@ extension BridgeJSLink {
             returnType: getter.type,
             intrinsicRegistry: intrinsicRegistry
         )
-        let jsName = getter.jsName ?? getter.name
+        let jsName = getter.resolvedJSName
         let accessExpr = try importedModuleRegistry.memberExpression(
             swiftModuleName: importObjectBuilder.moduleName,
             from: getter.from,
@@ -3542,7 +3554,7 @@ extension BridgeJSLink {
                 getter: getter,
                 abiName: getterAbiName,
                 emitCall: { thunkBuilder in
-                    return try thunkBuilder.callPropertyGetter(name: getter.jsName ?? getter.name)
+                    return try thunkBuilder.callPropertyGetter(name: getter.resolvedJSName)
                 }
             )
             importObjectBuilder.assignToImportObject(name: getterAbiName, function: js)
@@ -3558,7 +3570,7 @@ extension BridgeJSLink {
                     try thunkBuilder.liftParameter(
                         param: Parameter(label: nil, name: "newValue", type: setter.type)
                     )
-                    thunkBuilder.callPropertySetter(name: setter.jsName ?? setter.name)
+                    thunkBuilder.callPropertySetter(name: setter.resolvedJSName)
                 }
             )
             importObjectBuilder.assignToImportObject(name: setterAbiName, function: js)
@@ -3585,7 +3597,7 @@ extension BridgeJSLink {
                     )
                 }
                 for method in type.staticMethods {
-                    let methodName = method.jsName ?? method.name
+                    let methodName = method.resolvedJSName
                     let signature =
                         "\(renderTSPropertyName(methodName))\(renderTSSignature(parameters: method.parameters, returnType: method.returnType, effects: method.effects));"
                     dtsPrinter.write(signature)
@@ -3617,7 +3629,7 @@ extension BridgeJSLink {
         let ctorExpr = try importedModuleRegistry.memberExpression(
             swiftModuleName: importObjectBuilder.moduleName,
             from: type.from,
-            memberName: type.jsName ?? type.name
+            memberName: type.resolvedJSName
         )
         try thunkBuilder.callConstructor(
             ctorExpr: ctorExpr,
@@ -3676,10 +3688,10 @@ extension BridgeJSLink {
         let constructorExpr = try importedModuleRegistry.memberExpression(
             swiftModuleName: swiftModuleName,
             from: context.from,
-            memberName: context.jsName ?? context.name
+            memberName: context.resolvedJSName
         )
 
-        try thunkBuilder.callStaticMethod(on: constructorExpr, name: method.jsName ?? method.name)
+        try thunkBuilder.callStaticMethod(on: constructorExpr, name: method.resolvedJSName)
         let funcLines = thunkBuilder.renderFunction(name: method.abiName(context: context, operation: "static"))
         return (funcLines, [])
     }
@@ -3698,7 +3710,7 @@ extension BridgeJSLink {
             try thunkBuilder.liftParameter(param: param)
         }
 
-        try thunkBuilder.callMethod(name: method.jsName ?? method.name)
+        try thunkBuilder.callMethod(name: method.resolvedJSName)
         let funcLines = thunkBuilder.renderFunction(name: method.abiName(context: context))
         return (funcLines, [])
     }

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/ImportedJSModuleRegistry.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/ImportedJSModuleRegistry.swift
@@ -133,14 +133,14 @@ final class ImportedJSModuleRegistry {
         }
         for file in skeleton.imported?.children ?? [] {
             for function in file.functions {
-                visit(from: function.from, memberName: function.jsName ?? function.name)
+                visit(from: function.from, memberName: function.resolvedJSName)
             }
             for getter in file.globalGetters {
-                visit(from: getter.from, memberName: getter.jsName ?? getter.name)
+                visit(from: getter.from, memberName: getter.resolvedJSName)
             }
             for type in file.types {
                 guard type.constructor != nil || !type.staticMethods.isEmpty else { continue }
-                visit(from: type.from, memberName: type.jsName ?? type.name)
+                visit(from: type.from, memberName: type.resolvedJSName)
             }
         }
     }

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -2353,7 +2353,7 @@ struct IntrinsicJSFragment: Sendable {
             for method in structDef.methods where !method.effects.isStatic {
                 let paramList = DefaultValueUtils.formatParameterList(method.parameters)
                 printer.write(
-                    "\(instanceVar).\(method.name) = function(\(paramList)) {"
+                    "\(instanceVar).\(method.resolvedJSName) = function(\(paramList)) {"
                 )
                 try printer.indent {
                     printer.write(

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -861,6 +861,7 @@ public struct ExportedProtocol: Codable, Equatable {
 
 public struct ExportedFunction: Codable, Equatable, Sendable {
     public var name: String
+    public var jsName: String?
     public var abiName: String
     public var parameters: [Parameter]
     public var returnType: BridgeType
@@ -869,8 +870,11 @@ public struct ExportedFunction: Codable, Equatable, Sendable {
     public var staticContext: StaticContext?
     public var documentation: String?
 
+    public var resolvedJSName: String { jsName ?? name }
+
     public init(
         name: String,
+        jsName: String? = nil,
         abiName: String,
         parameters: [Parameter],
         returnType: BridgeType,
@@ -880,6 +884,7 @@ public struct ExportedFunction: Codable, Equatable, Sendable {
         documentation: String? = nil
     ) {
         self.name = name
+        self.jsName = jsName
         self.abiName = abiName
         self.parameters = parameters
         self.returnType = returnType
@@ -948,6 +953,7 @@ public struct ExportedConstructor: Codable, Equatable, Sendable {
 
 public struct ExportedProperty: Codable, Equatable, Sendable {
     public var name: String
+    public var jsName: String?
     public var type: BridgeType
     public var isReadonly: Bool
     public var isStatic: Bool
@@ -955,8 +961,11 @@ public struct ExportedProperty: Codable, Equatable, Sendable {
     public var staticContext: StaticContext?
     public var documentation: String?
 
+    public var resolvedJSName: String { jsName ?? name }
+
     public init(
         name: String,
+        jsName: String? = nil,
         type: BridgeType,
         isReadonly: Bool = false,
         isStatic: Bool = false,
@@ -965,6 +974,7 @@ public struct ExportedProperty: Codable, Equatable, Sendable {
         documentation: String? = nil
     ) {
         self.name = name
+        self.jsName = jsName
         self.type = type
         self.isReadonly = isReadonly
         self.isStatic = isStatic
@@ -1245,6 +1255,8 @@ public struct ImportedFunctionSkeleton: Codable {
     /// closure inits) that surface through this function's signature.
     public let accessLevel: BridgeJSAccessLevel
 
+    public var resolvedJSName: String { jsName ?? name }
+
     public init(
         name: String,
         jsName: String? = nil,
@@ -1336,6 +1348,8 @@ public struct ImportedGetterSkeleton: Codable {
     /// Source access level of the originating Swift declaration.
     public let accessLevel: BridgeJSAccessLevel
 
+    public var resolvedJSName: String { jsName ?? name }
+
     public init(
         name: String,
         jsName: String? = nil,
@@ -1395,6 +1409,8 @@ public struct ImportedSetterSkeleton: Codable {
     public let functionName: String?
     /// Source access level of the originating Swift declaration.
     public let accessLevel: BridgeJSAccessLevel
+
+    public var resolvedJSName: String { jsName ?? name }
 
     public init(
         name: String,
@@ -1457,6 +1473,8 @@ public struct ImportedTypeSkeleton: Codable {
     public let documentation: String?
     /// Source access level of the originating Swift `@JSClass` declaration.
     public let accessLevel: BridgeJSAccessLevel
+
+    public var resolvedJSName: String { jsName ?? name }
 
     public init(
         name: String,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
@@ -659,6 +659,87 @@ import Testing
     }
 
     @Test
+    func jsNameOnClassDiagnostic() throws {
+        let source = """
+            @JS("Renamed") class Box { @JS init() {} }
+            """
+        let diagnostics = try #require(moduleDiagnostics(source: source))
+        #expect(diagnostics.description.contains("A separate name for JavaScript is not supported here"))
+    }
+
+    @Test
+    func jsNameOnStructDiagnostic() throws {
+        let source = """
+            @JS("Renamed") struct Box { var x: Int }
+            """
+        let diagnostics = try #require(moduleDiagnostics(source: source))
+        #expect(diagnostics.description.contains("A separate name for JavaScript is not supported here"))
+    }
+
+    @Test
+    func jsNameOnEnumDiagnostic() throws {
+        let source = """
+            @JS("Renamed") enum Box { case a }
+            """
+        let diagnostics = try #require(moduleDiagnostics(source: source))
+        #expect(diagnostics.description.contains("A separate name for JavaScript is not supported here"))
+    }
+
+    @Test
+    func jsNameOnProtocolDiagnostic() throws {
+        let source = """
+            @JS("Renamed") protocol Box { func run() }
+            """
+        let diagnostics = try #require(moduleDiagnostics(source: source))
+        #expect(diagnostics.description.contains("A separate name for JavaScript is not supported here"))
+    }
+
+    @Test
+    func jsNameOnInitializerDiagnostic() throws {
+        let source = """
+            @JS class Box { @JS("create") init() {} }
+            """
+        let diagnostics = try #require(moduleDiagnostics(source: source))
+        #expect(diagnostics.description.contains("A separate name for JavaScript is not supported here"))
+    }
+
+    @Test
+    func jsNameOnProtocolRequirementDiagnostic() throws {
+        let source = """
+            @JS protocol Box { @JS("run") func run() }
+            """
+        let diagnostics = try #require(moduleDiagnostics(source: source))
+        #expect(diagnostics.description.contains("A separate name for JavaScript is not supported here"))
+    }
+
+    @Test
+    func invalidJSNameDiagnostic() throws {
+        let source = """
+            @JS("1notAnIdentifier") func a() -> Int { 42 }
+            @JS("has space") func b() -> Int { 42 }
+            @JS("has-dash") func c() -> Int { 42 }
+            @JS("") func d() -> Int { 42 }
+            """
+        let diagnostics = try #require(moduleDiagnostics(source: source))
+        #expect(diagnostics.description.contains("`1notAnIdentifier` is not a valid JavaScript identifier"))
+        #expect(diagnostics.description.contains("`has space` is not a valid JavaScript identifier"))
+        #expect(diagnostics.description.contains("`has-dash` is not a valid JavaScript identifier"))
+        #expect(diagnostics.description.contains("`` is not a valid JavaScript identifier"))
+    }
+
+    @Test
+    func jsNameOnMultipleBindingsDiagnostic() throws {
+        let source = """
+            @JS class Box {
+                @JS init() {}
+                @JS("renamed") var first: Int = 1, second: Int = 2
+            }
+            """
+        let diagnostics = try #require(moduleDiagnostics(source: source))
+        #expect(diagnostics.description.contains("Name targets declaration with multiple bindings"))
+    }
+
+    @Test
     func omitsNextLineWhenErrorIsOnLastLine() throws {
         let source = """
             preamble

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/JSNameOverride.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/JSNameOverride.swift
@@ -1,0 +1,40 @@
+@JS("makeGreeting") func renderGreeting(name: String) -> String
+
+@JS("greetName") func greet(_ name: String) -> String
+
+@JS("greetCount") func greet(_ count: Int) -> String
+
+@JS("namespacedRenamed", namespace: "Utils.Text") func namespacedFunction() -> Int
+
+@JS class RenamedMembers {
+    @JS("label") var title: String
+    @JS("total") let count: Int
+    @JS("sharedTotal") nonisolated(unsafe) static var sharedCount: Int = 0
+    @JS("readOnlyLimit") static let limit: Int = 10
+
+    @JS init(title: String, count: Int)
+    @JS("makeGreeting") func greet() -> String
+    @JS("makeDefault") static func createDefault() -> RenamedMembers
+}
+
+@JS struct RenamedVector {
+    var dx: Double
+    var dy: Double
+
+    @JS("originVector") static let origin: RenamedVector = RenamedVector(dx: 0, dy: 0)
+    @JS("magnitude") func length() -> Double
+    @JS("fromPolar") static func polar(radius: Double, angle: Double) -> RenamedVector
+}
+
+@JS enum RenamedEnumMembers {
+    case active
+    case inactive
+
+    @JS("describeCase") static func describe() -> String
+    @JS("currentDefault") nonisolated(unsafe) static var defaultValue: String = "active"
+}
+
+@JS enum RenamedNamespaceMembers {
+    @JS("plus") static func add(_ a: Int, _ b: Int) -> Int
+    @JS("theAnswer") nonisolated(unsafe) static var answer: Int = 42
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSNameOverride.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSNameOverride.json
@@ -1,0 +1,524 @@
+{
+  "exported" : {
+    "aliases" : [
+
+    ],
+    "classes" : [
+      {
+        "constructor" : {
+          "abiName" : "bjs_RenamedMembers_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "title",
+              "name" : "title",
+              "type" : {
+                "string" : {
+
+                }
+              }
+            },
+            {
+              "label" : "count",
+              "name" : "count",
+              "type" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+          {
+            "abiName" : "bjs_RenamedMembers_makeGreeting",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "jsName" : "makeGreeting",
+            "name" : "greet",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_RenamedMembers_static_makeDefault",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "jsName" : "makeDefault",
+            "name" : "createDefault",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "swiftHeapObject" : {
+                "_0" : "RenamedMembers"
+              }
+            },
+            "staticContext" : {
+              "className" : {
+                "_0" : "RenamedMembers"
+              }
+            }
+          }
+        ],
+        "name" : "RenamedMembers",
+        "properties" : [
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "jsName" : "label",
+            "name" : "title",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "jsName" : "total",
+            "name" : "count",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "isReadonly" : false,
+            "isStatic" : true,
+            "jsName" : "sharedTotal",
+            "name" : "sharedCount",
+            "staticContext" : {
+              "className" : {
+                "_0" : "RenamedMembers"
+              }
+            },
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : true,
+            "jsName" : "readOnlyLimit",
+            "name" : "limit",
+            "staticContext" : {
+              "className" : {
+                "_0" : "RenamedMembers"
+              }
+            },
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "RenamedMembers"
+      }
+    ],
+    "enums" : [
+      {
+        "cases" : [
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "active"
+          },
+          {
+            "associatedValues" : [
+
+            ],
+            "name" : "inactive"
+          }
+        ],
+        "emitStyle" : "const",
+        "name" : "RenamedEnumMembers",
+        "staticMethods" : [
+          {
+            "abiName" : "bjs_RenamedEnumMembers_static_describeCase",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "jsName" : "describeCase",
+            "name" : "describe",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "string" : {
+
+              }
+            },
+            "staticContext" : {
+              "enumName" : {
+                "_0" : "RenamedEnumMembers"
+              }
+            }
+          }
+        ],
+        "staticProperties" : [
+          {
+            "isReadonly" : false,
+            "isStatic" : true,
+            "jsName" : "currentDefault",
+            "name" : "defaultValue",
+            "staticContext" : {
+              "enumName" : {
+                "_0" : "RenamedEnumMembers"
+              }
+            },
+            "type" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "RenamedEnumMembers",
+        "tsFullPath" : "RenamedEnumMembers"
+      },
+      {
+        "cases" : [
+
+        ],
+        "emitStyle" : "const",
+        "name" : "RenamedNamespaceMembers",
+        "staticMethods" : [
+          {
+            "abiName" : "bjs_RenamedNamespaceMembers_static_plus",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "jsName" : "plus",
+            "name" : "add",
+            "namespace" : [
+              "RenamedNamespaceMembers"
+            ],
+            "parameters" : [
+              {
+                "label" : "_",
+                "name" : "a",
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              },
+              {
+                "label" : "_",
+                "name" : "b",
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            },
+            "staticContext" : {
+              "namespaceEnum" : {
+                "_0" : "RenamedNamespaceMembers"
+              }
+            }
+          }
+        ],
+        "staticProperties" : [
+          {
+            "isReadonly" : false,
+            "isStatic" : true,
+            "jsName" : "theAnswer",
+            "name" : "answer",
+            "namespace" : [
+              "RenamedNamespaceMembers"
+            ],
+            "staticContext" : {
+              "namespaceEnum" : {
+                "_0" : "RenamedNamespaceMembers"
+              }
+            },
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "RenamedNamespaceMembers",
+        "tsFullPath" : "RenamedNamespaceMembers"
+      }
+    ],
+    "exposeToGlobal" : false,
+    "functions" : [
+      {
+        "abiName" : "bjs_makeGreeting",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "jsName" : "makeGreeting",
+        "name" : "renderGreeting",
+        "parameters" : [
+          {
+            "label" : "name",
+            "name" : "name",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_greetName",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "jsName" : "greetName",
+        "name" : "greet",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "name",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_greetCount",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "jsName" : "greetCount",
+        "name" : "greet",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "count",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_Utils_Text_namespacedRenamed",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "jsName" : "namespacedRenamed",
+        "name" : "namespacedFunction",
+        "namespace" : [
+          "Utils",
+          "Text"
+        ],
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "integer" : {
+            "_0" : {
+              "isSigned" : true,
+              "width" : "word"
+            }
+          }
+        }
+      }
+    ],
+    "protocols" : [
+
+    ],
+    "structs" : [
+      {
+        "methods" : [
+          {
+            "abiName" : "bjs_RenamedVector_magnitude",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "jsName" : "magnitude",
+            "name" : "length",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "double" : {
+
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_RenamedVector_static_fromPolar",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "jsName" : "fromPolar",
+            "name" : "polar",
+            "parameters" : [
+              {
+                "label" : "radius",
+                "name" : "radius",
+                "type" : {
+                  "double" : {
+
+                  }
+                }
+              },
+              {
+                "label" : "angle",
+                "name" : "angle",
+                "type" : {
+                  "double" : {
+
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "swiftStruct" : {
+                "_0" : "RenamedVector"
+              }
+            },
+            "staticContext" : {
+              "structName" : {
+                "_0" : "RenamedVector"
+              }
+            }
+          }
+        ],
+        "name" : "RenamedVector",
+        "properties" : [
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "dx",
+            "type" : {
+              "double" : {
+
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : false,
+            "name" : "dy",
+            "type" : {
+              "double" : {
+
+              }
+            }
+          },
+          {
+            "isReadonly" : true,
+            "isStatic" : true,
+            "jsName" : "originVector",
+            "name" : "origin",
+            "staticContext" : {
+              "structName" : {
+                "_0" : "RenamedVector"
+              }
+            },
+            "type" : {
+              "swiftStruct" : {
+                "_0" : "RenamedVector"
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "RenamedVector"
+      }
+    ]
+  },
+  "moduleName" : "TestModule",
+  "usedExternalModules" : [
+
+  ]
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSNameOverride.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSNameOverride.swift
@@ -1,0 +1,351 @@
+extension RenamedEnumMembers: _BridgedSwiftCaseEnum {
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
+        return bridgeJSRawValue
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> RenamedEnumMembers {
+        return bridgeJSLiftParameter(value)
+    }
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> RenamedEnumMembers {
+        return RenamedEnumMembers(bridgeJSRawValue: value)!
+    }
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
+        return bridgeJSLowerParameter()
+    }
+
+    @_spi(BridgeJS) @usableFromInline init?(bridgeJSRawValue: Int32) {
+        switch bridgeJSRawValue {
+        case 0:
+            self = .active
+        case 1:
+            self = .inactive
+        default:
+            return nil
+        }
+    }
+
+    @_spi(BridgeJS) @usableFromInline var bridgeJSRawValue: Int32 {
+        switch self {
+        case .active:
+            return 0
+        case .inactive:
+            return 1
+        }
+    }
+}
+
+@_expose(wasm, "bjs_RenamedEnumMembers_static_describeCase")
+@_cdecl("bjs_RenamedEnumMembers_static_describeCase")
+public func _bjs_RenamedEnumMembers_static_describeCase() -> Void {
+    #if arch(wasm32)
+    let ret = RenamedEnumMembers.describe()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedEnumMembers_static_defaultValue_get")
+@_cdecl("bjs_RenamedEnumMembers_static_defaultValue_get")
+public func _bjs_RenamedEnumMembers_static_defaultValue_get() -> Void {
+    #if arch(wasm32)
+    let ret = RenamedEnumMembers.defaultValue
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedEnumMembers_static_defaultValue_set")
+@_cdecl("bjs_RenamedEnumMembers_static_defaultValue_set")
+public func _bjs_RenamedEnumMembers_static_defaultValue_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    #if arch(wasm32)
+    RenamedEnumMembers.defaultValue = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedNamespaceMembers_static_plus")
+@_cdecl("bjs_RenamedNamespaceMembers_static_plus")
+public func _bjs_RenamedNamespaceMembers_static_plus(_ a: Int32, _ b: Int32) -> Int32 {
+    #if arch(wasm32)
+    let ret = RenamedNamespaceMembers.add(_: Int.bridgeJSLiftParameter(a), _: Int.bridgeJSLiftParameter(b))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedNamespaceMembers_static_answer_get")
+@_cdecl("bjs_RenamedNamespaceMembers_static_answer_get")
+public func _bjs_RenamedNamespaceMembers_static_answer_get() -> Int32 {
+    #if arch(wasm32)
+    let ret = RenamedNamespaceMembers.answer
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedNamespaceMembers_static_answer_set")
+@_cdecl("bjs_RenamedNamespaceMembers_static_answer_set")
+public func _bjs_RenamedNamespaceMembers_static_answer_set(_ value: Int32) -> Void {
+    #if arch(wasm32)
+    RenamedNamespaceMembers.answer = Int.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension RenamedVector: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> RenamedVector {
+        let dy = Double.bridgeJSStackPop()
+        let dx = Double.bridgeJSStackPop()
+        return RenamedVector(dx: dx, dy: dy)
+    }
+
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
+        self.dx.bridgeJSStackPush()
+        self.dy.bridgeJSStackPush()
+    }
+
+    init(unsafelyCopying jsObject: JSObject) {
+        _bjs_struct_lower_RenamedVector(jsObject.bridgeJSLowerParameter())
+        self = Self.bridgeJSStackPop()
+    }
+
+    func toJSObject() -> JSObject {
+        let __bjs_self = self
+        __bjs_self.bridgeJSStackPush()
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_RenamedVector()))
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_RenamedVector")
+fileprivate func _bjs_struct_lower_RenamedVector_extern(_ objectId: Int32) -> Void
+#else
+fileprivate func _bjs_struct_lower_RenamedVector_extern(_ objectId: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lower_RenamedVector(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_RenamedVector_extern(objectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_RenamedVector")
+fileprivate func _bjs_struct_lift_RenamedVector_extern() -> Int32
+#else
+fileprivate func _bjs_struct_lift_RenamedVector_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_struct_lift_RenamedVector() -> Int32 {
+    return _bjs_struct_lift_RenamedVector_extern()
+}
+
+@_expose(wasm, "bjs_RenamedVector_static_origin_get")
+@_cdecl("bjs_RenamedVector_static_origin_get")
+public func _bjs_RenamedVector_static_origin_get() -> Void {
+    #if arch(wasm32)
+    let ret = RenamedVector.origin
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedVector_magnitude")
+@_cdecl("bjs_RenamedVector_magnitude")
+public func _bjs_RenamedVector_magnitude() -> Float64 {
+    #if arch(wasm32)
+    let ret = RenamedVector.bridgeJSLiftParameter().length()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedVector_static_fromPolar")
+@_cdecl("bjs_RenamedVector_static_fromPolar")
+public func _bjs_RenamedVector_static_fromPolar(_ radius: Float64, _ angle: Float64) -> Void {
+    #if arch(wasm32)
+    let ret = RenamedVector.polar(radius: Double.bridgeJSLiftParameter(radius), angle: Double.bridgeJSLiftParameter(angle))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeGreeting")
+@_cdecl("bjs_makeGreeting")
+public func _bjs_makeGreeting(_ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = renderGreeting(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_greetName")
+@_cdecl("bjs_greetName")
+public func _bjs_greetName(_ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = greet(_: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_greetCount")
+@_cdecl("bjs_greetCount")
+public func _bjs_greetCount(_ count: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = greet(_: Int.bridgeJSLiftParameter(count))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_Utils_Text_namespacedRenamed")
+@_cdecl("bjs_Utils_Text_namespacedRenamed")
+public func _bjs_Utils_Text_namespacedRenamed() -> Int32 {
+    #if arch(wasm32)
+    let ret = namespacedFunction()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedMembers_init")
+@_cdecl("bjs_RenamedMembers_init")
+public func _bjs_RenamedMembers_init(_ titleBytes: Int32, _ titleLength: Int32, _ count: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = RenamedMembers(title: String.bridgeJSLiftParameter(titleBytes, titleLength), count: Int.bridgeJSLiftParameter(count))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedMembers_makeGreeting")
+@_cdecl("bjs_RenamedMembers_makeGreeting")
+public func _bjs_RenamedMembers_makeGreeting(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = RenamedMembers.bridgeJSLiftParameter(_self).greet()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedMembers_static_makeDefault")
+@_cdecl("bjs_RenamedMembers_static_makeDefault")
+public func _bjs_RenamedMembers_static_makeDefault() -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = RenamedMembers.createDefault()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedMembers_title_get")
+@_cdecl("bjs_RenamedMembers_title_get")
+public func _bjs_RenamedMembers_title_get(_ _self: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let ret = RenamedMembers.bridgeJSLiftParameter(_self).title
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedMembers_title_set")
+@_cdecl("bjs_RenamedMembers_title_set")
+public func _bjs_RenamedMembers_title_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    #if arch(wasm32)
+    RenamedMembers.bridgeJSLiftParameter(_self).title = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedMembers_count_get")
+@_cdecl("bjs_RenamedMembers_count_get")
+public func _bjs_RenamedMembers_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = RenamedMembers.bridgeJSLiftParameter(_self).count
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedMembers_static_sharedCount_get")
+@_cdecl("bjs_RenamedMembers_static_sharedCount_get")
+public func _bjs_RenamedMembers_static_sharedCount_get() -> Int32 {
+    #if arch(wasm32)
+    let ret = RenamedMembers.sharedCount
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedMembers_static_sharedCount_set")
+@_cdecl("bjs_RenamedMembers_static_sharedCount_set")
+public func _bjs_RenamedMembers_static_sharedCount_set(_ value: Int32) -> Void {
+    #if arch(wasm32)
+    RenamedMembers.sharedCount = Int.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedMembers_static_limit_get")
+@_cdecl("bjs_RenamedMembers_static_limit_get")
+public func _bjs_RenamedMembers_static_limit_get() -> Int32 {
+    #if arch(wasm32)
+    let ret = RenamedMembers.limit
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_RenamedMembers_deinit")
+@_cdecl("bjs_RenamedMembers_deinit")
+public func _bjs_RenamedMembers_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<RenamedMembers>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension RenamedMembers: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_RenamedMembers_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_RenamedMembers_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "TestModule", name: "bjs_RenamedMembers_wrap")
+fileprivate func _bjs_RenamedMembers_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_RenamedMembers_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_RenamedMembers_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_RenamedMembers_wrap_extern(pointer)
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSNameOverride.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSNameOverride.d.ts
@@ -1,0 +1,68 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export const RenamedEnumMembersValues: {
+    readonly Active: 0;
+    readonly Inactive: 1;
+};
+export type RenamedEnumMembersTag = typeof RenamedEnumMembersValues[keyof typeof RenamedEnumMembersValues];
+
+export interface RenamedVector {
+    dx: number;
+    dy: number;
+    magnitude(): number;
+}
+export type RenamedEnumMembersObject = typeof RenamedEnumMembersValues & {
+    describeCase(): string;
+    currentDefault: string;
+};
+
+/// Represents a Swift heap object like a class instance or an actor instance.
+export interface SwiftHeapObject {
+    /// Release the heap object.
+    ///
+    /// Note: Calling this method will release the heap object and it will no longer be accessible.
+    release(): void;
+}
+export interface RenamedMembers extends SwiftHeapObject {
+    makeGreeting(): string;
+    label: string;
+    readonly total: number;
+}
+export type Exports = {
+    makeGreeting(name: string): string;
+    greetName(name: string): string;
+    greetCount(count: number): string;
+    RenamedEnumMembers: RenamedEnumMembersObject
+    RenamedMembers: {
+        new(title: string, count: number): RenamedMembers;
+        makeDefault(): RenamedMembers;
+        sharedTotal: number;
+        readonly readOnlyLimit: number;
+    },
+    RenamedNamespaceMembers: {
+        theAnswer: number;
+        plus(a: number, b: number): number;
+    },
+    RenamedVector: {
+        readonly originVector: RenamedVector;
+        fromPolar(radius: number, angle: number): RenamedVector;
+    },
+    Utils: {
+        Text: {
+            namespacedRenamed(): number;
+        },
+    },
+}
+export type Imports = {
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSNameOverride.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSNameOverride.js
@@ -1,0 +1,442 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export const RenamedEnumMembersValues = {
+    Active: 0,
+    Inactive: 1,
+};
+
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    let decodeString;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let strStack = [];
+    let i32Stack = [];
+    let i64Stack = [];
+    let f32Stack = [];
+    let f64Stack = [];
+    let ptrStack = [];
+    let taStack = [];
+    const enumHelpers = {};
+    const structHelpers = {};
+
+    let _exports = null;
+    let bjs = null;
+    const __bjs_createRenamedVectorHelpers = () => ({
+        lower: (value) => {
+            f64Stack.push(value.dx);
+            f64Stack.push(value.dy);
+        },
+        lift: () => {
+            const f64 = f64Stack.pop();
+            const f641 = f64Stack.pop();
+            const instance1 = { dx: f641, dy: f64 };
+            instance1.magnitude = function() {
+                structHelpers.RenamedVector.lower(this);
+                const ret = instance.exports.bjs_RenamedVector_magnitude();
+                return ret;
+            }.bind(instance1);
+            return instance1;
+        }
+    });
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            bjs = {};
+            importObject["bjs"] = bjs;
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                tmpRetString = decodeString(ptr, len);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                return swift.memory.retain(decodeString(ptr, len));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_i32"] = function(v) {
+                i32Stack.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                f32Stack.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                f64Stack.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const value = decodeString(ptr, len);
+                strStack.push(value);
+            }
+            bjs["swift_js_pop_i32"] = function() {
+                return i32Stack.pop();
+            }
+            bjs["swift_js_pop_f32"] = function() {
+                return f32Stack.pop();
+            }
+            bjs["swift_js_pop_f64"] = function() {
+                return f64Stack.pop();
+            }
+            bjs["swift_js_push_pointer"] = function(pointer) {
+                ptrStack.push(pointer);
+            }
+            bjs["swift_js_pop_pointer"] = function() {
+                return ptrStack.pop();
+            }
+            bjs["swift_js_push_i64"] = function(v) {
+                i64Stack.push(v);
+            }
+            bjs["swift_js_pop_i64"] = function() {
+                return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
+            }
+            bjs["swift_js_struct_lower_RenamedVector"] = function(objectId) {
+                structHelpers.RenamedVector.lower(swift.memory.getObject(objectId));
+            }
+            bjs["swift_js_struct_lift_RenamedVector"] = function() {
+                const value = structHelpers.RenamedVector.lift();
+                return swift.memory.retain(value);
+            }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = decodeString(ptr, len);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            bjs["swift_js_get_optional_int_presence"] = function() {
+                return tmpRetOptionalInt != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_int_value"] = function() {
+                const value = tmpRetOptionalInt;
+                tmpRetOptionalInt = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_string"] = function() {
+                const str = tmpRetString;
+                tmpRetString = undefined;
+                if (str == null) {
+                    return -1;
+                } else {
+                    const bytes = textEncoder.encode(str);
+                    tmpRetBytes = bytes;
+                    return bytes.length;
+                }
+            }
+            bjs["swift_js_get_optional_float_presence"] = function() {
+                return tmpRetOptionalFloat != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_float_value"] = function() {
+                const value = tmpRetOptionalFloat;
+                tmpRetOptionalFloat = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_double_presence"] = function() {
+                return tmpRetOptionalDouble != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_double_value"] = function() {
+                const value = tmpRetOptionalDouble;
+                tmpRetOptionalDouble = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_heap_object_pointer"] = function() {
+                const pointer = tmpRetOptionalHeapObject;
+                tmpRetOptionalHeapObject = undefined;
+                return pointer || 0;
+            }
+            bjs["swift_js_closure_unregister"] = function(funcRef) {}
+            // Wrapper functions for module: TestModule
+            if (!importObject["TestModule"]) {
+                importObject["TestModule"] = {};
+            }
+            importObject["TestModule"]["bjs_RenamedMembers_wrap"] = function(pointer) {
+                const obj = _exports['RenamedMembers'].__construct(pointer);
+                return swift.memory.retain(obj);
+            };
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            decodeString = (ptr, len) => { const bytes = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0); return textDecoder.decode(bytes); }
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            const swiftHeapObjectFinalizationRegistry = (typeof FinalizationRegistry === "undefined") ? { register: () => {}, unregister: () => {} } : new FinalizationRegistry((state) => {
+                if (state.hasReleased) {
+                    return;
+                }
+                state.hasReleased = true;
+                state.identityMap?.delete(state.pointer);
+                state.deinit(state.pointer);
+            });
+
+            /// Represents a Swift heap object like a class instance or an actor instance.
+            class SwiftHeapObject {
+                static __wrap(pointer, deinit, prototype, identityCache) {
+                    pointer = pointer >>> 0;
+                    const makeFresh = (identityMap) => {
+                        const obj = Object.create(prototype);
+                        const state = { pointer, deinit, hasReleased: false, identityMap };
+                        obj.pointer = pointer;
+                        obj.__swiftHeapObjectState = state;
+                        swiftHeapObjectFinalizationRegistry.register(obj, state, state);
+                        if (identityMap) {
+                            identityMap.set(pointer, new WeakRef(obj));
+                        }
+                        return obj;
+                    };
+
+                    if (!identityCache) {
+                        return makeFresh(null);
+                    }
+
+                    const cached = identityCache.get(pointer)?.deref();
+                    if (cached && !cached.__swiftHeapObjectState.hasReleased) {
+                        deinit(pointer);
+                        return cached;
+                    }
+                    if (identityCache.has(pointer)) {
+                        identityCache.delete(pointer);
+                    }
+
+                    return makeFresh(identityCache);
+                }
+
+                release() {
+                    const state = this.__swiftHeapObjectState;
+                    if (state.hasReleased) {
+                        return;
+                    }
+                    state.hasReleased = true;
+                    swiftHeapObjectFinalizationRegistry.unregister(state);
+                    state.identityMap?.delete(state.pointer);
+                    state.deinit(state.pointer);
+                }
+            }
+            class RenamedMembers extends SwiftHeapObject {
+                static __construct(ptr) {
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_RenamedMembers_deinit, RenamedMembers.prototype, null);
+                }
+
+                constructor(title, count) {
+                    const titleBytes = textEncoder.encode(title);
+                    const titleId = swift.memory.retain(titleBytes);
+                    const ret = instance.exports.bjs_RenamedMembers_init(titleId, titleBytes.length, count);
+                    return RenamedMembers.__construct(ret);
+                }
+                makeGreeting() {
+                    instance.exports.bjs_RenamedMembers_makeGreeting(this.pointer);
+                    const ret = tmpRetString;
+                    tmpRetString = undefined;
+                    return ret;
+                }
+                static makeDefault() {
+                    const ret = instance.exports.bjs_RenamedMembers_static_makeDefault();
+                    return RenamedMembers.__construct(ret);
+                }
+                get label() {
+                    instance.exports.bjs_RenamedMembers_title_get(this.pointer);
+                    const ret = tmpRetString;
+                    tmpRetString = undefined;
+                    return ret;
+                }
+                set label(value) {
+                    const valueBytes = textEncoder.encode(value);
+                    const valueId = swift.memory.retain(valueBytes);
+                    instance.exports.bjs_RenamedMembers_title_set(this.pointer, valueId, valueBytes.length);
+                }
+                get total() {
+                    const ret = instance.exports.bjs_RenamedMembers_count_get(this.pointer);
+                    return ret;
+                }
+                static get sharedTotal() {
+                    const ret = instance.exports.bjs_RenamedMembers_static_sharedCount_get();
+                    return ret;
+                }
+                static set sharedTotal(value) {
+                    instance.exports.bjs_RenamedMembers_static_sharedCount_set(value);
+                }
+                static get readOnlyLimit() {
+                    const ret = instance.exports.bjs_RenamedMembers_static_limit_get();
+                    return ret;
+                }
+            }
+            const RenamedVectorHelpers = __bjs_createRenamedVectorHelpers();
+            structHelpers.RenamedVector = RenamedVectorHelpers;
+
+            const exports = {
+                makeGreeting: function bjs_makeGreeting(name) {
+                    const nameBytes = textEncoder.encode(name);
+                    const nameId = swift.memory.retain(nameBytes);
+                    instance.exports.bjs_makeGreeting(nameId, nameBytes.length);
+                    const ret = tmpRetString;
+                    tmpRetString = undefined;
+                    return ret;
+                },
+                greetName: function bjs_greetName(name) {
+                    const nameBytes = textEncoder.encode(name);
+                    const nameId = swift.memory.retain(nameBytes);
+                    instance.exports.bjs_greetName(nameId, nameBytes.length);
+                    const ret = tmpRetString;
+                    tmpRetString = undefined;
+                    return ret;
+                },
+                greetCount: function bjs_greetCount(count) {
+                    instance.exports.bjs_greetCount(count);
+                    const ret = tmpRetString;
+                    tmpRetString = undefined;
+                    return ret;
+                },
+                RenamedEnumMembers: {
+                    ...RenamedEnumMembersValues,
+                    describeCase: function() {
+                        instance.exports.bjs_RenamedEnumMembers_static_describeCase();
+                        const ret = tmpRetString;
+                        tmpRetString = undefined;
+                        return ret;
+                    },
+                    get currentDefault() {
+                        instance.exports.bjs_RenamedEnumMembers_static_defaultValue_get();
+                        const ret = tmpRetString;
+                        tmpRetString = undefined;
+                        return ret;
+                    },
+                    set currentDefault(value) {
+                        const valueBytes = textEncoder.encode(value);
+                        const valueId = swift.memory.retain(valueBytes);
+                        instance.exports.bjs_RenamedEnumMembers_static_defaultValue_set(valueId, valueBytes.length);
+                    }
+                },
+                RenamedMembers,
+                RenamedNamespaceMembers: {
+                    get theAnswer() {
+                        const ret = instance.exports.bjs_RenamedNamespaceMembers_static_answer_get();
+                        return ret;
+                    },
+                    set theAnswer(value) {
+                        instance.exports.bjs_RenamedNamespaceMembers_static_answer_set(value);
+                    },
+                    plus: function bjs_RenamedNamespaceMembers_static_plus(a, b) {
+                        const ret = instance.exports.bjs_RenamedNamespaceMembers_static_plus(a, b);
+                        return ret;
+                    },
+                },
+                RenamedVector: {
+                    get originVector() {
+                        instance.exports.bjs_RenamedVector_static_origin_get();
+                        const structValue = structHelpers.RenamedVector.lift();
+                        return structValue;
+                    },
+                    fromPolar: function(radius, angle) {
+                        instance.exports.bjs_RenamedVector_static_fromPolar(radius, angle);
+                        const structValue = structHelpers.RenamedVector.lift();
+                        return structValue;
+                    },
+                },
+                Utils: {
+                    Text: {
+                        namespacedRenamed: function bjs_Utils_Text_namespacedRenamed() {
+                            const ret = instance.exports.bjs_Utils_Text_namespacedRenamed();
+                            return ret;
+                        },
+                    },
+                },
+            };
+            _exports = exports;
+            return exports;
+        },
+    }
+}

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Function.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Function.md
@@ -37,6 +37,27 @@ export type Exports = {
 }
 ```
 
+### Renaming functions in JavaScript
+
+If a different name is more appropriate in JavaScript or to export multiple overloaded Swift functions with distinct JavaScript names, you can pass a JavaScript identifier as the first argument to `@JS`.
+
+```swift
+import JavaScriptKit
+
+@JS("greetName") public func greet(_ name: String) -> String {
+    return "Hello, \(name)!"
+}
+
+@JS("greetPerson") public func greet(_ person: Person) -> String {
+    return "Hello, \(person.name)!"
+}
+```
+
+```javascript
+exports.greetName("World");
+exports.greetPerson({ name: "World" });
+```
+
 ### Throwing functions
 
 Swift functions can throw JavaScript errors using `throws(JSException)`.

--- a/Sources/JavaScriptKit/Macros.swift
+++ b/Sources/JavaScriptKit/Macros.swift
@@ -140,6 +140,7 @@ public enum JSName: ExpressibleByStringLiteral {
 ///
 /// For detailed usage information, see the article <doc:Exporting-Swift-to-JavaScript>.
 ///
+/// - Parameter name: A different name to use in the exported JavaScript.
 /// - Parameter namespace: A dot-separated string that defines the namespace hierarchy in JavaScript.
 ///                        Each segment becomes a nested object in the resulting JavaScript structure.
 /// - Parameter enumStyle: Controls how enums are emitted to TypeScript for this declaration:
@@ -151,6 +152,7 @@ public enum JSName: ExpressibleByStringLiteral {
 /// - Important: This feature is still experimental. No API stability is guaranteed, and the API may change in future releases.
 @attached(peer)
 public macro JS(
+    _ name: String? = nil,
     as aliasOf: Any.Type? = nil,
     namespace: String? = nil,
     enumStyle: JSEnumStyle = .const,

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -9814,6 +9814,39 @@ public func _bjs_makeAdder(_ base: Int32) -> Int32 {
     #endif
 }
 
+@_expose(wasm, "bjs_renamedEcho")
+@_cdecl("bjs_renamedEcho")
+public func _bjs_renamedEcho(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = jsNameEcho(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_greetName")
+@_cdecl("bjs_greetName")
+public func _bjs_greetName(_ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = greet(_: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_greetCount")
+@_cdecl("bjs_greetCount")
+public func _bjs_greetCount(_ count: Int32) -> Void {
+    #if arch(wasm32)
+    let ret = greet(_: Int.bridgeJSLiftParameter(count))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_roundTripPointerFields")
 @_cdecl("bjs_roundTripPointerFields")
 public func _bjs_roundTripPointerFields() -> Void {
@@ -13160,6 +13193,91 @@ fileprivate func _bjs_NestedTypeHost_wrap_extern(_ pointer: UnsafeMutableRawPoin
 #endif
 @inline(never) fileprivate func _bjs_NestedTypeHost_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     return _bjs_NestedTypeHost_wrap_extern(pointer)
+}
+
+@_expose(wasm, "bjs_JSNameRenamedClass_init")
+@_cdecl("bjs_JSNameRenamedClass_init")
+public func _bjs_JSNameRenamedClass_init(_ value: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = JSNameRenamedClass(value: Int.bridgeJSLiftParameter(value))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_JSNameRenamedClass_doubled")
+@_cdecl("bjs_JSNameRenamedClass_doubled")
+public func _bjs_JSNameRenamedClass_doubled(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSNameRenamedClass.bridgeJSLiftParameter(_self).timesTwo()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_JSNameRenamedClass_static_makeWithValue")
+@_cdecl("bjs_JSNameRenamedClass_static_makeWithValue")
+public func _bjs_JSNameRenamedClass_static_makeWithValue(_ value: Int32) -> UnsafeMutableRawPointer {
+    #if arch(wasm32)
+    let ret = JSNameRenamedClass.create(value: Int.bridgeJSLiftParameter(value))
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_JSNameRenamedClass_value_get")
+@_cdecl("bjs_JSNameRenamedClass_value_get")
+public func _bjs_JSNameRenamedClass_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+    #if arch(wasm32)
+    let ret = JSNameRenamedClass.bridgeJSLiftParameter(_self).value
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_JSNameRenamedClass_value_set")
+@_cdecl("bjs_JSNameRenamedClass_value_set")
+public func _bjs_JSNameRenamedClass_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+    #if arch(wasm32)
+    JSNameRenamedClass.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_JSNameRenamedClass_deinit")
+@_cdecl("bjs_JSNameRenamedClass_deinit")
+public func _bjs_JSNameRenamedClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    Unmanaged<JSNameRenamedClass>.fromOpaque(pointer).release()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+extension JSNameRenamedClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+    var jsValue: JSValue {
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_JSNameRenamedClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
+    }
+    consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
+        _bjs_JSNameRenamedClass_wrap(Unmanaged.passRetained(self).toOpaque())
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_JSNameRenamedClass_wrap")
+fileprivate func _bjs_JSNameRenamedClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+#else
+fileprivate func _bjs_JSNameRenamedClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func _bjs_JSNameRenamedClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_JSNameRenamedClass_wrap_extern(pointer)
 }
 
 @_expose(wasm, "bjs_OptionalHolder_init")

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -4842,6 +4842,105 @@
       },
       {
         "constructor" : {
+          "abiName" : "bjs_JSNameRenamedClass_init",
+          "effects" : {
+            "isAsync" : false,
+            "isStatic" : false,
+            "isThrows" : false
+          },
+          "parameters" : [
+            {
+              "label" : "value",
+              "name" : "value",
+              "type" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "methods" : [
+          {
+            "abiName" : "bjs_JSNameRenamedClass_doubled",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : false,
+              "isThrows" : false
+            },
+            "jsName" : "doubled",
+            "name" : "timesTwo",
+            "parameters" : [
+
+            ],
+            "returnType" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          },
+          {
+            "abiName" : "bjs_JSNameRenamedClass_static_makeWithValue",
+            "effects" : {
+              "isAsync" : false,
+              "isStatic" : true,
+              "isThrows" : false
+            },
+            "jsName" : "makeWithValue",
+            "name" : "create",
+            "parameters" : [
+              {
+                "label" : "value",
+                "name" : "value",
+                "type" : {
+                  "integer" : {
+                    "_0" : {
+                      "isSigned" : true,
+                      "width" : "word"
+                    }
+                  }
+                }
+              }
+            ],
+            "returnType" : {
+              "swiftHeapObject" : {
+                "_0" : "JSNameRenamedClass"
+              }
+            },
+            "staticContext" : {
+              "className" : {
+                "_0" : "JSNameRenamedClass"
+              }
+            }
+          }
+        ],
+        "name" : "JSNameRenamedClass",
+        "properties" : [
+          {
+            "isReadonly" : false,
+            "isStatic" : false,
+            "jsName" : "current",
+            "name" : "value",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "swiftCallName" : "JSNameRenamedClass"
+      },
+      {
+        "constructor" : {
           "abiName" : "bjs_OptionalHolder_init",
           "effects" : {
             "isAsync" : false,
@@ -16829,6 +16928,87 @@
               "sendingParameters" : false
             },
             "useJSTypedClosure" : false
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_renamedEcho",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "jsName" : "renamedEcho",
+        "name" : "jsNameEcho",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "value",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_greetName",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "jsName" : "greetName",
+        "name" : "greet",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "name",
+            "type" : {
+              "string" : {
+
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_greetCount",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "jsName" : "greetCount",
+        "name" : "greet",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "count",
+            "type" : {
+              "integer" : {
+                "_0" : {
+                  "isSigned" : true,
+                  "width" : "word"
+                }
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "string" : {
+
           }
         }
       },

--- a/Tests/BridgeJSRuntimeTests/JSNameAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/JSNameAPIs.swift
@@ -1,0 +1,34 @@
+import JavaScriptKit
+
+@JS("renamedEcho") func jsNameEcho(_ value: String) -> String {
+    return "echo: \(value)"
+}
+
+@JS("greetName") func greet(_ name: String) -> String {
+    return "Hello, \(name)!"
+}
+
+@JS("greetCount") func greet(_ count: Int) -> String {
+    return "Hello, \(count) people!"
+}
+
+@JS class JSNameRenamedClass {
+    private var storage: Int
+
+    @JS init(value: Int) {
+        self.storage = value
+    }
+
+    @JS("current") var value: Int {
+        get { storage }
+        set { storage = newValue }
+    }
+
+    @JS("doubled") func timesTwo() -> Int {
+        return storage * 2
+    }
+
+    @JS("makeWithValue") static func create(value: Int) -> JSNameRenamedClass {
+        return JSNameRenamedClass(value: value)
+    }
+}

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -281,6 +281,18 @@ function BridgeJSRuntimeTests_runJsWorks(instance, exports) {
         assert.equal(exports.roundTripUnsafeMutablePointer(p), p);
     }
 
+    assert.equal(exports.renamedEcho("hi"), "echo: hi");
+    assert.equal(exports.jsNameEcho, undefined);
+    assert.equal(exports.greetName("John"), "Hello, John!");
+    assert.equal(exports.greetCount(3), "Hello, 3 people!");
+    const renamed = new exports.JSNameRenamedClass(21);
+    assert.equal(renamed.doubled(), 42);
+    assert.equal(renamed.current, 21);
+    renamed.current = 5;
+    assert.equal(renamed.doubled(), 10);
+    const madeRenamed = exports.JSNameRenamedClass.makeWithValue(7);
+    assert.equal(madeRenamed.current, 7);
+
     const g = new exports.Greeter("John");
     assert.equal(g.greet(), "Hello, John!");
 


### PR DESCRIPTION
Allow using a different name in JavaScript for properties/methods. This is useful if a different name is more appropriate in JavaScript, or to export multiple overloaded Swift functions with distinct JavaScript names.

```swift
import JavaScriptKit

@JS("greetName") public func greet(_ name: String) -> String {
    return "Hello, \(name)!"
}

@JS("greetPerson") public func greet(_ person: Person) -> String {
    return "Hello, \(person.name)!"
}
```
```javascript
exports.greetName("World");
exports.greetPerson({ name: "World" });
```

I decided to avoid having an argument label, to match `@c` and `@objc` more closely.