### PR TITLE
BridgeJS: Lower imported optional stack parameters fully on the stack

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -971,6 +971,9 @@ extension BridgeType {
             throw BridgeJSCoreError("Namespace enums cannot be used as parameters")
         case .nullable(let wrappedType, _):
             let wrappedInfo = try wrappedType.loweringParameterInfo(context: context)
+            if wrappedInfo.loweredParameters.isEmpty {
+                return LoweringParameterInfo(loweredParameters: [])
+            }
             var params = [("isSome", WasmCoreType.i32)]
             params.append(contentsOf: wrappedInfo.loweredParameters)
             return LoweringParameterInfo(loweredParameters: params, useBorrowing: wrappedInfo.useBorrowing)

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -1051,16 +1051,13 @@ struct IntrinsicJSFragment: Sendable {
             )
         }
 
-        let innerFragment =
-            if wrappedType.optionalParameterUsesStackABI {
-                try stackLiftFragment(elementType: wrappedType)
-            } else {
-                try liftParameter(type: wrappedType, context: bridgeContext)
-            }
+        if wrappedType.optionalParameterUsesStackABI {
+            return try optionalElementRaiseFragment(wrappedType: wrappedType, kind: kind)
+        }
         return compositeOptionalLiftParameter(
             wrappedType: wrappedType,
             kind: kind,
-            innerFragment: innerFragment
+            innerFragment: try liftParameter(type: wrappedType, context: bridgeContext)
         )
     }
 
@@ -1075,22 +1072,14 @@ struct IntrinsicJSFragment: Sendable {
         kind: JSOptionalKind,
         innerFragment: IntrinsicJSFragment
     ) -> IntrinsicJSFragment {
-        let isStackConvention = wrappedType.optionalParameterUsesStackABI
         let absenceLiteral = kind.absenceLiteral
 
-        let outerParams: [String]
-        if isStackConvention {
-            outerParams = ["isSome"]
-        } else {
-            outerParams = ["isSome"] + innerFragment.parameters
-        }
-
         return IntrinsicJSFragment(
-            parameters: outerParams,
+            parameters: ["isSome"] + innerFragment.parameters,
             printCode: { arguments, context in
                 let (scope, printer) = (context.scope, context.printer)
                 let isSome = arguments[0]
-                let innerArgs = isStackConvention ? [] : Array(arguments.dropFirst())
+                let innerArgs = Array(arguments.dropFirst())
 
                 let bufferPrinter = CodeFragmentPrinter()
                 let innerResults = try innerFragment.printCode(

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.swift
@@ -626,20 +626,20 @@ func _$Promise_resolve_Sq10AsyncThemeO(_ promise: JSObject, _ value: Optional<As
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sq10AsyncPointV")
-fileprivate func promise_resolve_TestModule_Sq10AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+fileprivate func promise_resolve_TestModule_Sq10AsyncPointV_extern(_ promise: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_Sq10AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_Sq10AsyncPointV_extern(_ promise: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_Sq10AsyncPointV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_TestModule_Sq10AsyncPointV_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_TestModule_Sq10AsyncPointV(_ promise: Int32) -> Void {
+    return promise_resolve_TestModule_Sq10AsyncPointV_extern(promise)
 }
 
 func _$Promise_resolve_Sq10AsyncPointV(_ promise: JSObject, _ value: Optional<AsyncPoint>) throws(JSException) -> Void {
-    let valueIsSome = value.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
     let promiseValue = promise.bridgeJSLowerParameter()
-    promise_resolve_TestModule_Sq10AsyncPointV(promiseValue, valueIsSome)
+    promise_resolve_TestModule_Sq10AsyncPointV(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/GenericImports.swift
@@ -354,20 +354,20 @@ func _$importGenericDictionary<T: BridgedSwiftGenericBridgeable>(_ values: [Stri
 
 #if arch(wasm32)
 @_extern(wasm, module: "TestModule", name: "bjs_importGenericAfterOptionalArray")
-fileprivate func bjs_importGenericAfterOptionalArray_extern(_ values: Int32, _ _generic0TypeId: Int32) -> Void
+fileprivate func bjs_importGenericAfterOptionalArray_extern(_ _generic0TypeId: Int32) -> Void
 #else
-fileprivate func bjs_importGenericAfterOptionalArray_extern(_ values: Int32, _ _generic0TypeId: Int32) -> Void {
+fileprivate func bjs_importGenericAfterOptionalArray_extern(_ _generic0TypeId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_importGenericAfterOptionalArray(_ values: Int32, _ _generic0TypeId: Int32) -> Void {
-    return bjs_importGenericAfterOptionalArray_extern(values, _generic0TypeId)
+@inline(never) fileprivate func bjs_importGenericAfterOptionalArray(_ _generic0TypeId: Int32) -> Void {
+    return bjs_importGenericAfterOptionalArray_extern(_generic0TypeId)
 }
 
 func _$importGenericAfterOptionalArray<T: BridgedSwiftGenericBridgeable>(_ values: Optional<[Int]>, _ value: T) throws(JSException) -> T {
     value.bridgeJSStackPush()
-    let valuesIsSome = values.bridgeJSLowerParameter()
-    bjs_importGenericAfterOptionalArray(valuesIsSome, T.bridgeJSTypeID)
+    let _ = values.bridgeJSLowerParameter()
+    bjs_importGenericAfterOptionalArray(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
         throw error
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportArray.swift
@@ -41,20 +41,20 @@ func _$logStrings(_ items: [String]) throws(JSException) -> Void {
 
 #if arch(wasm32)
 @_extern(wasm, module: "TestModule", name: "bjs_optionalArrayThenArray")
-fileprivate func bjs_optionalArrayThenArray_extern(_ a: Int32) -> Int32
+fileprivate func bjs_optionalArrayThenArray_extern() -> Int32
 #else
-fileprivate func bjs_optionalArrayThenArray_extern(_ a: Int32) -> Int32 {
+fileprivate func bjs_optionalArrayThenArray_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_optionalArrayThenArray(_ a: Int32) -> Int32 {
-    return bjs_optionalArrayThenArray_extern(a)
+@inline(never) fileprivate func bjs_optionalArrayThenArray() -> Int32 {
+    return bjs_optionalArrayThenArray_extern()
 }
 
 func _$optionalArrayThenArray(_ a: Optional<[Int]>, _ b: [Int]) throws(JSException) -> Int {
     let _ = b.bridgeJSLowerParameter()
-    let aIsSome = a.bridgeJSLowerParameter()
-    let ret = bjs_optionalArrayThenArray(aIsSome)
+    let _ = a.bridgeJSLowerParameter()
+    let ret = bjs_optionalArrayThenArray()
     if let error = _swift_js_take_exception() {
         throw error
     }
@@ -63,21 +63,21 @@ func _$optionalArrayThenArray(_ a: Optional<[Int]>, _ b: [Int]) throws(JSExcepti
 
 #if arch(wasm32)
 @_extern(wasm, module: "TestModule", name: "bjs_borrowedStringAroundStackParams")
-fileprivate func bjs_borrowedStringAroundStackParams_extern(_ sBytes: Int32, _ sLength: Int32, _ a: Int32) -> Int32
+fileprivate func bjs_borrowedStringAroundStackParams_extern(_ sBytes: Int32, _ sLength: Int32) -> Int32
 #else
-fileprivate func bjs_borrowedStringAroundStackParams_extern(_ sBytes: Int32, _ sLength: Int32, _ a: Int32) -> Int32 {
+fileprivate func bjs_borrowedStringAroundStackParams_extern(_ sBytes: Int32, _ sLength: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_borrowedStringAroundStackParams(_ sBytes: Int32, _ sLength: Int32, _ a: Int32) -> Int32 {
-    return bjs_borrowedStringAroundStackParams_extern(sBytes, sLength, a)
+@inline(never) fileprivate func bjs_borrowedStringAroundStackParams(_ sBytes: Int32, _ sLength: Int32) -> Int32 {
+    return bjs_borrowedStringAroundStackParams_extern(sBytes, sLength)
 }
 
 func _$borrowedStringAroundStackParams(_ s: String, _ a: Optional<[Int]>, _ b: [Int]) throws(JSException) -> Int {
     let ret0 = s.bridgeJSWithLoweredParameter { (sBytes, sLength) in
         let _ = b.bridgeJSLowerParameter()
-        let aIsSome = a.bridgeJSLowerParameter()
-        let ret = bjs_borrowedStringAroundStackParams(sBytes, sLength, aIsSome)
+        let _ = a.bridgeJSLowerParameter()
+        let ret = bjs_borrowedStringAroundStackParams(sBytes, sLength)
         return ret
     }
     let ret = ret0

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
@@ -992,14 +992,14 @@ public func _invoke_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO(_ b
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV")
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(_ callback: Int32, _ param0: Int32) -> Void
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(_ callback: Int32) -> Void
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(_ callback: Int32, _ param0: Int32) -> Void {
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(_ callback: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(_ callback: Int32, _ param0: Int32) -> Void {
-    return invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(_ callback: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(callback)
 }
 
 #if arch(wasm32)
@@ -1019,9 +1019,9 @@ private enum _BJS_Closure_10TestModuleSq6AnimalV_Sq6AnimalV {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
-            let param0IsSome = param0.bridgeJSLowerParameter()
+            let _ = param0.bridgeJSLowerParameter()
             let callbackValue = callback.bridgeJSLowerParameter()
-            invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(callbackValue, param0IsSome)
+            invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(callbackValue)
             return Optional<Animal>.bridgeJSLiftReturn()
             #else
             fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
@@ -75,19 +75,19 @@ func _$translate(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException) -> Po
 
 #if arch(wasm32)
 @_extern(wasm, module: "TestModule", name: "bjs_roundTripOptional")
-fileprivate func bjs_roundTripOptional_extern(_ point: Int32) -> Void
+fileprivate func bjs_roundTripOptional_extern() -> Void
 #else
-fileprivate func bjs_roundTripOptional_extern(_ point: Int32) -> Void {
+fileprivate func bjs_roundTripOptional_extern() -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_roundTripOptional(_ point: Int32) -> Void {
-    return bjs_roundTripOptional_extern(point)
+@inline(never) fileprivate func bjs_roundTripOptional() -> Void {
+    return bjs_roundTripOptional_extern()
 }
 
 func _$roundTripOptional(_ point: Optional<Point>) throws(JSException) -> Optional<Point> {
-    let pointIsSome = point.bridgeJSLowerParameter()
-    bjs_roundTripOptional(pointIsSome)
+    let _ = point.bridgeJSLowerParameter()
+    bjs_roundTripOptional()
     if let error = _swift_js_take_exception() {
         throw error
     }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
@@ -584,16 +584,10 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_Sq10AsyncPointV"] = function(promise, value) {
+            bjs["promise_resolve_TestModule_Sq10AsyncPointV"] = function(promise) {
                 try {
-                    let optResult;
-                    if (value) {
-                        const struct = structHelpers.M10TestModuleT10AsyncPoint.lift();
-                        optResult = struct;
-                    } else {
-                        optResult = null;
-                    }
-                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(optResult);
+                    const optValue = __bjs_codec_Optional_M10TestModuleT10AsyncPoint.lift();
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(optValue);
                 } catch (error) {
                     setException(error);
                 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GenericImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/GenericImports.js
@@ -389,6 +389,7 @@ export async function createInstantiator(options, swift) {
     }
 
     const __bjs_codec_Array_Int = __bjs_arrayCodec(__bjs_primitiveCodecs.Int);
+    const __bjs_codec_Optional_Array_Int = __bjs_optionalCodec(__bjs_codec_Array_Int);
     const __bjs_codec_M10TestModuleT12GenericPoint = {
         lower: (v) => {
             structHelpers.M10TestModuleT12GenericPoint.lower(v);
@@ -771,18 +772,12 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            TestModule["bjs_importGenericAfterOptionalArray"] = function bjs_importGenericAfterOptionalArray(values, tTypeId) {
+            TestModule["bjs_importGenericAfterOptionalArray"] = function bjs_importGenericAfterOptionalArray(tTypeId) {
                 try {
                     const codecT = __bjs_codecForTypeId(tTypeId);
-                    let optResult;
-                    if (values) {
-                        const arrayResult = __bjs_codec_Array_Int.lift();
-                        optResult = arrayResult;
-                    } else {
-                        optResult = null;
-                    }
+                    const optValue = __bjs_codec_Optional_Array_Int.lift();
                     const value = codecT.lift();
-                    let ret = imports.importGenericAfterOptionalArray(optResult, value);
+                    let ret = imports.importGenericAfterOptionalArray(optValue, value);
                     codecT.lower(ret);
                 } catch (error) {
                     setException(error);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportArray.js
@@ -356,6 +356,7 @@ export async function createInstantiator(options, swift) {
 
     const __bjs_codec_Array_Int = __bjs_arrayCodec(__bjs_primitiveCodecs.Int);
     const __bjs_codec_Array_String = __bjs_arrayCodec(__bjs_stringCodec);
+    const __bjs_codec_Optional_Array_Int = __bjs_optionalCodec(__bjs_codec_Array_Int);
 
 
     return {
@@ -549,35 +550,23 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            TestModule["bjs_optionalArrayThenArray"] = function bjs_optionalArrayThenArray(a) {
+            TestModule["bjs_optionalArrayThenArray"] = function bjs_optionalArrayThenArray() {
                 try {
-                    let optResult;
-                    if (a) {
-                        const arrayResult = __bjs_codec_Array_Int.lift();
-                        optResult = arrayResult;
-                    } else {
-                        optResult = null;
-                    }
-                    const arrayResult1 = __bjs_codec_Array_Int.lift();
-                    let ret = imports.optionalArrayThenArray(optResult, arrayResult1);
+                    const optValue = __bjs_codec_Optional_Array_Int.lift();
+                    const arrayResult = __bjs_codec_Array_Int.lift();
+                    let ret = imports.optionalArrayThenArray(optValue, arrayResult);
                     return ret;
                 } catch (error) {
                     setException(error);
                     return 0
                 }
             }
-            TestModule["bjs_borrowedStringAroundStackParams"] = function bjs_borrowedStringAroundStackParams(sBytes, sCount, a) {
+            TestModule["bjs_borrowedStringAroundStackParams"] = function bjs_borrowedStringAroundStackParams(sBytes, sCount) {
                 try {
                     const string = decodeString(sBytes, sCount);
-                    let optResult;
-                    if (a) {
-                        const arrayResult = __bjs_codec_Array_Int.lift();
-                        optResult = arrayResult;
-                    } else {
-                        optResult = null;
-                    }
-                    const arrayResult1 = __bjs_codec_Array_Int.lift();
-                    let ret = imports.borrowedStringAroundStackParams(string, optResult, arrayResult1);
+                    const optValue = __bjs_codec_Optional_Array_Int.lift();
+                    const arrayResult = __bjs_codec_Array_Int.lift();
+                    let ret = imports.borrowedStringAroundStackParams(string, optValue, arrayResult);
                     return ret;
                 } catch (error) {
                     setException(error);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -1099,17 +1099,11 @@ export async function createInstantiator(options, swift) {
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV"] = function(callbackId, param0) {
+            bjs["invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV"] = function(callbackId) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
-                    let optResult;
-                    if (param0) {
-                        const struct = structHelpers.M10TestModuleT6Animal.lift();
-                        optResult = struct;
-                    } else {
-                        optResult = null;
-                    }
-                    let ret = callback(optResult);
+                    const optValue = __bjs_codec_Optional_M10TestModuleT6Animal.lift();
+                    let ret = callback(optValue);
                     __bjs_codec_Optional_M10TestModuleT6Animal.lower(ret);
                 } catch (error) {
                     setException(error);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
@@ -568,16 +568,10 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            TestModule["bjs_roundTripOptional"] = function bjs_roundTripOptional(point) {
+            TestModule["bjs_roundTripOptional"] = function bjs_roundTripOptional() {
                 try {
-                    let optResult;
-                    if (point) {
-                        const struct = structHelpers.M10TestModuleT5Point.lift();
-                        optResult = struct;
-                    } else {
-                        optResult = null;
-                    }
-                    let ret = imports.roundTripOptional(optResult);
+                    const optValue = __bjs_codec_Optional_M10TestModuleT5Point.lift();
+                    let ret = imports.roundTripOptional(optValue);
                     __bjs_codec_Optional_M10TestModuleT5Point.lower(ret);
                 } catch (error) {
                     setException(error);

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -2063,14 +2063,8 @@ extension _BridgedAsOptional where Wrapped: _BridgedSwiftStackType, Wrapped.Stac
 extension _BridgedAsOptional
 where Wrapped: _BridgedSwiftStackType, Wrapped.StackLiftResult == Wrapped, Wrapped: _BridgedSwiftTypeLoweredIntoVoidType
 {
-    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
-        switch asOptional {
-        case .none:
-            return 0
-        case .some(let array):
-            array.bridgeJSLowerReturn()
-            return 1
-        }
+    @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() {
+        Wrapped.bridgeJSStackPushAsOptional(asOptional)
     }
 
     @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Void {
@@ -2487,24 +2481,6 @@ extension _BridgedAsOptional where Wrapped: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension _BridgedAsOptional where Wrapped: _BridgedSwiftStruct {
-    @_spi(BridgeJS) public static func bridgeJSLiftParameter(_ isSome: Int32) -> Self {
-        if isSome == 0 {
-            return Self(optional: nil)
-        } else {
-            return Self(optional: Wrapped.bridgeJSStackPop())
-        }
-    }
-
-    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() -> Void {
-        Wrapped.bridgeJSStackPushAsOptional(asOptional)
-    }
-
-    @_spi(BridgeJS) public static func bridgeJSLiftParameter() -> Self {
-        Self.bridgeJSStackPop()
-    }
-}
-
 // MARK: - Array Support
 
 extension Array: _BridgedSwiftTypeLoweredIntoVoidType
@@ -2577,41 +2553,6 @@ where Key == String, Value: _BridgedSwiftStackType, Value.StackLiftResult == Val
     }
     @_spi(BridgeJS) public static func bridgeJSLiftReturn() -> [String: Value] {
         bridgeJSStackPop()
-    }
-}
-
-extension _BridgedAsOptional {
-    @_spi(BridgeJS) public consuming func bridgeJSLowerParameter<Value>() -> Int32
-    where Wrapped == Dictionary<String, Value>, Value: _BridgedSwiftStackType, Value.StackLiftResult == Value {
-        switch asOptional {
-        case .none:
-            return 0
-        case .some(let dict):
-            dict.bridgeJSStackPush()
-            return 1
-        }
-    }
-
-    @_spi(BridgeJS) public static func bridgeJSLiftParameter<Value>(_ isSome: Int32) -> Self
-    where Wrapped == Dictionary<String, Value>, Value: _BridgedSwiftStackType, Value.StackLiftResult == Value {
-        if isSome == 0 {
-            return Self(optional: nil)
-        }
-        return Self(optional: Dictionary<String, Value>.bridgeJSStackPop())
-    }
-
-    @_spi(BridgeJS) public static func bridgeJSLiftReturn<Value>() -> Self
-    where Wrapped == Dictionary<String, Value>, Value: _BridgedSwiftStackType, Value.StackLiftResult == Value {
-        let isSome = _swift_js_pop_i32()
-        if isSome == 0 {
-            return Self(optional: nil)
-        }
-        return Self(optional: Dictionary<String, Value>.bridgeJSStackPop())
-    }
-
-    @_spi(BridgeJS) public consuming func bridgeJSLowerReturn<Value>() -> Void
-    where Wrapped == Dictionary<String, Value>, Value: _BridgedSwiftStackType, Value.StackLiftResult == Value {
-        Wrapped.bridgeJSStackPushAsOptional(asOptional)
     }
 }
 

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -14625,20 +14625,20 @@ func _$Promise_resolve_Sa11PublicPointV(_ promise: JSObject, _ value: [PublicPoi
 
 #if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ promise: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ promise: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(promise)
 }
 
 func _$Promise_resolve_Sq11PublicPointV(_ promise: JSObject, _ value: Optional<PublicPoint>) throws(JSException) -> Void {
-    let valueIsSome = value.bridgeJSLowerParameter()
+    let _ = value.bridgeJSLowerParameter()
     let promiseValue = promise.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(promiseValue, valueIsSome)
+    promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
@@ -17234,20 +17234,20 @@ func _$jsRoundTripOptionalImportedPayloadSignal(_ value: Optional<ImportedPayloa
 
 #if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsJoinOptionalArrayThenArray")
-fileprivate func bjs_jsJoinOptionalArrayThenArray_extern(_ a: Int32) -> Int32
+fileprivate func bjs_jsJoinOptionalArrayThenArray_extern() -> Int32
 #else
-fileprivate func bjs_jsJoinOptionalArrayThenArray_extern(_ a: Int32) -> Int32 {
+fileprivate func bjs_jsJoinOptionalArrayThenArray_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_jsJoinOptionalArrayThenArray(_ a: Int32) -> Int32 {
-    return bjs_jsJoinOptionalArrayThenArray_extern(a)
+@inline(never) fileprivate func bjs_jsJoinOptionalArrayThenArray() -> Int32 {
+    return bjs_jsJoinOptionalArrayThenArray_extern()
 }
 
 func _$jsJoinOptionalArrayThenArray(_ a: Optional<[Int]>, _ b: [Int]) throws(JSException) -> String {
     let _ = b.bridgeJSLowerParameter()
-    let aIsSome = a.bridgeJSLowerParameter()
-    let ret = bjs_jsJoinOptionalArrayThenArray(aIsSome)
+    let _ = a.bridgeJSLowerParameter()
+    let ret = bjs_jsJoinOptionalArrayThenArray()
     if let error = _swift_js_take_exception() {
         throw error
     }
@@ -17256,20 +17256,20 @@ func _$jsJoinOptionalArrayThenArray(_ a: Optional<[Int]>, _ b: [Int]) throws(JSE
 
 #if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsJoinOptionalStructThenArray")
-fileprivate func bjs_jsJoinOptionalStructThenArray_extern(_ a: Int32) -> Int32
+fileprivate func bjs_jsJoinOptionalStructThenArray_extern() -> Int32
 #else
-fileprivate func bjs_jsJoinOptionalStructThenArray_extern(_ a: Int32) -> Int32 {
+fileprivate func bjs_jsJoinOptionalStructThenArray_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_jsJoinOptionalStructThenArray(_ a: Int32) -> Int32 {
-    return bjs_jsJoinOptionalStructThenArray_extern(a)
+@inline(never) fileprivate func bjs_jsJoinOptionalStructThenArray() -> Int32 {
+    return bjs_jsJoinOptionalStructThenArray_extern()
 }
 
 func _$jsJoinOptionalStructThenArray(_ a: Optional<Point>, _ b: [Int]) throws(JSException) -> String {
     let _ = b.bridgeJSLowerParameter()
-    let aIsSome = a.bridgeJSLowerParameter()
-    let ret = bjs_jsJoinOptionalStructThenArray(aIsSome)
+    let _ = a.bridgeJSLowerParameter()
+    let ret = bjs_jsJoinOptionalStructThenArray()
     if let error = _swift_js_take_exception() {
         throw error
     }
@@ -17300,21 +17300,21 @@ func _$jsJoinEnumThenArray(_ a: ImportedPayloadSignal, _ b: [Int]) throws(JSExce
 
 #if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsJoinStringThenStackParams")
-fileprivate func bjs_jsJoinStringThenStackParams_extern(_ sBytes: Int32, _ sLength: Int32, _ a: Int32) -> Int32
+fileprivate func bjs_jsJoinStringThenStackParams_extern(_ sBytes: Int32, _ sLength: Int32) -> Int32
 #else
-fileprivate func bjs_jsJoinStringThenStackParams_extern(_ sBytes: Int32, _ sLength: Int32, _ a: Int32) -> Int32 {
+fileprivate func bjs_jsJoinStringThenStackParams_extern(_ sBytes: Int32, _ sLength: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_jsJoinStringThenStackParams(_ sBytes: Int32, _ sLength: Int32, _ a: Int32) -> Int32 {
-    return bjs_jsJoinStringThenStackParams_extern(sBytes, sLength, a)
+@inline(never) fileprivate func bjs_jsJoinStringThenStackParams(_ sBytes: Int32, _ sLength: Int32) -> Int32 {
+    return bjs_jsJoinStringThenStackParams_extern(sBytes, sLength)
 }
 
 func _$jsJoinStringThenStackParams(_ s: String, _ a: Optional<[Int]>, _ b: [Int]) throws(JSException) -> String {
     let ret0 = s.bridgeJSWithLoweredParameter { (sBytes, sLength) in
         let _ = b.bridgeJSLowerParameter()
-        let aIsSome = a.bridgeJSLowerParameter()
-        let ret = bjs_jsJoinStringThenStackParams(sBytes, sLength, aIsSome)
+        let _ = a.bridgeJSLowerParameter()
+        let ret = bjs_jsJoinStringThenStackParams(sBytes, sLength)
         return ret
     }
     let ret = ret0
@@ -17517,20 +17517,20 @@ func _$jsGenericDictRoundTrip<T: BridgedSwiftGenericBridgeable>(_ values: [Strin
 
 #if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsGenericAfterOptionalArray")
-fileprivate func bjs_jsGenericAfterOptionalArray_extern(_ values: Int32, _ _generic0TypeId: Int32) -> Int32
+fileprivate func bjs_jsGenericAfterOptionalArray_extern(_ _generic0TypeId: Int32) -> Int32
 #else
-fileprivate func bjs_jsGenericAfterOptionalArray_extern(_ values: Int32, _ _generic0TypeId: Int32) -> Int32 {
+fileprivate func bjs_jsGenericAfterOptionalArray_extern(_ _generic0TypeId: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_jsGenericAfterOptionalArray(_ values: Int32, _ _generic0TypeId: Int32) -> Int32 {
-    return bjs_jsGenericAfterOptionalArray_extern(values, _generic0TypeId)
+@inline(never) fileprivate func bjs_jsGenericAfterOptionalArray(_ _generic0TypeId: Int32) -> Int32 {
+    return bjs_jsGenericAfterOptionalArray_extern(_generic0TypeId)
 }
 
 func _$jsGenericAfterOptionalArray<T: BridgedSwiftGenericBridgeable>(_ values: Optional<[Int]>, _ value: T) throws(JSException) -> String {
     value.bridgeJSStackPush()
-    let valuesIsSome = values.bridgeJSLowerParameter()
-    let ret = bjs_jsGenericAfterOptionalArray(valuesIsSome, T.bridgeJSTypeID)
+    let _ = values.bridgeJSLowerParameter()
+    let ret = bjs_jsGenericAfterOptionalArray(T.bridgeJSTypeID)
     if let error = _swift_js_take_exception() {
         throw error
     }
@@ -17689,19 +17689,19 @@ func _$jsTranslatePoint(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException
 
 #if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_jsRoundTripOptionalPoint")
-fileprivate func bjs_jsRoundTripOptionalPoint_extern(_ point: Int32) -> Void
+fileprivate func bjs_jsRoundTripOptionalPoint_extern() -> Void
 #else
-fileprivate func bjs_jsRoundTripOptionalPoint_extern(_ point: Int32) -> Void {
+fileprivate func bjs_jsRoundTripOptionalPoint_extern() -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_jsRoundTripOptionalPoint(_ point: Int32) -> Void {
-    return bjs_jsRoundTripOptionalPoint_extern(point)
+@inline(never) fileprivate func bjs_jsRoundTripOptionalPoint() -> Void {
+    return bjs_jsRoundTripOptionalPoint_extern()
 }
 
 func _$jsRoundTripOptionalPoint(_ point: Optional<Point>) throws(JSException) -> Optional<Point> {
-    let pointIsSome = point.bridgeJSLowerParameter()
-    bjs_jsRoundTripOptionalPoint(pointIsSome)
+    let _ = point.bridgeJSLowerParameter()
+    bjs_jsRoundTripOptionalPoint()
     if let error = _swift_js_take_exception() {
         throw error
     }
@@ -18758,50 +18758,50 @@ fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringUndefined_s
 
 #if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull_static")
-fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull_static_extern(_ v: Int32) -> Void
+fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull_static_extern() -> Void
 #else
-fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull_static_extern(_ v: Int32) -> Void {
+fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull_static_extern() -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull_static(_ v: Int32) -> Void {
-    return bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull_static_extern(v)
+@inline(never) fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull_static() -> Void {
+    return bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull_static_extern()
 }
 
 #if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined_static")
-fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined_static_extern(_ v: Int32) -> Void
+fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined_static_extern() -> Void
 #else
-fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined_static_extern(_ v: Int32) -> Void {
+fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined_static_extern() -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined_static(_ v: Int32) -> Void {
-    return bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined_static_extern(v)
+@inline(never) fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined_static() -> Void {
+    return bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined_static_extern()
 }
 
 #if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull_static")
-fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull_static_extern(_ v: Int32) -> Void
+fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull_static_extern() -> Void
 #else
-fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull_static_extern(_ v: Int32) -> Void {
+fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull_static_extern() -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull_static(_ v: Int32) -> Void {
-    return bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull_static_extern(v)
+@inline(never) fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull_static() -> Void {
+    return bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull_static_extern()
 }
 
 #if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefined_static")
-fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefined_static_extern(_ v: Int32) -> Void
+fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefined_static_extern() -> Void
 #else
-fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefined_static_extern(_ v: Int32) -> Void {
+fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefined_static_extern() -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefined_static(_ v: Int32) -> Void {
-    return bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefined_static_extern(v)
+@inline(never) fileprivate func bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefined_static() -> Void {
+    return bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefined_static_extern()
 }
 
 #if arch(wasm32)
@@ -18867,8 +18867,8 @@ func _$OptionalSupportImports_jsRoundTripOptionalStringUndefined(_ name: JSUndef
 }
 
 func _$OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull(_ v: Optional<[JSValue]>) throws(JSException) -> Optional<[JSValue]> {
-    let vIsSome = v.bridgeJSLowerParameter()
-    bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull_static(vIsSome)
+    let _ = v.bridgeJSLowerParameter()
+    bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull_static()
     if let error = _swift_js_take_exception() {
         throw error
     }
@@ -18876,8 +18876,8 @@ func _$OptionalSupportImports_jsRoundTripOptionalJSValueArrayNull(_ v: Optional<
 }
 
 func _$OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined(_ v: JSUndefinedOr<[JSValue]>) throws(JSException) -> JSUndefinedOr<[JSValue]> {
-    let vIsSome = v.bridgeJSLowerParameter()
-    bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined_static(vIsSome)
+    let _ = v.bridgeJSLowerParameter()
+    bjs_OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined_static()
     if let error = _swift_js_take_exception() {
         throw error
     }
@@ -18885,8 +18885,8 @@ func _$OptionalSupportImports_jsRoundTripOptionalJSValueArrayUndefined(_ v: JSUn
 }
 
 func _$OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull(_ v: Optional<[String: String]>) throws(JSException) -> Optional<[String: String]> {
-    let vIsSome = v.bridgeJSLowerParameter()
-    bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull_static(vIsSome)
+    let _ = v.bridgeJSLowerParameter()
+    bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull_static()
     if let error = _swift_js_take_exception() {
         throw error
     }
@@ -18894,8 +18894,8 @@ func _$OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryNull(_ 
 }
 
 func _$OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefined(_ v: JSUndefinedOr<[String: String]>) throws(JSException) -> JSUndefinedOr<[String: String]> {
-    let vIsSome = v.bridgeJSLowerParameter()
-    bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefined_static(vIsSome)
+    let _ = v.bridgeJSLowerParameter()
+    bjs_OptionalSupportImports_jsRoundTripOptionalStringToStringDictionaryUndefined_static()
     if let error = _swift_js_take_exception() {
         throw error
     }


### PR DESCRIPTION
## Overview

Imported optional parameters with stack-only payloads (`[T]?`, `[String: V]?`, `@JS struct?`) used a hybrid convention: the `isSome` flag crossed as a wasm `i32` argument while the payload went on the shared stacks. Optional returns and optional array elements of the same types already put both on the stacks.

This lowers those parameters the same way. The wasm signature carries no argument for them; JS pops the flag and conditionally lifts, through the same fragment as optional returns. Scalars, strings, `JSObject`, closures, enums and heap objects keep their current optional ABIs, as do all exported signatures.

```swift
// before: flag as a wasm argument, payload on the stacks
let aIsSome = a.bridgeJSLowerParameter()
let ret = bjs_f(aIsSome)      // JS: function bjs_f(a) { if (a) { ...lift... } }

// after: all-stack
let _ = a.bridgeJSLowerParameter()
let ret = bjs_f()             // JS: pops flag, conditionally lifts
```

This also removes the mixed parameter representation that caused the argument-order bug fixed in #794. Optional stack-based values now use the same stack-only representation as other stack-based parameters.

## Test plan

- [x] BridgeJS plugin tests and snapshots
- [x] Regenerated committed BridgeJS bindings
- [x] `make unittest`
